### PR TITLE
nomis/dso 158 restore cnom audit from snapshot

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -68,12 +68,12 @@ locals {
             monitored = false
           }
         },
-        ORACLEDR = {
+        CNAUDT1DR = {
           always_on          = false
           ami_name           = data.aws_ami.database.name
-          asm_data_capacity  = 100
+          asm_data_capacity  = 200
           asm_flash_capacity = 2
-          description        = "Test Oracle DR database."
+          description        = "Test Oracle DR database with CNAUDT1 spec."
           tags = {
             monitored = false
           }

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -63,9 +63,9 @@ locals {
           asm_flash_capacity     = 2
           description            = "Copy of Test NOMIS Audit database in Azure T1PDL0010, replicating with T1PDL0010."
           termination_protection = true
-          oracle_sids            = ["MIST1", "CNMAUDT1"]
+          oracle_sids        = ["T1CNMAUD"]
           tags = {
-            monitored = false
+            monitored = true
           }
         },
       },

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -130,6 +130,23 @@ locals {
             monitored = true
           }
         },
+        AUDITDR = {
+          always_on              = true
+          ami_name               = "nomis_database_2022-07-21T11-43-27.346Z"
+          ami_owner              = local.environment_management.account_ids[terraform.workspace]
+          instance_type          = "r6i.2xlarge"
+          asm_data_capacity      = 4000
+          asm_flash_capacity     = 1000
+          description            = "DR instance of Oracle DB to perform backup/restore testing."
+          termination_protection = false # temporary VM, will be destroyed
+          oracle_app_disk_size = {
+            "/dev/sdb" = 100  # /u01
+            "/dev/sdc" = 5120 # /u02
+          }
+          tags = {
+            monitored = false
+          }
+        },
         NOMIS = {
           always_on              = true
           ami_name               = "nomis_database_2022-07-21T11-43-27.346Z"

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -68,27 +68,6 @@ locals {
             monitored = false
           }
         },
-        CNAUDT1DR = {
-          always_on          = false
-          ami_name           = data.aws_ami.database.name
-          asm_data_capacity  = 200
-          asm_flash_capacity = 2
-          description        = "Test Oracle DR database with CNAUDT1 spec."
-          tags = {
-            monitored = false
-          }
-        },
-        CNAUDT1RESTORE = {
-          always_on          = false
-          ami_name           = "database-CNAUDT1-snapshot"
-          asm_data_capacity  = 200
-          asm_flash_capacity = 2
-          description        = "Restoring CNAUDT1 from VM backup."
-          oracle_sids        = ["T1CNMAUD"]
-          tags = {
-            monitored = true
-          }
-        },
       },
       # Add weblogic instances here.  They will be created using the weblogic module
       weblogics = {

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -78,6 +78,17 @@ locals {
             monitored = false
           }
         },
+        CNAUDT1RESTORE = {
+          always_on          = false
+          ami_name           = "database-CNAUDT1-snapshot"
+          asm_data_capacity  = 200
+          asm_flash_capacity = 2
+          description        = "Restoring CNAUDT1 from VM backup."
+          oracle_sids        = ["T1CNMAUD"]
+          tags = {
+            monitored = true
+          }
+        },
       },
       # Add weblogic instances here.  They will be created using the weblogic module
       weblogics = {


### PR DESCRIPTION
- DSO-158-new-spec
- DSO-158 - adding cnom audit instance from EC2 snapshot.
