### PR TITLE
Add DDoS alarm to Performance Hub

### DIFF
--- a/terraform/environments/performance-hub/monitoring.tf
+++ b/terraform/environments/performance-hub/monitoring.tf
@@ -1,0 +1,50 @@
+# DDoS Alarm
+
+resource "aws_cloudwatch_metric_alarm" "ddos_attack_external" {
+  alarm_name                = "DDoSDetected"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "DDoSDetected"
+  namespace                 = "AWS/DDoSProtection"
+  period                    = "60"
+  statistic                 = "Average"
+  threshold                 = "0"
+  alarm_description         = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [aws_sns_topic.high_priority.arn]
+  dimensions = {
+    ResourceArn    = aws_lb.external.arn
+  }
+}
+
+# SNS topic for monitoring to send alarms to
+resource "aws_sns_topic" "high_priority" {
+  name = "high_priority"
+}
+
+## Pager duty integration
+
+# Get the map of pagerduty integration keys from the modernisation platform account
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
+}
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}
+
+# Add a local to get the keys
+locals {
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+}
+
+# link the sns topic to the service
+module "pagerduty_high_priority_alerts" {
+  depends_on = [
+    aws_sns_topic.high_priority
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.high_priority.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys[local.is-production ? "high_priority_alarms" : "low_priority_alarms"]
+}


### PR DESCRIPTION
- Create an alarm from the AWS Shield Advanced DDoSDetected metric.
- Create a high priority SNS topic where we can push the alarm to.
- Subscribe to the topic the pagerduty cloudwatch endpoints:
  low-priority service for non prod, high-priority service for production.

This will allow us to be notified if any DDoS attacks are detected on
performance hub in the #modernisation-platform-high-priority-alarms
channel.