### PR TITLE
Equip redirects

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -225,3 +225,51 @@ resource "aws_lb_listener_rule" "analytics-equip-service-justice-gov-uk" {
     }
   }
 }
+
+resource "aws_lb_listener_rule" "equip-analytics-rocstac-com" {
+  listener_arn = aws_lb_listener.lb_listener_https.arn
+  action {
+    type = "redirect"
+    redirect {
+      host        = "analytics.equip.service.justice.gov.uk"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = ["equip-analytics.rocstac.com"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "equip-gateway-rocstac-com" {
+  listener_arn = aws_lb_listener.lb_listener_https.arn
+  action {
+    type = "redirect"
+    redirect {
+      host        = "gateway.equip.service.justice.gov.uk"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = ["equip-gateway.rocstac.com"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "equip-portal-rocstac-com" {
+  listener_arn = aws_lb_listener.lb_listener_https.arn
+  action {
+    type = "redirect"
+    redirect {
+      host        = "portal.equip.service.justice.gov.uk"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = ["equip-portal.rocstac.com"]
+    }
+  }
+}

--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -43,7 +43,7 @@ resource "aws_route53_record" "equip-portal" {
 }
 
 resource "aws_route53_record" "gateway" {
-  count    = local.is-development ? 1 : 0
+  count    = local.is-production ? 1 : 0
   provider = aws.core-network-services
 
   zone_id = data.aws_route53_zone.application-zone.zone_id


### PR DESCRIPTION
* Point `gateway.equip.service.justice.gov.uk` record at production
* Create `HTTP_301` redirects for legacy addresses