### PR TITLE
Increase the amount of memory associated with the Lambda

### DIFF
--- a/terraform/environments/xhibit-portal/lambda.tf
+++ b/terraform/environments/xhibit-portal/lambda.tf
@@ -151,12 +151,14 @@ resource "aws_lambda_function" "delete_old_ami" {
   # checkov:skip=CKV_AWS_50: "X-ray tracing is not required"
   # checkov:skip=CKV_AWS_117: "Lambda is not environment specific"
   # checkov:skip=CKV_AWS_116: "DLQ not required"
-  filename                       = "lambda/delete_old_ami.zip"
-  function_name                  = "delete_old_ami"
-  role                           = aws_iam_role.delete_snapshot_lambda.arn
-  handler                        = "delete_old_ami.lambda_handler"
-  source_code_hash               = data.archive_file.delete_lambda_zip.output_base64sha256
-  runtime                        = "python3.8"
+  filename         = "lambda/delete_old_ami.zip"
+  function_name    = "delete_old_ami"
+  role             = aws_iam_role.delete_snapshot_lambda.arn
+  handler          = "delete_old_ami.lambda_handler"
+  source_code_hash = data.archive_file.delete_lambda_zip.output_base64sha256
+  runtime          = "python3.8"
+  # "large" amount of memory because of the amount of snapshots
+  memory_size                    = "1280"
   timeout                        = "240"
   reserved_concurrent_executions = 1
 }


### PR DESCRIPTION
There's been issues running the lambda, possibly due to the large amount of snapshots we have (We need to iterate over them to clear up any orphaned snaps)