### PR TITLE
allow all traffic back from db

### DIFF
--- a/terraform/environments/xhibit-portal/app-server.tf
+++ b/terraform/environments/xhibit-portal/app-server.tf
@@ -42,16 +42,28 @@ resource "aws_security_group_rule" "app-from-portal" {
 }
 
 
-resource "aws_security_group_rule" "app-from-database" {
+# resource "aws_security_group_rule" "app-from-database" {
+#   depends_on               = [aws_security_group.app-server]
+#   security_group_id        = aws_security_group.app-server.id
+#   type                     = "ingress"
+#   description              = "allow DTC traffic from DB"
+#   from_port                = 135
+#   to_port                  = 135
+#   protocol                 = "TCP"
+#   source_security_group_id = aws_security_group.database-server.id
+# }
+
+resource "aws_security_group_rule" "app-all-from-database" {
   depends_on               = [aws_security_group.app-server]
   security_group_id        = aws_security_group.app-server.id
   type                     = "ingress"
-  description              = "allow DTC traffic from DB"
-  from_port                = 135
-  to_port                  = 135
-  protocol                 = "TCP"
+  description              = "allow all traffic from DB"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
   source_security_group_id = aws_security_group.database-server.id
 }
+
 
 
 


### PR DESCRIPTION
MS DTC seems to need lots of random open ports bidirectionally. 

Opening up ports to test whether the app starts when the ports are open. We'll have to figure out a way to lock these ports and just open the required ones later. 