### PR TITLE
add ssm:GetParameters to pull secrets from Parameter Store

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -23,10 +23,11 @@ data "aws_iam_policy_document" "ssm_custom" {
     effect = "Allow"
     actions = [
       "ssm:DescribeAssociation",
+      "ssm:DescribeDocument",
       "ssm:GetDeployablePatchSnapshotForInstance",
       "ssm:GetDocument",
-      "ssm:DescribeDocument",
       "ssm:GetManifest",
+      "ssm:GetParameters",
       "ssm:ListAssociations",
       "ssm:ListInstanceAssociations",
       "ssm:PutInventory",


### PR DESCRIPTION
ssm documents that need to pull values from Parameter Store require the ssm:GetParameters role

In this case it's so that the AWS-ApplyAnsiblePlaybooks doc can pull a Github PAT out of the Parameter Store via the tokenInfo parameter but supplying any parameter to a playbook is going to need this permission

also put the roles back into alphabetical order 