### PR TITLE
Update providers to restrict access

### DIFF
--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/bench/providers.tf
+++ b/terraform/environments/bench/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/heater/providers.tf
+++ b/terraform/environments/heater/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/justice-on-the-web/providers.tf
+++ b/terraform/environments/justice-on-the-web/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/ops-engineering/providers.tf
+++ b/terraform/environments/ops-engineering/providers.tf
@@ -26,16 +26,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/remote-supervision/providers.tf
+++ b/terraform/environments/remote-supervision/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -18,16 +18,6 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
-  }
-}
-
-# AWS provider for core-network-services-production, to share VPCs into this account
-provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
   }
 }


### PR DESCRIPTION
We have updated our templates to not give this repo access to the shared
services provider, and only use a dns role specific to the account
business unit, so that they cannot amend dns entries of another business
unit.  This change updates the files that have already been created so
that they are in line with the new template.