### PR TITLE
Allow automated environment creation from a JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,32 @@
-# Ministry of Justice Template Repository
+# modernisation-platform-terraform-environments
 
-Use this template to [create a repository] with the default initial files for a Ministry of Justice Github repository, including:
+This repository holds a Terraform module that creates organisational units and accounts for environments.
 
-* The correct LICENSE
-* Github actions
-* .gitignore file
+## Usage
+```
+module "environments" {
+  source                             = "github.com/ministryofjustice/modernisation-platform-terraform-environments"
+  environment_types                  = ["production", "non-production"]
+  environment_directory              = "./environments"
+  environment_parent_organisation_id = "ou-123456789"
+  environment_prefix                 = "modernisation-platform"
+  region                             = "eu-west-2"
+}
+```
 
-Once you have created your repository, please:
+## Inputs
+|      Name     |               Description              |  Type  | Default | Required |
+|:-------------:|:--------------------------------------:|:------:|:-------:|----------|
+| environment_types | Environment types (or subfolders) in the environments directory | list | n/a     | yes      |
+| environment_directory | Directory path for environment definitions | string | n/a     | yes      |
+| environment_parent_organisation_id | Organisation ID for newly configured environments to sit within | string | n/a     | yes      |
+| environment_prefix | Prefix for all new environment and account names | string | n/a     | yes      |
+| region | Region to run the module in | string | n/a     | yes      |
 
-* Edit the copy of this README.md file to document your project
-* Grant permissions to the appropriate MoJ teams
-* Setup branch protection
+## Outputs
+| Name                    | Description                                | Sensitive |
+|-------------------------|--------------------------------------------|-----------|
+| environment_account_ids | Account IDs for the newly created accounts | Yes       |
 
-[create a repository]: https://github.com/ministryofjustice/template-repository/generate
+## Looking for issues?
+If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region = var.region
+}
+
+locals {
+  applications = flatten([
+    for type in var.environment_types : [
+      for application in fileset("${var.environment_directory}/${type}", "*.json") : {
+        application = jsondecode(file("${var.environment_directory}/${type}/${application}"))
+        namespace   = type
+      }
+    ]
+  ])
+  application_ous = {
+    for definition in local.applications :
+    definition.application.name => definition.namespace
+  }
+  application_envs = flatten([
+    for definition in local.applications : [
+      for env in definition.application.environments : {
+        definition = definition
+        namespace  = env
+      }
+    ]
+  ])
+  application_envs_accounts = {
+    for account in local.application_envs :
+    "${account.definition.application.name}-${account.namespace}" => account
+  }
+}
+
+# Create environment type organisation units
+resource "aws_organizations_organizational_unit" "types" {
+  for_each  = toset(var.environment_types)
+  name      = "${var.environment_prefix}-${each.value}"
+  parent_id = var.environment_parent_organisation_id
+}
+
+# Create application organisation units
+resource "aws_organizations_organizational_unit" "applications" {
+  for_each  = local.application_ous
+  name      = "${var.environment_prefix}-${each.key}-${each.value}"
+  parent_id = aws_organizations_organizational_unit.types[each.value].id
+}
+
+# Create application accounts in their respective OUs
+resource "aws_organizations_account" "accounts" {
+  for_each                   = local.application_envs_accounts
+  name                       = each.key
+  email                      = "aws+mp+${each.key}@digital.justice.gov.uk"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.applications[each.value.definition.application.name].id
+  tags                       = each.value.definition.application.tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "environment_account_ids" {
+  sensitive = true
+  value = {
+    for account in aws_organizations_account.accounts:
+      account.name => account.id
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "environment_account_ids" {
   sensitive = true
   value = {
-    for account in aws_organizations_account.accounts:
-      account.name => account.id
+    for account in aws_organizations_account.accounts :
+    account.name => account.id
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "environment_types" {
+  description = "Environment types (or subfolders) in the environments directory"
+  type        = list
+}
+
+variable "environment_directory" {
+  description = "Directory path for environment definitions"
+  type        = string
+}
+
+variable "environment_parent_organisation_id" {
+  description = "Organisation ID for newly configured environments to sit within"
+  type        = string
+}
+
+variable "environment_prefix" {
+  description = "Prefix for all new environment and account names"
+  type        = string
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
This PR is an extrapolation of ministryofjustice/modernisation-platform#23 into a Terraform module.

This PR automates the following:
- the creation of organisational units for environments
- the creation of child organisation units in environments for applications
- the creation of attached child OU accounts for applications with some sensible defaults such as allowing access to billing, a standardised email address, and tags.

After this PR is merged, it would be sensible to rename the repository to `modernisation-platform-terraform-environments`.