### PR TITLE
Trigger preproduction plan and deployment upon merge to the main branch

### DIFF
--- a/.github/workflows/performance-hub.yml
+++ b/.github/workflows/performance-hub.yml
@@ -117,7 +117,7 @@ jobs:
   plan-preproduction:
     name: Plan Preproduction - performance-hub
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2.3.4
@@ -138,7 +138,7 @@ jobs:
   deploy-preproduction:
     name: Deploy Preproduction - performance-hub
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: performance-hub-preproduction
     steps:


### PR DESCRIPTION
Trigger preproduction plan and deployment upon merge to the main branch. Otherwise, if configured to be triggered through a feature branch we would get the error: Branch is not allowed to deploy to performance-hub-preproduction due to environment protection rules.
