### PR TITLE
Nomis/dsos 1368 prod db

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -113,7 +113,7 @@ locals {
           instance_type          = "r6i.4xlarge"
           asm_data_capacity      = 4000
           asm_flash_capacity     = 1000
-          description            = "Copy of Production NOMIS database in Azure, a replacement for PDPDL00035."
+          description            = "Copy of Production NOMIS database in Azure PDPDL00035, replicating with PDPDL00035, a replacement for PDPDL10036."
           termination_protection = true
           oracle_sids            = ["MISPD,CNOMP"]
           oracle_app_disk_size = {

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -106,6 +106,20 @@ locals {
             "/dev/sdb" = 100  # /u01
             "/dev/sdc" = 5120 # /u02
           }
+        },
+        NOMIS = {
+          always_on              = true
+          ami_name               = "nomis_db_STIG-2022-04-26*"
+          instance_type          = "r6i.4xlarge"
+          asm_data_capacity      = 4000
+          asm_flash_capacity     = 1000
+          description            = "Copy of Production NOMIS database in Azure, a replacement for PDPDL00035."
+          termination_protection = true
+          oracle_sids            = ["MISPD,CNOMP"]
+          oracle_app_disk_size = {
+            "/dev/sdb" = 100  # /u01
+            "/dev/sdc" = 5120 # /u02
+          }
         }
       },
       # Add weblogic instances here.  They will be created using the weblogic module

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -104,7 +104,7 @@ locals {
           oracle_sids            = ["PCNMAUD"]
           oracle_app_disk_size = {
             "/dev/sdb" = 100  # /u01
-            "/dev/sdc" = 5120 # /u02
+            "/dev/sdc" = 2048 # /u02
           }
         },
         NOMIS = {
@@ -113,12 +113,12 @@ locals {
           instance_type          = "r6i.4xlarge"
           asm_data_capacity      = 4000
           asm_flash_capacity     = 1000
-          description            = "Copy of Production NOMIS database in Azure PDPDL00035, replicating with PDPDL00035, a replacement for PDPDL10036."
+          description            = "Copy of Production NOMIS CNOM database in Azure PDPDL00035, replicating with PDPDL00035, a replacement for PDPDL10036."
           termination_protection = true
           oracle_sids            = ["MISPD,CNOMP"]
           oracle_app_disk_size = {
             "/dev/sdb" = 100  # /u01
-            "/dev/sdc" = 5120 # /u02
+            "/dev/sdc" = 512 # /u02
           }
         }
       },

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -117,7 +117,7 @@ locals {
           termination_protection = true
           oracle_sids            = ["MISPD,CNOMP"]
           oracle_app_disk_size = {
-            "/dev/sdb" = 100  # /u01
+            "/dev/sdb" = 100 # /u01
             "/dev/sdc" = 512 # /u02
           }
         }

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -104,7 +104,7 @@ locals {
           oracle_sids            = ["PCNMAUD"]
           oracle_app_disk_size = {
             "/dev/sdb" = 100  # /u01
-            "/dev/sdc" = 2048 # /u02
+            "/dev/sdc" = 5120 # /u02
           }
         },
         NOMIS = {

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -115,7 +115,7 @@ locals {
           asm_flash_capacity     = 1000
           description            = "Copy of Production NOMIS CNOM database in Azure PDPDL00035, replicating with PDPDL00035, a replacement for PDPDL10036."
           termination_protection = true
-          oracle_sids            = ["MISPD,CNOMP"]
+          oracle_sids            = ["PCNOM,PMISS1"]
           oracle_app_disk_size = {
             "/dev/sdb" = 100 # /u01
             "/dev/sdc" = 512 # /u02


### PR DESCRIPTION
Adding prod db - changes to disk sizes have been approved by Sandhya 

REF: disk sizes we have backups being stored in S3 buckets and there's no archiving for nomis so less space required