### PR TITLE
create ASM passwords and give newly created database instances tempor…

### DIFF
--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -19,7 +19,7 @@ module "nomis_stack" {
   database_common_security_group_id = aws_security_group.database_common.id
   weblogic_common_security_group_id = aws_security_group.weblogic_common.id
 
-  instance_profile_id        = aws_iam_instance_profile.ec2_common_profile.id
+  instance_profile_name      = aws_iam_instance_profile.ec2_common_profile.name
   key_name                   = aws_key_pair.ec2-user.key_name
   load_balancer_listener_arn = aws_lb_listener.internal.arn
 

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
@@ -226,8 +226,8 @@ resource "time_offset" "asm_parameter" {
 data "aws_iam_policy_document" "asm_parameter" {
   statement {
     effect    = "Allow"
-    actions   = ["ssm:GetParameter"]
-    resources = ["arn:aws:ssm:region:account-id:parameter/database/${var.stack_name}/*"]
+    actions   = ["ssm:GetParameter*"]
+    resources = ["arn:aws:ssm:${var.region}:*:parameter/database/${var.stack_name}/*"]
     condition {
       test     = "DateLessThan"
       variable = "aws:CurrentTime"

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
@@ -166,7 +166,7 @@ resource "random_password" "asm_sys" {
 }
 
 resource "aws_ssm_parameter" "asm_sys" {
-  name        = "database/${var.stack_name}/ASMSYS"
+  name        = "/database/${var.stack_name}/ASMSYS"
   description = "${var.stack_name} ASMSYS password"
   type        = "SecureString"
   value       = random_password.asm_sys.result
@@ -238,6 +238,6 @@ data "aws_iam_instance_profile" "ec2_common_profile" {
 
 resource "aws_iam_role_policy" "asm_parameter" {
   name   = "asm-parameter-access-${var.stack_name}"
-  role   = data.aws_iam_instance_profile.ec2_common_profile.role_id
+  role   = data.aws_iam_instance_profile.ec2_common_profile.role_name
   policy = data.aws_iam_policy_document.asm_parameter.json
 }

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
@@ -207,7 +207,7 @@ resource "aws_ssm_parameter" "asm_ssnmp" {
 
 resource "time_offset" "asm_parameter" {
   # static time resource for controlling access to parameter
-  offset_minutes = 60
+  offset_minutes = 30
   triggers = {
     # if the instance is recycled we reset the timestamp to give access again
     instance_id = aws_instance.database_server.arn
@@ -218,7 +218,7 @@ data "aws_iam_policy_document" "asm_parameter" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:GetParameter"]
-    resources = ["/database/${var.stack_name}/*"]
+    resources = ["arn:aws:ssm:region:account-id:parameter/database/${var.stack_name}/*"]
     condition {
       test     = "DateLessThan"
       variable = "aws:CurrentTime"

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_weblogic.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_weblogic.tf
@@ -37,7 +37,7 @@ resource "aws_instance" "weblogic_server" {
   ami                         = data.aws_ami.weblogic_image.id
   associate_public_ip_address = false
   # ebs_optimized          = true
-  iam_instance_profile   = var.instance_profile_id
+  iam_instance_profile   = var.instance_profile_name
   instance_type          = var.weblogic_instance_type
   key_name               = var.key_name
   monitoring             = false

--- a/terraform/environments/nomis/modules/nomis_stack/user_data/database_init.sh
+++ b/terraform/environments/nomis/modules/nomis_stack/user_data/database_init.sh
@@ -63,9 +63,11 @@ disks() {
     local devices=($(lsblk -npf -o FSTYPE,PKNAME | awk '/oracleasm/ {print $2}'))
     unset IFS
 
-    for item in "${devices[@]}"; do
-        echo "resizing device ${item}"
-        parted --script "${item}" resizepart 1 100%
+    # Note use of $${} syntax - this is because this file is being used as a terraform template
+    # so we need the extra $ to prevent terraform trying to interpolate it
+    for item in "$${devices[@]}"; do
+        echo "resizing device $${item}"
+        parted --script "$${item}" resizepart 1 100%
     done
 
     # rescan oracle asm disks as they don't always appear on first launch of instance

--- a/terraform/environments/nomis/modules/nomis_stack/variables.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/variables.tf
@@ -66,7 +66,7 @@ variable "environment" {
   description = "Application environment - i.e. the terraform workspace"
 }
 
-variable "instance_profile_id" {
+variable "instance_profile_name" {
   type        = string
   description = "IAM instance profile to be attached to the instances"
 }


### PR DESCRIPTION
We need to set the ASM passwords on each db instance to something unique.  This pr creates a password resource which is added to parameter store.  The instance IAM profile is then updated to give temporary access to the parameter so that it can be used when the instance is first started.  After x minutes access to the parameter is revoked to prevent anyone with access to the instance from reading the secret.  I also removed the AmazonSSMManagedInstanceCore policy from the instance IAM profile as it allowed access to all parameters.  This is replaced with an almost identical policy accept access is given to only specific, non-secret, parameters.