### PR TITLE
fix/equip-ebs-lifecycle

### DIFF
--- a/terraform/environments/equip/main.tf
+++ b/terraform/environments/equip/main.tf
@@ -256,6 +256,7 @@ data "aws_ami" "windows_2016_std_SQL17_ami" {
 }
 
 resource "aws_instance" "SOC" {
+  lifecycle { ignore_changes = [ebs_block_device] }
   ami = "ami-0781096210795e2d3"
 
   instance_type          = "t3a.xlarge"


### PR DESCRIPTION
* added lifecycle statement to stop thrashing of SOC instance when volumes are replaced by snapshots