### PR TITLE
Error: Error putting S3 policy: MalformedPolicy: Invalid principal in…

### DIFF
--- a/terraform/environments/equip/s3-ukcloud-replica.tf
+++ b/terraform/environments/equip/s3-ukcloud-replica.tf
@@ -55,7 +55,7 @@ module "s3-bucket-ukcloud-replica" {
 
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
   count  = local.is-development ? 1 : 0
-  bucket = module.s3-bucket-ukcloud-replica[0].bucket.id
+  bucket = module.s3-bucket-ukcloud-replica[0].bucket.arn
   policy = data.aws_iam_policy_document.allow_access_from_another_account[0].json
 }
 
@@ -68,8 +68,8 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
       "s3:List*"
     ]
     resources = [
-      module.s3-bucket-ukcloud-replica[0].bucket.id,
-      "${module.s3-bucket-ukcloud-replica[0].bucket.id}/*"
+      module.s3-bucket-ukcloud-replica[0].bucket.arn,
+      "${module.s3-bucket-ukcloud-replica[0].bucket.arn}/*"
     ]
     principals {
       type        = "AWS"
@@ -99,8 +99,8 @@ resource "aws_iam_policy" "read_list_s3_access_policy" {
           "s3:List*"
         ],
         "Resource" : [
-          module.s3-bucket-ukcloud-replica[0].bucket.id,
-          "${module.s3-bucket-ukcloud-replica[0].bucket.id}/*"
+          module.s3-bucket-ukcloud-replica[0].bucket.arn,
+          "${module.s3-bucket-ukcloud-replica[0].bucket.arn}/*"
         ]
       }
     ]

--- a/terraform/environments/equip/s3-ukcloud-replica.tf
+++ b/terraform/environments/equip/s3-ukcloud-replica.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
     principals {
       type        = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.environment_management.account_ids["equip-production"]}:*"
+        "arn:aws:iam::${local.environment_management.account_ids["equip-production"]}:root"
       ]
     }
   }

--- a/terraform/environments/equip/s3-ukcloud-replica.tf
+++ b/terraform/environments/equip/s3-ukcloud-replica.tf
@@ -55,7 +55,7 @@ module "s3-bucket-ukcloud-replica" {
 
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
   count  = local.is-development ? 1 : 0
-  bucket = module.s3-bucket-ukcloud-replica[0].bucket.arn
+  bucket = module.s3-bucket-ukcloud-replica[0].bucket.id
   policy = data.aws_iam_policy_document.allow_access_from_another_account[0].json
 }
 


### PR DESCRIPTION
… policy

	status code: 400, request id: T26PNSZK2ZDM5DFK, host id: JuoOiev7oL0/GqazjUmy8YdyWUGlJsVHO2I5fmMFkNcGriW/NZ5UeF+qimEHBjqLnGxeD/qyDKo=

  with aws_s3_bucket_policy.allow_access_from_another_account[0],
  on s3-ukcloud-replica.tf line 56, in resource "aws_s3_bucket_policy" "allow_access_from_another_account":
  56: resource "aws_s3_bucket_policy" "allow_access_from_another_account" {

Error: error creating IAM Policy read_list_s3_access_policy: MalformedPolicyDocument: Resource s3-bucket-ukcloud-replica20220511075839843300000001 must be in ARN format or "*".
	status code: 400, request id: 14a4062d-249a-4696-b179-81160074157c

  with aws_iam_policy.read_list_s3_access_policy[0],
  on s3-ukcloud-replica.tf line 83, in resource "aws_iam_policy" "read_list_s3_access_policy":
  83: resource "aws_iam_policy" "read_list_s3_access_policy" {