### PR TITLE
DSOS-1455: fix monitoring of prod nomis DB from mod platform

### DIFF
--- a/terraform/environments/nomis/nomis-production.tf
+++ b/terraform/environments/nomis/nomis-production.tf
@@ -119,7 +119,7 @@ locals {
           oracle-sids              = "PCNMAUD"
           monitored                = false
           always-on                = true
-          fixngo-connection-target = "10.40.3.132"
+          fixngo-connection-target = "10.40.0.136"
         }
         ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"
         ami_owner = "self" # remove this line next time AMI is updated so core-shared-services-production used instead


### PR DESCRIPTION
Doh, use the wrong IP.  Test using the OEM management server instead of thenomis DB.