### PR TITLE
nomis: resource tidyup

### DIFF
--- a/terraform/environments/nomis/nomis-production.tf
+++ b/terraform/environments/nomis/nomis-production.tf
@@ -55,42 +55,6 @@ locals {
           monitored = true
         }
       }
-      NOMIS = {
-        always_on              = true
-        ami_name               = "nomis_database_2022-07-21T11-43-27.346Z"
-        ami_owner              = local.account_id
-        instance_type          = "r6i.4xlarge"
-        asm_data_capacity      = 4000
-        asm_flash_capacity     = 1000
-        description            = "Copy of Production NOMIS CNOM database in Azure PDPDL00035, replicating with PDPDL00035, a replacement for PDPDL10036."
-        termination_protection = true
-        oracle_sids            = ["PCNOM", "PMISS1"]
-        oracle_app_disk_size = {
-          "/dev/sdb" = 100 # /u01
-          "/dev/sdc" = 512 # /u02
-        }
-        tags = {
-          monitored = false //not yet live
-        }
-      }
-      NDH = {
-        always_on              = false
-        ami_name               = "nomis_database_2022-08-09T15-04-29.500Z"
-        ami_owner              = local.account_id
-        instance_type          = "r6i.xlarge"
-        asm_data_capacity      = 4000
-        asm_flash_capacity     = 1000
-        description            = "NDH & TRDATA standby databases in Azure PDPDL00038, replicating with PDPDL00037, a replacement for PDPDL00038."
-        termination_protection = true
-        oracle_sids            = ["PNDH", "PTRDAT"]
-        oracle_app_disk_size = {
-          "/dev/sdb" = 100 # /u01
-          "/dev/sdc" = 512 # /u02
-        }
-        tags = {
-          monitored = false # not yet live
-        }
-      }
     }
 
     # Add database instances here. They will be created using ec2-database.tf

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -55,21 +55,6 @@ locals {
           monitored = true
         }
       }
-      TEST_DB = {
-        always_on              = false
-        ami_name               = "nomis_database_2022-08-25T08-18-55.566Z*"
-        asm_data_capacity      = 50
-        asm_flash_capacity     = 10
-        description            = "Blank db install for Sandhya, to be removed EOD Monday"
-        termination_protection = false
-        oracle_app_disk_size = {
-          "/dev/sdb" = 100 # /u01
-          "/dev/sdc" = 100 # /u02
-        }
-        tags = {
-          monitored = false
-        }
-      }
     }
 
     # Add database instances here. They will be created using ec2-database.tf
@@ -87,7 +72,7 @@ locals {
           monitored   = false
           always-on   = true
         }
-        ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
+        ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"
         instance = {
           disable_api_termination = true
         }
@@ -106,26 +91,6 @@ locals {
       }
     }
     # Add base instances here. They will be created using the base_instance module
-    test_instances_asg = {
-      AUDITUPLOADTEST = {
-        always_on     = false
-        ami_name      = "nomis_db_STIG_CNOMT1-2022-04-21T11.33.39Z*"
-        description   = "Test instance for audit upload script"
-        instance_type = "r6i.xlarge"
-        tags = {
-          monitored = false
-        }
-      }
-      RHEL79BASE = {
-        always_on     = false
-        ami_name      = "nomis_rhel_7_9_baseimage*"
-        description   = "Test instance for RHEL7.9 base image"
-        instance_type = "t2.medium"
-        tags = {
-          monitored   = false
-          server-type = "base"
-        }
-      }
-    }
+    test_instances_asg = {}
   }
 }

--- a/terraform/environments/nomis/templates/ansible.sh.tftpl
+++ b/terraform/environments/nomis/templates/ansible.sh.tftpl
@@ -68,11 +68,11 @@ run_ansible() {
   ansible-galaxy role install -r requirements.yml
   ansible-galaxy collection install -r requirements.yml
 
-  # run ansible
+  # run ansible (comma after localhost deliberate)
   echo "# Execute ansible"
   ansible-playbook site.yml \
    --connection=local \
-   --inventory localhost \
+   --inventory localhost, \
    --extra-vars "ansible_python_interpreter=$python" \
    --extra-vars "target=localhost" \
    --extra-vars "@group_vars/environment_name_$environment_name.yml" \


### PR DESCRIPTION
Deleting unused databases and ASGs.  The databases need to be rebuilt using the new naming.
Since t1-nomis-db-2 accidentally zapped, updating the AMI it uses.
Minor fix to ansible template file to suppress warnings.