### PR TITLE
New Script to remove non-AWS Backup managed items

### DIFF
--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "snapshot_lambda" {
             "ec2:CreateImage",
             "logs:CreateLogGroup",
             "logs:CreateLogStream",
-            "logs:PutLogEvents"
+            "logs:PutLogEvents",
           ]
           Effect   = "Allow"
           Resource = "*"
@@ -47,9 +47,10 @@ resource "aws_iam_role" "snapshot_lambda" {
 #Create ZIP archive and lambda
 data "archive_file" "lambda_zip" {
 
-  type        = "zip"
-  source_file = "lambda/index.py"
-  output_path = "lambda/lambda_function.zip"
+  type             = "zip"
+  source_file      = "lambda/index.py"
+  output_file_mode = "0666"
+  output_path      = "lambda/lambda_function.zip"
 }
 
 # tfsec:ignore:aws-lambda-enable-tracing
@@ -61,7 +62,7 @@ resource "aws_lambda_function" "root_snapshot_to_ami" {
   function_name                  = "root_snapshot_to_ami"
   role                           = aws_iam_role.snapshot_lambda.arn
   handler                        = "index.lambda_handler"
-  source_code_hash               = data.archive_file.lambda_zip.output_path
+  source_code_hash               = data.archive_file.lambda_zip.output_base64sha256
   runtime                        = "python3.8"
   timeout                        = "120"
   reserved_concurrent_executions = 1
@@ -86,3 +87,97 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.every_day.arn
 }
+
+
+# Delete AMI Lambda
+data "aws_iam_policy_document" "lambda_delete_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "delete_snapshot_lambda" {
+
+  name = "delete_snapshot_lambda"
+
+  assume_role_policy = data.aws_iam_policy_document.lambda_delete_assume_role_policy.json
+
+  inline_policy {
+    name = "delete_snapshot_lambda_policy"
+
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "ec2:DescribeImageAttribute",
+            "ec2:DeregisterImage",
+            "ec2:DescribeImages",
+            "ec2:DescribeSnapshotAttribute",
+            "ec2:DescribeSnapshots",
+            "ec2:DescribeTags",
+            "ec2:CreateTags",
+            "ec2:DeleteTags",
+            "ec2:DeleteSnapshot",
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+#Create ZIP archive and lambda
+data "archive_file" "delete_lambda_zip" {
+
+  type             = "zip"
+  source_file      = "lambda/delete_old_ami.py"
+  output_file_mode = "0666"
+  output_path      = "lambda/delete_old_ami.zip"
+}
+
+# tfsec:ignore:aws-lambda-enable-tracing
+resource "aws_lambda_function" "delete_old_ami" {
+  # checkov:skip=CKV_AWS_50: "X-ray tracing is not required"
+  # checkov:skip=CKV_AWS_117: "Lambda is not environment specific"
+  # checkov:skip=CKV_AWS_116: "DLQ not required"
+  filename                       = "lambda/delete_old_ami.zip"
+  function_name                  = "delete_old_ami"
+  role                           = aws_iam_role.delete_snapshot_lambda.arn
+  handler                        = "index.lambda_handler"
+  source_code_hash               = data.archive_file.delete_lambda_zip.output_base64sha256
+  runtime                        = "python3.8"
+  timeout                        = "120"
+  reserved_concurrent_executions = 1
+}
+
+resource "aws_cloudwatch_event_rule" "every_day_0230" {
+  name                = "run-daily"
+  description         = "Runs daily at 2:30am"
+  schedule_expression = "cron(30 2 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "trigger_lambda_every_day_0230" {
+  rule      = aws_cloudwatch_event_rule.every_day_0230.name
+  target_id = "delete_old_ami"
+  arn       = aws_lambda_function.delete_old_ami.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_delete_ami_lambda" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.delete_old_ami.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_day_0230.arn
+}
+
+

--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -69,7 +69,7 @@ resource "aws_lambda_function" "root_snapshot_to_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_day" {
-  name                = "run-daily"
+  name                = "run-daily_01_30"
   description         = "Runs daily at 1:30am"
   schedule_expression = "cron(30 1 * * ? *)"
 }
@@ -161,7 +161,7 @@ resource "aws_lambda_function" "delete_old_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_day_0230" {
-  name                = "run-daily"
+  name                = "run-daily_0230"
   description         = "Runs daily at 2:30am"
   schedule_expression = "cron(30 2 * * ? *)"
 }

--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -69,7 +69,7 @@ resource "aws_lambda_function" "root_snapshot_to_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_day" {
-  name                = "run-daily_01_30"
+  name                = "run-daily-0130"
   description         = "Runs daily at 1:30am"
   schedule_expression = "cron(30 1 * * ? *)"
 }
@@ -161,7 +161,7 @@ resource "aws_lambda_function" "delete_old_ami" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_day_0230" {
-  name                = "run-daily_0230"
+  name                = "run-daily-0230"
   description         = "Runs daily at 2:30am"
   schedule_expression = "cron(30 2 * * ? *)"
 }

--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -68,14 +68,14 @@ resource "aws_lambda_function" "root_snapshot_to_ami" {
   reserved_concurrent_executions = 1
 }
 
-resource "aws_cloudwatch_event_rule" "every_day" {
+resource "aws_cloudwatch_event_rule" "every_day_0130" {
   name                = "run-daily-0130"
   description         = "Runs daily at 1:30am"
   schedule_expression = "cron(30 1 * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "trigger_lambda_every_day" {
-  rule      = aws_cloudwatch_event_rule.every_day.name
+  rule      = aws_cloudwatch_event_rule.every_day_0130.name
   target_id = "root_snapshot_to_ami"
   arn       = aws_lambda_function.root_snapshot_to_ami.arn
 }
@@ -85,7 +85,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.root_snapshot_to_ami.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.every_day.arn
+  source_arn    = aws_cloudwatch_event_rule.every_day_0130.arn
 }
 
 

--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -153,7 +153,7 @@ resource "aws_lambda_function" "delete_old_ami" {
   filename                       = "lambda/delete_old_ami.zip"
   function_name                  = "delete_old_ami"
   role                           = aws_iam_role.delete_snapshot_lambda.arn
-  handler                        = "index.lambda_handler"
+  handler                        = "delete_old_ami.lambda_handler"
   source_code_hash               = data.archive_file.delete_lambda_zip.output_base64sha256
   runtime                        = "python3.8"
   timeout                        = "120"

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -5,7 +5,7 @@ from dateutil import parser
 
 
 def lambda_handler(event, context):
-    today = datetime.datetime.now()
+    today = datetime.now()
     date_time = today.date()
     deletion_time = date_time - timedelta(days=122)
     client = boto3.client("ec2")
@@ -27,8 +27,7 @@ def lambda_handler(event, context):
                     ):
                         try:
                             snap_id = bdm.get("Ebs").get("SnapshotId")
-                            client.delete_snapshot(
-                                SnapshotId=snap_id, dry_run=True)
+                            client.delete_snapshot(SnapshotId=snap_id, dry_run=True)
                         except Exception as e:
                             if "InvalidSnapshot.InUse" in e.message:
                                 print(f"Snapshot {id} in use")

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -27,6 +27,7 @@ def lambda_handler(event, context):
                     ):
                         try:
                             snap_id = bdm.get("Ebs").get("SnapshotId")
+                            print(f"Deleting Snapshot {snap_id}")
                             client.delete_snapshot(SnapshotId=snap_id, dry_run=True)
                         except Exception as e:
                             if "InvalidSnapshot.InUse" in e.message:
@@ -34,6 +35,7 @@ def lambda_handler(event, context):
                                 continue
                 try:
                     image_id = image["ImageId"]
+                    print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id, dry_run=True)
                 except Exception as e:
                     print(f"Error deleting image: {e.message}")

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -1,0 +1,41 @@
+# We want to delete old ami/snapshots created by the index.py lambda function
+import boto3
+from datetime import datetime, timedelta
+from dateutil import parser
+
+
+def lambda_handler(event, context):
+    today = datetime.datetime.now()
+    date_time = today.date()
+    deletion_time = date_time - timedelta(days=122)
+    client = boto3.client("ec2")
+    print("AMI Filtering process started %s...\n" % datetime.now())
+    image_response = client.describe_images(Owners=["self"])
+    # Get all the images
+    for image in image_response["Images"]:
+        if parser.parse(image["CreationDate"]).date() < deletion_time:
+            # Check if it's in use
+            instance_response = client.describe_instances(
+                Filters=[{"Name": "image-id", "Values": [image["ImageId"]]}]
+            )
+            if len(instance_response["Reservations"]) == 0:
+                for bdm in image["BlockDeviceMappings"]:
+                    # Ignore ephemeral bdm
+                    if (
+                        bdm.get("Ebs") is not None
+                        and bdm.get("Ebs").get("SnapshotId") is not None
+                    ):
+                        try:
+                            snap_id = bdm.get("Ebs").get("SnapshotId")
+                            client.delete_snapshot(
+                                SnapshotId=snap_id, dry_run=True)
+                        except Exception as e:
+                            if "InvalidSnapshot.InUse" in e.message:
+                                print(f"Snapshot {id} in use")
+                                continue
+                try:
+                    image_id = image["ImageId"]
+                    client.deregister_image(ImageId=image_id, dry_run=True)
+                except Exception as e:
+                    print(f"Error deleting image: {e.message}")
+                    continue

--- a/terraform/environments/xhibit-portal/lambda/index.py
+++ b/terraform/environments/xhibit-portal/lambda/index.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 
 def lambda_handler(event, context):
-    today = datetime.datetime.now()
+    today = datetime.now()
     date_time = today.date()
 
     format_time = today.strftime("%m/%d/%Y")
@@ -22,10 +22,7 @@ def lambda_handler(event, context):
     ]
     print("Connecting to EC2")
     client = boto3.client("ec2")
-    print(
-        "Root block snapshot to ami process started at %s...\n"
-        % datetime.datetime.now()
-    )
+    print("Root block snapshot to ami process started at %s...\n" % datetime.now())
     for element in root_snapshots:
         print(element)
         response = client.describe_snapshots(

--- a/terraform/environments/xhibit-portal/lambda/index.py
+++ b/terraform/environments/xhibit-portal/lambda/index.py
@@ -1,46 +1,61 @@
 import boto3
-import datetime
+from datetime import datetime
+
+
 def lambda_handler(event, context):
     today = datetime.datetime.now()
     date_time = today.date()
+
     format_time = today.strftime("%m/%d/%Y")
-    root_snapshots = ["root-block-device-portal-xhibit-portal","root-block-device-app-xhibit-portal","root-block-device-infra2-xhibit-portal","root-block-device-sms-server-xhibit-portal","root-block-device-database-xhibit-portal","root-block-device-cjim-xhibit-portal","root-block-device-infra1-xhibit-portal","root-block-device-exchange-server-xhibit-portal","root-block-device-cjip-xhibit-portal"]
+    root_snapshots = [
+        "root-block-device-portal-xhibit-portal",
+        "root-block-device-app-xhibit-portal",
+        "root-block-device-infra2-xhibit-portal",
+        "root-block-device-sms-server-xhibit-portal",
+        "root-block-device-database-xhibit-portal",
+        "root-block-device-cjim-xhibit-portal",
+        "root-block-device-infra1-xhibit-portal",
+        "root-block-device-exchange-server-xhibit-portal",
+        "root-block-device-cjip-xhibit-portal",
+        "root-block-device-baremetal-xhibit-portal",
+        "root-block-device-importmachine-xhibit-portal",
+    ]
     print("Connecting to EC2")
-    client = boto3.client('ec2')
-    print("Root block snapshot to ami process started at %s...\n" % datetime.datetime.now())
+    client = boto3.client("ec2")
+    print(
+        "Root block snapshot to ami process started at %s...\n"
+        % datetime.datetime.now()
+    )
     for element in root_snapshots:
-        print (element)
-        response=client.describe_snapshots(OwnerIds=['self'], Filters=[
-                    {
-                        'Name': 'tag:Name',
-                        'Values': [
-                            element
-                        ]
-                    }
-                ])
-        for snapshot in response['Snapshots']:
-            if snapshot['StartTime'].date() == date_time:
-                description = snapshot ['Description']
+        print(element)
+        response = client.describe_snapshots(
+            OwnerIds=["self"], Filters=[{"Name": "tag:Name", "Values": [element]}]
+        )
+        for snapshot in response["Snapshots"]:
+            if snapshot["StartTime"].date() == date_time:
+                description = snapshot["Description"]
                 if "Create" in description:
-                    snapshot_id = (snapshot['SnapshotId'])
-                    snapshot_volume_size = snapshot['VolumeSize']
+                    snapshot_id = snapshot["SnapshotId"]
+                    snapshot_volume_size = snapshot["VolumeSize"]
                     # create a AMI from snapshot
                     image = client.register_image(
                         BlockDeviceMappings=[
-                    {
-                    'DeviceName': '/dev/sda1',
-                    'Ebs': {
-                        'DeleteOnTermination': True,
-                        'SnapshotId': snapshot_id,
-                        'VolumeSize': snapshot_volume_size,
-                        'VolumeType': 'gp2'
-                    }
-                },
-            ],
-            Description='AMI created from snapshot ' + snapshot_id + ' using a custom Lambda' ,
-            Name=element + '-' + format_time,
-            RootDeviceName='/dev/sda1',
-            VirtualizationType='hvm'
-        )
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "DeleteOnTermination": True,
+                                    "SnapshotId": snapshot_id,
+                                    "VolumeSize": snapshot_volume_size,
+                                    "VolumeType": "gp2",
+                                },
+                            },
+                        ],
+                        Description="AMI created from snapshot "
+                        + snapshot_id
+                        + " using a custom Lambda",
+                        Name=element + "-" + format_time,
+                        RootDeviceName="/dev/sda1",
+                        VirtualizationType="hvm",
+                    )
                     # print the resource ID of created EBS volume
-                    print(f'AMI created: {image}')
+                    print(f"AMI created: {image}")


### PR DESCRIPTION
We create backups of just the root disk for our disaster recovery process, via a timed lambda.

The issue with this is it is not managed by AWS backup, and will just sit in the environment, costing us more and more.

By adding this script, it should delete anything over 122 days (it won't yet as I've enabled the dry_run flag) and remove those resources we no longer need. 