### PR TITLE
Destroying CNOMT1TEST as it's been created without oracle_sid parameter

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -81,16 +81,17 @@ locals {
             monitored = true
           }
         },
-        CNOMT1TEST = {
-          always_on          = false
-          ami_name           = "nomis_db_CNOMT1-2022-03-04T14.55.18Z"
-          asm_data_capacity  = 100
-          asm_flash_capacity = 2
-          description        = "Test NOMIS T1 database with a dataset of T1PDL0009 (note: only NOMIS db, NDH db is not included."
-          tags = {
-            monitored = false
-          }
-        },
+        # CNOMT1TEST = {
+        #   always_on          = false
+        #   ami_name           = "nomis_db_CNOMT1-2022-03-04T14.55.18Z"
+        #   asm_data_capacity  = 100
+        #   asm_flash_capacity = 2
+        #   description        = "Test NOMIS T1 database with a dataset of T1PDL0009 (note: only NOMIS db, NDH db is not included."
+        #   oracle_sids        = ["CNOMT1"]
+        #   tags = {
+        #     monitored = false
+        #   }
+        # },
       },
       # Add weblogic instances here.  They will be created using the weblogic module
       weblogics = {


### PR DESCRIPTION
As per PR description - need to destroy to recreate it correctly