### PR TITLE
Update the ECS cluster AMI for performance hub preproduction

### DIFF
--- a/terraform/environments/performance-hub/application_variables.json
+++ b/terraform/environments/performance-hub/application_variables.json
@@ -30,7 +30,7 @@
         },
         "preproduction": {
           "region": "eu-west-2",
-          "ami_image_id": "ami-0d850e86c113a7ae1",
+          "ami_image_id": "ami-035b1d60ffc27a71d",
           "instance_type": "t3.medium",
           "key_name": "performance-hub-ec2",
           "app_count": "1",


### PR DESCRIPTION
Update the ECS cluster AMI to the new Windows_Server-2019-English-Full-ECS_Optimized AMI.

aws ssm get-parameters --names /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized --profile performance-hub-preproduction

{
    "Parameters": [
        {
            "Name": "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized",
            "Type": "String",
            "Value": "{\"image_name\":\"Windows_Server-2019-English-Full-ECS_Optimized-2022.02.10\",\"image_id\":\"ami-035b1d60ffc27a71d\",\"ecs_runtime_version\":\"Docker version 20.10.9\",\"ecs_agent_version\":\"1.59.0\"}",
            "Version": 37,
            "LastModifiedDate": "2022-02-14T23:41:21.534000+00:00",
            "ARN": "arn:aws:ssm:eu-west-2::parameter/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized",
            "DataType": "text"
        }
    ],
    "InvalidParameters": []
}