### PR TITLE
Creating an audit database in Production

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -35,12 +35,14 @@ locals {
           ami_name           = "nomis_db_STIG_CNOMT1-2022-04-21*"
           asm_data_capacity  = 100
           asm_flash_capacity = 2
+          description        = "Test NOMIS T1 database with a dataset of T1PDL0009 (note: only NOMIS db, NDH db is not included."
         },
         CNAUDT1 = {
           always_on              = true
           ami_name               = "nomis_db-2022-03-03*"
           asm_data_capacity      = 200
           asm_flash_capacity     = 2
+          description            = "Copy of Test NOMIS Audit database in Azure T1PDL0010, replicating with T1PDL0010."
           termination_protection = true
         }
       },
@@ -81,12 +83,14 @@ locals {
       },
       # Add database instances here.  They will be created using the database module
       databases = {
-        TEST = {
+        AUDIT = {
           always_on              = true
           ami_name               = "nomis_db_STIG-2022-04-26*"
-          asm_data_capacity      = 200
-          asm_flash_capacity     = 2
-          termination_protection = false
+          instance_type          = "r6i.2xlarge"
+          asm_data_capacity      = 4000
+          asm_flash_capacity     = 1000
+          description            = "Copy of Production NOMIS Audit database in Azure PDPDL00038, replacting with PDPDL00038, a replacement for PDPDL00037."
+          termination_protection = true
         }
       },
       # Add weblogic instances here.  They will be created using the weblogic module

--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -17,6 +17,7 @@ module "database" {
   ami_name           = each.value.ami_name
   asm_data_capacity  = each.value.asm_data_capacity
   asm_flash_capacity = each.value.asm_flash_capacity
+  description        = each.value.description
 
   ami_owner              = try(each.value.ami_owner, "${local.environment_management.account_ids["nomis-test"]}")
   asm_data_iops          = try(each.value.asm_data_iops, null)
@@ -26,6 +27,7 @@ module "database" {
   oracle_app_disk_size   = try(each.value.oracle_app_disk_size, null)
   extra_ingress_rules    = try(each.value.extra_ingress_rules, null)
   termination_protection = try(each.value.termination_protection, null)
+  instance_type          = try(each.value.termination_protection, null)
 
   common_security_group_id  = aws_security_group.database_common.id
   instance_profile_policies = concat(local.ec2_common_managed_policies, [aws_iam_policy.s3_db_backup_bucket_access.arn])

--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -27,7 +27,7 @@ module "database" {
   oracle_app_disk_size   = try(each.value.oracle_app_disk_size, null)
   extra_ingress_rules    = try(each.value.extra_ingress_rules, null)
   termination_protection = try(each.value.termination_protection, null)
-  instance_type          = try(each.value.termination_protection, null)
+  instance_type          = try(each.value.instance_type, null)
 
   common_security_group_id  = aws_security_group.database_common.id
   instance_profile_policies = concat(local.ec2_common_managed_policies, [aws_iam_policy.s3_db_backup_bucket_access.arn])

--- a/terraform/environments/nomis/modules/database/main.tf
+++ b/terraform/environments/nomis/modules/database/main.tf
@@ -108,6 +108,7 @@ resource "aws_instance" "database" {
     var.tags,
     {
       Name          = "database-${var.name}"
+      description   = var.description
       component     = "data"
       os_type       = "Linux"
       os_version    = "RHEL 7.9"

--- a/terraform/environments/nomis/modules/database/variables.tf
+++ b/terraform/environments/nomis/modules/database/variables.tf
@@ -92,6 +92,13 @@ variable "business_unit" {
   nullable    = false
 }
 
+variable "description" {
+  type        = string
+  description = "VM description, should include information such as what is running on it, etc."
+  default     = ""
+  nullable    = false
+}
+
 variable "extra_ingress_rules" {
   type = list(object({
     description = string


### PR DESCRIPTION
This is an empty DB in prod env, it will be used for syncing with the PDPDL00038 Prod Audit DB.