### PR TITLE
Recreating RHEL7TEST base_instance with a fresh AMI

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -80,7 +80,7 @@ locals {
       base_instances = {
         RHEL7TEST = {
           always_on   = false
-          ami_name    = "nomis_RHEL7-9_BaseImage*"
+          ami_name    = "nomis_rhel_7_9_baseimage*"
           description = "Test instance for the new nomis_RHEL7-9_BaseImage AMI"
           tags = {
             monitored = false


### PR DESCRIPTION
I'm rebuilding RHEL7TEST base_instance with a new ami with updated set of packages - I'll be using it for testing node_exporter ansible role.