### PR TITLE
Nomis/db route53 record

### DIFF
--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -120,7 +120,7 @@ resource "aws_acm_certificate" "internal_lb" {
   domain_name       = "${local.application_name}.${data.aws_route53_zone.external.name}"
   validation_method = "DNS"
 
-  subject_alternative_names = ["*.${var.application_name}.${data.aws_route53_zone.external.name}"]
+  subject_alternative_names = ["*.${local.application_name}.${data.aws_route53_zone.external.name}"]
 
   tags = merge(
     local.tags,

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -117,10 +117,10 @@ resource "aws_route53_record" "internal_lb" {
 #------------------------------------------------------------------------------
 
 resource "aws_acm_certificate" "internal_lb" {
-  domain_name       = "${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"
+  domain_name       = "${local.application_name}.${data.aws_route53_zone.external.name}"
   validation_method = "DNS"
 
-  subject_alternative_names = ["*.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+  subject_alternative_names = ["*.${var.application_name}.${data.aws_route53_zone.external.name}"]
 
   tags = merge(
     local.tags,

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
@@ -154,11 +154,21 @@ resource "aws_volume_attachment" "database_server_ami_volume" {
 # Route 53 record
 #------------------------------------------------------------------------------
 
-resource "aws_route53_record" "database" {
+resource "aws_route53_record" "database_internal" {
   provider = aws.core-vpc
 
   zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "database-${var.stack_name}.${var.application_name}.${var.business_unit}-${var.environment}.modernisation-platform.internal"
+  name    = "database-${var.stack_name}.${var.application_name}.${data.aws_route53_zone.internal.name}"
+  type    = "A"
+  ttl     = "60"
+  records = [aws_instance.database_server.private_ip]
+}
+
+resource "aws_route53_record" "database_external" {
+  provider = aws.core-vpc
+
+  zone_id = data.aws_route53_zone.external.zone_id
+  name    = "database-${var.stack_name}.${var.application_name}.${data.aws_route53_zone.external.name}"
   type    = "A"
   ttl     = "60"
   records = [aws_instance.database_server.private_ip]

--- a/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/ec2_database.tf
@@ -158,7 +158,7 @@ resource "aws_route53_record" "database_internal" {
   provider = aws.core-vpc
 
   zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "database-${var.stack_name}.${var.application_name}.${data.aws_route53_zone.internal.name}"
+  name    = "db.${var.stack_name}.${var.application_name}.${data.aws_route53_zone.internal.name}"
   type    = "A"
   ttl     = "60"
   records = [aws_instance.database_server.private_ip]
@@ -168,7 +168,7 @@ resource "aws_route53_record" "database_external" {
   provider = aws.core-vpc
 
   zone_id = data.aws_route53_zone.external.zone_id
-  name    = "database-${var.stack_name}.${var.application_name}.${data.aws_route53_zone.external.name}"
+  name    = "db.${var.stack_name}.${var.application_name}.${data.aws_route53_zone.external.name}"
   type    = "A"
   ttl     = "60"
   records = [aws_instance.database_server.private_ip]

--- a/terraform/environments/nomis/modules/nomis_stack/loadbalancer_rules.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/loadbalancer_rules.tf
@@ -52,7 +52,7 @@ resource "aws_lb_listener_rule" "weblogic" {
   }
   condition {
     host_header {
-      values = ["${var.application_name}-${var.stack_name}.${var.business_unit}-${var.environment}.modernisation-platform.service.justice.gov.uk"]
+      values = ["${var.stack_name}.${var.application_name}.${data.aws_route53_zone.external.name}"]
     }
   }
 }

--- a/terraform/environments/nomis/modules/nomis_stack/networking.tf
+++ b/terraform/environments/nomis/modules/nomis_stack/networking.tf
@@ -41,3 +41,10 @@ data "aws_route53_zone" "internal" {
   name         = "${var.business_unit}-${var.environment}.modernisation-platform.internal."
   private_zone = true
 }
+
+data "aws_route53_zone" "external" {
+  provider = aws.core-vpc
+
+  name         = "${var.business_unit}-${var.environment}.modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}


### PR DESCRIPTION
Added public dns record for database internal IP for access from CP and fix n go.  Mod Platform policy is that private IPs do not need to be considered secret.