### PR TITLE
Nomis: DSOS-1507: audit db swap fix

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -152,6 +152,7 @@ module "db_ec2_instance" {
   ssm_parameters        = merge(local.database.ssm_parameters, lookup(each.value, "ssm_parameters", {}))
   route53_records       = merge(local.database.route53_records, lookup(each.value, "route53_records", {}))
 
+  iam_resource_names_prefix = "ec2-database"
   instance_profile_policies = concat(local.ec2_common_managed_policies, [aws_iam_policy.s3_db_backup_bucket_access.arn])
 
   business_unit     = local.vpc_name
@@ -165,7 +166,7 @@ module "db_ec2_instance" {
 
   ansible_repo         = "modernisation-platform-configuration-management"
   ansible_repo_basedir = "ansible"
-  branch               = var.BRANCH_NAME
+  branch               = try(each.value.branch, "main")
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/nomis/modules/ec2_instance/README.md
+++ b/terraform/environments/nomis/modules/ec2_instance/README.md
@@ -1,3 +1,43 @@
 # ec2-instance module
 
 Terraform module for standing up a single EC2 instance
+
+## EBS Volumes
+
+If you specify nothing, the volumes will be derived from those in the AMI image
+and will be created as a separate resource to allow easy resizing.
+
+You can optionally assign a "label" to the volume to make the volumes easy
+to identify, e.g.
+
+```
+ebs_volumes = {
+  "/dev/sde" = { label = "data" }  # DATA01
+  "/dev/sdf" = { label = "data" }  # DATA02
+}
+```
+
+The label will then be included in the device name. You can also override the
+default AMI settings. If all the volumes with the same label have hte same
+settings, set like this:
+
+```
+ebs_volume_config = {
+  data = {
+    iops       = 3000
+    throughput = 125
+    total_size = 200
+  }
+}
+```
+
+The size of each volume is `total_size` divided by the number of volumes with that label.
+
+Alternatively, override settings directly within the `ebs_volumes` variable.
+
+```
+ebs_volumes = {
+  "/dev/sde" = { size = 100 }  # DATA01
+  "/dev/sdf" = { size = 150 }  # DATA02
+}
+```

--- a/terraform/environments/nomis/modules/ec2_instance/README.md
+++ b/terraform/environments/nomis/modules/ec2_instance/README.md
@@ -17,8 +17,8 @@ ebs_volumes = {
 }
 ```
 
-The label will then be included in the device name. You can also override the
-default AMI settings. If all the volumes with the same label have hte same
+The label will then be included in the tag:Name. You can also override the
+default AMI settings. If all the volumes with the same label have the same
 settings, set like this:
 
 ```
@@ -37,7 +37,7 @@ Alternatively, override settings directly within the `ebs_volumes` variable.
 
 ```
 ebs_volumes = {
-  "/dev/sde" = { size = 100 }  # DATA01
-  "/dev/sdf" = { size = 150 }  # DATA02
+  "/dev/sde" = { size = 100 }
+  "/dev/sdf" = { size = 150 }
 }
 ```

--- a/terraform/environments/nomis/modules/ec2_instance/data.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/data.tf
@@ -44,7 +44,7 @@ data "aws_route53_zone" "external" {
   private_zone = false
 }
 
-data "aws_ec2_instance_type" "database" {
+data "aws_ec2_instance_type" "this" {
   instance_type = var.instance.instance_type
 }
 

--- a/terraform/environments/nomis/modules/ec2_instance/main.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/main.tf
@@ -75,7 +75,10 @@ resource "aws_ebs_volume" "this" {
   tags = merge(
     local.tags,
     {
-      Name = join("-", [var.name, each.value.label, each.key])
+      Name = try(
+        join("-", [var.name, each.value.label, each.key]),
+        join("-", [var.name, each.key])
+      )
     }
   )
 
@@ -175,7 +178,7 @@ data "aws_iam_policy_document" "asm_parameter" {
 }
 
 resource "aws_iam_role" "this" {
-  name                 = "ec2-database-role-${var.name}"
+  name                 = "${var.iam_resource_names_prefix}-role-${var.name}"
   path                 = "/"
   max_session_duration = "3600"
   assume_role_policy = jsonencode(
@@ -199,7 +202,7 @@ resource "aws_iam_role" "this" {
   tags = merge(
     local.tags,
     {
-      Name = "ec2-database-role-${var.name}"
+      Name = "${var.iam_resource_names_prefix}-role-${var.name}"
     },
   )
 }
@@ -211,7 +214,7 @@ resource "aws_iam_role_policy" "asm_parameter" {
 }
 
 resource "aws_iam_instance_profile" "this" {
-  name = "ec2-database-profile-${var.name}"
+  name = "${var.iam_resource_names_prefix}-profile-${var.name}"
   role = aws_iam_role.this.name
   path = "/"
 }

--- a/terraform/environments/nomis/modules/ec2_instance/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/variables.tf
@@ -142,6 +142,11 @@ variable "route53_records" {
   })
 }
 
+variable "iam_resource_names_prefix" {
+  type        = string
+  description = "Prefix IAM resources with this prefix, e.g. ec2-database"
+}
+
 variable "instance_profile_policies" {
   type        = list(string)
   description = "A list of managed IAM policy document ARNs to be attached to the database instance profile"

--- a/terraform/environments/nomis/modules/ec2_instance/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/variables.tf
@@ -145,6 +145,7 @@ variable "route53_records" {
 variable "iam_resource_names_prefix" {
   type        = string
   description = "Prefix IAM resources with this prefix, e.g. ec2-database"
+  default     = "ec2"
 }
 
 variable "instance_profile_policies" {


### PR DESCRIPTION
Minor tweaks/fixes to ec2_instance module
- fix swap disk size (4 Gb -> 16 Gb on the new audit DBs).  This can be applied dynamically
- remove the database specific stuff and replace with variable
- cloning ansible with a branch is now an opt-in feature per ec2 instance.  This avoids unwanted user-data plan changes.
- adding an extra label to disk names (e.g. app/data) is optional.  Added README about this.