### PR TITLE
Add a workflow to check for tags in configurations

### DIFF
--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      run: npm install
+      run: node ./scripts/check-tags.js

--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14'
-      run: npm install
-      run: node ./scripts/check-tags.js
+      - run: npm install
+      - run: node ./scripts/check-tags.js

--- a/non-production/example-application.json
+++ b/non-production/example-application.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-application",
+  "email": "example-application@digital.justice.gov.uk",
+  "environments": ["dev", "stage", "uat", "test"],
+  "tags": {
+    "business-unit": "Platforms",
+    "application": "example-application",
+    "is-production": false,
+    "owner": "<Example Application Owner>: example-application@digital.justice.gov.uk"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "modernisation-platform-environments",
+  "version": "1.0.0",
+  "description": "A proof of concept for automated environment creation",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ministryofjustice/modernisation-platform-environments.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ministryofjustice/modernisation-platform-environments/issues"
+  },
+  "homepage": "https://github.com/ministryofjustice/modernisation-platform-environments#readme"
+}

--- a/scripts/check-tags.js
+++ b/scripts/check-tags.js
@@ -1,0 +1,45 @@
+const utilities = require('./utilities.js');
+
+(async function runner () {
+  try {
+    // Get all configuration files
+    const configurations = await utilities.getFilesRecursively('./non-production').then(configuration => configuration.map(application => {
+      // Ensure each configuration has the correct keys and/or tags
+      const missingConfiguration = utilities.checkKeys(application, ['name', 'email', 'environments', 'tags'])
+      const missingRequiredTags = utilities.checkKeys(application.tags, ['business-unit', 'application', 'is-production', 'owner'])
+      const missingOptionalTags = utilities.checkKeys(application.tags, ['environment-name', 'component', 'infrastructure-support', 'runbook', 'source-code'], false)
+
+      return {
+        ...application,
+        ...{
+          missing: {
+            required: missingConfiguration.concat(missingRequiredTags),
+            optional: missingOptionalTags
+          }
+        }
+      }
+    }))
+
+    // Filter out configurations with missing required keys
+    const missingRequired = configurations.filter(configuration => configuration.missing.required.length)
+
+    // If there are any, throw an error
+    if (missingRequired.length) {
+      const e = missingRequired.map(configuration => `${configuration.name} is missing: ${configuration.missing.required.join(', ')}`).join('\n')
+      throw new Error(`[REQUIRED]: Configuration is missing:\n${e}`)
+    }
+
+    // Filter out configurations with missing optional keys
+    const missingOptional = configurations.filter(configuration => configuration.missing.optional.length)
+
+    // If there are any, console.warn a user
+    if (missingOptional.length) {
+      const message = missingOptional.map(configuration => `${configuration.name} is missing: ${configuration.missing.optional.join(', ')}`).join('\n')
+
+      console.warn(`Warning: ${message}`)
+    }
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+})()

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,0 +1,27 @@
+const fs = require('fs').promises
+
+const utilities = {
+  async getFilesRecursively (directory) {
+    const ls = await fs.readdir(directory, { withFileTypes: true })
+    const files = ls.filter(file => !file.isDirectory()).map(async file => {
+      const filePath = `${directory}/${file.name}`
+      const contents = await fs.readFile(filePath, 'utf8').then(content => JSON.parse(content))
+      return { ...contents, ...{ source: filePath } }
+    })
+
+    const folders = ls.filter(file => file.isDirectory())
+
+    for (const folder of folders) {
+      files.push(...await utilities.getFilesRecursively(`${directory}/${folder.name}/`))
+    }
+
+    return Promise.all(files)
+  },
+  checkKeys (object, keys, required = true) {
+    const objKeys = Object.keys(object)
+
+    return keys.filter(key => !objKeys.includes(key))
+  }
+}
+
+module.exports = utilities


### PR DESCRIPTION
This PR:
- Adds some sample data to this repository
- Adds a script that will warn about missing key value pairs that are needed to create an OU and account for an application to sit on the Modernisation Platform, and will throw an error if required tags from the [MoJ Technical Guidance](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#tagging-your-infrastructure) are missing
- Creates a GitHub workflow to run the script on new PRs