### PR TITLE
nomis: DSOS-1558: rhel 6 10 fixes

### DIFF
--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -41,6 +41,7 @@ locals {
       # For ad-hoc testing.  Comment in and out as needed
       dev-nomis-db-1 = {
         tags = {
+          ami               = "nomis-rhel-7-9-oracledb"
           server-type       = "nomis-db"
           description       = "Dev database using T1 data set"
           oracle-sids       = "CNOMT1"
@@ -61,6 +62,7 @@ locals {
     ec2_test_autoscaling_groups = {
       dev-redhat-rhel79 = {
         tags = {
+          ami         = "nomis_rhel_7_9_oracledb"
           description = "For testing official RedHat RHEL7.9 base image"
           server-type = "base-rhel79"
           monitored   = false
@@ -71,6 +73,7 @@ locals {
       }
       dev-base-rhel79 = {
         tags = {
+          ami         = "nomis_rhel_7_9_baseimage"
           description = "For testing our base RHEL7.9 base image"
           monitored   = false
         }
@@ -79,11 +82,13 @@ locals {
       }
       dev-base-rhel610 = {
         tags = {
+          ami         = "nomis_rhel_6_10_baseimage"
           description = "For testing our base RHEL6.10 base image"
           monitored   = false
         }
         instance = {
-          instance_type = "t2.medium"
+          instance_type                = "t2.medium"
+          metadata_options_http_tokens = "optional"
         }
         ami_name = "nomis_rhel_6_10_baseimage*"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
@@ -94,7 +99,8 @@ locals {
           monitored   = false
         }
         instance = {
-          instance_type = "t2.medium"
+          instance_type                = "t2.medium"
+          metadata_options_http_tokens = "optional"
         }
         ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3*"
         # branch   = var.BRANCH_NAME # comment in if testing ansible

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -41,7 +41,6 @@ locals {
       # For ad-hoc testing.  Comment in and out as needed
       dev-nomis-db-1 = {
         tags = {
-          ami               = "nomis-rhel-7-9-oracledb"
           server-type       = "nomis-db"
           description       = "Dev database using T1 data set"
           oracle-sids       = "CNOMT1"
@@ -62,7 +61,6 @@ locals {
     ec2_test_autoscaling_groups = {
       dev-redhat-rhel79 = {
         tags = {
-          ami         = "nomis_rhel_7_9_oracledb"
           description = "For testing official RedHat RHEL7.9 base image"
           server-type = "base-rhel79"
           monitored   = false

--- a/terraform/environments/nomis/templates/ansible-ec2provision.sh.tftpl
+++ b/terraform/environments/nomis/templates/ansible-ec2provision.sh.tftpl
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -euo pipefail
+# Don't set set -u as ansible activate script fails with it on RHEL6
+set -eo pipefail
 
 run_ansible() {
   export PATH=/usr/local/bin:$PATH
@@ -36,9 +37,9 @@ run_ansible() {
   git clone -b ${branch} "https://github.com/ministryofjustice/${ansible_repo}.git" || git clone "https://github.com/ministryofjustice/${ansible_repo}.git"
 
   # set python version
-  if [[ $(which python3.9) ]]; then
+  if [[ $(which python3.9 2> /dev/null) ]]; then
     python=$(which python3.9)
-  elif [[ $(which python3.6) ]]; then
+  elif [[ $(which python3.6 2> /dev/null) ]]; then
     python=$(which python3.6)
   else
     echo "Python3.9/3.6 not found"


### PR DESCRIPTION
Update ansible template to work on RHEL6 (no set -u option)
Use optional metadata tokens on RHEL6 test instances
Add ami tag on ec2-test instances for testing ansible patching with AMI repo.
