### PR TITLE
Nomis: DSOS-1439: update bastion search zones

### DIFF
--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -45,12 +45,12 @@ module "bastion_linux" {
   environment   = local.environment
   region        = local.region
 
-  extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
-    region           = local.region
-    vpc_name         = local.vpc_name
-    application_name = local.application_name
-    environment      = local.environment
-  })
+  #  extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
+  #    region           = local.region
+  #    vpc_name         = local.vpc_name
+  #    application_name = local.application_name
+  #    environment      = local.environment
+  #  })
 
   # Tags
   tags_common = merge(

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -43,7 +43,13 @@ module "bastion_linux" {
   business_unit = local.vpc_name
   subnet_set    = local.subnet_set
   environment   = local.environment
-  region        = "eu-west-2"
+  region        = local.region
+
+  extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
+    region           = local.region
+    application_name = local.application_name
+    environment      = local.environment
+  })
 
   # Tags
   tags_common = merge(

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -45,12 +45,12 @@ module "bastion_linux" {
   environment   = local.environment
   region        = local.region
 
-  #  extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
-  #    region           = local.region
-  #    vpc_name         = local.vpc_name
-  #    application_name = local.application_name
-  #    environment      = local.environment
-  #  })
+  extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
+    region           = local.region
+    vpc_name         = local.vpc_name
+    application_name = local.application_name
+    environment      = local.environment
+  })
 
   # Tags
   tags_common = merge(

--- a/terraform/environments/nomis/bastion_linux.tf
+++ b/terraform/environments/nomis/bastion_linux.tf
@@ -47,6 +47,7 @@ module "bastion_linux" {
 
   extra_user_data_content = templatefile("templates/bastion-user-data.sh.tftpl", {
     region           = local.region
+    vpc_name         = local.vpc_name
     application_name = local.application_name
     environment      = local.environment
   })

--- a/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
+++ b/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
@@ -1,5 +1,5 @@
 cat > /etc/dhcp/dhclient-eth0.conf << 'EOF'
 append domain-search "${region}.compute.internal"; 
-append domain-search "${application_name}.${environment}.modernisation-platform.internal";
+append domain-search "${vpc_name}-${application_name}.${environment}.modernisation-platform.internal";
 EOF
 systemctl restart network

--- a/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
+++ b/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
@@ -1,5 +1,5 @@
 cat > /etc/dhcp/dhclient-eth0.conf << 'EOF'
 append domain-search "${region}.compute.internal"; 
-append domain-search "${vpc_name}-${application_name}.${environment}.modernisation-platform.internal";
+append domain-search "${application_name}.${vpc_name}-${environment}.modernisation-platform.internal";
 EOF
 systemctl restart network

--- a/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
+++ b/terraform/environments/nomis/templates/bastion-user-data.sh.tftpl
@@ -1,0 +1,5 @@
+cat > /etc/dhcp/dhclient-eth0.conf << 'EOF'
+append domain-search "${region}.compute.internal"; 
+append domain-search "${application_name}.${environment}.modernisation-platform.internal";
+EOF
+systemctl restart network


### PR DESCRIPTION
Add the mod platform internal zone as an additional dns zone to search.  This way, EC2 short names, e.g. t1-db-audit can be accessed directly without the FQDN, t1-db-audit.nomis.hmpps-test.modernisation-platform.internal