### PR TITLE
Updating ECS host to Windows 2022

### DIFF
--- a/terraform/environments/nomis/cmk.tf
+++ b/terraform/environments/nomis/cmk.tf
@@ -1,0 +1,51 @@
+resource "aws_kms_key" "nomis-cmk" {
+  description             = "Nomis Managed Key for AMI Sharing"
+  deletion_window_in_days = 10
+  policy                  = data.aws_iam_policy_document.shared_image_builder_cmk_policy.json
+}
+
+resource "aws_kms_alias" "nomis-key" {
+  name          = "alias/nomis-image-builder"
+  target_key_id = aws_kms_key.nomis-cmk.key_id
+}
+
+data "aws_iam_policy_document" "shared_image_builder_cmk_policy" {
+  statement {
+    effect = "Allow"
+    actions = ["kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:ReEncryptFrom",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    "kms:CreateGrant"]
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:root",
+      "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root"]
+    }
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:root"]
+    }
+  }
+}

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -238,7 +238,8 @@ data "aws_iam_policy_document" "packer_ansible_permissions" {
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeVpcs",
       "ec2:DescribeKeyPairs",
-      "sts:DecodeAuthorizationMessage"
+      "sts:DecodeAuthorizationMessage",
+      "kms:ReEncrypt*" # for building from cmk-encrypted AMIs
     ]
     resources = ["*"]
   }

--- a/terraform/environments/performance-hub/application_variables.json
+++ b/terraform/environments/performance-hub/application_variables.json
@@ -2,7 +2,7 @@
     "accounts": {
         "development": {
           "region": "eu-west-2",
-          "ami_image_id": "ami-0d850e86c113a7ae1",
+          "ami_image_id": "ami-06ea02f1bdee62c2c",
           "instance_type": "t3.medium",
           "key_name": "performance-hub-ec2",
           "app_count": "1",
@@ -30,7 +30,7 @@
         },
         "preproduction": {
           "region": "eu-west-2",
-          "ami_image_id": "ami-035b1d60ffc27a71d",
+          "ami_image_id": "ami-06ea02f1bdee62c2c",
           "instance_type": "t3.medium",
           "key_name": "performance-hub-ec2",
           "app_count": "1",
@@ -58,7 +58,7 @@
         },
         "production": {
           "region": "eu-west-2",
-          "ami_image_id": "ami-0d850e86c113a7ae1",
+          "ami_image_id": "ami-06ea02f1bdee62c2c",
           "instance_type": "t3.medium",
           "key_name": "performance-hub-ec2",
           "app_count": "1",


### PR DESCRIPTION
Performance Hub: CannotPullContainerError: a Windows version 10.0.203…48-based image is incompatible with a 10.0.17763 host