### PR TITLE
Add missing permission "DescribeInstances" for the delete old ami Lambda

### DIFF
--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -118,6 +118,7 @@ resource "aws_iam_role" "delete_snapshot_lambda" {
             "ec2:DescribeImageAttribute",
             "ec2:DeregisterImage",
             "ec2:DescribeImages",
+            "ec2:DescribeInstaces",
             "ec2:DescribeSnapshotAttribute",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",

--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -118,7 +118,7 @@ resource "aws_iam_role" "delete_snapshot_lambda" {
             "ec2:DescribeImageAttribute",
             "ec2:DeregisterImage",
             "ec2:DescribeImages",
-            "ec2:DescribeInstaces",
+            "ec2:DescribeInstances",
             "ec2:DescribeSnapshotAttribute",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",


### PR DESCRIPTION
I missed off the DescribeInstances permission for the Delete old AMI's Lambda. Adding in now.