### PR TITLE
Take EBS snapshots via DLM policy

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -5,7 +5,7 @@
 ##############################################################
 
 data "aws_acm_certificate" "production_cert" {
-  count = local.environment == "production" ? 1 : 0
+  count    = local.environment == "production" ? 1 : 0
   domain   = "equip.service.justice.gov.uk"
   statuses = ["ISSUED"]
 }
@@ -14,35 +14,35 @@ data "aws_acm_certificate" "production_cert" {
 #tfsec:ignore:aws-elb-alb-not-public
 resource "aws_lb" "citrix_alb" {
 
-  name        = format("alb-%s-%s-citrix", local.application_name, local.environment)
+  name               = format("alb-%s-%s-citrix", local.application_name, local.environment)
   load_balancer_type = "application"
-  security_groups = [aws_security_group.alb_sg.id]
-  subnets         = [data.aws_subnet.public_az_a.id, data.aws_subnet.public_az_b.id]
+  security_groups    = [aws_security_group.alb_sg.id]
+  subnets            = [data.aws_subnet.public_az_a.id, data.aws_subnet.public_az_b.id]
 
-  enable_deletion_protection       = true
-  drop_invalid_header_fields       = true
-  enable_waf_fail_open             = true
-  ip_address_type                  = "ipv4"
+  enable_deletion_protection = true
+  drop_invalid_header_fields = true
+  enable_waf_fail_open       = true
+  ip_address_type            = "ipv4"
 
-    tags = merge(local.tags,
+  tags = merge(local.tags,
     { Name = format("alb-%s-%s-citrix", local.application_name, local.environment)
       Role = "Equip public load balancer"
     }
   )
 
   access_logs {
-    bucket = aws_s3_bucket.this.id
+    bucket  = aws_s3_bucket.this.id
     enabled = "true"
   }
 
 }
 
 resource "aws_lb_target_group" "lb_tg_http" {
-  name             = format("tg-%s-%s-80", local.application_name, local.environment)
-  target_type      = "ip"
-  protocol         = "HTTP"
-  vpc_id           = data.aws_vpc.shared.id
-  port             = "80"
+  name        = format("tg-%s-%s-80", local.application_name, local.environment)
+  target_type = "ip"
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.shared.id
+  port        = "80"
 
   health_check {
     enabled             = true
@@ -60,11 +60,11 @@ resource "aws_lb_target_group" "lb_tg_http" {
 }
 
 resource "aws_lb_target_group" "lb_tg_https" {
-  name             = format("tg-%s-%s-443", local.application_name, local.environment)
-  target_type      = "ip"
-  protocol         = "HTTPS"
-  vpc_id           = data.aws_vpc.shared.id
-  port             = "443"
+  name        = format("tg-%s-%s-443", local.application_name, local.environment)
+  target_type = "ip"
+  protocol    = "HTTPS"
+  vpc_id      = data.aws_vpc.shared.id
+  port        = "443"
 
   health_check {
     enabled             = true

--- a/terraform/environments/equip/dlm-snapshot/data.tf
+++ b/terraform/environments/equip/dlm-snapshot/data.tf
@@ -1,6 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-
 data "aws_iam_policy_document" "dlm_lifecycle_role" {
   statement {
     actions = ["sts:AssumeRole", ]
@@ -8,24 +7,5 @@ data "aws_iam_policy_document" "dlm_lifecycle_role" {
       type        = "Service"
       identifiers = ["dlm.amazonaws.com"]
     }
-  }
-}
-
-data "aws_iam_policy_document" "dlm_lifecycle_policy" {
-  statement {
-    actions   = ["ec2:CreateTags", ]
-    resources = ["arn:aws:ec2::${data.aws_caller_identity.current.account_id}:snapshot/*"]
-  }
-
-  statement {
-    actions = [
-      "ec2:CreateSnapshot",
-      "ec2:CreateSnapshots",
-      "ec2:DeleteSnapshot",
-      "ec2:DescribeInstances",
-      "ec2:DescribeVolumes",
-      "ec2:DescribeSnapshots"
-    ]
-    resources = ["arn:aws:ec2::${data.aws_caller_identity.current.account_id}"]
   }
 }

--- a/terraform/environments/equip/dlm-snapshot/data.tf
+++ b/terraform/environments/equip/dlm-snapshot/data.tf
@@ -1,0 +1,31 @@
+data "aws_caller_identity" "current" {}
+
+
+data "aws_iam_policy_document" "dlm_lifecycle_role" {
+  statement {
+    actions = ["sts:AssumeRole", ]
+    principals {
+      type        = "Service"
+      identifiers = ["dlm.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "dlm_lifecycle_policy" {
+  statement {
+    actions   = ["ec2:CreateTags", ]
+    resources = ["arn:aws:ec2::${data.aws_caller_identity.current.account_id}:snapshot/*"]
+  }
+
+  statement {
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:CreateSnapshots",
+      "ec2:DeleteSnapshot",
+      "ec2:DescribeInstances",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeSnapshots"
+    ]
+    resources = ["arn:aws:ec2::${data.aws_caller_identity.current.account_id}"]
+  }
+}

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
 
 
 resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy" {
-  name   = lower(format("dlm-lifecycle-policy-%s-%s", var.service, var.environment))
-  role   = aws_iam_role.dlm_lifecycle_role.id
-  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/AWSDataLifecycleManagerServiceRole"
+  name       = lower(format("dlm-lifecycle-policy-%s-%s", var.service, var.environment))
+  role       = [aws_iam_role.dlm_lifecycle_role.id]
+  policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerServiceRole"
 }

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -39,8 +39,8 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
 }
 
 
-resource "aws_iam_role_policy" "dlm_lifecycle_policy" {
+resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy" {
   name   = lower(format("dlm-lifecycle-policy-%s-%s", var.service, var.environment))
   role   = aws_iam_role.dlm_lifecycle_role.id
-  policy = data.aws_iam_policy_document.dlm_lifecycle_policy.json
+  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/AWSDataLifecycleManagerServiceRole"
 }

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -2,7 +2,9 @@ resource "aws_dlm_lifecycle_policy" "dlm_daily_snapshots" {
   description        = format("DLM lifecycle policy for %s-%s EC2 volume snapshots", var.service, var.environment)
   execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
   state              = upper(var.state)
-  tags               = var.tags
+  tags               = merge(var.tags,
+    { Name = format("%s-%s-dlm-policy", var.service, var.environment) }
+  )
 
   policy_details {
     resource_types = ["VOLUME"]

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -39,8 +39,7 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
 }
 
 
-resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy" {
-  name       = lower(format("dlm-lifecycle-policy-%s-%s", var.service, var.environment))
-  role       = [aws_iam_role.dlm_lifecycle_role.id]
+resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy_attachment" {
+  role       = aws_iam_role.dlm_lifecycle_role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerServiceRole"
 }

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -41,5 +41,5 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
 
 resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy_attachment" {
   role       = aws_iam_role.dlm_lifecycle_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerDefaultRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
 }

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -8,7 +8,7 @@ resource "aws_dlm_lifecycle_policy" "dlm_daily_snapshots" {
     resource_types = ["VOLUME"]
 
     schedule {
-      name = "Daily snapshot at 3:00AM"
+      name = format("%s-%s-schedule", var.service, var.environment)
 
       create_rule {
         interval      = 24

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -41,5 +41,5 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
 
 resource "aws_iam_role_policy_attachment" "dlm_lifecycle_policy_attachment" {
   role       = aws_iam_role.dlm_lifecycle_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerServiceRole"
+  policy_arn = "arn:aws:iam::aws:policy/AWSDataLifecycleManagerDefaultRole"
 }

--- a/terraform/environments/equip/dlm-snapshot/main.tf
+++ b/terraform/environments/equip/dlm-snapshot/main.tf
@@ -1,0 +1,46 @@
+resource "aws_dlm_lifecycle_policy" "dlm_daily_snapshots" {
+  description        = format("DLM lifecycle policy for %s-%s EC2 volume snapshots", var.service, var.environment)
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
+  state              = upper(var.state)
+  tags               = var.tags
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Daily snapshot at 3:00AM"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["03:00"]
+      }
+
+      retain_rule {
+        count = 14
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = true
+    }
+
+    target_tags = var.target_tags
+
+  }
+}
+
+resource "aws_iam_role" "dlm_lifecycle_role" {
+  name               = lower(format("dlm-lifecycle-role-%s-%s", var.service, var.environment))
+  assume_role_policy = data.aws_iam_policy_document.dlm_lifecycle_role.json
+  tags               = var.tags
+}
+
+
+resource "aws_iam_role_policy" "dlm_lifecycle_policy" {
+  name   = lower(format("dlm-lifecycle-policy-%s-%s", var.service, var.environment))
+  role   = aws_iam_role.dlm_lifecycle_role.id
+  policy = data.aws_iam_policy_document.dlm_lifecycle_policy.json
+}

--- a/terraform/environments/equip/dlm-snapshot/variables.tf
+++ b/terraform/environments/equip/dlm-snapshot/variables.tf
@@ -1,0 +1,22 @@
+variable "environment" {
+  description = "Environment name, EG. Development"
+}
+
+variable "service" {
+  description = "Name of service to use this module. EG. SuperCaliFragiListic"
+}
+
+variable "state" {
+  description = "State for the DLM policy. Valid values are `ENABLED` and `DISABLED`"
+  default     = "ENABLED"
+}
+
+variable "tags" {
+  description = "Map of tags to apply"
+  type        = map(any)
+}
+
+variable "target_tags" {
+  description = "Map of tags to look for in order to create a snapshot"
+  default     = { Snapshot = "true" }
+}

--- a/terraform/environments/equip/dlm-snapshot/versions.tf
+++ b/terraform/environments/equip/dlm-snapshot/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 1.0.1"
+}

--- a/terraform/environments/equip/dlm.tf
+++ b/terraform/environments/equip/dlm.tf
@@ -1,0 +1,10 @@
+module "daily-snapshots" {
+  count       = local.is-development ? 1 : 0
+  source      = "./dlm-snapshot"
+  environment = local.environment
+  service     = local.application_name
+  tags        = local.tags
+  target_tags = {
+    is-production = "false"
+  }
+}

--- a/terraform/environments/equip/ec2-instance-module/main.tf
+++ b/terraform/environments/equip/ec2-instance-module/main.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "this" {
       }
     }
   }
-  
+
   dynamic "root_block_device" {
     for_each = var.root_block_device
     content {

--- a/terraform/environments/equip/ec2-instance-module/outputs.tf
+++ b/terraform/environments/equip/ec2-instance-module/outputs.tf
@@ -1,60 +1,60 @@
 output "id" {
   description = "The ID of the instance"
-  value       =   aws_instance.this[*].id
+  value       = aws_instance.this[*].id
 }
 
 output "arn" {
   description = "The ARN of the instance"
-  value       =   aws_instance.this[*].arn
+  value       = aws_instance.this[*].arn
 }
 
 output "capacity_reservation_specification" {
   description = "Capacity reservation specification of the instance"
-  value       =   aws_instance.this[*].capacity_reservation_specification
+  value       = aws_instance.this[*].capacity_reservation_specification
 }
 
 output "instance_state" {
   description = "The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`"
-  value       =   aws_instance.this[*].instance_state
+  value       = aws_instance.this[*].instance_state
 }
 
 output "outpost_arn" {
   description = "The ARN of the Outpost the instance is assigned to"
-  value       =   aws_instance.this[*].outpost_arn
+  value       = aws_instance.this[*].outpost_arn
 }
 
 output "password_data" {
   description = "Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true"
-  value       =   aws_instance.this[*].password_data
+  value       = aws_instance.this[*].password_data
 }
 
 output "primary_network_interface_id" {
   description = "The ID of the instance's primary network interface"
-  value       =   aws_instance.this[*].primary_network_interface_id
+  value       = aws_instance.this[*].primary_network_interface_id
 }
 
 output "private_dns" {
   description = "The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
-  value       =   aws_instance.this[*].private_dns
+  value       = aws_instance.this[*].private_dns
 }
 
 output "public_dns" {
   description = "The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       =   aws_instance.this[*].public_dns
+  value       = aws_instance.this[*].public_dns
 }
 
 output "public_ip" {
   description = "The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached"
-  value       =   aws_instance.this[*].public_ip
+  value       = aws_instance.this[*].public_ip
 }
 
 output "private_ip" {
   description = "The private IP address assigned to the instance."
-  value       =   aws_instance.this[*].private_ip
+  value       = aws_instance.this[*].private_ip
 }
 
 
 output "tags_all" {
   description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
-  value       =   aws_instance.this[*].tags_all
+  value       = aws_instance.this[*].tags_all
 }

--- a/terraform/environments/equip/instance_role.tf
+++ b/terraform/environments/equip/instance_role.tf
@@ -43,7 +43,7 @@ resource "aws_iam_policy_attachment" "citrix_adc_instance_attachment" {
 }
 
 resource "aws_iam_policy_attachment" "read_list_s3_access_attachment" {
-  count  = local.is-development ? 1 : 0
+  count      = local.is-development ? 1 : 0
   name       = "read_list_s3_access_attachment"
   roles      = [aws_iam_role.ssm-instance-role-moj.name]
   policy_arn = aws_iam_policy.read_list_s3_access_policy[0].arn

--- a/terraform/environments/equip/s3-ukcloud-replica.tf
+++ b/terraform/environments/equip/s3-ukcloud-replica.tf
@@ -5,7 +5,7 @@ module "s3-bucket-ukcloud-replica" {
   versioning_enabled  = false
   replication_enabled = false
   # The following providers configuration will not be used because 'replication_enabled' is false
-  providers           = {
+  providers = {
     aws.bucket-replication = aws
   }
 
@@ -24,7 +24,7 @@ module "s3-bucket-ukcloud-replica" {
         {
           days          = 90
           storage_class = "STANDARD_IA"
-        }, {
+          }, {
           days          = 365
           storage_class = "GLACIER"
         }
@@ -38,7 +38,7 @@ module "s3-bucket-ukcloud-replica" {
         {
           days          = 90
           storage_class = "STANDARD_IA"
-        }, {
+          }, {
           days          = 365
           storage_class = "GLACIER"
         }
@@ -62,8 +62,8 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 data "aws_iam_policy_document" "allow_access_from_another_account" {
   count = local.is-development ? 1 : 0
   statement {
-    effect    = "Allow"
-    actions   = [
+    effect = "Allow"
+    actions = [
       "s3:Get*",
       "s3:List*"
     ]
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
       "${module.s3-bucket-ukcloud-replica[0].bucket.arn}/*"
     ]
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         "arn:aws:iam::${local.environment_management.account_ids["equip-production"]}:root"
       ]
@@ -81,8 +81,8 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 }
 
 resource "aws_iam_policy" "read_list_s3_access_policy" {
-  count  = local.is-development ? 1 : 0
-  name   = "read_list_s3_access_policy"
+  count = local.is-development ? 1 : 0
+  name  = "read_list_s3_access_policy"
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [


### PR DESCRIPTION
* Clean up linting through use of `terraform fmt`
* Employ and invoke a module to make use of AWS Data Lifecycle Manager to make EBS Snapshots of EC2 instances in development environment