### PR TITLE
auto-nuke not reporting correct number of failed envs

### DIFF
--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -49,6 +49,7 @@ ROOT_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
 ROOT_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN}"
 
 for key in "${!account_ids[@]}"; do
+  exit_code=0
   echo "BEGIN: nuke ${key}"
   assume_role_json=$(aws sts assume-role --role-arn "arn:aws:iam::${account_ids[$key]}:role/MemberInfrastructureAccess" --role-session-name "${key}_SESSION" 2>&1)
   if [[ "$assume_role_json" != *"Credentials"* ]]; then

--- a/scripts/terraform-apply-after-nuke.sh
+++ b/scripts/terraform-apply-after-nuke.sh
@@ -18,6 +18,7 @@ redeployed_envs=()
 skipped_envs=()
 failed_envs=()
 for key in "${!account_ids[@]}"; do
+  exit_code=0
   to_dir_name "$key"
   if [[ "$NUKE_DO_NOT_RECREATE_ENVIRONMENTS" != *"${dir_name}-development,"* ]]; then
     echo "BEGIN: terraform apply ${dir_name}-development"


### PR DESCRIPTION
Fix a bug in auto-nuke not reporting correct number of failed environments