### PR TITLE
Increase data & flash disk capacity for testing

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -45,8 +45,8 @@ locals {
         CNOMT1_COPY = {
           always_on          = false
           ami_name           = "nomis_db_STIG_CNOMT1-2022-04-21*"
-          asm_data_capacity  = 100
-          asm_flash_capacity = 2
+          asm_data_capacity  = 125
+          asm_flash_capacity = 4
           description        = "Test NOMIS T1 database with a dataset of T1PDL0009 (note: only NOMIS db, NDH db is not included. Used for oracle secure web install testing."
           oracle_sids        = ["CNOMT1"]
           tags = {


### PR DESCRIPTION
I'm increasing Oracle ASM disk capacity for both data and flash disks in order to test the procedure described in Confluence: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/3958145072/Increasing+Oracle+ASM+Disk+Group+Capacity