### PR TITLE
Fix/equip adjust lb targets

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -61,16 +61,16 @@ resource "aws_lb_target_group" "lb_tg_https_gateway" {
 resource "aws_lb_target_group" "lb_tg_https_equip-portal" {
   name        = "tg-equip-portal"
   target_type = "ip"
-  protocol    = "HTTPS"
+  protocol    = "HTTP"
   vpc_id      = data.aws_vpc.shared.id
-  port        = "443"
+  port        = "80"
 
   health_check {
     enabled             = true
     path                = "/"
     interval            = 30
-    protocol            = "HTTPS"
-    port                = 443
+    protocol            = "HTTP"
+    port                = 80
     timeout             = 5
     healthy_threshold   = 5
     unhealthy_threshold = 2
@@ -124,22 +124,22 @@ resource "aws_lb_target_group" "lb_tg_https_analytics" {
   tags = local.tags
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_443_gateway" {
+resource "aws_lb_target_group_attachment" "lb_tga_gateway" {
   target_group_arn = aws_lb_target_group.lb_tg_https_gateway.arn
   target_id        = aws_network_interface.adc_vip_interface.private_ip_list[0]
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_443_equip-portal" {
+resource "aws_lb_target_group_attachment" "lb_tga_equip-portal" {
   target_group_arn = aws_lb_target_group.lb_tg_https_equip-portal.arn
-  target_id        = aws_network_interface.adc_snip_interface.private_ip_list[1]
+  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_443_portal" {
+resource "aws_lb_target_group_attachment" "lb_tga_portal" {
   target_group_arn = aws_lb_target_group.lb_tg_https_portal.arn
   target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_443_analytics" {
+resource "aws_lb_target_group_attachment" "lb_tga_analytics" {
   target_group_arn = aws_lb_target_group.lb_tg_https_analytics.arn
   target_id        = join("", module.win2012_STD_multiple["COR-A-SF01"].private_ip)
 }

--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -111,7 +111,7 @@ resource "aws_lb_target_group" "lb_tg_analytics" {
 
   health_check {
     enabled             = true
-    path                = "/"
+    path                = "/spotfire/login.html"
     interval            = 30
     protocol            = "HTTP"
     port                = 8080
@@ -153,7 +153,7 @@ resource "aws_lb_listener" "lb_listener_https" {
   certificate_arn   = data.aws_acm_certificate.equip_cert.arn
 
   default_action {
-    target_group_arn = aws_lb_target_group.lb_tg_https_gateway.arn
+    target_group_arn = aws_lb_target_group.lb_tg_gateway.arn
     type             = "forward"
   }
 }
@@ -178,7 +178,7 @@ resource "aws_lb_listener_rule" "gateway-equip-service-justice-gov-uk" {
   listener_arn = aws_lb_listener.lb_listener_https.arn
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.lb_tg_https_gateway.arn
+    target_group_arn = aws_lb_target_group.lb_tg_gateway.arn
   }
   condition {
     host_header {
@@ -191,7 +191,7 @@ resource "aws_lb_listener_rule" "equip-portal-equip-service-justice-gov-uk" {
   listener_arn = aws_lb_listener.lb_listener_https.arn
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.lb_tg_https_equip-portal.arn
+    target_group_arn = aws_lb_target_group.lb_tg_equip-portal.arn
   }
   condition {
     host_header {
@@ -204,7 +204,7 @@ resource "aws_lb_listener_rule" "portal-equip-service-justice-gov-uk" {
   listener_arn = aws_lb_listener.lb_listener_https.arn
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.lb_tg_https_portal.arn
+    target_group_arn = aws_lb_target_group.lb_tg_portal.arn
   }
   condition {
     host_header {
@@ -217,7 +217,7 @@ resource "aws_lb_listener_rule" "analytics-equip-service-justice-gov-uk" {
   listener_arn = aws_lb_listener.lb_listener_https.arn
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.lb_tg_https_analytics.arn
+    target_group_arn = aws_lb_target_group.lb_tg_analytics.arn
   }
   condition {
     host_header {

--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -125,22 +125,22 @@ resource "aws_lb_target_group" "lb_tg_analytics" {
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_gateway" {
-  target_group_arn = aws_lb_target_group.lb_tg_https_gateway.arn
+  target_group_arn = aws_lb_target_group.lb_tg_gateway.arn
   target_id        = aws_network_interface.adc_vip_interface.private_ip_list[0]
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_equip-portal" {
-  target_group_arn = aws_lb_target_group.lb_tg_https_equip-portal.arn
+  target_group_arn = aws_lb_target_group.lb_tg_equip-portal.arn
   target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_portal" {
-  target_group_arn = aws_lb_target_group.lb_tg_https_portal.arn
+  target_group_arn = aws_lb_target_group.lb_tg_portal.arn
   target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_analytics" {
-  target_group_arn = aws_lb_target_group.lb_tg_https_analytics.arn
+  target_group_arn = aws_lb_target_group.lb_tg_analytics.arn
   target_id        = join("", module.win2012_STD_multiple["COR-A-SF01"].private_ip)
 }
 

--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -36,7 +36,7 @@ resource "aws_lb" "citrix_alb" {
 
 }
 
-resource "aws_lb_target_group" "lb_tg_https_gateway" {
+resource "aws_lb_target_group" "lb_tg_gateway" {
   name        = "tg-gateway"
   target_type = "ip"
   protocol    = "HTTPS"
@@ -58,7 +58,7 @@ resource "aws_lb_target_group" "lb_tg_https_gateway" {
   tags = local.tags
 }
 
-resource "aws_lb_target_group" "lb_tg_https_equip-portal" {
+resource "aws_lb_target_group" "lb_tg_equip-portal" {
   name        = "tg-equip-portal"
   target_type = "ip"
   protocol    = "HTTP"
@@ -80,7 +80,7 @@ resource "aws_lb_target_group" "lb_tg_https_equip-portal" {
   tags = local.tags
 }
 
-resource "aws_lb_target_group" "lb_tg_https_portal" {
+resource "aws_lb_target_group" "lb_tg_portal" {
   name        = "tg-portal"
   target_type = "ip"
   protocol    = "HTTP"
@@ -102,7 +102,7 @@ resource "aws_lb_target_group" "lb_tg_https_portal" {
   tags = local.tags
 }
 
-resource "aws_lb_target_group" "lb_tg_https_analytics" {
+resource "aws_lb_target_group" "lb_tg_analytics" {
   name        = "tg-analytics"
   target_type = "ip"
   protocol    = "HTTP"

--- a/terraform/environments/equip/application_variables.json
+++ b/terraform/environments/equip/application_variables.json
@@ -49,16 +49,16 @@
     }
   },
   "alb_to_equip_rules": {
-    "TCP_8080": {
-      "from_port": 8080,
-      "to_port": 8080,
+    "TCP_80": {
+      "from_port": 80,
+      "to_port": 80,
       "protocol": "TCP"
     }
   },
   "alb_to_spotfire_rules": {
-    "TCP_80": {
-      "from_port": 80,
-      "to_port": 80,
+    "TCP_8080": {
+      "from_port": 8080,
+      "to_port": 8080,
       "protocol": "TCP"
     }
   },

--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -13,6 +13,7 @@ resource "aws_route53_record" "external" {
 }
 
 resource "aws_route53_record" "analytics" {
+  count    = local.is-development ? 1 : 0
   provider = aws.core-network-services
 
   zone_id = data.aws_route53_zone.application-zone.zone_id
@@ -27,6 +28,7 @@ resource "aws_route53_record" "analytics" {
 }
 
 resource "aws_route53_record" "equip-portal" {
+  count    = local.is-development ? 1 : 0
   provider = aws.core-network-services
 
   zone_id = data.aws_route53_zone.application-zone.zone_id
@@ -41,6 +43,7 @@ resource "aws_route53_record" "equip-portal" {
 }
 
 resource "aws_route53_record" "gateway" {
+  count    = local.is-development ? 1 : 0
   provider = aws.core-network-services
 
   zone_id = data.aws_route53_zone.application-zone.zone_id
@@ -55,6 +58,7 @@ resource "aws_route53_record" "gateway" {
 }
 
 resource "aws_route53_record" "portal" {
+  count    = local.is-development ? 1 : 0
   provider = aws.core-network-services
 
   zone_id = data.aws_route53_zone.application-zone.zone_id


### PR DESCRIPTION
* Adjust target for `equip-portal`
* Adjust security groups for traffic from alb to backend instances
* Tidy up names of target group attachments as ports no longer specified in those resources