### PR TITLE
nomis: DSOS-1439: setup ansible framework

### DIFF
--- a/terraform/environments/nomis/ansible/README.md
+++ b/terraform/environments/nomis/ansible/README.md
@@ -16,8 +16,8 @@ for an example user data script for provisioning ansible.
 
 ## Running ansible against an EC2 instance post build
 
-A generic [site.yml](/ansible/site.yml) is provided with a dynamic inventory
-[inventory_aws_ec2.yml](/ansible/inventory_aws_ec2.yml). This creates groups
+A generic [site.yml](/terraform/environments/nomis/ansible/site.yml) is provided with a dynamic inventory
+[inventory_aws_ec2.yml](/terraform/environments/nomis/ansible/inventory_aws_ec2.yml). This creates groups
 based of the following tags
 
 - business-unit
@@ -28,7 +28,7 @@ based of the following tags
 
 Ansible tasks are executed on ec2 instances via AWS Session Manager, so you must have [awscli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html#cliv2-mac-install-cmd) installed in addition to the Session Manager [plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#install-plugin-macos-signed). The target ec2 instance must also have [ssm-agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) installed. You do not need to have an account on the remote ec2 instance in order to connect.
 
-The `ansible_connection` variable is set to use the `community.aws.aws_ssm` plugin in [group_vars/aws_ec2.yml](/ansible/group_vars/aws_ec2.yml). The `aws_ec2` group is the default group for all instances that are obtained from dynamic inventory.
+The `ansible_connection` variable is set to use the `community.aws.aws_ssm` plugin in [group_vars/aws_ec2.yml](/terraform/environments/nomis/ansible/group_vars/aws_ec2.yml). The `aws_ec2` group is the default group for all instances that are obtained from dynamic inventory.
 
 Ensure you have set your AWS credentials as environment variables or setup your `~/.aws/credentials` accordingly before attempting to run ansible. Note that at the time of writing, it does not seem possible to run Ansible with credentials obtained from `aws sso login`. Temporary credentials can be obtained from https://moj.awsapps.com/start#/
 

--- a/terraform/environments/nomis/ansible/README.md
+++ b/terraform/environments/nomis/ansible/README.md
@@ -1,0 +1,63 @@
+## Introduction
+
+EC2 instances can use ansible as part of the provisioning process and/or
+in-life operational management.
+
+## Using ansible to provision an EC2 instance
+
+See [modules/test_instance_asg/user_data/ansible.sh.tftpl](/terraform/environments/nomis/modules/test_instance_asg/user_data/ansible.sh.tftpl)
+for an example user data script for provisioning ansible.
+
+- makes use of an ansible virtual environment installed in the base image
+- clones this repo
+- installs dependencies
+- runs ansible against localhost
+- tidies up
+
+## Running ansible against an EC2 instance post build
+
+A generic [site.yml](/ansible/site.yml) is provided with a dynamic inventory
+[inventory_aws_ec2.yml](/ansible/inventory_aws_ec2.yml). This creates groups
+based of the following tags
+
+- business-unit
+- environment-name
+- application
+- component
+- server-type
+
+Ansible tasks are executed on ec2 instances via AWS Session Manager, so you must have [awscli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html#cliv2-mac-install-cmd) installed in addition to the Session Manager [plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#install-plugin-macos-signed). The target ec2 instance must also have [ssm-agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) installed. You do not need to have an account on the remote ec2 instance in order to connect.
+
+The `ansible_connection` variable is set to use the `community.aws.aws_ssm` plugin in [group_vars/aws_ec2.yml](/ansible/group_vars/aws_ec2.yml). The `aws_ec2` group is the default group for all instances that are obtained from dynamic inventory.
+
+Ensure you have set your AWS credentials as environment variables or setup your `~/.aws/credentials` accordingly before attempting to run ansible. Note that at the time of writing, it does not seem possible to run Ansible with credentials obtained from `aws sso login`. Temporary credentials can be obtained from https://moj.awsapps.com/start#/
+
+You may encounter an error similar to `ERROR! A worker was found in a dead state`. Apparently this is a Python issue and the workaround is to set an env:
+
+```
+export no_proxy='*'
+```
+
+The Session Manager plugin requires that an S3 bucket is specified as one of the connection variables. Set this within an environment specific variable, for example [group_vars/environment_name_nomis_test.yml](/terraform/environments/nomis/ansible/group_vars/environment_name_nomis_test.yml)
+
+Define the list of roles to run on each type of server under a server-type specific variable. For example [group_vars/server_type_base.yml](/terraform/environments/nomis/ansible/group_vars/server_type_base.yml)
+
+```
+---
+ansible_python_interpreter: /usr/local/bin/python3.9
+roles_list:
+  - get-ec2-facts
+```
+
+Run ansible
+
+```
+# Run against all hosts in check mode
+ansible-playbook site.yml -i inventory_aws_ec2.yml --check
+
+# Limit to a particular server
+ansible-playbook site.yml -i inventory_aws_ec2.yml --check --limit bastion
+
+# Limit to a particular role
+ansible-playbook site.yml -i inventory_aws_ec2.yml --check --limit bastion -e "role=node-exporter"
+```

--- a/terraform/environments/nomis/ansible/group_vars/aws_ec2.yml
+++ b/terraform/environments/nomis/ansible/group_vars/aws_ec2.yml
@@ -1,7 +1,4 @@
-# ansible_ssh_common_args: -J {{ hostvars['bastion_linux'].instance_id }} # commented out as connecting direct to each VM via instance-id
-# ansible_ssh_common_args: -o StrictHostKeyChecking=no -o ProxyCommand="sh -c \"aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'\""
 ansible_connection: community.aws.aws_ssm
 ssm_timeout: 2000
 ansible_aws_ssm_region: eu-west-2
-ansible_aws_ssm_bucket_name: s3-bucket20210929163229537900000001 # for some reason you need to specify a bucket
 instance_id: "{{ hostvars[inventory_hostname].instance_id }}" # for scenarios where {{ ansible_host }} is set to the ip address rather than instance_id

--- a/terraform/environments/nomis/ansible/group_vars/environment_name_nomis_test.yml
+++ b/terraform/environments/nomis/ansible/group_vars/environment_name_nomis_test.yml
@@ -1,0 +1,2 @@
+---
+ansible_aws_ssm_bucket_name: s3-bucket20210929163229537900000001 # for some reason you need to specify a bucket

--- a/terraform/environments/nomis/ansible/group_vars/server_type_base.yml
+++ b/terraform/environments/nomis/ansible/group_vars/server_type_base.yml
@@ -1,0 +1,4 @@
+---
+ansible_python_interpreter: /usr/local/bin/python3.9
+roles_list:
+  - get-ec2-facts

--- a/terraform/environments/nomis/ansible/inventory_aws_ec2.yml
+++ b/terraform/environments/nomis/ansible/inventory_aws_ec2.yml
@@ -1,0 +1,28 @@
+plugin: amazon.aws.aws_ec2
+regions:
+  - eu-west-2
+
+hostnames:
+  - tag:Name
+
+compose:
+  ansible_host: instance_id # private_ip_address - use ip address if need to go through bastion
+  ansible_become: true
+
+groups:
+  bastion: tags.Name is search('bastion')
+  windows: (platform is defined) and (platform in 'windows')
+
+keyed_groups:
+  - key: tags['business-unit']
+    prefix: business-unit
+  - key: tags['environment-name']
+    prefix: environment-name
+  - key: tags['application']
+    prefix: application
+  - key: tags['component']
+    prefix: component
+  - key: tags['server-type']
+    prefix: server-type
+
+strict: no

--- a/terraform/environments/nomis/ansible/roles/get-ec2-facts/README.md
+++ b/terraform/environments/nomis/ansible/roles/get-ec2-facts/README.md
@@ -1,0 +1,14 @@
+Use this module to retrieve information about the EC2 host.
+You can then use the EC2 metadata and tag facts within other
+roles.
+
+See [ec2_metadata_facts_module.html](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_metadata_facts_module.html)
+for available metadata variables.
+
+Tags are registered to `ec2` host variable. Example usage
+to debug the "application" tag value.
+
+```
+- debug:
+    var: ec2.tags.application
+```

--- a/terraform/environments/nomis/ansible/roles/get-ec2-facts/tasks/main.yml
+++ b/terraform/environments/nomis/ansible/roles/get-ec2-facts/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Get EC2 Metadata Facts
+  amazon.aws.ec2_metadata_facts:
+
+- name: Retrieve EC2 Tags
+  amazon.aws.ec2_tag_info:
+    region: "{{ ansible_ec2_placement_region }}"
+    resource: "{{ ansible_ec2_instance_id }}"
+  register: ec2

--- a/terraform/environments/nomis/ansible/site.yml
+++ b/terraform/environments/nomis/ansible/site.yml
@@ -1,0 +1,57 @@
+---
+# Generic site.yml that deploys the appropriate set of roles for each
+# host.
+#
+# Define a "roles_list" variable for each host containing the roles
+# to run against that host.  Since the same roles typically
+# run on the same component, and we are using dynamic inventory with
+# tagging, define the "roles_list" variable in group_vars.
+#
+# For example, for a NOMIS database, define a roles_list variable in
+#
+# group_vars/server_type_db_nomis.yml
+# ---
+# roles_list:
+#  - time
+#  - hugepages
+#  - oracle
+#
+# Example usage:
+#
+#   # Run all relevant roles against all hosts in check mode
+#   ansible-playbook site.yml --check
+#
+#   # Run a subset of roles
+#   ansible-playbook site.yml -e role=time,hugepages
+#
+#   # Limit the hosts (2 ways of doing this)
+#   ansible-playbook site.yml --limit db-nomis
+#   ansible-playbook site.yml -e target=localhost
+
+- hosts: "{{ target | default('all') }}"
+  tasks:
+    - name: Set roles_defined fact
+      set_fact:
+        # These are roles_list defined in inventory. Default is empty list.
+        roles_defined: "{{ roles_list | default([]) }}"
+
+    # The actual roles to run is intersection of requested role arg and roles_defined.
+    # Special value "all" in role parameter means to run all defined roles.
+    - name: Set roles_to_run fact
+      set_fact:
+        roles_to_run: |
+          {% if role is not defined or role == "all" %}
+          {# all defined roles #}
+          {{ roles_defined }}
+          {% elif role is defined and not role == "" %}
+          {{ role.split(",") | map("trim") | intersect(roles_defined) }}
+          {% else %}
+          []
+          {% endif %}
+
+    - name: Execute roles
+      include_role:
+        name: "{{ role_to_run }}"
+      with_items: "{{ roles_to_run }}"
+      loop_control:
+        loop_var: role_to_run

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -119,6 +119,16 @@ locals {
             monitored = false
           }
         }
+        RHEL79BASE = {
+          always_on     = false
+          ami_name      = "nomis_rhel_7_9_baseimage*"
+          description   = "Test instance for RHEL7.9 base image"
+          instance_type = "t2.medium"
+          tags = {
+            monitored   = false
+            server-type = "base"
+          }
+        }
       }
     },
     production = {

--- a/terraform/environments/nomis/ec2-test_instance.tf
+++ b/terraform/environments/nomis/ec2-test_instance.tf
@@ -24,13 +24,14 @@ module "test_instance_asg" {
   instance_profile_policies = local.ec2_common_managed_policies
   key_name                  = aws_key_pair.ec2-user.key_name
 
-  application_name = local.application_name
-  business_unit    = local.vpc_name
-  environment      = local.environment
-  subnet_set       = local.subnet_set
-  tags             = merge(local.tags, try(each.value.tags, {}))
-  branch           = var.BRANCH_NAME
-  ansible_repo     = try(each.value.ansible_repo, null)
+  application_name     = local.application_name
+  business_unit        = local.vpc_name
+  environment          = local.environment
+  subnet_set           = local.subnet_set
+  tags                 = merge(local.tags, try(each.value.tags, {}))
+  branch               = var.BRANCH_NAME
+  ansible_repo         = lookup(each.value, "ansible_repo", "modernisation-platform-environments")
+  ansible_repo_basedir = lookup(each.value, "ansible_repo_basedir", "terraform/environments/nomis/ansible")
 }
 #------------------------------------------------------------------------------
 # Security Group for Test Instances

--- a/terraform/environments/nomis/modules/test_instance_asg/main.tf
+++ b/terraform/environments/nomis/modules/test_instance_asg/main.tf
@@ -35,8 +35,9 @@ data "aws_subnets" "this" {
 
 locals {
   ansible_script_args = {
-    branch       = var.branch == "" ? "main" : var.branch
-    ansible_repo = var.ansible_repo == null ? "" : var.ansible_repo
+    branch               = var.branch == "" ? "main" : var.branch
+    ansible_repo         = var.ansible_repo == null ? "" : var.ansible_repo
+    ansible_repo_basedir = var.ansible_repo_basedir == null ? "" : var.ansible_repo_basedir
   }
   ansible_script = templatefile("${path.module}/user_data/ansible.sh.tftpl", local.ansible_script_args)
 }

--- a/terraform/environments/nomis/modules/test_instance_asg/user_data/ansible.sh.tftpl
+++ b/terraform/environments/nomis/modules/test_instance_asg/user_data/ansible.sh.tftpl
@@ -34,7 +34,7 @@ cd /var/lib/venv
 source $venv/bin/activate
 
 echo "# Installing ansible requirements"
-cd $ansible_dir/${ansible_repo}/ansible
+cd $ansible_dir/${ansible_repo}/${ansible_repo_basedir}
 python3.9 -m pip install -r requirements.txt
 ansible-galaxy role install -r requirements.yml
 ansible-galaxy collection install -r requirements.yml

--- a/terraform/environments/nomis/modules/test_instance_asg/variables.tf
+++ b/terraform/environments/nomis/modules/test_instance_asg/variables.tf
@@ -130,6 +130,12 @@ variable "ansible_repo" {
   default     = null
 }
 
+variable "ansible_repo_basedir" {
+  type        = string
+  description = "Base directory within ansible_repo where ansible code is located"
+  default     = null
+}
+
 variable "branch" {
   type        = string
   description = "Git hub branch code is being run from.  For cloning ansible repo"


### PR DESCRIPTION
Since we don't have a separate ansible repo (yet), and Julia has added ansible into environments repo for now, this PR builds on that work:
- add README, generic site.yml from the strategy ticket (copied across from AMI repo)
- update test-instance-asg module to use environments repo as default repo and allow any path
- add a new ASG for testing base 7.9 image (will be used to validate naming stuff for test audit DB)