### PR TITLE
Changed the CPU units to 1536 to enable placement on a t3.medium

### DIFF
--- a/terraform/environments/performance-hub/templates/task_definition.json
+++ b/terraform/environments/performance-hub/templates/task_definition.json
@@ -1,7 +1,7 @@
 [{
   "name": "performance-hub",
   "image": "${ecr_url}:${container_version}",
-  "cpu": 2048,
+  "cpu": 1536,
   "portMappings": [
     {
       "containerPort": 80,


### PR DESCRIPTION
Changed the CPU units to 1536 to enable placement on a t3.medium instance.