### PR TITLE
nomis DSOS-1443: preprod audit db

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -141,6 +141,23 @@ locals {
             monitored = true
           }
         },
+        "preprod-database-misaudit" = {
+          always_on              = true
+          ami_name               = "nomis_db_STIG-2022-04-26*"
+          instance_type          = "r6i.2xlarge"
+          asm_data_capacity      = 4000
+          asm_flash_capacity     = 1000
+          description            = "PreProduction NOMIS MIS and Audit database to replace Azure PPPDL00017"
+          termination_protection = true
+          oracle_sids            = ["PPMIS", "PPCNMAUD"]
+          oracle_app_disk_size = {
+            "/dev/sdb" = 100  # /u01
+            "/dev/sdc" = 5120 # /u02
+          }
+          tags = {
+            monitored = false # not yet live
+          }
+        },
         NOMIS = {
           always_on              = true
           ami_name               = "nomis_database_2022-07-21T11-43-27.346Z"

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -141,7 +141,7 @@ locals {
             monitored = true
           }
         },
-        "preprod-database-misaudit" = {
+        MISAUDITPP = {
           always_on              = true
           ami_name               = "nomis_db_STIG-2022-04-26*"
           instance_type          = "r6i.2xlarge"


### PR DESCRIPTION
Spin up a new database for preprod audit.
Note this doesn't follow the proposed naming conventions yet as this isn't in the scope of the ticket.
