### PR TITLE
Nomis: DSOS-1507: T1 and preprod audit db

### DIFF
--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -108,9 +108,10 @@ locals {
       },
 
       databases = {
-        t1-db-audit = {
+        t1-nomis-db-2 = {
           tags = {
-            description = "Test NOMIS Audit database replicating with T1PDL0010"
+            server-type = "nomis-db"
+            description = "T1 NOMIS Audit database to replace Azure T1PDL0010"
             oracle-sids = "T1CNMAUD"
             monitored   = false
             always-on   = true

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -304,7 +304,35 @@ locals {
           }
         }
       },
-      databases = {},
+      databases = {
+        preprod-nomis-db-2 = {
+          tags = {
+            server-type = "nomis-db"
+            description = "PreProduction NOMIS MIS and Audit database to replace Azure PPPDL00017"
+            oracle-sids = "PPMIS, PPCNMAUD"
+            monitored   = false
+            always-on   = true
+          }
+          ami_name = "nomis_rhel_7_9_oracledb_11_2*"
+          instance = {
+            instance_type           = "r6i.2xlarge"
+            disable_api_termination = true
+          }
+          ebs_volumes = {
+            "/dev/sdb" = { size = 100 }  # /u01
+            "/dev/sdc" = { size = 5120 } # /u02
+          }
+          ebs_volume_config = {
+            data = {
+              total_size = 4000
+            }
+            flash = {
+              total_size = 1000
+            }
+          }
+        }
+      }
+
       # Add weblogic instances here.  They will be created using the weblogic module
       weblogics = {},
       # Add base instances here. They will be created using the base_instance module

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -305,6 +305,7 @@ locals {
         }
       },
       databases = {
+        # NOTE: this is temporarily under prod account while we wait for network connectivity
         preprod-nomis-db-2 = {
           tags = {
             server-type = "nomis-db"

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -116,7 +116,7 @@ locals {
             monitored   = false
             always-on   = true
           }
-          ami_name = "nomis_rhel_7_9_oracledb_11_2*"
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
           instance = {
             disable_api_termination = true
           }
@@ -297,7 +297,7 @@ locals {
             monitored   = false
             always-on   = true
           }
-          ami_name = "nomis_rhel_7_9_oracledb_11_2*"
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
           instance = {
             instance_type           = "r6i.2xlarge"
             disable_api_termination = true

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -288,6 +288,7 @@ locals {
         }
       },
       databases = {
+
         # NOTE: this is temporarily under prod account while we wait for network connectivity
         preprod-nomis-db-2 = {
           tags = {

--- a/terraform/environments/nomis/application_variables.tf
+++ b/terraform/environments/nomis/application_variables.tf
@@ -250,23 +250,6 @@ locals {
             monitored = true
           }
         },
-        MISAUDITPP = {
-          always_on              = true
-          ami_name               = "nomis_db_STIG-2022-04-26*"
-          instance_type          = "r6i.2xlarge"
-          asm_data_capacity      = 4000
-          asm_flash_capacity     = 1000
-          description            = "PreProduction NOMIS MIS and Audit database to replace Azure PPPDL00017"
-          termination_protection = true
-          oracle_sids            = ["PPMIS", "PPCNMAUD"]
-          oracle_app_disk_size = {
-            "/dev/sdb" = 100  # /u01
-            "/dev/sdc" = 5120 # /u02
-          }
-          tags = {
-            monitored = false # not yet live
-          }
-        },
         NOMIS = {
           always_on              = true
           ami_name               = "nomis_database_2022-07-21T11-43-27.346Z"

--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -147,7 +147,7 @@ module "db_ec2_instance" {
   instance              = merge(local.database.instance, lookup(each.value, "instance", {}))
   user_data             = merge(local.database.user_data, lookup(each.value, "user_data", {}))
   ebs_volume_config     = merge(local.database.ebs_volume_config, lookup(each.value, "ebs_volume_config", {}))
-  ebs_volumes           = merge(local.database.ebs_volumes, lookup(each.value, "ebs_volumes", {}))
+  ebs_volumes           = { for k, v in local.database.ebs_volumes : k => merge(v, try(each.value.ebs_volumes[k], {})) }
   ssm_parameters_prefix = "database/"
   ssm_parameters        = merge(local.database.ssm_parameters, lookup(each.value, "ssm_parameters", {}))
   route53_records       = merge(local.database.route53_records, lookup(each.value, "route53_records", {}))

--- a/terraform/environments/nomis/modules/ec2_instance/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/variables.tf
@@ -123,15 +123,15 @@ variable "ebs_volume_config" {
 
 variable "ebs_volumes" {
   description = "EC2 volumes, see aws_ebs_volume for documentation.  key=volume name, value=ebs_volume_config key.  label is used as part of the Name tag"
-# Commenting below out as it has unexpected results when used with merge()
-#  type = map(object({
-#    label       = string
-#    snapshot_id = optional(string)
-#    iops        = optional(number)
-#    throughput  = optional(number)
-#    size        = optional(number)
-#    type        = optional(string)
-#  }))
+  # Commenting below out as it has unexpected results when used with merge()
+  #  type = map(object({
+  #    label       = string
+  #    snapshot_id = optional(string)
+  #    iops        = optional(number)
+  #    throughput  = optional(number)
+  #    size        = optional(number)
+  #    type        = optional(string)
+  #  }))
 }
 
 variable "route53_records" {

--- a/terraform/environments/nomis/modules/ec2_instance/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/variables.tf
@@ -122,10 +122,16 @@ variable "ebs_volume_config" {
 }
 
 variable "ebs_volumes" {
-  description = "EC2 volumes, see aws_ebs_volume for documentation.  key=volume name, value=ebs_volume_config key"
-  type = map(object({
-    label = optional(string)
-  }))
+  description = "EC2 volumes, see aws_ebs_volume for documentation.  key=volume name, value=ebs_volume_config key.  label is used as part of the Name tag"
+# Commenting below out as it has unexpected results when used with merge()
+#  type = map(object({
+#    label       = string
+#    snapshot_id = optional(string)
+#    iops        = optional(number)
+#    throughput  = optional(number)
+#    size        = optional(number)
+#    type        = optional(string)
+#  }))
 }
 
 variable "route53_records" {


### PR DESCRIPTION
Rebuild of T1 and preprod Audit database.
- Use latest image
- Zap the old T1/preprod databases
- Standup t1 and preprod instances.