### PR TITLE
Remove dry run after successful run

### DIFF
--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -40,5 +40,6 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting AMI {e.response['Error']['Message']}")
                     continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -29,8 +29,7 @@ def lambda_handler(event, context):
                         snap_id = bdm.get("Ebs").get("SnapshotId")
                         try:
                             print(f"Deleting Snapshot {snap_id}")
-                            client.delete_snapshot(
-                                SnapshotId=snap_id, DryRun=True)
+                            client.delete_snapshot(SnapshotId=snap_id)
                         except botocore.exceptions.ClientError as e:
                             print(
                                 f"Error deleting Snapshot {e.response['Error']['Message']}"
@@ -39,8 +38,7 @@ def lambda_handler(event, context):
                 image_id = image["ImageId"]
                 try:
                     print(f"Deleting Image {image_id}")
-                    client.deregister_image(ImageId=image_id, DryRun=True)
+                    client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue


### PR DESCRIPTION
After a successful run - remove the dry run variable to actually remove the old snapshots/ami's