### PR TITLE
Adding NDHT2 test database

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -68,6 +68,18 @@ locals {
             monitored = true
           }
         },
+        NDHT2 = {
+          always_on              = false
+          ami_name               = "nomis_db-2022-03-03*"
+          asm_data_capacity      = 200
+          asm_flash_capacity     = 2
+          description            = "Test NDH & TRDATA databases with a dataset of T1PDL0009 (note:NOMIS db not included), replicating with T2PDL0012."
+          termination_protection = true
+          oracle_sids            = ["T2NDH", "T2TRDAT"]
+          tags = {
+            monitored = false
+          }
+        },
         CNOMT1TEST = {
           always_on          = false
           ami_name           = "nomis_db_STIG_CNOMT1-2022-04-21T11.33.39Z"


### PR DESCRIPTION
As per [https://dsdmoj.atlassian.net/jira/software/c/projects/DSOS/boards/889?modal=detail&selectedIssue=DSOS-1429](url) I'm adding test instance with NDH & TRDATA databases. It's needed to enable replication with T2PDL0012.AZURE.NOMS.ROOT in preparation for migration of NDH and TRDAT databases into Mod Platform.