### PR TITLE
Update providers to use new role

### DIFF
--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/bench/providers.tf
+++ b/terraform/environments/bench/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/heater/providers.tf
+++ b/terraform/environments/heater/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/justice-on-the-web/providers.tf
+++ b/terraform/environments/justice-on-the-web/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/ops-engineering/providers.tf
+++ b/terraform/environments/ops-engineering/providers.tf
@@ -26,7 +26,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/performance-hub/main.tf
+++ b/terraform/environments/performance-hub/main.tf
@@ -83,14 +83,14 @@ data "terraform_remote_state" "core_network_services" {
 }
 
 data "template_file" "launch-template" {
-  template = "${file("templates/user-data.txt")}"
+  template = file("templates/user-data.txt")
   vars = {
     cluster_name = local.application_name
   }
 }
 
 data "template_file" "task_definition" {
-  template = "${file("templates/task_definition.json")}"
+  template = file("templates/task_definition.json")
   vars = {
     app_name = local.application_name
     #app_image         = format("%s%s", data.aws_caller_identity.current.account".dkr.ecr."${var.region}".amazonaws.com/"${local.application_name})

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/remote-supervision/providers.tf
+++ b/terraform/environments/remote-supervision/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/dns-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 


### PR DESCRIPTION
Now that we have the new role for accessing core vpc data, switching
providers to use it.