### PR TITLE
Remove ignore changes to root block device to increase drive size in the import server

### DIFF
--- a/terraform/environments/xhibit-portal/importmachine.tf
+++ b/terraform/environments/xhibit-portal/importmachine.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "importmachine" {
 
   root_block_device {
     encrypted   = true
-    volume_size = 60
+    volume_size = 70
   }
 
   lifecycle {
@@ -76,7 +76,6 @@ resource "aws_instance" "importmachine" {
       # [1]: https://github.com/terraform-providers/terraform-provider-aws/issues/770
       volume_tags,
       #user_data,         # Prevent changes to user_data from destroying existing EC2s
-      root_block_device,
       # Prevent changes to encryption from destroying existing EC2s - can delete once encryption complete
     ]
     prevent_destroy = true

--- a/terraform/environments/xhibit-portal/importmachine.tf
+++ b/terraform/environments/xhibit-portal/importmachine.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "importmachine" {
 
   root_block_device {
     encrypted   = true
-    volume_size = 70
+    volume_size = 60
   }
 
   lifecycle {

--- a/terraform/environments/xhibit-portal/importmachine.tf
+++ b/terraform/environments/xhibit-portal/importmachine.tf
@@ -76,7 +76,6 @@ resource "aws_instance" "importmachine" {
       # [1]: https://github.com/terraform-providers/terraform-provider-aws/issues/770
       volume_tags,
       #user_data,         # Prevent changes to user_data from destroying existing EC2s
-      # Prevent changes to encryption from destroying existing EC2s - can delete once encryption complete
     ]
     prevent_destroy = true
   }

--- a/terraform/environments/xhibit-portal/importmachine.tf
+++ b/terraform/environments/xhibit-portal/importmachine.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "importmachine" {
 
   root_block_device {
     encrypted   = true
-    volume_size = 60
+    volume_size = 70
   }
 
   lifecycle {


### PR DESCRIPTION
The AWS instance configuration for the import machine ignored any changes made to the root block device. We increased the size of the disk in a previous PR but because this setting was there, nothing ever happened.

Fixing this issue.

Outcome in Dev - increasing the disk to 70GB leaves us with 10GB of unallocated space - as expected. Needs user to manually extend the partition.