### PR TITLE
DSOS-1561: db ami snapshot fix

### DIFF
--- a/terraform/environments/nomis/modules/ec2_instance/main.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/main.tf
@@ -70,11 +70,11 @@ resource "aws_instance" "this" {
 resource "aws_ebs_volume" "this" {
   for_each = local.ebs_volumes
 
-  # Note that block devices must be also present in the AMI.  AMI values are used
-  # if they are not otherwise defined  
+  # Values are retrieved from AMI data rather than using snapshot_id, since 
+  # it's not always possible to access the snapshot_id if the AMI is in a 
+  # different account.
   availability_zone = var.availability_zone
   encrypted         = true
-  snapshot_id       = each.value.snapshot_id
   iops              = try(each.value.iops > 0, false) ? each.value.iops : null
   throughput        = try(each.value.throughput > 0, false) ? each.value.throughput : null
   size              = each.value.size

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -78,7 +78,7 @@ locals {
       dev-nomis-db-2 = {
         tags = {
           server-type = "nomis-db"
-          description = "temp, testing terraform only"
+          description = "temp for testing terraform only"
           oracle-sids = "CNOMT1"
           monitored   = false
         }

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -55,6 +55,20 @@ locals {
         }
         # branch = var.BRANCH_NAME # comment in if testing ansible
       }
+      dev-nomis-db-2 = {
+        tags = {
+          server-type       = "nomis-db"
+          description       = "temp, testing terraform only"
+          oracle-sids       = "CNOMT1"
+          monitored         = false
+        }
+        ami_name  = "nomis_rhel_7_9_oracledb_11_2_*"
+        ebs_volume_config = {
+          data  = { total_size = 200 }
+          flash = { total_size = 2 }
+        }
+        # branch = var.BRANCH_NAME # comment in if testing ansible
+      }
     }
     weblogics          = {}
     ec2_test_instances = {}

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -75,20 +75,6 @@ locals {
         }
         # branch = var.BRANCH_NAME # comment in if testing ansible
       }
-      dev-nomis-db-2 = {
-        tags = {
-          server-type = "nomis-db"
-          description = "temp for testing terraform only"
-          oracle-sids = "CNOMT1"
-          monitored   = false
-        }
-        ami_name = "nomis_rhel_7_9_oracledb_11_2_*"
-        ebs_volume_config = {
-          data  = { total_size = 200 }
-          flash = { total_size = 2 }
-        }
-        # branch = var.BRANCH_NAME # comment in if testing ansible
-      }
     }
     weblogics          = {}
     ec2_test_instances = {}

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -50,19 +50,39 @@ locals {
         ami_name  = "nomis_rhel_7_9_oracledb_11_2_*"
         ami_owner = "self"
         ebs_volume_config = {
-          data  = { total_size = 200 }
-          flash = { total_size = 2 }
+          app = {
+            iops       = 300   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
+          data = {
+            iops       = 120   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 200
+          }
+          flash = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 2
+          }
+          swap = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
         }
         # branch = var.BRANCH_NAME # comment in if testing ansible
       }
       dev-nomis-db-2 = {
         tags = {
-          server-type       = "nomis-db"
-          description       = "temp, testing terraform only"
-          oracle-sids       = "CNOMT1"
-          monitored         = false
+          server-type = "nomis-db"
+          description = "temp, testing terraform only"
+          oracle-sids = "CNOMT1"
+          monitored   = false
         }
-        ami_name  = "nomis_rhel_7_9_oracledb_11_2_*"
+        ami_name = "nomis_rhel_7_9_oracledb_11_2_*"
         ebs_volume_config = {
           data  = { total_size = 200 }
           flash = { total_size = 2 }

--- a/terraform/environments/nomis/nomis-production.tf
+++ b/terraform/environments/nomis/nomis-production.tf
@@ -80,12 +80,35 @@ locals {
           disable_api_termination = true
         }
         ebs_volumes = {
-          "/dev/sdb" = { size = 100 }  # /u01
-          "/dev/sdc" = { size = 5120 } # /u02 - reduce this to 1000 when we move into preprod subscription
+          "/dev/sdb" = { size = 100 } # /u01
+          "/dev/sdc" = {              # /u02
+            iops = 15360              # Temporary. See DSOS-1561
+            size = 5120               # reduce this to 1000 when we move into preprod subscription
+          }
         }
         ebs_volume_config = {
-          data  = { total_size = 4000 }
-          flash = { total_size = 1000 }
+          app = {
+            iops       = 300   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
+          data = {
+            iops       = 2400  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 4000
+          }
+          flash = {
+            iops       = 1500  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 1000
+          }
+          swap = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
         }
       }
 
@@ -104,12 +127,35 @@ locals {
           disable_api_termination = true
         }
         ebs_volumes = {
-          "/dev/sdb" = { size = 100 }  # /u01
-          "/dev/sdc" = { size = 3000 } # /u02
+          "/dev/sdb" = { size = 100 } # /u01
+          "/dev/sdc" = {              # /u02
+            size = 3000
+            iops = 9000 # Temporary. See DSOS-1561
+          }
         }
         ebs_volume_config = {
-          data  = { total_size = 4000 }
-          flash = { total_size = 1000 }
+          app = {
+            iops       = 300   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
+          data = {
+            iops       = 2400  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 4000
+          }
+          flash = {
+            iops       = 1500  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 1000
+          }
+          swap = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
         }
       }
 
@@ -127,12 +173,35 @@ locals {
           disable_api_termination = true
         }
         ebs_volumes = {
-          "/dev/sdb" = { size = 100 }  # /u01
+          "/dev/sdb" = { # /u01
+            iops = 300   # Temporary. See DSOS-1561
+            size = 100
+          }
           "/dev/sdc" = { size = 1000 } # /u02
         }
         ebs_volume_config = {
-          data  = { total_size = 3000 }
-          flash = { total_size = 500 }
+          app = {
+            iops       = 3000  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
+          data = {
+            iops       = 1800  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 3000
+          }
+          flash = {
+            iops       = 750   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 500
+          }
+          swap = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
         }
       }
     }

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -66,9 +66,43 @@ locals {
         instance = {
           disable_api_termination = true
         }
+        ebs_volumes = {
+          "/dev/sdb" = {       # /u01
+            iops       = 300   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            size       = 100
+          }
+          "/dev/sdc" = {       # /u02
+            iops       = 300   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            size       = 100
+          }
+        }
         ebs_volume_config = {
-          data  = { total_size = 200 }
-          flash = { total_size = 2 }
+          app = {
+            iops       = 3000  # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
+          data = {
+            iops       = 120   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 200
+          }
+          flash = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+            total_size = 2
+          }
+          swap = {
+            iops       = 100   # Temporary. See DSOS-1561
+            throughput = 0     # Temporary. See DSOS-1561
+            type       = "gp2" # Temporary. See DSOS-1561
+          }
         }
       }
     }


### PR DESCRIPTION
Removing snapshot_id, which is an optional parameter, from the ebs_volume terraform.  Snapshots can't be accessed if the AMI is sitting in another account such as core-shared-services-production.  This removes the need to copy DB AMIs across to other accounts.

It's safe to remove the snapshot_id since all of the volume settings are known anyway from the data.aws_ami resource.  However, I spotted a bug where the disk settings weren't been set properly.  I've updated the variable files to make sure there's no plan changes, but we need to adjust some of the disk settings in a follow up PR.