### PR TITLE
Remove reference to a specfic version of the vm import module

### DIFF
--- a/terraform/environments/xhibit-portal/importrole.tf
+++ b/terraform/environments/xhibit-portal/importrole.tf
@@ -1,6 +1,6 @@
 module "vm-import" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import?ref=412c8e6d7a4c33c51c9ad6fa739857e64f405804"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import"
 
   bucket_prefix    = local.application_data.accounts[local.environment].bucket_prefix
   tags             = local.tags


### PR DESCRIPTION
The existing reference to the VM import module referenced a specific MOJ version, however we don't have all the permissions required.