### PR TITLE
Do not recreate testing-test after it's being automatically nuked

### DIFF
--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -9,7 +9,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  NUKE_DO_NOT_RECREATE_ENVIRONMENTS: performance-hub-development,example-development,sample-development,
+  NUKE_DO_NOT_RECREATE_ENVIRONMENTS: performance-hub-development,example-development,testing-test-development,
   TF_IN_AUTOMATION: true
 defaults:
   run:


### PR DESCRIPTION
- Do not recreate testing-test after it's being automatically nuked. The -development suffix is the naming convention used in the terraform-apply-after-nuke.sh script.
- Note that the secret nuke_account_ids in the Modernisation Platform account now also includes two additional environments: "EXAMPLE_DEVELOPMENT_ACCID":"083957762049","TESTING_TEST_DEVELOPMENT_ACCID":"836052629367"