### PR TITLE
DSOS-1350: Adding DNS record for Oracle Manager

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -68,8 +68,7 @@ locals {
       # Details of OMS Manager in FixNGo (only needs defining if databases in the environment are managed)
       database_oracle_manager = {
         oms_ip_address = "10.40.0.136"
-        oms_hostname   = "pcmcl00041"
-        oms_domain     = "azure.hmpp.root"
+        oms_hostname   = "oms"
       }
       # vars common across ec2 instances
       ec2_common = {

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -64,6 +64,13 @@ locals {
         cloud_platform       = "172.20.0.0/16"
         azure_noms_mgmt_live = "10.40.128.0/20"
       },
+
+      # Details of OMS Manager in FixNGo (only needs defining if databases in the environment are managed)
+      database_oracle_manager = {
+        oms_ip_address = "10.40.0.136"
+        oms_hostname   = "pcmcl00041"
+        oms_domain     = "azure.hmpp.root"
+      }
       # vars common across ec2 instances
       ec2_common = {
         public_key                = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdCvr+81dRu1qxFi1LSWEybb/ztbzlbfjd3Hj1EOHcEQt6lo9Cr94SUXjjUvD6krNzm9QWs8TdVRNfDCjaZRmO6KFX8UUUwE0UB0p6LZPy2I8cYirGN8f2fwCrh8dZg6x8sxa7fXW5gMZal6Z0O10u0XM5ajXkQz2f4T4zCxff7MDEuqZV0OWhaiTWPT9eph4UZH5FWA8Lxzml6qIAwyHa6O5j7hQpvX4kiMjvg9F9C5Fxo6EBpCAjdRcXgsMmDHQjqLJO3b2wWPlm45yES7NaAwZCb6Yq0BRmDPv2/ZokVNE8tudtf+cNa2+aLB9WiBVnFXggIuFeelArNi5X9U4nLzvaDX3y7+TnY+QY5FcDugJDwHKcb/ah64WMpSiWjrFiyg6fF04jFfV6YKdsH//7E/DSZAkVsj+XKHt23SyWS6RKXag+IW3UIp3pttELNHbIO+7vUGZT8btqIBtN5iM6PLiYzfDFHDRmd/aO0a844ZFioFzabGo7MuyAU+NkfLHIBXazrrxd2s+HXnBtL80iur4Jm7Vut1QoPJmknCq9iBv+itE8RYM8oN74g5BVTPAsw5vr2c5fvXwVdu0XhwRnkSsfCppdntf2ObX51PxjxXcq63jCEYRdq0bBPyGWa8hKiMcwx4TIz3IW2xGmLK6PO+2LLpVg89Q7EicMAFHC3w=="

--- a/terraform/environments/nomis/modules/weblogic/main.tf
+++ b/terraform/environments/nomis/modules/weblogic/main.tf
@@ -123,7 +123,7 @@ resource "aws_launch_template" "weblogic" {
 
   lifecycle {
     ignore_changes = [
-      tags, description, image_id, latest_version
+      tags, description, image_id
     ]
   }
 

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "oracle-manager" {
   provider = aws.core-vpc
-  for_each = local.accounts[local.environment].database_oracle_manager
+  count = try(local.accounts[local.environment].database_oracle_manager, false) ? 1 : 0
 
   zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "${each.value.oms_hostname}.${local.application_name}.${data.aws_route53_zone.internal.name}"
+  name    = "${local.accounts[local.environment].database_oracle_manager.oms_hostname}.${local.application_name}.${data.aws_route53_zone.internal.name}"
   type    = "A"
   ttl     = "60"
-  records = [each.value.oms_ip_address]
+  records = [local.accounts[local.environment].database_oracle_manager.oms_ip_address]
 }

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,7 +1,17 @@
-resource "aws_route53_zone" "private" {
-  name = "azure.hmpp.root"
+data "aws_route53_zone" "internal" {
+  provider = aws.core-vpc
 
-  vpc {
-    vpc_id = local.vpc_id
-  }
+  name         = "${local.business_unit}-${local.environment}.modernisation-platform.internal."
+  private_zone = true
+}
+
+resource "aws_route53_record" "oracle-manager" {
+  provider = aws.core-vpc
+  for_each = local.accounts[local.environment].database_oracle_manager
+
+  zone_id = data.aws_route53_zone.internal.zone_id
+  name    = "${each.oms_hostname.value}.${local.application_name}.${data.aws_route53_zone.internal.name}"
+  type    = "A"
+  ttl     = "60"
+  records = [each.oms_ip_address.value]
 }

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "oracle-manager" {
   provider = aws.core-vpc
-  count = can(local.accounts[local.environment].database_oracle_manager) ? 1 : 0
+  count    = can(local.accounts[local.environment].database_oracle_manager) ? 1 : 0
 
 
   zone_id = data.aws_route53_zone.internal.zone_id

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "oracle-manager" {
   provider = aws.core-vpc
-  count = try(local.accounts[local.environment].database_oracle_manager, false) ? 1 : 0
+  count = can(local.accounts[local.environment].database_oracle_manager) ? 1 : 0
 
   zone_id = data.aws_route53_zone.internal.zone_id
   name    = "${local.accounts[local.environment].database_oracle_manager.oms_hostname}.${local.application_name}.${data.aws_route53_zone.internal.name}"

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "private" {
+  name = "azure.hmpp.root"
+
+  vpc {
+    vpc_id = local.vpc_id
+  }
+}

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -3,8 +3,8 @@ resource "aws_route53_record" "oracle-manager" {
   for_each = local.accounts[local.environment].database_oracle_manager
 
   zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "${each.oms_hostname.value}.${local.application_name}.${data.aws_route53_zone.internal.name}"
+  name    = "${each.value.oms_hostname}.${local.application_name}.${data.aws_route53_zone.internal.name}"
   type    = "A"
   ttl     = "60"
-  records = [each.oms_ip_address.value]
+  records = [each.value.oms_ip_address]
 }

--- a/terraform/environments/nomis/r53-oracle-manager-dns.tf
+++ b/terraform/environments/nomis/r53-oracle-manager-dns.tf
@@ -1,10 +1,3 @@
-data "aws_route53_zone" "internal" {
-  provider = aws.core-vpc
-
-  name         = "${local.business_unit}-${local.environment}.modernisation-platform.internal."
-  private_zone = true
-}
-
 resource "aws_route53_record" "oracle-manager" {
   provider = aws.core-vpc
   for_each = local.accounts[local.environment].database_oracle_manager


### PR DESCRIPTION
In order to avoid changing /etc/hosts file on the VM itself, the IP address for the OMS should be retrieved from a private hosting zone. 