### PR TITLE
Use the bastion linux terraform module from separate repository and pinned to a release

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         scan_type: changed
         tfsec_exclude: AWS095
-        tflint_exclude: terraform_module_pinned_source
 
   terraform-static-analysis-full-scan:
     name: Terraform Static Analysis - scan all directories

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@
 tmp/
 .vscode/
 .terraform.lock.hcl
+
+##########################
+## IntelliJ
+##########################
+*.iml
+.idea/
+*.ipr
+*.iws
+out/
+.idea_modules/

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform/terraform/modules/bastion_linux"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.1"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/performance-hub/bastion_linux.tf
+++ b/terraform/environments/performance-hub/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform/terraform/modules/bastion_linux"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/sprinkler/bastion_linux.tf
+++ b/terraform/environments/sprinkler/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform/terraform/modules/bastion_linux"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts


### PR DESCRIPTION
- Use the terraform bastion linux module from separate repository and pinned to a release: github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v1.0.0
- Add IntelliJ files to .gitignore