### PR TITLE
Add tfsec & Checkov Ignore Flags To ALB Listener

### DIFF
--- a/terraform/environments/mlra/modules/alb/main.tf
+++ b/terraform/environments/mlra/modules/alb/main.tf
@@ -40,10 +40,14 @@ locals {
   }
 }
 
+# tls termination performed by the laa platform mlra alb (phase 1)
 resource "aws_lb_listener" "alb_listener" {
   load_balancer_arn = module.lb-access-logs-enabled.load_balancer.arn
-  port              = var.listener_port
-  protocol          = var.listener_protocol # tls termination performed by the laa platform mlra alb (phase 1)
+
+  #checkov:skip=CKV_AWS_2:Ensure ALB protocol is HTTPS
+  #checkov:skip=CKV_AWS_103:Ensure that load balancer is using TLS 1.2
+  port     = var.listener_port
+  protocol = var.listener_protocol #tfsec:ignore:aws-elb-http-not-used
 
   default_action {
     type = "forward"


### PR DESCRIPTION
In the first phase, TLS termination is being performed by an upstream ALB retained within the LAA AWS account, and so it is not necessary here. Adding tfsec and checkov flags to suppress http/s warnings during linting