### PR TITLE
Give packer-build role permission to retrieve AWS parameters

### DIFF
--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -220,6 +220,11 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
     actions   = ["iam:PassRole"]
     resources = [aws_iam_role.packer_ssm_role.arn]
   }
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameters"]
+    resources = ["arn:aws:ssm:eu-west-2::document/AWS-StartPortForwardingSession"]
+  }
 }
 
 # some extra permissions required for Ansible ec2 module

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -222,8 +222,8 @@ data "aws_iam_policy_document" "packer_ssm_permissions" {
   }
   statement {
     effect    = "Allow"
-    actions   = ["ssm:GetParameters"]
-    resources = ["arn:aws:ssm:eu-west-2::document/AWS-StartPortForwardingSession"]
+    actions   = ["ssm:GetParameter"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
Give packer-build role permission to retrieve AWS "parameter store" parameters