### PR TITLE
updating database user-data script to fix memlock settings

### DIFF
--- a/terraform/environments/nomis/application_variables.json
+++ b/terraform/environments/nomis/application_variables.json
@@ -13,13 +13,6 @@
                     "ami_name": "nomis_db_CNOMT1-2022-03-04*",
                     "asm_data_capacity": 100,
                     "asm_flash_capacity": 2
-                },
-                "CNAUDT1": {
-                    "always_on": true,
-                    "ami_name": "nomis_db-2022-03-03*",
-                    "asm_data_capacity": 200,
-                    "asm_flash_capacity": 2,
-                    "termination_protection": false
                 }
             },
             "weblogics": {

--- a/terraform/environments/nomis/application_variables.json
+++ b/terraform/environments/nomis/application_variables.json
@@ -13,6 +13,12 @@
                     "ami_name": "nomis_db_CNOMT1-2022-03-04*",
                     "asm_data_capacity": 100,
                     "asm_flash_capacity": 2
+                },
+                "CNAUDT1": {
+                    "always_on": true,
+                    "ami_name": "nomis_db-2022-03-03*",
+                    "asm_data_capacity": 200,
+                    "asm_flash_capacity": 2
                 }
             },
             "weblogics": {

--- a/terraform/environments/nomis/application_variables.json
+++ b/terraform/environments/nomis/application_variables.json
@@ -12,6 +12,12 @@
                     "ami_name": "nomis_db_CNOMT1-2022-03-04*",
                     "asm_data_capacity": 100,
                     "asm_flash_capacity": 2
+                },
+                "CNAUDT1": {
+                    "ami_name": "nomis_db-2022-03-03*",
+                    "asm_data_capacity": 200,
+                    "asm_flash_capacity": 2,
+                    "termination_protection": true
                 }
             },
             "weblogics": {

--- a/terraform/environments/nomis/application_variables.json
+++ b/terraform/environments/nomis/application_variables.json
@@ -19,7 +19,7 @@
                     "ami_name": "nomis_db-2022-03-03*",
                     "asm_data_capacity": 200,
                     "asm_flash_capacity": 2,
-                    "termination_protection": true
+                    "termination_protection": false
                 }
             },
             "weblogics": {

--- a/terraform/environments/nomis/application_variables.json
+++ b/terraform/environments/nomis/application_variables.json
@@ -9,11 +9,13 @@
             "session_manager_log_retention_days": 90,
             "databases": {
                 "CNOMT1": {
+                    "always_on": false,
                     "ami_name": "nomis_db_CNOMT1-2022-03-04*",
                     "asm_data_capacity": 100,
                     "asm_flash_capacity": 2
                 },
                 "CNAUDT1": {
+                    "always_on": true,
                     "ami_name": "nomis_db-2022-03-03*",
                     "asm_data_capacity": 200,
                     "asm_flash_capacity": 2,

--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -13,6 +13,7 @@ module "database" {
 
   name = each.key
 
+  always_on          = each.value.always_on
   ami_name           = each.value.ami_name
   asm_data_capacity  = each.value.asm_data_capacity
   asm_flash_capacity = each.value.asm_flash_capacity

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -226,10 +226,10 @@ resource "aws_volume_attachment" "swap" {
 
 locals {
   volume_ids = concat(
-    aws_ebs_volume.asm_data[*].volume_id,
-    aws_ebs_volume.asm_flash[*].volume_id,
-    aws_ebs_volume.oracle_app[*].volume_id,
-    aws_ebs_volume.swap[*].volume_id
+    aws_ebs_volume.asm_data[*].id,
+    aws_ebs_volume.asm_flash[*].id,
+    aws_ebs_volume.oracle_app[*].id,
+    aws_ebs_volume.swap[*].id
   )
 }
 

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -226,10 +226,10 @@ resource "aws_volume_attachment" "swap" {
 
 locals {
   volume_ids = concat(
-    aws_ebs_volume.asm_data[*].id,
-    aws_ebs_volume.asm_flash[*].id,
-    aws_ebs_volume.oracle_app[*].id,
-    aws_ebs_volume.swap[*].id
+    [for item in aws_ebs_volume.asm_data : item.id],
+    [for item in aws_ebs_volume.asm_flash : item.id],
+    [for item in aws_ebs_volume.oracle_app : item.id],
+    [for item in aws_ebs_volume.swap : item.id]
   )
 }
 

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -226,10 +226,10 @@ resource "aws_volume_attachment" "swap" {
 
 locals {
   volume_ids = concat(
-    [for item in aws_ebs_volume.asm_data : item.id],
-    [for item in aws_ebs_volume.asm_flash : item.id],
-    [for item in aws_ebs_volume.oracle_app : item.id],
-    [for item in aws_ebs_volume.swap : item.id]
+    [for k, v in aws_ebs_volume.asm_data : v.id],
+    [for k, v in aws_ebs_volume.asm_flash : v.id],
+    [for k, v in aws_ebs_volume.oracle_app : v.id],
+    [aws_ebs_volume.swap.id]
   )
 }
 

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -110,7 +110,7 @@ resource "aws_instance" "database" {
       component  = "data"
       os_type    = "Linux"
       os_version = "RHEL 7.9"
-      always_on  = var.environment == "production" ? "true" : "false"
+      always_on  = var.always_on
     }
   )
 }

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -43,6 +43,7 @@ data "template_file" "user_data" {
   vars = {
     parameter_name_ASMSYS  = aws_ssm_parameter.asm_sys.name
     parameter_name_ASMSNMP = aws_ssm_parameter.asm_snmp.name
+    volume_ids             = join(" ", local.volume_ids)
   }
 }
 
@@ -221,6 +222,15 @@ resource "aws_volume_attachment" "swap" {
   device_name = local.swap_disk
   volume_id   = aws_ebs_volume.swap.id
   instance_id = aws_instance.database.id
+}
+
+locals {
+  volume_ids = concat(
+    aws_ebs_volume.asm_data[*].volume_id,
+    aws_ebs_volume.asm_flash[*].volume_id,
+    aws_ebs_volume.oracle_app[*].volume_id,
+    aws_ebs_volume.swap[*].volume_id
+  )
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/nomis/modules/database/user-data/user-data.sh
+++ b/terraform/environments/nomis/modules/database/user-data/user-data.sh
@@ -40,6 +40,9 @@ hugepages() {
 
 swap_disk() {
 
+    echo "+++Waiting for volumes to be attached to instance"
+    aws ec2 wait volume-in-use --volume-ids ${volume_ids}
+
     echo "+++Configuring swap partition..."
     # get current swap partition
     local swap_disk=$(awk '/partition/ {print $1}' /proc/swaps)
@@ -58,9 +61,6 @@ swap_disk() {
 }
 
 disks() {
-
-    echo "+++Waiting for volumes to be attached to instance"
-    aws ec2 wait volume-in-use --volume-ids ${volume_ids}
     
     echo "+++Resizing Oracle application disks"
     xfs_growfs -d /u01

--- a/terraform/environments/nomis/modules/database/user-data/user-data.sh
+++ b/terraform/environments/nomis/modules/database/user-data/user-data.sh
@@ -58,6 +58,9 @@ swap_disk() {
 }
 
 disks() {
+
+    echo "+++Waiting for volumes to be attached to instance"
+    aws ec2 wait volume-in-use --volume-ids ${volume_ids}
     
     echo "+++Resizing Oracle application disks"
     xfs_growfs -d /u01

--- a/terraform/environments/nomis/modules/database/variables.tf
+++ b/terraform/environments/nomis/modules/database/variables.tf
@@ -1,3 +1,10 @@
+variable "always_on" {
+  type        = bool
+  description = "Set to false if the instance should be shutdown at evenings and weekends"
+  default     = true
+  nullable    = false
+}
+
 variable "ami_name" {
   type        = string
   description = "Name of AMI to be used to launch the database ec2 instance"

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -4,14 +4,6 @@ terraform {
       version = "~> 4.0"
       source  = "hashicorp/aws"
     }
-    github = {
-      version = "4.9.4"
-      source  = "integrations/github"
-    }
   }
   required_version = ">= 1.1.7"
-}
-
-provider "github" {
-  owner = "ministryofjustice"
 }

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -4,6 +4,14 @@ terraform {
       version = "~> 4.0"
       source  = "hashicorp/aws"
     }
+    github = {
+      version = "4.9.4"
+      source  = "integrations/github"
+    }
   }
   required_version = ">= 1.1.7"
+}
+
+provider "github" {
+  owner = "ministryofjustice"
 }


### PR DESCRIPTION
Set out to correct the memlock settings required for oracle based on instance size but during testing uncovered an issue where the ebs volumes are slow to attach during instance creation, causing disk operations in the user-data script to fail.  Added a wait condition to user-data and made the user-data script dependent on the volume ids of the ebs volumes, thus all ebs volumes will be created before the instance itself (but not attached yet).  Also added audit database.