### PR TITLE
Rule to allow access to CP prometheus server

### DIFF
--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -77,6 +77,14 @@ resource "aws_security_group" "weblogic_common" {
     ]
   }
 
+  ingress {
+  description = "access from Cloud Platform Prometheus server"
+  from_port   = "9100"
+  to_port     = "9100"
+  protocol    = "TCP"
+  cidr_blocks = ["172.20.0.0/16"]
+}
+
   egress {
     description = "allow all"
     from_port   = 0


### PR DESCRIPTION
Need this security group rule to allow the Cloud Platform prometheus server to scrape metrics