### PR TITLE
Equip EBS volume lifecycle statement

### DIFF
--- a/terraform/environments/equip/ec2-instance-module/main.tf
+++ b/terraform/environments/equip/ec2-instance-module/main.tf
@@ -4,6 +4,7 @@ locals {
 }
 #tfsec:ignore:aws-ec2-enable-at-rest-encryption
 resource "aws_instance" "this" {
+  lifecycle { ignore_changes = [ebs_block_device] }
 
   ami                  = var.ami
   instance_type        = var.instance_type


### PR DESCRIPTION
* Prevent changes to EBS volume from setting off a cycle of spurious rebuilds
* EG, replacing a volume from a snapshot will trigger the deletion and recreation of an instance