### PR TITLE
had issue with latest packer run in that it could not tag the final i…

### DIFF
--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -172,7 +172,10 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
   statement { # need this as Packer seems to copy the image and then tag it
     effect    = "Allow"
     actions   = ["ec2:CreateTags"]
-    resources = ["arn:aws:ec2:eu-west-2::image/ami-*"]
+    resources = [
+      "arn:aws:ec2:eu-west-2::image/ami-*",
+      "arn:aws:ec2:eu-west-2::snapshot/snap-*"
+      ]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -90,7 +90,6 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
     #checkov:skip=CKV_AWS_107
     effect = "Allow"
     actions = [
-      "ec2:AuthorizeSecurityGroupIngress",
       "ec2:CopyImage",
       "ec2:CreateImage",
       "ec2:CreateKeypair",
@@ -133,6 +132,13 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       values   = ["Packer", "packer", "ansible"]
     }
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ec2:AuthorizeSecurityGroupIngress"]
+    resources = [aws_security_group.packer_security_group.arn]
+  }
+
   statement {
     effect    = "Allow"
     actions   = ["ec2:DeleteKeyPair"]
@@ -161,6 +167,11 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
         "RegisterImage"
       ]
     }
+
+  statement { # need this as Packer seems to copy the image and then tag it
+    effect    = "Allow"
+    actions   = ["ec2:CreateTags"]
+    resources = ["arn:aws:ec2:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:image/*"]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -170,12 +170,12 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
   }
 
   statement { # need this as Packer seems to copy the image and then tag it
-    effect    = "Allow"
-    actions   = ["ec2:CreateTags"]
+    effect  = "Allow"
+    actions = ["ec2:CreateTags"]
     resources = [
       "arn:aws:ec2:eu-west-2::image/ami-*",
       "arn:aws:ec2:eu-west-2::snapshot/snap-*"
-      ]
+    ]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -168,11 +168,11 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
       ]
     }
   }
-  
+
   statement { # need this as Packer seems to copy the image and then tag it
     effect    = "Allow"
     actions   = ["ec2:CreateTags"]
-    resources = ["arn:aws:ec2:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:image/*"]
+    resources = ["arn:aws:ec2:eu-west-2::image/ami-*"]
   }
 }
 

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -167,7 +167,8 @@ data "aws_iam_policy_document" "packer_minimum_permissions" {
         "RegisterImage"
       ]
     }
-
+  }
+  
   statement { # need this as Packer seems to copy the image and then tag it
     effect    = "Allow"
     actions   = ["ec2:CreateTags"]


### PR DESCRIPTION
…mage, so opening up permissions a bit to allow it to tag any image.  Unfortunately restricting to tagging on image copy isn't working