### PR TITLE
Update Terraform version in performance-hub

### DIFF
--- a/.github/workflows/performance-hub.yml
+++ b/.github/workflows/performance-hub.yml
@@ -35,10 +35,11 @@ jobs:
   #      - name: Load and Configure Terraform
   #        uses: hashicorp/setup-terraform@v2.0.0
   #        with:
-  #          terraform_version: 1.0.1
+  #          terraform_version: "~1"
   #          terraform_wrapper: false
   #      - name: Terraform plan - development
   #        run: |
+  #          terraform --version
   #          echo "Terraform plan - ${TF_ENV}"
   #          bash scripts/terraform-init.sh terraform/environments/performance-hub
   #          terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -58,10 +59,11 @@ jobs:
   #      - name: Load and Configure Terraform
   #        uses: hashicorp/setup-terraform@v2.0.0
   #        with:
-  #          terraform_version: 1.0.1
+  #          terraform_version: "~1"
   #          terraform_wrapper: false
   #      - name: Terraform apply - development
   #        run: |
+  #          terraform --version
   #          echo "Terraform apply - ${TF_ENV}"
   #          bash scripts/terraform-init.sh terraform/environments/performance-hub
   #          terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -79,10 +81,11 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@v2.0.0
   #       with:
-  #         terraform_version: 1.0.1
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Terraform plan - test
   #       run: |
+  #         terraform --version
   #         echo "Terraform plan - ${TF_ENV}"
   #         bash scripts/terraform-init.sh terraform/environments/performance-hub
   #         terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -102,10 +105,11 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@v2.0.0
   #       with:
-  #         terraform_version: 1.0.1
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Terraform apply - test
   #       run: |
+  #         terraform --version
   #         echo "Terraform apply - ${TF_ENV}"
   #         bash scripts/terraform-init.sh terraform/environments/performance-hub
   #         terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -124,10 +128,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - preproduction
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/performance-hub
           terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -147,10 +152,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - preproduction
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/performance-hub
           terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -168,10 +174,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/performance-hub
           terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"
@@ -191,10 +198,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/performance-hub
           terraform -chdir="terraform/environments/performance-hub" workspace select "performance-hub-${TF_ENV}"

--- a/terraform/environments/performance-hub/versions.tf
+++ b/terraform/environments/performance-hub/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
We also want to ensure we can automatically update for minor version
changes.

Note the difference in versioning specification.
The Terraform action requires the syntax "~1"
The Terraform version block requires "~1.0"

Also added `terraform --version` line so that we can see easily what
version the action is running with.

Tested as follows to prove -

Terraform version(which checks the version of TF complies):

```
required_version = "~> 0"
using terraform 1.0.1
Plan completes!
```
And obviously...
```
required_version = "~> 1"
using terraform 1.0.1
Plan completes!
```
So to follow up...
```
required_version = "~> 2"
using terraform 1.0.1
Plan fails

```
So for the terraform action version which impacts the installed version of terraform, I tried:
`terraform_version: "~0"`
And that got TF version:
`Terraform v0.15.5`

Then I tried:
`terraform_version: "~1"`
And that got TF version:
`Terraform v1.2.4`

Then I tried:
`terraform_version: "~1.0"`
And got:
`Terraform v1.0.11`