### PR TITLE
Update Terraform version for Xhibit Portal

### DIFF
--- a/.github/workflows/xhibit-portal.yml
+++ b/.github/workflows/xhibit-portal.yml
@@ -34,10 +34,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace list
@@ -57,10 +58,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace select "xhibit-portal-${TF_ENV}"
@@ -78,10 +80,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - preproduction
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace select "xhibit-portal-${TF_ENV}"
@@ -100,10 +103,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - preproduction
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace select "xhibit-portal-${TF_ENV}"
@@ -121,10 +125,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace select "xhibit-portal-${TF_ENV}"
@@ -145,10 +150,11 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 1.0.1
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/xhibit-portal
           terraform -chdir="terraform/environments/xhibit-portal" workspace select "xhibit-portal-${TF_ENV}"

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }
 
 


### PR DESCRIPTION
We also want to ensure we can automatically update for minor version
changes.

Note the difference in versioning specification.
The Terraform action requires the syntax "~1"
The Terraform version block requires "~1.0"

Also added `terraform --version` line so that we can see easily what
version the action is running with.

Tested as follows to prove -

Terraform version(which checks the version of TF complies):

```
required_version = "~> 0"
using terraform 1.0.1
Plan completes!
```
And obviously...
```
required_version = "~> 1"
using terraform 1.0.1
Plan completes!
```
So to follow up...
```
required_version = "~> 2"
using terraform 1.0.1
Plan fails

```
So for the terraform action version which impacts the installed version of terraform, I tried:
`terraform_version: "~0"`
And that got TF version:
`Terraform v0.15.5`

Then I tried:
`terraform_version: "~1"`
And that got TF version:
`Terraform v1.2.4`

Then I tried:
`terraform_version: "~1.0"`
And got:
`Terraform v1.0.11`