### PR TITLE
Portal/change order of deleting ami and snapshot

### DIFF
--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -25,7 +25,8 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     snapshot_response = client.describe_snapshots(OwnerIds=["self"])
@@ -37,5 +38,6 @@ def lambda_handler(event, context):
                 print(f"Deleting Snapshot {snap_id}")
                 client.delete_snapshot(SnapshotId=snap_id)
             except botocore.exceptions.ClientError as e:
-                print(f"Error deleting Snapshot {e.response['Error']['Message']}")
+                print(
+                    f"Error deleting Snapshot {e.response['Error']['Message']}")
                 continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     snapshot_response = client.describe_snapshots(OwnerIds=["self"])
-    for snapshot in snapshot_response["snapshots"]:
+    for snapshot in snapshot_response["Snapshots"]:
         if parser.parse(snapshot.get("StartTime")).date() < deletion_time:
             snap_id = snapshot.get("SnapshotId")
             try:

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -25,7 +25,8 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     snapshot_response = client.describe_snapshots(OwnerIds=["self"])
@@ -36,5 +37,6 @@ def lambda_handler(event, context):
                 print(f"Deleting Snapshot {snap_id}")
                 client.delete_snapshot(SnapshotId=snap_id)
             except botocore.exceptions.ClientError as e:
-                print(f"Error deleting Snapshot {e.response['Error']['Message']}")
+                print(
+                    f"Error deleting Snapshot {e.response['Error']['Message']}")
                 continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -25,18 +25,16 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     snapshot_response = client.describe_snapshots(OwnerIds=["self"])
     for snapshot in snapshot_response["Snapshots"]:
-        if parser.parse(snapshot.get("StartTime")).date() < deletion_time:
+        if snapshot.get("StartTime") < deletion_time:
             snap_id = snapshot.get("SnapshotId")
             try:
                 print(f"Deleting Snapshot {snap_id}")
                 client.delete_snapshot(SnapshotId=snap_id)
             except botocore.exceptions.ClientError as e:
-                print(
-                    f"Error deleting Snapshot {e.response['Error']['Message']}")
+                print(f"Error deleting Snapshot {e.response['Error']['Message']}")
                 continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -20,6 +20,14 @@ def lambda_handler(event, context):
                 Filters=[{"Name": "image-id", "Values": [image["ImageId"]]}]
             )
             if len(instance_response["Reservations"]) == 0:
+                image_id = image["ImageId"]
+                try:
+                    print(f"Deleting Image {image_id}")
+                    client.deregister_image(ImageId=image_id)
+                except botocore.exceptions.ClientError as e:
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    continue
+
                 for bdm in image["BlockDeviceMappings"]:
                     # Ignore ephemeral bdm
                     if (
@@ -35,11 +43,3 @@ def lambda_handler(event, context):
                                 f"Error deleting Snapshot {e.response['Error']['Message']}"
                             )
                             continue
-                image_id = image["ImageId"]
-                try:
-                    print(f"Deleting Image {image_id}")
-                    client.deregister_image(ImageId=image_id)
-                except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
-                    continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -25,19 +25,16 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     snapshot_response = client.describe_snapshots(OwnerIds=["self"])
     for snapshot in snapshot_response["snapshots"]:
-        # Ignore ephemeral bdm
-        if snapshot.get("StartTime") < deletion_time:
+        if parser.parse(snapshot.get("StartTime")).date() < deletion_time:
             snap_id = snapshot.get("SnapshotId")
             try:
                 print(f"Deleting Snapshot {snap_id}")
                 client.delete_snapshot(SnapshotId=snap_id)
             except botocore.exceptions.ClientError as e:
-                print(
-                    f"Error deleting Snapshot {e.response['Error']['Message']}")
+                print(f"Error deleting Snapshot {e.response['Error']['Message']}")
                 continue


### PR DESCRIPTION
We must delete the AMI before deleting the snapshot - as this may take some time to propagate, I've split the logic of deleting the AMI and Snapshots into two seperate loops