### PR TITLE
Feature/dsos 377 image builder use shared cmk

### DIFF
--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -170,7 +170,7 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
 
 resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
   name              = "image-builder-shared-cmk-grant"
-  key_id            = data.aws_kms_key.hmpps_key.key_id
+  key_id            = data.aws_kms_key.hmpps_key.arn
   grantee_principal = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [
     "Encrypt",

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -171,7 +171,7 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
 resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
   name              = "image-builder-shared-cmk-grant"
   key_id            = data.aws_kms_key.hmpps_key.key_id
-  grantee_principal = aws_iam_role.image-builder-distro-role.arn
+  grantee_principal = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [
     "Encrypt",
     "Decrypt",

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -175,7 +175,7 @@ resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
   operations = [
     "Encrypt",
     "Decrypt",
-    "Recrypt*",
+    "ReEncrypt*",
     "GenerateDataKey*",
     "DescribeKey",
     "CreateGrant"

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -177,7 +177,7 @@ resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
     "Decrypt",
     "ReEncryptFrom",
     "GenerateDataKey",
-    "GenereateDataKeyWithoutPlaintext",
+    "GenerateDataKeyWithoutPlaintext",
     "DescribeKey",
     "CreateGrant"
   ]

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -167,3 +167,17 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
   role       = aws_iam_role.core-services-launch-template-reader.name
 
 }
+
+resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
+  name              = "image-builder-shared-cmk-grant"
+  key_id            = data.aws_kms_key.hmpps_key.key_id
+  grantee_principal = aws_iam_role.image-builder-distro-role.arn
+  operations = [
+    "Encrypt",
+    "Decrypt",
+    "Recrypt*",
+    "GenerateDataKey*",
+    "DescribeKey",
+    "CreateGrant"
+  ]
+}

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -168,8 +168,8 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
 
 }
 
-resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
-  name              = "image-builder-shared-cmk-grant"
+resource "aws_kms_grant" "image-builder-hmpps-shared-cmk-grant" {
+  name              = "image-builder-hmpps-shared-cmk-grant"
   key_id            = data.aws_kms_key.hmpps_key.arn
   grantee_principal = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -168,8 +168,8 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
 
 }
 
-resource "aws_kms_grant" "image-builder-hmpps-shared-cmk-grant" {
-  name              = "image-builder-hmpps-shared-cmk-grant"
+resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
+  name              = "image-builder-shared-cmk-grant"
   key_id            = data.aws_kms_key.hmpps_key.arn
   grantee_principal = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -175,8 +175,9 @@ resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
   operations = [
     "Encrypt",
     "Decrypt",
-    "ReEncrypt*",
-    "GenerateDataKey*",
+    "ReEncryptFrom",
+    "GenerateDataKey",
+    "GenereateDataKeyWithoutPlaintext",
     "DescribeKey",
     "CreateGrant"
   ]

--- a/terraform/environments/nomis/modules/weblogic/main.tf
+++ b/terraform/environments/nomis/modules/weblogic/main.tf
@@ -135,7 +135,7 @@ resource "aws_launch_template" "weblogic" {
 resource "aws_autoscaling_group" "weblogic" {
   launch_template {
     id      = aws_launch_template.weblogic.id
-    version = "$Latest"
+    version = "$Default"
   }
 
   initial_lifecycle_hook {


### PR DESCRIPTION
grants the service-linked role `AWSServiceRoleForAutoScaling` to the shared cmk key (hmpps_key - alias: ebs-hmpps) in the MP shared services account

Main thrust of this/comments from [this thread in slack](https://mojdt.slack.com/archives/C966L8ZFY/p1659950245221929?thread_ts=1659620647.170869&cid=C966L8ZFY)
 
 We already have the 'CreateGrant' action for this request to succeed