### PR TITLE
Update non member account providers

### DIFF
--- a/terraform/environments/analytical-platform-data/providers.tf
+++ b/terraform/environments/analytical-platform-data/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/analytical-platform-management/providers.tf
+++ b/terraform/environments/analytical-platform-management/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/bichard7/providers.tf
+++ b/terraform/environments/bichard7/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -9,25 +9,26 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-sandbox"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/mi-platform/providers.tf
+++ b/terraform/environments/mi-platform/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/nomis/providers.tf
+++ b/terraform/environments/nomis/providers.tf
@@ -16,15 +16,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -32,9 +33,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -53,6 +54,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -63,6 +65,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/remote-supervision/providers.tf
+++ b/terraform/environments/remote-supervision/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -20,7 +20,7 @@ provider "aws" {
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-sandbox"
   }
 }
 

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -20,7 +20,7 @@ provider "aws" {
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-sandbox"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
 }
 
@@ -29,7 +29,6 @@ provider "aws" {
   alias                  = "core-network-services"
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
-
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -48,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -58,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/tariff/providers.tf
+++ b/terraform/environments/tariff/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/testing/providers.tf
+++ b/terraform/environments/testing/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,6 +58,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/xhibit-portal/providers.tf
+++ b/terraform/environments/xhibit-portal/providers.tf
@@ -9,15 +9,16 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
+  alias                  = "modernisation-platform"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias  = "core-vpc"
-  region = "eu-west-2"
-
+  alias                  = "core-vpc"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -25,9 +26,9 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias  = "core-network-services"
-  region = "eu-west-2"
-
+  alias                  = "core-network-services"
+  region                 = "eu-west-2"
+  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -46,6 +47,7 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -56,9 +58,10 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
+#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
 #   }
 # }
-######################### Run Terraform Plan Locally Only ####################################
+######################### Run Terraform Plan Locally Only ##################################


### PR DESCRIPTION
After enabling security hub alarms for the modernisation platform core
account, there were a lot of unauthorized api alarms -

```
Sum unauthorised-api-calls GreaterThanOrEqualToThreshold 1.0
```

Tracking down the alarm reason in cloudtrail shows that the unauthorised
call was to DescribeAccountAttributes from the member-ci user.

This is because calls from the member-ci user assume a role normally,
and the only thing the ci user has direct permissions for is to access
the state. When the Terraform AWS provider first starts it checks the
supported EC2 platforms which uses the above permission.  We don't need
it to do this for the non member accounts that the member-ci has access
to, as it will only ever create EC2 resources in the member account
(which has this permission as it assumes the member admin role)

https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_get_ec2_platforms

So this PR is adding the skip option for all the AWS providers that are
not the members account, eg the modernisation-platform core, network-services
and core-vpc accounts.