### PR TITLE
PPUD transfer allow SSM access

### DIFF
--- a/terraform/environments/ppud/ppud_data_transfer_instance.tf
+++ b/terraform/environments/ppud/ppud_data_transfer_instance.tf
@@ -73,6 +73,11 @@ resource "aws_iam_role" "ppud_data_transfer_role" {
   )
 }
 
+resource "aws_iam_role_policy_attachment" "ppud_data_transfer_managed" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.ppud_data_transfer_role.name
+}
+
 #wildcards permissible read access to specific buckets
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "ppud_data_transfer_ssm_s3_policy_document" {


### PR DESCRIPTION
This shamelessly rips off the IAM config from the bastion module - this
should in theory allow me to use SSM to log into the EC2 instance
(rather than having to open up SSH access).