### PR TITLE
nomis/db image builder work

### DIFF
--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -291,7 +291,8 @@ data "aws_iam_policy_document" "packer_s3_bucket_access" {
     actions = [
       "s3:GetObject",
       "s3:ListBucket",
-      "s3:*"
+      "s3:PutObject",
+      "s3:PutObjectAcl"
     ]
     resources = [
       module.s3-bucket.bucket.arn,

--- a/terraform/environments/nomis/packer.tf
+++ b/terraform/environments/nomis/packer.tf
@@ -290,7 +290,8 @@ data "aws_iam_policy_document" "packer_s3_bucket_access" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:*"
     ]
     resources = [
       module.s3-bucket.bucket.arn,


### PR DESCRIPTION
- Temporarily allowing limited write permissions to packer instance profile for SSM logging.
- Temporarily allowing limited write permissions to packer instance profile for SSM logging.
