### PR TITLE
Prevent auto upgrade to AWS provider 4.0.0

### DIFF
--- a/terraform/environments/analytical-platform-data/versions.tf
+++ b/terraform/environments/analytical-platform-data/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/analytical-platform-management/versions.tf
+++ b/terraform/environments/analytical-platform-management/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/bichard7/versions.tf
+++ b/terraform/environments/bichard7/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/dex-ta/versions.tf
+++ b/terraform/environments/dex-ta/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/mi-platform/versions.tf
+++ b/terraform/environments/mi-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/performance-hub/versions.tf
+++ b/terraform/environments/performance-hub/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/ppud/versions.tf
+++ b/terraform/environments/ppud/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/remote-supervision/versions.tf
+++ b/terraform/environments/remote-supervision/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/sprinkler/versions.tf
+++ b/terraform/environments/sprinkler/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/tariff/versions.tf
+++ b/terraform/environments/tariff/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/testing/versions.tf
+++ b/terraform/environments/testing/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 3.47.0"
+      version = ">= 3.47.0, < 4.0.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Currently our versioning is as follows:

      version = ">= 3.47.0"

This means that the pipelines will always get the latest version (this doesn’t happen locally as you have to run an init upgrade if you’ve run init previously), this is causing issues now when we move to version 4 where there are breaking changes.

If we change the way we version to only allow patch and minor changes, but not major version changes:

version = ">= 3.47.0, < 4.0.0"

This will still allow minor upgrades to happen automatically, but any breaking changes won’t.
Then we can go through each tf and upgrade and make the changes required manually.