### PR TITLE
Restrict default permissons to read only

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -2,8 +2,13 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions: {}
+
 jobs:
   format-code:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -15,8 +15,13 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   create-and-commit-dependabot-file:
+    permissions:
+      pull-request: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,6 +14,10 @@ env:
   # sandbox_accounts_test.go test. For example: "xhibit-portal-development,another-development,".
   # As can be observed in the example above, every account name needs a leading comma, hence the last comma in the list.
   NUKE_SKIP_SANDBOX_ACCOUNTS: xhibit-portal-development,
+
+permissions:
+  contents: read
+
 jobs:
   go-tests:
     name: Run Go Unit Tests

--- a/.github/workflows/nuke.yml
+++ b/.github/workflows/nuke.yml
@@ -14,6 +14,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
 
   nuke:

--- a/.github/workflows/run-opa-tests.yml
+++ b/.github/workflows/run-opa-tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -12,8 +12,13 @@ on:
       - 'terraform/**'
       - '.github/workflows/terraform-static-analysis.yml'
 
+permissions:
+  contents: read
+
 jobs:
   terraform-static-analysis:
+    permissions:
+      pull-requests: write
     name: Terraform Static Analysis
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'


### PR DESCRIPTION
Following github best practices, restricting the top level permissions to read only and allowing write in the jobs where required.