### PR TITLE
Add Pagination for the Snapshot deletion process

### DIFF
--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "delete_old_ami" {
   handler                        = "delete_old_ami.lambda_handler"
   source_code_hash               = data.archive_file.delete_lambda_zip.output_base64sha256
   runtime                        = "python3.8"
-  timeout                        = "120"
+  timeout                        = "240"
   reserved_concurrent_executions = 1
 }
 

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -13,6 +13,7 @@ def lambda_handler(event, context):
     print("AMI Filtering process started %s...\n" % datetime.now())
     image_response = client.describe_images(Owners=["self"])
     # Get all the images
+    print("Checking AMI's")
     for image in image_response["Images"]:
         if parser.parse(image["CreationDate"]).date() < deletion_date:
             # Check if it's in use
@@ -25,18 +26,18 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
-    snapshot_response = client.describe_snapshots(OwnerIds=["self"])
-    for snapshot in snapshot_response["Snapshots"]:
-        if snapshot.get("StartTime").date() < deletion_date:
-            snap_id = snapshot.get("SnapshotId")
-            try:
-                print(f"Deleting Snapshot {snap_id}")
-                client.delete_snapshot(SnapshotId=snap_id)
-            except botocore.exceptions.ClientError as e:
-                print(
-                    f"Error deleting Snapshot {e.response['Error']['Message']}")
-                continue
+    print("Checking Snapshots")
+    snapshot_paginator = client.get_paginator("describe_snapshots").paginate()
+    for page in snapshot_paginator:
+        for snapshot in page["Snapshots"]:
+            if snapshot.get("StartTime").date() < deletion_date:
+                snap_id = snapshot.get("SnapshotId")
+                try:
+                    print(f"Deleting Snapshot {snap_id}")
+                    client.delete_snapshot(SnapshotId=snap_id)
+                except botocore.exceptions.ClientError as e:
+                    print(f"Error deleting Snapshot {e.response['Error']['Message']}")
+                    continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -26,7 +26,8 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     print("Checking Snapshots")
@@ -39,5 +40,6 @@ def lambda_handler(event, context):
                     print(f"Deleting Snapshot {snap_id}")
                     client.delete_snapshot(SnapshotId=snap_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting Snapshot {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting Snapshot {e.response['Error']['Message']}")
                     continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -26,12 +26,13 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     print("Checking Snapshots")
-    snapshot_paginator = client.get_paginator("describe_snapshots").paginate()
+    snapshot_paginator = client.get_paginator("describe_snapshots").paginate(
+        OwnerId="self"
+    )
     for page in snapshot_paginator:
         for snapshot in page["Snapshots"]:
             if snapshot.get("StartTime").date() < deletion_date:
@@ -40,6 +41,5 @@ def lambda_handler(event, context):
                     print(f"Deleting Snapshot {snap_id}")
                     client.delete_snapshot(SnapshotId=snap_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting Snapshot {e.response['Error']['Message']}")
+                    print(f"Error deleting Snapshot {e.response['Error']['Message']}")
                     continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -26,7 +26,8 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     print("Checking Snapshots")
@@ -41,5 +42,6 @@ def lambda_handler(event, context):
                     print(f"Deleting Snapshot {snap_id}")
                     client.delete_snapshot(SnapshotId=snap_id)
                 except botocore.exceptions.ClientError as e:
-                    print(f"Error deleting Snapshot {e.response['Error']['Message']}")
+                    print(
+                        f"Error deleting Snapshot {e.response['Error']['Message']}")
                     continue

--- a/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
+++ b/terraform/environments/xhibit-portal/lambda/delete_old_ami.py
@@ -26,13 +26,12 @@ def lambda_handler(event, context):
                     print(f"Deleting Image {image_id}")
                     client.deregister_image(ImageId=image_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting AMI {e.response['Error']['Message']}")
+                    print(f"Error deleting AMI {e.response['Error']['Message']}")
                     continue
     # Seperate the AMi deletion and Snapshot deletion as it may take a few mins for the AMI to be deleted, and allow the snapshot to be deleted
     print("Checking Snapshots")
     snapshot_paginator = client.get_paginator("describe_snapshots").paginate(
-        OwnerId="self"
+        OwnerIds=["self"]
     )
     for page in snapshot_paginator:
         for snapshot in page["Snapshots"]:
@@ -42,6 +41,5 @@ def lambda_handler(event, context):
                     print(f"Deleting Snapshot {snap_id}")
                     client.delete_snapshot(SnapshotId=snap_id)
                 except botocore.exceptions.ClientError as e:
-                    print(
-                        f"Error deleting Snapshot {e.response['Error']['Message']}")
+                    print(f"Error deleting Snapshot {e.response['Error']['Message']}")
                     continue


### PR DESCRIPTION
The lambda was timing out when attempting to iterate over the snapshots - this way we'll at least process some of the snapshots before reaching our timeout value.

Also increased the timeout value due to the amount of data being returned