### PR TITLE
Result #11 MEDIUM Bucket does not have versioning enabled

### DIFF
--- a/terraform/environments/sprinkler/bastion_linux.tf
+++ b/terraform/environments/sprinkler/bastion_linux.tf
@@ -2,6 +2,7 @@ locals {
   public_key_data = jsondecode(file("./bastion_linux.json"))
 }
 
+# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 module "bastion_linux" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v3.0.4"
 


### PR DESCRIPTION
────────────────────────────────────────────────────────────────────────────────
  github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.1.1/main.tf:151-156
   via s3.tf:4-67 (module.s3-bucket)
────────────────────────────────────────────────────────────────────────────────
  151    resource "aws_s3_bucket_versioning" "default" {
  152      bucket = aws_s3_bucket.default.id
  153      versioning_configuration {
  154        status = (var.versioning_enabled != true) ? "Suspended" : "Enabled"
  155      }
  156    }
────────────────────────────────────────────────────────────────────────────────
          ID aws-s3-enable-versioning
      Impact Deleted or modified data would not be recoverable
  Resolution Enable versioning to protect against accidental/malicious removal or modification

  More Information
  - https://aquasecurity.github.io/tfsec/latest/checks/aws/s3/enable-versioning/
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#versioning
────────────────────────────────────────────────────────────────────────────────