### PR TITLE
added declarative rules for DC to DC traffic

### DIFF
--- a/terraform/environments/equip/securitygroup.tf
+++ b/terraform/environments/equip/securitygroup.tf
@@ -1099,164 +1099,326 @@ resource "aws_security_group_rule" "aws_domain_security_group_egress_1" {
   security_group_id = aws_security_group.aws_domain_security_group.id
 }
 
-resource "aws_security_group_rule" "egress_tcp_88" {
-  description       = "Allow internal Kerberos key distribution center traffic"
-  from_port         = 88
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+## Domain Controller internal traffic
+## https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/config-firewall-for-ad-domains-and-trusts
+resource "aws_security_group_rule" "egress_tcp_53" {
+  description              = "Allow internal DNS traffic"
+  from_port                = 53
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 88
-  type              = "egress"
+  to_port                  = 53
+  type                     = "egress"
 }
 
-resource "aws_security_group_rule" "ingress_tcp_88" {
-  description       = "Allow internal Kerberos key distribution center traffic"
-  from_port         = 88
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+resource "aws_security_group_rule" "ingress_tcp_53" {
+  description              = "Allow internal DNS traffic"
+  from_port                = 53
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 88
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "egress_tcp_135" {
-  description       = "Allow internal RPC traffic"
-  from_port         = 135
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 135
-  type              = "egress"
-}
-
-resource "aws_security_group_rule" "ingress_tcp_135" {
-  description       = "Allow internal RPC traffic"
-  from_port         = 135
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 135
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "egress_tcp_139" {
-  description       = "Allow internal NetBIOS traffic"
-  from_port         = 139
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 139
-  type              = "egress"
-}
-
-resource "aws_security_group_rule" "ingress_tcp_139" {
-  description       = "Allow internal NetBIOS traffic"
-  from_port         = 139
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 139
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "egress_tcp_389" {
-  description       = "Allow internal LDAP traffic"
-  from_port         = 389
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 389
-  type              = "egress"
-}
-
-resource "aws_security_group_rule" "ingress_tcp_389" {
-  description       = "Allow internal LDAP traffic"
-  from_port         = 389
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 389
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "egress_tcp_445" {
-  description       = "Allow internal SMB traffic"
-  from_port         = 445
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 445
-  type              = "egress"
-}
-
-resource "aws_security_group_rule" "ingress_tcp_445" {
-  description       = "Allow internal SMB traffic"
-  from_port         = 445
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
-  source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 445
-  type              = "ingress"
+  to_port                  = 53
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "egress_udp_53" {
-  description       = "Allow internal DNS traffic"
-  from_port         = 53
-  protocol          = "UDP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal DNS traffic"
+  from_port                = 53
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 53
-  type              = "egress"
+  to_port                  = 53
+  type                     = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_udp_53" {
-  description       = "Allow internal DNS traffic"
-  from_port         = 53
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal DNS traffic"
+  from_port                = 53
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 53
-  type              = "ingress"
+  to_port                  = 53
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_88" {
+  description              = "Allow internal Kerberos key distribution center traffic"
+  from_port                = 88
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 88
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_88" {
+  description              = "Allow internal Kerberos key distribution center traffic"
+  from_port                = 88
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 88
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_udp_88" {
+  description              = "Allow internal Kerberos key distribution center traffic"
+  from_port                = 88
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 88
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_udp_88" {
+  description              = "Allow internal Kerberos key distribution center traffic"
+  from_port                = 88
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 88
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_udp_123" {
+  description              = "Allow internal NTP traffic"
+  from_port                = 123
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 123
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_udp_123" {
+  description              = "Allow internal NTP traffic"
+  from_port                = 123
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 123
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_135" {
+  description              = "Allow internal RPC traffic"
+  from_port                = 135
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 135
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_135" {
+  description              = "Allow internal RPC traffic"
+  from_port                = 135
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 135
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_139" {
+  description              = "Allow internal NetBIOS traffic"
+  from_port                = 139
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 139
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_139" {
+  description              = "Allow internal NetBIOS traffic"
+  from_port                = 139
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 139
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_389" {
+  description              = "Allow internal LDAP traffic"
+  from_port                = 389
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 389
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_389" {
+  description              = "Allow internal LDAP traffic"
+  from_port                = 389
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 389
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "egress_udp_389" {
-  description       = "Allow internal LDAP traffic"
-  from_port         = 389
-  protocol          = "UDP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal LDAP traffic"
+  from_port                = 389
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 389
-  type              = "egress"
+  to_port                  = 389
+  type                     = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_udp_389" {
-  description       = "Allow internal DNS traffic"
-  from_port         = 389
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal LDAP traffic"
+  from_port                = 389
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 389
-  type              = "ingress"
+  to_port                  = 389
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_445" {
+  description              = "Allow internal SMB traffic"
+  from_port                = 445
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 445
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_445" {
+  description              = "Allow internal SMB traffic"
+  from_port                = 445
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 445
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_464" {
+  description              = "Allow internal Kerberos password traffic"
+  from_port                = 464
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 464
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_464" {
+  description              = "Allow internal Kerberos traffic"
+  from_port                = 464
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 464
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_udp_464" {
+  description              = "Allow internal Kerberos password traffic"
+  from_port                = 464
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 464
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_udp_464" {
+  description              = "Allow internal Kerberos traffic"
+  from_port                = 464
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 464
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_636" {
+  description              = "Allow internal LDAPS traffic"
+  from_port                = 636
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 636
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_636" {
+  description              = "Allow internal LDAPS traffic"
+  from_port                = 636
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 636
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_3268-3269" {
+  description              = "Allow internal Global Catalogue traffic"
+  from_port                = 3268
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 3269
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_3268-3269" {
+  description              = "Allow internal Global Catalogue traffic"
+  from_port                = 3268
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = 3269
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "egress_tcp_49152-65535" {
-  description       = "Allow internal DNS traffic"
-  from_port         = 49512
-  protocol          = "UDP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal high ports"
+  from_port                = 49512
+  protocol                 = "UDP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 65535
-  type              = "egress"
+  to_port                  = 65535
+  type                     = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_tcp_49152-65535" {
-  description       = "Allow internal DNS traffic"
-  from_port         = 49512
-  protocol          = "TCP"
-  security_group_id = aws_security_group.aws_domain_security_group.id
+  description              = "Allow internal high ports"
+  from_port                = 49512
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
   source_security_group_id = aws_security_group.aws_domain_security_group.id
-  to_port           = 65535
-  type              = "ingress"
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_icmp" {
+  description              = "Allow all ICMP out"
+  from_port                = -1
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = -1
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_icmp" {
+  description              = "Allow all ICMP in"
+  from_port                = -1
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 #############################################################

--- a/terraform/environments/equip/securitygroup.tf
+++ b/terraform/environments/equip/securitygroup.tf
@@ -1099,6 +1099,166 @@ resource "aws_security_group_rule" "aws_domain_security_group_egress_1" {
   security_group_id = aws_security_group.aws_domain_security_group.id
 }
 
+resource "aws_security_group_rule" "egress_tcp_88" {
+  description       = "Allow internal Kerberos key distribution center traffic"
+  from_port         = 88
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 88
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_88" {
+  description       = "Allow internal Kerberos key distribution center traffic"
+  from_port         = 88
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 88
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_135" {
+  description       = "Allow internal RPC traffic"
+  from_port         = 135
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 135
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_135" {
+  description       = "Allow internal RPC traffic"
+  from_port         = 135
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 135
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_139" {
+  description       = "Allow internal NetBIOS traffic"
+  from_port         = 139
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 139
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_139" {
+  description       = "Allow internal NetBIOS traffic"
+  from_port         = 139
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 139
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_389" {
+  description       = "Allow internal LDAP traffic"
+  from_port         = 389
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 389
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_389" {
+  description       = "Allow internal LDAP traffic"
+  from_port         = 389
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 389
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_445" {
+  description       = "Allow internal SMB traffic"
+  from_port         = 445
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 445
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_445" {
+  description       = "Allow internal SMB traffic"
+  from_port         = 445
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 445
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_udp_53" {
+  description       = "Allow internal DNS traffic"
+  from_port         = 53
+  protocol          = "UDP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 53
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_udp_53" {
+  description       = "Allow internal DNS traffic"
+  from_port         = 53
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 53
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_udp_389" {
+  description       = "Allow internal LDAP traffic"
+  from_port         = 389
+  protocol          = "UDP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 389
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_udp_389" {
+  description       = "Allow internal DNS traffic"
+  from_port         = 389
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 389
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "egress_tcp_49152-65535" {
+  description       = "Allow internal DNS traffic"
+  from_port         = 49512
+  protocol          = "UDP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 65535
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_tcp_49152-65535" {
+  description       = "Allow internal DNS traffic"
+  from_port         = 49512
+  protocol          = "TCP"
+  security_group_id = aws_security_group.aws_domain_security_group.id
+  source_security_group_id = aws_security_group.aws_domain_security_group.id
+  to_port           = 65535
+  type              = "ingress"
+}
+
 #############################################################
 
 #All Internal Security Group


### PR DESCRIPTION
This PR explicitly adds rules for inter-DC traffic, to ensure that all documented ports requested are permitted explicitly between domain controller hosts