### PR TITLE
add ListObject and GetObject permissions to get db backups from s3

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -261,7 +261,7 @@ resource "aws_security_group" "database_common" {
 }
 
 #------------------------------------------------------------------------------
-# Policy for PUT access to database backups
+# Policy for PUT, GET, LIST access to database backups
 #------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "s3_db_backup_bucket_access" {
@@ -270,6 +270,8 @@ data "aws_iam_policy_document" "s3_db_backup_bucket_access" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
+      "s3:ListObject",
+      "s3:GetObject"
     ]
     resources = [module.nomis-db-backup-bucket.bucket.arn,
     "${module.nomis-db-backup-bucket.bucket.arn}/*"]


### PR DESCRIPTION
role defined in ec2-database.tf to PUT items in 'nomis-db-backup-bucket* expanded to allow retrieval of database backups from here as well