### PR TITLE
add resources, role and policy required for packer

### DIFF
--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -59,7 +59,11 @@ data "aws_iam_policy_document" "packer_assume_role_policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-
+    condition {
+      test     = "StringLike"
+      variable = "sts:RoleSessionName"
+      values   = ["&{aws:username}"]      
+    }
     principals {
       type        = "AWS"
       identifiers = [data.aws_iam_user.packer_member_user.arn]
@@ -144,7 +148,7 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:StartSession"]
-    resources = ["arn:aws:ec2:eu-west-2:612659970365:instance/*"]
+    resources = ["arn:aws:ec2:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:instance/*"]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/creator"
@@ -246,4 +250,10 @@ resource "aws_security_group" "packer_security_group" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  tags = merge(
+    local.tags,
+    {
+      Name = "packer-build-sg"
+    },
+  )
 }

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -42,14 +42,13 @@ data "aws_iam_policy_document" "packer_member_policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    resources = aws_iam_role.packer.arn
+    resources = [aws_iam_role.packer.arn]
   }
 }
 
 # attach inline policy
 resource "aws_iam_group_policy" "packer_member_policy" {
   name        = "packer-member-policy"
-  description = "IAM Policy for packer member user"
   policy      = data.aws_iam_policy_document.packer_member_policy.json
   # group      = aws_iam_group.packer_member_group.name
   group = "packer_member_group"
@@ -107,7 +106,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       "ec2:RegisterImage",
       "ec2:RunInstances"
     ]
-    resources = "*"
+    resources = ["*"]
   }
   statement {
     effect = "Allow"
@@ -121,7 +120,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       "ec2:StopInstances",
       "ec2:TerminateInstances"
     ]
-    resources = "*"
+    resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "ec2:ResourceTag/creator"
@@ -131,7 +130,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
   statement {
     effect    = "Allow"
     actions   = ["ec2:DeleteKeyPair"]
-    resources = "*"
+    resources = ["*"]
     condition {
       test     = "StringLike"
       variable = "ec2:KeyPairName"
@@ -145,7 +144,7 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:StartSession"]
-    resources = "arn:aws:ec2:eu-west-2:612659970365:instance/*"
+    resources = ["arn:aws:ec2:eu-west-2:612659970365:instance/*"]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/creator"
@@ -155,7 +154,7 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:StartSession"]
-    resources = "arn:aws:ssm:eu-west-2::document/AWS-StartPortForwardingSession"
+    resources = ["arn:aws:ssm:eu-west-2::document/AWS-StartPortForwardingSession"]
   }
   statement {
     effect = "Allow"
@@ -163,17 +162,17 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
       "ssm:TerminateSession",
       "ssm:ResumeSession"
     ]
-    resources = "arn:aws:ssm:*:*:session/&{aws:username}-*"
+    resources = ["arn:aws:ssm:*:*:session/&{aws:username}-*"]
   }
   statement {
     effect   = "Allow"
     actions  = ["iam:GetInstanceProfile"]
-    resource = aws_iam_instance_profile.packer_ssm_profile.arn
+    resources = [aws_iam_instance_profile.packer_ssm_profile.arn]
   }
   statement {
     effect   = "Allow"
     actions  = ["iam:PassRole"]
-    resource = aws_iam_instance_profile.packer_ssm_role.arn
+    resources = [aws_iam_instance_profile.packer_ssm_role.arn]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -85,6 +85,9 @@ resource "aws_iam_role" "packer" {
 # build policy json for Packer base permissions
 data "aws_iam_policy_document" "packer_minimum_permissions" {
   statement {
+    #checkov:skip=CKV_AWS_111
+    #checkov:skip=CKV_AWS_109
+    #checkov:skip=CKV_AWS_107
     effect = "Allow"
     actions = [
       "ec2:AuthorizeSecurityGroupIngress",
@@ -106,7 +109,6 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       "ec2:DescribeSubnets",
       "ec2:DescribeTags",
       "ec2:DescribeVolumes",
-      "ec2:GetPasswordData",
       "ec2:RegisterImage",
       "ec2:RunInstances"
     ]
@@ -121,6 +123,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       "ec2:ModifyImageAttribute",
       "ec2:ModifyInstanceAttribute",
       "ec2:ModifySnapshotAttribute",
+      "ec2:GetPasswordData",
       "ec2:StopInstances",
       "ec2:TerminateInstances"
     ]
@@ -240,10 +243,11 @@ resource "aws_iam_instance_profile" "packer_ssm_profile" {
 #------------------------------------------------------------------------------
 
 resource "aws_security_group" "packer_security_group" {
+  #checkov:skip=CKV2_AWS_5
   description = "Security Group for Packer builds"
   name        = "packer-build-${local.application_name}"
   vpc_id      = data.aws_vpc.shared_vpc.id
-  egress {
+  egress { #tfsec:ignore:AWS009
     description = "allow all"
     from_port   = 0
     to_port     = 0

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -51,7 +51,7 @@ resource "aws_iam_group_policy" "packer_member_policy" {
   name   = "packer-member-policy"
   policy = data.aws_iam_policy_document.packer_member_policy.json
   # group      = aws_iam_group.packer_member_group.name
-  group = "packer_member_group"
+  group = "packer-member-group"
 }
 
 # Role to provide required packer permissions
@@ -196,7 +196,7 @@ resource "aws_iam_role_policy" "packer" {
 #------------------------------------------------------------------------------
 
 resource "aws_iam_role" "packer_ssm_role" {
-  name                 = "packer_ssm_role"
+  name                 = "packer-ssm-role"
   path                 = "/"
   max_session_duration = "3600"
   assume_role_policy = jsonencode(
@@ -218,13 +218,13 @@ resource "aws_iam_role" "packer_ssm_role" {
   tags = merge(
     local.tags,
     {
-      Name = "packer_ssm_role"
+      Name = "packer-ssm-role"
     },
   )
 }
 
 resource "aws_iam_instance_profile" "packer_ssm_profile" {
-  name = "packer_ssm_profile"
+  name = "packer-ssm-profile"
   role = aws_iam_role.packer_ssm_role.name
   path = "/"
 }

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "packer_assume_role_policy" {
     condition {
       test     = "StringLike"
       variable = "sts:RoleSessionName"
-      values   = ["&{aws:username}"]      
+      values   = ["&{aws:username}"]
     }
     principals {
       type        = "AWS"

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -247,12 +247,12 @@ resource "aws_security_group" "packer_security_group" {
   description = "Security Group for Packer builds"
   name        = "packer-build-${local.application_name}"
   vpc_id      = data.aws_vpc.shared_vpc.id
-  egress { #tfsec:ignore:AWS009
+  egress {
     description = "allow all"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
   }
   tags = merge(
     local.tags,

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -24,7 +24,7 @@ data "aws_iam_user" "packer_member_user" {
 # }
 
 data "aws_iam_group" "packer_member_group" {
-  group_name = "packer_member_group"
+  group_name = "packer-member-group"
 }
 
 # resource "aws_iam_group_membership" "packer_member" {

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -172,7 +172,7 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
   statement {
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = [aws_iam_instance_profile.packer_ssm_role.arn]
+    resources = [aws_iam_role.packer_ssm_role.arn]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -10,6 +10,9 @@ resource "aws_iam_user" "packer_member_user" {
   name = "packer-member-user"
 }
 
+resource "aws_iam_access_key" "packer_member_user_key" {
+  user = aws_iam_user.packer_member_user.name
+}
 resource "aws_iam_group" "packer_member_group" {
   name = "packer-member-group"
 }
@@ -36,7 +39,7 @@ resource "aws_iam_group_policy_attachment" "aws_config_attach" {
   policy_arn = aws_iam_policy.policy.arn
 }
 
-resource "aws_iam_group_membership" "packer-member" {
+resource "aws_iam_group_membership" "packer_member" {
   name = "packer-member-group-membership"
 
   users = [
@@ -78,8 +81,8 @@ resource "aws_iam_role_policy" "packer" {
   role = aws_iam_role.packer.id
 
   policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
+    "Version" : "2012-10-17"
+    "Statement" : [
       {
         "Effect" : "Allow",
         "Action" : [
@@ -87,10 +90,11 @@ resource "aws_iam_role_policy" "packer" {
           "ec2:CopyImage",
           "ec2:CreateImage",
           "ec2:CreateKeypair",
-          "ec2:CreateSecurityGroup",
           "ec2:CreateSnapshot",
           "ec2:CreateTags",
           "ec2:CreateVolume",
+          "ec2:DeleteSnapshot",  # unfortunately Packer does not tag intermediate snapshots it creates
+          "ec2:DeregisterImage", # unfortunately Packer does not tag intermediate images it creates
           "ec2:DescribeImageAttribute",
           "ec2:DescribeImages",
           "ec2:DescribeInstances",
@@ -103,7 +107,7 @@ resource "aws_iam_role_policy" "packer" {
           "ec2:DescribeVolumes",
           "ec2:GetPasswordData",
           "ec2:RegisterImage",
-          "ec2:RunInstances",
+          "ec2:RunInstances"
         ],
         "Resource" : "*"
       },
@@ -111,17 +115,13 @@ resource "aws_iam_role_policy" "packer" {
         "Effect" : "Allow",
         "Action" : [
           "ec2:AttachVolume",
-          "ec2:DeleteKeyPair",
-          "ec2:DeleteSecurityGroup",
-          "ec2:DeleteSnapshot",
           "ec2:DeleteVolume",
-          "ec2:DeregisterImage",
           "ec2:DetachVolume",
           "ec2:ModifyImageAttribute",
           "ec2:ModifyInstanceAttribute",
           "ec2:ModifySnapshotAttribute",
           "ec2:StopInstances",
-          "ec2:TerminateInstances"
+          "ec2:TerminateInstances",
         ],
         "Resource" : "*",
         "Condition" : {
@@ -129,6 +129,53 @@ resource "aws_iam_role_policy" "packer" {
             "ec2:ResourceTag/creator" : "Packer"
           }
         }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "ssm:StartSession",
+        "Resource" : "arn:aws:ec2:eu-west-2:612659970365:instance/*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/creator" : "Packer"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "ssm:StartSession",
+        "Resource" : "arn:aws:ssm:eu-west-2::document/AWS-StartPortForwardingSession"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssm:TerminateSession",
+          "ssm:ResumeSession"
+        ],
+        "Resource" : [
+          "arn:aws:ssm:*:*:session/$${aws:username}-*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteKeyPair"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:KeyPairName" : "packer_*"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "iam:GetInstanceProfile",
+        "Resource" : "${aws_iam_instance_profile.packer_ssm_profile.arn}"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "iam:PassRole",
+        "Resource" : "${aws_iam_instance_profile.packer_ssm_role.arn}"
       }
     ]
   })
@@ -136,7 +183,7 @@ resource "aws_iam_role_policy" "packer" {
 
 #------------------------------------------------------------------------------
 # Instance profile to be assumed by Packer build instance
-# This is required enable SSH via Systems Manager
+# This is required to enable SSH via Systems Manager
 #------------------------------------------------------------------------------
 
 resource "aws_iam_role" "packer_ssm_role" {
@@ -171,4 +218,24 @@ resource "aws_iam_instance_profile" "packer_ssm_profile" {
   name = "packer_ssm_profile"
   role = aws_iam_role.packer_ssm_role.name
   path = "/"
+}
+
+#------------------------------------------------------------------------------
+# Security Group to be used by Packer.  This is required as there is currently
+# not a simple way to restrict Packer to only allow deleting of security groups
+# it created (it does not tag the security group like other resources)
+#------------------------------------------------------------------------------
+
+resource "aws_security_group" "packer_security_group" {
+  description = "Security Group for Packer builds"
+  name        = "packer-build-${local.application_name}"
+  vpc_id      = data.aws_vpc.shared_vpc.id
+  egress {
+    description      = "allow all"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 }

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -140,8 +140,8 @@ resource "aws_iam_role_policy" "packer" {
 #------------------------------------------------------------------------------
 
 resource "aws_iam_role" "packer_ssm_role" {
-  name = "packer_ssm_role"
-  path = "/"
+  name                 = "packer_ssm_role"
+  path                 = "/"
   max_session_duration = "3600"
   assume_role_policy = jsonencode(
     {

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -42,8 +42,7 @@ data "aws_iam_policy_document" "packer_member_policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    # resources = aws_iam_role.packer.arn
-    resources = data.aws_iam_role.packer.arn
+    resources = aws_iam_role.packer.arn
   }
 }
 
@@ -124,7 +123,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
     ]
     resources = "*"
     condition {
-      test     = StringEquals
+      test     = "StringEquals"
       variable = "ec2:ResourceTag/creator"
       values   = ["Packer"]
     }
@@ -134,7 +133,7 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
     actions   = ["ec2:DeleteKeyPair"]
     resources = "*"
     condition {
-      test     = StringLike
+      test     = "StringLike"
       variable = "ec2:KeyPairName"
       values   = ["packer_*"]
     }
@@ -148,7 +147,7 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
     actions   = ["ssm:StartSession"]
     resources = "arn:aws:ec2:eu-west-2:612659970365:instance/*"
     condition {
-      test     = StringEquals
+      test     = "StringEquals"
       variable = "aws:ResourceTag/creator"
       values   = ["Packer"]
     }

--- a/terraform/environments/nomis/packer_cicd_user.tf
+++ b/terraform/environments/nomis/packer_cicd_user.tf
@@ -1,0 +1,116 @@
+resource "aws_iam_user" "packer_member_user" {
+  name = "packer-member-user"
+}
+
+resource "aws_iam_group" "packer_member_group" {
+  name = "packer-member-group"
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = "packer-member-policy"
+  description = "IAM Policy for packer member user"
+  policy = jsonencode({ #tfsec:ignore:AWS099
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole",
+        ]
+        Effect   = "Allow"
+        Resource = aws_iam_role.packer.arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "aws_config_attach" {
+  group      = aws_iam_group.packer_member_group.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+resource "aws_iam_group_membership" "packer-member" {
+  name = "packer-member-group-membership"
+
+  users = [
+    aws_iam_user.packer_member_user.name
+  ]
+
+  group = aws_iam_group.packer_member_group.name
+}
+
+# Role to provide required packer permissions
+resource "aws_iam_role" "packer" {
+  name = "packer-build"
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : aws_iam_user.packer_member_user.arn
+          },
+          "Action" : "sts:AssumeRole",
+          "Condition" : {}
+        }
+      ]
+  })
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "packer-build"
+    },
+  )
+}
+
+# policy for the packer role, and attach to role
+resource "aws_iam_role_policy" "packer" {
+  name = "modify-dns-records"
+  role = aws_iam_role.packer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AttachVolume",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CopyImage",
+          "ec2:CreateImage",
+          "ec2:CreateKeypair",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateSnapshot",
+          "ec2:CreateTags",
+          "ec2:CreateVolume",
+          "ec2:DeleteKeyPair",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteVolume",
+          "ec2:DeregisterImage",
+          "ec2:DescribeImageAttribute",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeRegions",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
+          "ec2:DetachVolume",
+          "ec2:GetPasswordData",
+          "ec2:ModifyImageAttribute",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifySnapshotAttribute",
+          "ec2:RegisterImage",
+          "ec2:RunInstances",
+          "ec2:StopInstances",
+          "ec2:TerminateInstances"
+        ],
+        "Resource" : "*" # limit delete actions to instances with packer tag??
+      },
+    ]
+  })
+}

--- a/terraform/environments/nomis/packer_cicd_user.tf
+++ b/terraform/environments/nomis/packer_cicd_user.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role" "packer" {
 
 # policy for the packer role, and attach to role
 resource "aws_iam_role_policy" "packer" {
-  name = "modify-dns-records"
+  name = "packer-minimum-permissions"
   role = aws_iam_role.packer.id
 
   policy = jsonencode({
@@ -75,7 +75,6 @@ resource "aws_iam_role_policy" "packer" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "ec2:AttachVolume",
           "ec2:AuthorizeSecurityGroupIngress",
           "ec2:CopyImage",
           "ec2:CreateImage",
@@ -84,11 +83,6 @@ resource "aws_iam_role_policy" "packer" {
           "ec2:CreateSnapshot",
           "ec2:CreateTags",
           "ec2:CreateVolume",
-          "ec2:DeleteKeyPair",
-          "ec2:DeleteSecurityGroup",
-          "ec2:DeleteSnapshot",
-          "ec2:DeleteVolume",
-          "ec2:DeregisterImage",
           "ec2:DescribeImageAttribute",
           "ec2:DescribeImages",
           "ec2:DescribeInstances",
@@ -99,18 +93,35 @@ resource "aws_iam_role_policy" "packer" {
           "ec2:DescribeSubnets",
           "ec2:DescribeTags",
           "ec2:DescribeVolumes",
-          "ec2:DetachVolume",
           "ec2:GetPasswordData",
+          "ec2:RegisterImage",
+          "ec2:RunInstances",
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AttachVolume",
+          "ec2:DeleteKeyPair",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteVolume",
+          "ec2:DeregisterImage",
+          "ec2:DetachVolume",
           "ec2:ModifyImageAttribute",
           "ec2:ModifyInstanceAttribute",
           "ec2:ModifySnapshotAttribute",
-          "ec2:RegisterImage",
-          "ec2:RunInstances",
           "ec2:StopInstances",
           "ec2:TerminateInstances"
         ],
-        "Resource" : "*" # limit delete actions to instances with packer tag??
-      },
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:ResourceTag/creator" : "Packer"
+          }
+        }
+      }
     ]
   })
 }


### PR DESCRIPTION
This provides a number of resources required to run packer:
Role that can be assumed by the packer cicd user providing the minimum permissions required by Packer
Policy definition and attachment to Role
Policy definition and attachment to packer user group allowing members to assume Role
Instance profile to be attached to the Packer build instances to allow connection with Session Manager (SSM)
Security group for Packer to attach to its build instance.