### PR TITLE
target group health check and stickiness settings added

### DIFF
--- a/terraform/environments/mlra/main.tf
+++ b/terraform/environments/mlra/main.tf
@@ -49,16 +49,30 @@ resource "aws_lb_listener" "alb_listener" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.alb_target_group.arn
+  #TODO cloudfront rule may still need to be applied. pending cutover strategy decisions
   }
 }
 
 resource "aws_lb_target_group" "alb_target_group" {
-  name     = "${local.application_name}-target-group"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = data.aws_vpc.shared.id
+  name                 = "${local.application_name}-target-group"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = data.aws_vpc.shared.id
+  deregistration_delay = 30
+  health_check {
+    interval            = 15
+    path                = "/mlra/"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+  stickiness {
+    enabled         = true
+    type            = "lb_cookie"
+    cookie_duration = 10800
+  }
 }
-
 
 
 

--- a/terraform/environments/mlra/main.tf
+++ b/terraform/environments/mlra/main.tf
@@ -49,7 +49,7 @@ resource "aws_lb_listener" "alb_listener" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.alb_target_group.arn
-  #TODO cloudfront rule may still need to be applied. pending cutover strategy decisions
+    #TODO cloudfront rule may still need to be applied. pending cutover strategy decisions
   }
 }
 

--- a/terraform/environments/mlra/platform_secrets.tf
+++ b/terraform/environments/mlra/platform_secrets.tf
@@ -14,7 +14,7 @@ data "aws_secretsmanager_secret_version" "environment_management" {
 
 
 ######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
 
 # # Get secret by arn for environment management
 # data "aws_ssm_parameter" "environment_management_arn" {

--- a/terraform/environments/mlra/providers.tf
+++ b/terraform/environments/mlra/providers.tf
@@ -37,7 +37,7 @@ provider "aws" {
 
 
 ######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
 
 # provider "aws" {
 #   region = "eu-west-2"


### PR DESCRIPTION
terraform changes to the MLRA ALB target group to include the deregistration_delay, health_check and stickiness settings
