### PR TITLE
Update Terraform version in MP controlled TF

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/example
           terraform -chdir="terraform/environments/example" workspace select "example-${TF_ENV}"
@@ -59,10 +60,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/example
           terraform -chdir="terraform/environments/example" workspace select "example-${TF_ENV}"

--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - after nuke
         run: |
+          terraform --version
           echo "BEGIN: Redeploy after nuke"
           bash scripts/terraform-apply-after-nuke.sh
           echo "END: Redeploy after nuke"

--- a/.github/workflows/nuke.yml
+++ b/.github/workflows/nuke.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Install AWS Nuke
         run: |

--- a/.github/workflows/ppud.yml
+++ b/.github/workflows/ppud.yml
@@ -36,10 +36,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform plan - development
 #        run: |
+#          terraform --version
 #          echo "Terraform plan - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -59,10 +60,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform apply - development
 #        run: |
+#          terraform --version
 #          echo "Terraform apply - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -80,10 +82,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform plan - test
 #        run: |
+#          terraform --version
 #          echo "Terraform plan - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -103,10 +106,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform apply - test
 #        run: |
+#          terraform --version
 #          echo "Terraform apply - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -125,10 +129,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform plan - preproduction
 #        run: |
+#          terraform --version
 #          echo "Terraform plan - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -148,10 +153,11 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@v2.0.0
 #        with:
-#          terraform_version: 1.0.1
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Terraform apply - preproduction
 #        run: |
+#          terraform --version
 #          echo "Terraform apply - ${TF_ENV}"
 #          bash scripts/terraform-init.sh terraform/environments/ppud
 #          terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -169,10 +175,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/ppud
           terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"
@@ -192,10 +199,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/ppud
           terraform -chdir="terraform/environments/ppud" workspace select "ppud-${TF_ENV}"

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -36,10 +36,11 @@ jobs:
      - name: Load and Configure Terraform
        uses: hashicorp/setup-terraform@v2.0.0
        with:
-         terraform_version: 1.0.1
+         terraform_version: "~1"
          terraform_wrapper: false
      - name: Terraform plan - development
        run: |
+         terraform --version
          echo "Terraform plan - ${TF_ENV}"
          bash scripts/terraform-init.sh terraform/environments/sprinkler
          terraform -chdir="terraform/environments/sprinkler" workspace select "sprinkler-${TF_ENV}"
@@ -59,10 +60,11 @@ jobs:
      - name: Load and Configure Terraform
        uses: hashicorp/setup-terraform@v2.0.0
        with:
-         terraform_version: 1.0.1
+         terraform_version: "~1"
          terraform_wrapper: false
      - name: Terraform apply - development
        run: |
+         terraform --version
          echo "Terraform apply - ${TF_ENV}"
          bash scripts/terraform-init.sh terraform/environments/sprinkler
          terraform -chdir="terraform/environments/sprinkler" workspace select "sprinkler-${TF_ENV}"

--- a/.github/workflows/tariff.yml
+++ b/.github/workflows/tariff.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/tariff
           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -59,10 +60,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/tariff
           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -80,10 +82,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform plan - test
 #         run: |
+#           terraform --version
 #           echo "Terraform plan - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -103,10 +106,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform apply - test
 #         run: |
+#           terraform --version
 #           echo "Terraform apply - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -125,10 +129,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform plan - preproduction
 #         run: |
+#           terraform --version
 #           echo "Terraform plan - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -148,10 +153,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform apply - preproduction
 #         run: |
+#           terraform --version
 #           echo "Terraform apply - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -169,10 +175,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform plan - production
 #         run: |
+#           terraform --version
 #           echo "Terraform plan - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"
@@ -192,10 +199,11 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@v2.0.0
 #         with:
-#           terraform_version: 1.0.1
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Terraform apply - production
 #         run: |
+#           terraform --version
 #           echo "Terraform apply - ${TF_ENV}"
 #           bash scripts/terraform-init.sh terraform/environments/tariff
 #           terraform -chdir="terraform/environments/tariff" workspace select "tariff-${TF_ENV}"

--- a/.github/workflows/threat-and-vulnerability-mgmt.yml
+++ b/.github/workflows/threat-and-vulnerability-mgmt.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/threat-and-vulnerability-mgmt
           terraform -chdir="terraform/environments/threat-and-vulnerability-mgmt" workspace select "threat-and-vulnerability-mgmt-${TF_ENV}"
@@ -59,10 +60,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/threat-and-vulnerability-mgmt
           terraform -chdir="terraform/environments/threat-and-vulnerability-mgmt" workspace select "threat-and-vulnerability-mgmt-${TF_ENV}"
@@ -80,10 +82,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/threat-and-vulnerability-mgmt
           terraform -chdir="terraform/environments/threat-and-vulnerability-mgmt" workspace select "threat-and-vulnerability-mgmt-${TF_ENV}"
@@ -103,10 +106,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/threat-and-vulnerability-mgmt
           terraform -chdir="terraform/environments/threat-and-vulnerability-mgmt" workspace select "threat-and-vulnerability-mgmt-${TF_ENV}"

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/example/versions.tf
+++ b/terraform/environments/example/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/ppud/versions.tf
+++ b/terraform/environments/ppud/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {

--- a/terraform/environments/sprinkler/versions.tf
+++ b/terraform/environments/sprinkler/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/tariff/versions.tf
+++ b/terraform/environments/tariff/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }

--- a/terraform/environments/threat-and-vulnerability-mgmt/versions.tf
+++ b/terraform/environments/threat-and-vulnerability-mgmt/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
We also want to ensure we can automatically update for minor version
changes.

Note the difference in versioning specification.
The Terraform action requires the syntax "~1"
The Terraform version block requires "~1.0"

Also added `terraform --version` line so that we can see easily what
version the action is running with.

Tested as follows to prove -

Terraform version(which checks the version of TF complies):

```
required_version = "~> 0"
using terraform 1.0.1
Plan completes!
```
And obviously...
```
required_version = "~> 1"
using terraform 1.0.1
Plan completes!
```
So to follow up...
```
required_version = "~> 2"
using terraform 1.0.1
Plan fails

```
So for the terraform action version which impacts the installed version of terraform, I tried:
`terraform_version: "~0"`
And that got TF version:
`Terraform v0.15.5`

Then I tried:
`terraform_version: "~1"`
And that got TF version:
`Terraform v1.2.4`

Then I tried:
`terraform_version: "~1.0"`
And got:
`Terraform v1.0.11`