### PR TITLE
feature/equip-move-netscaler-interfaces

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -17,7 +17,7 @@ resource "aws_lb" "citrix_alb" {
   name               = format("alb-%s-%s-citrix", local.application_name, local.environment)
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb_sg.id]
-  subnets            = [data.aws_subnet.public_az_a.id, data.aws_subnet.public_az_b.id]
+  subnets            = [data.aws_subnet.public_subnet_a.id, data.aws_subnet.public_subnet_b.id]
 
   enable_deletion_protection = true
   drop_invalid_header_fields = true

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "citrix_adc_instance" {
   ami                    = "ami-0dd0aa051b3fc4e4b"
   instance_type          = "m5.xlarge"
   key_name               = aws_key_pair.windowskey.key_name
-  subnet_id              = data.aws_subnet.private_subnets_a.id
+  subnet_id              = data.aws_subnet.private_subnet_a.id
   vpc_security_group_ids = [aws_security_group.citrix_adc_mgmt.id]
   iam_instance_profile   = aws_iam_instance_profile.instance-profile-moj.name
   monitoring             = true
@@ -37,7 +37,7 @@ resource "aws_instance" "citrix_adc_instance" {
 resource "aws_network_interface" "adc_vip_interface" {
   security_groups   = [aws_security_group.citrix_adc_vip.id]
   source_dest_check = false
-  subnet_id         = data.aws_subnet.public_az_a.id
+  subnet_id         = data.aws_subnet.public_subnet_a.id
 
   attachment {
     device_index = 1
@@ -55,7 +55,7 @@ resource "aws_network_interface" "adc_vip_interface" {
 resource "aws_network_interface" "adc_snip_interface" {
   security_groups   = [aws_security_group.citrix_adc_snip.id]
   source_dest_check = false
-  subnet_id         = data.aws_subnet.private_subnets_a.id
+  subnet_id         = data.aws_subnet.private_subnet_a.id
 
   attachment {
     device_index = 2

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -1,12 +1,12 @@
 resource "aws_instance" "citrix_adc_instance" {
-  depends_on                  = [aws_network_interface.adc_mgmt_interface]
-  ami                         = "ami-0dd0aa051b3fc4e4b"
-  availability_zone           = format("%sa", local.region)
-  instance_type               = "m5.xlarge"
-  key_name                    = aws_key_pair.windowskey.key_name
-  iam_instance_profile        = aws_iam_instance_profile.instance-profile-moj.name
-  monitoring                  = true
-  ebs_optimized               = true
+  depends_on           = [aws_network_interface.adc_mgmt_interface]
+  ami                  = "ami-0dd0aa051b3fc4e4b"
+  availability_zone    = format("%sa", local.region)
+  instance_type        = "m5.xlarge"
+  key_name             = aws_key_pair.windowskey.key_name
+  iam_instance_profile = aws_iam_instance_profile.instance-profile-moj.name
+  monitoring           = true
+  ebs_optimized        = true
 
   network_interface {
     network_interface_id = aws_network_interface.adc_mgmt_interface.id

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -1,10 +1,15 @@
 resource "aws_instance" "citrix_adc_instance" {
-  ami                    = "ami-0dd0aa051b3fc4e4b"
-  instance_type          = "m5.xlarge"
-  key_name               = aws_key_pair.windowskey.key_name
-  iam_instance_profile   = aws_iam_instance_profile.instance-profile-moj.name
-  monitoring             = true
-  ebs_optimized          = true
+  ami                  = "ami-0dd0aa051b3fc4e4b"
+  instance_type        = "m5.xlarge"
+  key_name             = aws_key_pair.windowskey.key_name
+  iam_instance_profile = aws_iam_instance_profile.instance-profile-moj.name
+  monitoring           = true
+  ebs_optimized        = true
+
+  network_interface {
+    network_interface_id = aws_network_interface.adc_mgmt_interface.id
+    device_index         = 0
+  }
 
 
   root_block_device {
@@ -36,11 +41,6 @@ resource "aws_network_interface" "adc_mgmt_interface" {
   security_groups   = [aws_security_group.citrix_adc_mgmt.id]
   source_dest_check = false
   subnet_id         = data.aws_subnet.data_subnet_a.id
-
-  attachment {
-    device_index = 0
-    instance     = aws_instance.citrix_adc_instance.id
-  }
 
   tags = merge(local.tags,
     { Name = "ENI-NPS-COR-A-ADC01_MGMT"

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -2,8 +2,6 @@ resource "aws_instance" "citrix_adc_instance" {
   ami                    = "ami-0dd0aa051b3fc4e4b"
   instance_type          = "m5.xlarge"
   key_name               = aws_key_pair.windowskey.key_name
-  subnet_id              = data.aws_subnet.private_subnet_a.id
-  vpc_security_group_ids = [aws_security_group.citrix_adc_mgmt.id]
   iam_instance_profile   = aws_iam_instance_profile.instance-profile-moj.name
   monitoring             = true
   ebs_optimized          = true
@@ -29,6 +27,24 @@ resource "aws_instance" "citrix_adc_instance" {
   tags = merge(local.tags,
     { Name = "NPS-COR-A-ADC01"
       Role = "Citrix Netscaler ADC VPX"
+    }
+  )
+
+}
+
+resource "aws_network_interface" "adc_mgmt_interface" {
+  security_groups   = [aws_security_group.citrix_adc_mgmt.id]
+  source_dest_check = false
+  subnet_id         = data.aws_subnet.data_subnet_a.id
+
+  attachment {
+    device_index = 0
+    instance     = aws_instance.citrix_adc_instance.id
+  }
+
+  tags = merge(local.tags,
+    { Name = "ENI-NPS-COR-A-ADC01_MGMT"
+      ROLE = "Citrix Netscaler ADC VPX MGMT Interface"
     }
   )
 

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -39,7 +39,7 @@ resource "aws_instance" "citrix_adc_instance" {
 
 resource "aws_network_interface" "adc_mgmt_interface" {
   security_groups   = [aws_security_group.citrix_adc_mgmt.id]
-  source_dest_check = true
+  source_dest_check = false
   subnet_id         = data.aws_subnet.data_subnet_a.id
 
   tags = merge(local.tags,

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -1,5 +1,6 @@
 resource "aws_instance" "citrix_adc_instance" {
   ami                  = "ami-0dd0aa051b3fc4e4b"
+  availability_zone    = format("%sa", local.region)
   instance_type        = "m5.xlarge"
   key_name             = aws_key_pair.windowskey.key_name
   iam_instance_profile = aws_iam_instance_profile.instance-profile-moj.name
@@ -10,7 +11,6 @@ resource "aws_instance" "citrix_adc_instance" {
     network_interface_id = aws_network_interface.adc_mgmt_interface.id
     device_index         = 0
   }
-
 
   root_block_device {
     encrypted   = true

--- a/terraform/environments/equip/citrix_adc.tf
+++ b/terraform/environments/equip/citrix_adc.tf
@@ -1,11 +1,12 @@
 resource "aws_instance" "citrix_adc_instance" {
-  ami                  = "ami-0dd0aa051b3fc4e4b"
-  availability_zone    = format("%sa", local.region)
-  instance_type        = "m5.xlarge"
-  key_name             = aws_key_pair.windowskey.key_name
-  iam_instance_profile = aws_iam_instance_profile.instance-profile-moj.name
-  monitoring           = true
-  ebs_optimized        = true
+  depends_on                  = [aws_network_interface.adc_mgmt_interface]
+  ami                         = "ami-0dd0aa051b3fc4e4b"
+  availability_zone           = format("%sa", local.region)
+  instance_type               = "m5.xlarge"
+  key_name                    = aws_key_pair.windowskey.key_name
+  iam_instance_profile        = aws_iam_instance_profile.instance-profile-moj.name
+  monitoring                  = true
+  ebs_optimized               = true
 
   network_interface {
     network_interface_id = aws_network_interface.adc_mgmt_interface.id
@@ -34,12 +35,11 @@ resource "aws_instance" "citrix_adc_instance" {
       Role = "Citrix Netscaler ADC VPX"
     }
   )
-
 }
 
 resource "aws_network_interface" "adc_mgmt_interface" {
   security_groups   = [aws_security_group.citrix_adc_mgmt.id]
-  source_dest_check = false
+  source_dest_check = true
   subnet_id         = data.aws_subnet.data_subnet_a.id
 
   tags = merge(local.tags,
@@ -47,7 +47,6 @@ resource "aws_network_interface" "adc_mgmt_interface" {
       ROLE = "Citrix Netscaler ADC VPX MGMT Interface"
     }
   )
-
 }
 
 resource "aws_network_interface" "adc_vip_interface" {
@@ -65,7 +64,6 @@ resource "aws_network_interface" "adc_vip_interface" {
       ROLE = "Citrix Netscaler ADC VPX VIP Interface"
     }
   )
-
 }
 
 resource "aws_network_interface" "adc_snip_interface" {
@@ -83,5 +81,4 @@ resource "aws_network_interface" "adc_snip_interface" {
       ROLE = "Citrix Netscaler ADC VPX SNIP Interface"
     }
   )
-
 }

--- a/terraform/environments/equip/data.tf
+++ b/terraform/environments/equip/data.tf
@@ -16,45 +16,66 @@ data "aws_subnets" "shared-data" {
   }
 }
 
-data "aws_subnet" "private_subnets_a" {
+data "aws_subnet" "private_subnet_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
   }
 }
 
-data "aws_subnet" "private_subnets_b" {
+data "aws_subnet" "private_subnet_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
   }
 }
 
-data "aws_subnet" "private_subnets_c" {
+data "aws_subnet" "private_subnet_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
   }
 }
 
-data "aws_subnet" "public_az_a" {
+data "aws_subnet" "public_subnet_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
   }
 }
 
-data "aws_subnet" "public_az_b" {
+data "aws_subnet" "public_subnet_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
   }
 }
 
-data "aws_subnet" "public_az_c" {
+data "aws_subnet" "public_subnet_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
     Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+  }
+}
+
+data "aws_subnet" "data_subnet_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+  }
+}
+
+data "aws_subnet" "data_subnet_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+  }
+}
+
+data "aws_subnet" "data_subnet_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
   }
 }
 

--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -69,15 +69,15 @@ resource "aws_route53_resolver_endpoint" "equip-domain" {
   ]
 
   ip_address {
-    subnet_id = data.aws_subnet.private_subnets_a.id
+    subnet_id = data.aws_subnet.private_subnet_a.id
   }
 
   ip_address {
-    subnet_id = data.aws_subnet.private_subnets_b.id
+    subnet_id = data.aws_subnet.private_subnet_b.id
   }
 
   ip_address {
-    subnet_id = data.aws_subnet.private_subnets_c.id
+    subnet_id = data.aws_subnet.private_subnet_c.id
   }
 
   tags = {

--- a/terraform/environments/equip/main.tf
+++ b/terraform/environments/equip/main.tf
@@ -44,7 +44,7 @@ locals {
   win2016_instances = {
     COR-A-DC01 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_domain_security_group.id]
       root_block_device = [
         {
@@ -64,7 +64,7 @@ locals {
     }
     COR-A-DC02 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_b.id
+      subnet_id              = data.aws_subnet.private_subnet_b.id
       vpc_security_group_ids = [aws_security_group.aws_domain_security_group.id]
       root_block_device = [
         {
@@ -85,7 +85,7 @@ locals {
     }
     COR-A-CTX01 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_citrix_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -117,7 +117,7 @@ locals {
     }
     COR-A-CTX02 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_citrix_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -137,7 +137,7 @@ locals {
     }
     COR-A-CTX03 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_b.id
+      subnet_id              = data.aws_subnet.private_subnet_b.id
       vpc_security_group_ids = [aws_security_group.aws_citrix_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -157,7 +157,7 @@ locals {
     }
     COR-A-PXY01 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_proxy_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -189,7 +189,7 @@ locals {
     }
     COR-A-TST01 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_equip_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -259,7 +259,7 @@ resource "aws_instance" "SOC" {
 
   instance_type          = "t3a.xlarge"
   availability_zone      = "${local.region}a"
-  subnet_id              = data.aws_subnet.private_subnets_a.id
+  subnet_id              = data.aws_subnet.private_subnet_a.id
   vpc_security_group_ids = [aws_security_group.aws_proxy_security_group.id, aws_security_group.all_internal_groups.id]
   monitoring             = true
   ebs_optimized          = true
@@ -327,7 +327,7 @@ locals {
   win2019_SQL_instances = {
     COR-A-SF02 = {
       instance_type          = "t3a.xlarge"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_spotfire_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -410,7 +410,7 @@ locals {
   win2012_STD_instances = {
     COR-A-EQP01 = {
       instance_type          = "t3a.xlarge"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_equip_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -466,7 +466,7 @@ locals {
     }
     COR-A-EQP02 = {
       instance_type          = "t3a.xlarge"
-      subnet_id              = data.aws_subnet.private_subnets_b.id
+      subnet_id              = data.aws_subnet.private_subnet_b.id
       vpc_security_group_ids = [aws_security_group.aws_equip_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -498,7 +498,7 @@ locals {
     }
     COR-A-EQP03 = {
       instance_type          = "t3a.xlarge"
-      subnet_id              = data.aws_subnet.private_subnets_c.id
+      subnet_id              = data.aws_subnet.private_subnet_c.id
       vpc_security_group_ids = [aws_security_group.aws_equip_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -518,7 +518,7 @@ locals {
     }
     COR-A-SF01 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_spotfire_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {
@@ -538,7 +538,7 @@ locals {
     }
     COR-A-SF03 = {
       instance_type          = "t3a.large"
-      subnet_id              = data.aws_subnet.private_subnets_a.id
+      subnet_id              = data.aws_subnet.private_subnet_a.id
       vpc_security_group_ids = [aws_security_group.aws_spotfire_security_group.id, aws_security_group.all_internal_groups.id]
       root_block_device = [
         {

--- a/terraform/environments/equip/nacl.tf
+++ b/terraform/environments/equip/nacl.tf
@@ -4,7 +4,7 @@ data "aws_network_acls" "public_acl" {
 
   filter {
     name   = "association.subnet-id"
-    values = [data.aws_subnet.public_az_a.id]
+    values = [data.aws_subnet.public_subnet_a.id]
   }
 }
 


### PR DESCRIPTION
* Refactors data calls for subnet IDs to be consistent in naming
* Adds data calls for data subnets
* Changes management interface on Netscaler EC2 instance to be defined as separate resource