### PR TITLE
External KMS access for EC2 Image Builder from core-shared-services

### DIFF
--- a/.github/workflows/dex-ta.yml
+++ b/.github/workflows/dex-ta.yml
@@ -202,7 +202,7 @@ jobs:
   #        bash scripts/terraform-apply.sh terraform/environments/dex-ta
   #      env:
   #        TF_ENV: production
-=======
+# =======
 #   plan-test:
 #     name: Plan Test - dex-ta
 #     runs-on: ubuntu-latest

--- a/terraform/environments/sprinkler/kms.tf
+++ b/terraform/environments/sprinkler/kms.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
 
   # Allow root users full management access to key
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = [
       "kms:*"
     ]
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
   # Conditions for principals is based on approach taken for S3 example in https://aws.amazon.com/blogs/security/iam-share-aws-resources-groups-aws-accounts-aws-organizations/
   # Conditions for key grants is based on https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-service-integration
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = [
       "kms:DescribeKey",
       "kms:ReEncrypt*",
@@ -53,26 +53,29 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
-      values   = ["${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"]
+      values   = [
+        "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
+      ]
     }
 
   }
 
- # Allow all core-shared-services-production to use this key so that it can create encrypted volumes with EC2 Image Builder
+  # Allow all core-shared-services-production to use this key so that it can create encrypted volumes with EC2 Image Builder
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = [
-       "kms:CreateGrant",
-       "kms:Encrypt",
-       "kms:Decrypt",
-       "kms:ReEncrypt*",
-       "kms:GenerateDataKey*",
-       "kms:DescribeKey"]
-  }
+      "kms:CreateGrant",
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
 
     resources = ["*"]
     principals {
       type        = "AWS"
-      identifiers = [arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root]
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root"]
     }
+  }
 }

--- a/terraform/environments/sprinkler/kms.tf
+++ b/terraform/environments/sprinkler/kms.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
 
   # Allow root users full management access to key
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     actions = [
       "kms:*"
     ]
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
   # Conditions for principals is based on approach taken for S3 example in https://aws.amazon.com/blogs/security/iam-share-aws-resources-groups-aws-accounts-aws-organizations/
   # Conditions for key grants is based on https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-service-integration
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     actions = [
       "kms:DescribeKey",
       "kms:ReEncrypt*",
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgPaths"
-      values   = [
+      values = [
         "${data.aws_organizations_organization.root_account.id}/*/${local.environment_management.modernisation_platform_organisation_unit_id}/*"
       ]
     }
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
 
   # Allow all core-shared-services-production to use this key so that it can create encrypted volumes with EC2 Image Builder
   statement {
-    effect  = "Allow"
+    effect = "Allow"
     actions = [
       "kms:CreateGrant",
       "kms:Encrypt",

--- a/terraform/environments/sprinkler/kms.tf
+++ b/terraform/environments/sprinkler/kms.tf
@@ -57,4 +57,22 @@ data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
     }
 
   }
+
+ # Allow all core-shared-services-production to use this key so that it can create encrypted volumes with EC2 Image Builder
+  statement {
+    effect = "Allow"
+    actions = [
+       "kms:CreateGrant",
+       "kms:Encrypt",
+       "kms:Decrypt",
+       "kms:ReEncrypt*",
+       "kms:GenerateDataKey*",
+       "kms:DescribeKey"]
+  }
+
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = [arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root]
+    }
 }


### PR DESCRIPTION
Adds some extra KMS permissions as detailed here:
https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html#policy-example-cmk-cross-account-access

These are required for access to the KMS key across accounts.