### PR TITLE
OIDC and Usability refactor for digital-prison-reporting

### DIFF
--- a/.github/workflows/digital-prison-reporting.yml
+++ b/.github/workflows/digital-prison-reporting.yml
@@ -2,7 +2,7 @@
 name: digital-prison-reporting
 on:
   push:
-    branches: 
+    branches:
       - main
     paths:
       - 'terraform/environments/digital-prison-reporting/**'
@@ -16,190 +16,162 @@ on:
       - '.github/workflows/digital-prison-reporting.yml'
   workflow_dispatch:
 env:
-  AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
+  AWS_REGION: "eu-west-2"
+  ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 defaults:
   run:
     shell: bash
 
 jobs:
-  
-  # These jobs run when creating a pull request
-  plan-development:
-    name: Plan Development - digital-prison-reporting
+
+  plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform plan - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_ENV: ${{ matrix.environment }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Terraform plan - development
+      - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
+          terraform --version
           echo "Terraform plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/digital-prison-reporting
-        env:
-          TF_ENV: development
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW
 
-  deploy-development:
-    name: Deploy Development - digital-prison-reporting
+  # These jobs run when creating a pull request
+  deploy-dev-test:
+    needs: plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform apply - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_ENV: ${{ matrix.environment }}
     environment:
-      name: digital-prison-reporting-development
+      name: ${{ github.workflow }}-${{ matrix.environment }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3.1.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Terraform apply - development
+      - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
+          terraform --version
           echo "Terraform apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/digital-prison-reporting
-        env:
-          TF_ENV: development
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
 
-#  plan-test:
-#    name: Plan Test - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform plan - test
-#        run: |
-#          echo "Terraform plan - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-plan.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: test
-#
-#  deploy-test:
-#    name: Deploy Test - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-#    environment:
-#      name: digital-prison-reporting-test
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform apply - test
-#        run: |
-#          echo "Terraform apply - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-apply.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: test
-#
-#  # These jobs run after merging to main
-#  plan-preproduction:
-#    name: Plan Preproduction - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform plan - preproduction
-#        run: |
-#          echo "Terraform plan - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-plan.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: preproduction
-#
-#  deploy-preproduction:
-#    name: Deploy Preproduction - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-#    environment:
-#      name: digital-prison-reporting-preproduction
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform apply - preproduction
-#        run: |
-#          echo "Terraform apply - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-apply.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: preproduction
-#
-#  plan-production:
-#    name: Plan Production - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform plan - production
-#        run: |
-#          echo "Terraform plan - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-plan.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: production
-#
-#  deploy-production:
-#    name: Deploy Production - digital-prison-reporting
-#    runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/main'
-#    environment:
-#      name: digital-prison-reporting-production
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v3.1.0
-#      - name: Load and Configure Terraform
-#        uses: hashicorp/setup-terraform@v2.0.0
-#        with:
-#          terraform_version: "~1"
-#          terraform_wrapper: false
-#      - name: Terraform apply - production
-#        run: |
-#          echo "Terraform apply - ${TF_ENV}"
-#          bash scripts/terraform-init.sh terraform/environments/digital-prison-reporting
-#          terraform -chdir="terraform/environments/digital-prison-reporting" workspace select "digital-prison-reporting-${TF_ENV}"
-#          bash scripts/terraform-apply.sh terraform/environments/digital-prison-reporting
-#        env:
-#          TF_ENV: production
-#
+#  # Plan + deploy for pre-production and production environments, only from main
+#   plan-preprod-prod:
+#     strategy:
+#       matrix:
+#         include:
+#           - environment: preproduction
+#           - environment: production
+#     name: Terraform plan - ${{ github.workflow }} - ${{  matrix.environment }}
+#     runs-on: ubuntu-latest
+#     if: github.ref == 'refs/heads/main'
+#     env:
+#       TF_ENV: ${{ matrix.environment }}
+#     steps:
+#       - name: Checkout Repository
+#         uses: actions/checkout@v3.1.0
+#       - name: Set Account Number
+#         run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+#       - name: configure aws credentials
+#         uses: aws-actions/configure-aws-credentials@v1
+#         with:
+#           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+#           role-session-name: githubactionsrolesession
+#           aws-region: ${{ env.AWS_REGION }}
+#       - name: Load and Configure Terraform
+#         uses: hashicorp/setup-terraform@v2.0.0
+#         with:
+#           terraform_version: "~1"
+#           terraform_wrapper: false
+#       - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
+#         run: |
+#           terraform --version
+#           echo "Terraform plan - ${TF_ENV}"
+#           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+#           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+#           bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW
+#   # These jobs run when creating a pull request
+#   deploy-preprod-prod:
+#     needs: plan-preprod-prod
+#     if: success()
+#     strategy:
+#       matrix:
+#         include:
+#           - environment: preproduction
+#           - environment: production
+#     name: Terraform apply - ${{ github.workflow }} - ${{  matrix.environment }}
+#     runs-on: ubuntu-latest
+#     env:
+#       TF_ENV: ${{ matrix.environment }}
+#     environment:
+#       name: ${{ github.workflow }}-${{ matrix.environment }}
+#     steps:
+#       - name: Checkout Repository
+#         uses: actions/checkout@v3.1.0
+#       - name: Set Account Number
+#         run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+#       - name: configure aws credentials
+#         uses: aws-actions/configure-aws-credentials@v1
+#         with:
+#           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+#           role-session-name: githubactionsrolesession
+#           aws-region: ${{ env.AWS_REGION }}
+#       - name: Load and Configure Terraform
+#         uses: hashicorp/setup-terraform@v2.0.0
+#         with:
+#           terraform_version: "~1"
+#           terraform_wrapper: false
+#       - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
+#         run: |
+#           terraform --version
+#           echo "Terraform apply - ${TF_ENV}"
+#           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+#           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+#           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -7,11 +7,22 @@ data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
 
+data "aws_caller_identity" "oidc_session" {
+  provider = aws.oidc-session
+}
+
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
 locals {
 
   application_name = "digital-prison-reporting"
 
   environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.

--- a/terraform/environments/digital-prison-reporting/platform_secrets.tf
+++ b/terraform/environments/digital-prison-reporting/platform_secrets.tf
@@ -1,5 +1,9 @@
-######################### Run Terraform via CICD ##################################
-# Get secret by name for environment management
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
 data "aws_secretsmanager_secret" "environment_management" {
   provider = aws.modernisation-platform
   name     = "environment_management"
@@ -10,24 +14,3 @@ data "aws_secretsmanager_secret_version" "environment_management" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }
-######################### Run Terraform via CICD ##################################
-
-
-######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
-
-# # Get secret by arn for environment management
-# data "aws_ssm_parameter" "environment_management_arn" {
-#   name = "environment_management_arn"
-# }
-
-# data "aws_secretsmanager_secret" "environment_management" {
-#   arn = data.aws_ssm_parameter.environment_management_arn.value
-# }
-
-# # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
-# data "aws_secretsmanager_secret_version" "environment_management" {
-#   secret_id = data.aws_secretsmanager_secret.environment_management.id
-# }
-
-######################### Run Terraform Plan Locally Only ##################################

--- a/terraform/environments/digital-prison-reporting/providers.tf
+++ b/terraform/environments/digital-prison-reporting/providers.tf
@@ -1,9 +1,14 @@
-######################### Run Terraform via CICD ##################################
+# ######################### Run Terraform via CICD ##################################
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  alias  = "oidc-session"
+  region = "eu-west-2"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/MemberInfrastructureAccess"
+    role_arn = "arn:aws:iam::${data.aws_caller_identity.oidc_session.id}:role/MemberInfrastructureAccess"
   }
 }
 
@@ -12,6 +17,9 @@ provider "aws" {
   alias                  = "modernisation-platform"
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
+  assume_role {
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+  }
 }
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
@@ -37,10 +45,25 @@ provider "aws" {
 
 
 ######################### Run Terraform Plan Locally Only ##################################
-# To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
+# # To run a Terraform Plan locally, uncomment this bottom section of code and comment out the top section
 
 # provider "aws" {
 #   region = "eu-west-2"
+# }
+
+# provider "aws" {
+#   alias  = "oidc-session"
+#   region = "eu-west-2"
+# }
+
+# # AWS provider for the Modernisation Platform, to get things from there if required
+# provider "aws" {
+#   alias                  = "modernisation-platform"
+#   region                 = "eu-west-2"
+#   skip_get_ec2_platforms = true
+#   assume_role {
+#     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+#   }
 # }
 
 # # AWS provider for core-vpc-<environment>, to share VPCs into this account


### PR DESCRIPTION
This PR updated the nomis code to authenticate with AWS using the github OIDC provider rather than static AWS credentials.

Additionally, changes in locals.tf, platform_secrets.tf and providers.tf have been made to allow local plans to run with the new setup.

These changes are being rolled out to all member environments to improve general security posture of the platform as well as user experience when running Github Actions.

If you have any questions or concerns please reach out on ask-modernisation-platform channel

Changes:

.github/workflows/digital-prison-reporting.yml

- AWS secrets env vars have been removed
- plan and deploy jobs have been amended to use a different AWS authentication action
- plan and deploy jobs have been refactored to use the new matrix strategy to improve code quality

providers.tf

- changed provider definition to use oidc
- amended local plan provider definitions for compatibility

platform_secrets.tf

- changed secret definitions to allow retrieval from modernisation-platform account
- removed commented out section as changes to secrets are no longer required to run local plans

locals.tf

- added a datasource to lookup OIDC session information
- added a new local to retrieve the account id of modernisation-platform account (using a datasource creates a cycle)

 
