### PR TITLE
Add configuration to allow developers to run plans

### DIFF
--- a/terraform/environments/analytical-platform-data/providers.tf
+++ b/terraform/environments/analytical-platform-data/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/analytical-platform-data/secrets.tf
+++ b/terraform/environments/analytical-platform-data/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/analytical-platform-management/secrets.tf
+++ b/terraform/environments/analytical-platform-management/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/bench/providers.tf
+++ b/terraform/environments/bench/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/bench/secrets.tf
+++ b/terraform/environments/bench/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/bichard7/secrets.tf
+++ b/terraform/environments/bichard7/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/cooker/secrets.tf
+++ b/terraform/environments/cooker/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/heater/providers.tf
+++ b/terraform/environments/heater/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/heater/secrets.tf
+++ b/terraform/environments/heater/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/justice-on-the-web/providers.tf
+++ b/terraform/environments/justice-on-the-web/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/justice-on-the-web/secrets.tf
+++ b/terraform/environments/justice-on-the-web/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/nomis/providers.tf
+++ b/terraform/environments/nomis/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,10 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
-provider "aws" {
-  alias  = "bucket-replication"
-  region = "eu-west-1"
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
-  }
-}
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/nomis/secrets.tf
+++ b/terraform/environments/nomis/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/ops-engineering/providers.tf
+++ b/terraform/environments/ops-engineering/providers.tf
@@ -1,14 +1,7 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
-  assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
-  }
-}
-
-provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
   }
@@ -39,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/ops-engineering/secrets.tf
+++ b/terraform/environments/ops-engineering/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/performance-hub/secrets.tf
+++ b/terraform/environments/performance-hub/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,6 +10,28 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################
+
 
 ## == DATABASE CONNECTIONS ==
 

--- a/terraform/environments/remote-supervision/providers.tf
+++ b/terraform/environments/remote-supervision/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/remote-supervision/secrets.tf
+++ b/terraform/environments/remote-supervision/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/sprinkler/secrets.tf
+++ b/terraform/environments/sprinkler/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/tariff/providers.tf
+++ b/terraform/environments/tariff/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/tariff/secrets.tf
+++ b/terraform/environments/tariff/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/testing/providers.tf
+++ b/terraform/environments/testing/providers.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
@@ -31,3 +32,33 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# provider "aws" {
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for core-vpc-<environment>, to share VPCs into this account
+# provider "aws" {
+#   alias  = "core-vpc"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
+#   }
+# }
+
+# # AWS provider for network services to enable dns entries for certificate validation to be created
+# provider "aws" {
+#   alias  = "core-network-services"
+#   region = "eu-west-2"
+
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
+#   }
+# }
+######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/testing/secrets.tf
+++ b/terraform/environments/testing/secrets.tf
@@ -1,3 +1,4 @@
+######################### Run Terraform via CICD ##################################
 # Get secret by name for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
@@ -9,3 +10,24 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
+######################### Run Terraform via CICD ##################################
+
+
+######################### Run Terraform Plan Locally Only ##################################
+# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+
+# # Get secret by arn for environment management
+# data "aws_ssm_parameter" "environment_management_arn" {
+#   name = "environment_management_arn"
+# }
+
+# data "aws_secretsmanager_secret" "environment_management" {
+#   arn = data.aws_ssm_parameter.environment_management_arn.value
+# }
+
+# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+# data "aws_secretsmanager_secret_version" "environment_management" {
+#   secret_id = data.aws_secretsmanager_secret.environment_management.id
+# }
+
+######################### Run Terraform Plan Locally Only ##################################


### PR DESCRIPTION
Configuration needed to run a terraform plan locally using the developer
SSO role.

For guidance on how to use this configuration please see here:

https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/running-terraform-plan-locally.html