### PR TITLE
Adjust evening power off times

### DIFF
--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -147,7 +147,7 @@ resource "aws_route53_record" "internal_lb" {
   provider = aws.core-vpc
 
   zone_id = data.aws_route53_zone.external.zone_id
-  name    = "*.${data.aws_route53_zone.external.name}"
+  name    = "*.${local.application_name}.${data.aws_route53_zone.external.name}"
   type    = "A"
 
   alias {

--- a/terraform/environments/nomis/modules/weblogic/main.tf
+++ b/terraform/environments/nomis/modules/weblogic/main.tf
@@ -186,7 +186,7 @@ resource "aws_autoscaling_schedule" "scale_down" {
   min_size               = 0
   max_size               = var.asg_max_size # this should make sure instances move to warm pool rather than being deleted
   desired_capacity       = 0
-  recurrence             = "0 19 * * *"
+  recurrence             = "0 19 * * Mon-Fri"
   autoscaling_group_name = aws_autoscaling_group.weblogic.name
 }
 
@@ -195,7 +195,7 @@ resource "aws_autoscaling_schedule" "scale_up" {
   min_size               = var.asg_min_size
   max_size               = var.asg_max_size
   desired_capacity       = var.asg_desired_capacity
-  recurrence             = "0 7 * * *"
+  recurrence             = "0 7 * * Mon-Fri"
   autoscaling_group_name = aws_autoscaling_group.weblogic.name
 }
 


### PR DESCRIPTION
Keeping the database on an hour longer to accommodate weblogic instances being created for the warm pool during the evening scale in event.  Also changed autoscaling schedule to power down weblogics at the weekend.