### PR TITLE
Moving listeners to new load balancer

### DIFF
--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -191,7 +191,9 @@ resource "aws_security_group" "weblogic_common" {
     protocol    = "TCP"
     security_groups = [
       aws_security_group.jumpserver-windows.id,
-      aws_security_group.internal_elb.id
+      # TODO: Add a 'security_group_id' output to the MP load balancer module.
+      # Hardcoding as a string for now.
+      "sg-075cf385b5a966b04"
     ]
   }
 

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -193,7 +193,7 @@ resource "aws_security_group" "weblogic_common" {
       aws_security_group.jumpserver-windows.id,
       # TODO: Add a 'security_group_id' output to the MP load balancer module.
       # Hardcoding as a string for now.
-      "sg-075cf385b5a966b04"
+      local.environment == "test" ? "sg-075cf385b5a966b04" : aws_security_group.internal_elb.id
     ]
   }
 

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -12,7 +12,6 @@ data "aws_subnets" "private" {
 }
 
 resource "aws_security_group" "internal_elb" {
-  count       = local.environment == "test" ? 0 : 1
   name        = "internal-lb-${local.application_name}"
   description = "Allow inbound traffic to internal load balancer"
   vpc_id      = local.vpc_id
@@ -26,7 +25,6 @@ resource "aws_security_group" "internal_elb" {
 }
 
 resource "aws_security_group_rule" "internal_lb_ingress_1" {
-  count             = local.environment == "test" ? 0 : 1
   description       = "allow 443 inbound from PTTP devices"
   security_group_id = aws_security_group.internal_elb.id
   type              = "ingress"
@@ -37,7 +35,6 @@ resource "aws_security_group_rule" "internal_lb_ingress_1" {
 }
 
 resource "aws_security_group_rule" "internal_lb_ingress_2" {
-  count                    = local.environment == "test" ? 0 : 1
   description              = "allow 443 inbound from Jump Server"
   security_group_id        = aws_security_group.internal_elb.id
   type                     = "ingress"
@@ -48,7 +45,6 @@ resource "aws_security_group_rule" "internal_lb_ingress_2" {
 }
 
 resource "aws_security_group_rule" "internal_lb_ingress_3" {
-  count             = local.environment == "test" ? 0 : 1
   description       = "allow 80 inbound from PTTP devices"
   security_group_id = aws_security_group.internal_elb.id
   type              = "ingress"
@@ -59,7 +55,6 @@ resource "aws_security_group_rule" "internal_lb_ingress_3" {
 }
 
 resource "aws_security_group_rule" "internal_lb_ingress_4" {
-  count                    = local.environment == "test" ? 0 : 1
   description              = "allow 80 inbound from Jump Server"
   security_group_id        = aws_security_group.internal_elb.id
   type                     = "ingress"
@@ -70,7 +65,6 @@ resource "aws_security_group_rule" "internal_lb_ingress_4" {
 }
 
 resource "aws_security_group_rule" "internal_lb_egress_1" {
-  count                    = local.environment == "test" ? 0 : 1
   description              = "allow outbound to weblogic targets"
   security_group_id        = aws_security_group.internal_elb.id
   type                     = "egress"

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -1,15 +1,15 @@
 #------------------------------------------------------------------------------
 # Load Balancer - Internal
 #------------------------------------------------------------------------------
-# data "aws_subnets" "private" {
-#   filter {
-#     name   = "vpc-id"
-#     values = [local.vpc_id]
-#   }
-#   tags = {
-#     Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
-#   }
-# }
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+  tags = {
+    Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
+  }
+}
 
 # resource "aws_security_group" "internal_elb" {
 

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -1,102 +1,102 @@
 #------------------------------------------------------------------------------
 # Load Balancer - Internal
 #------------------------------------------------------------------------------
-data "aws_subnets" "private" {
-  filter {
-    name   = "vpc-id"
-    values = [local.vpc_id]
-  }
-  tags = {
-    Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
-  }
-}
+# data "aws_subnets" "private" {
+#   filter {
+#     name   = "vpc-id"
+#     values = [local.vpc_id]
+#   }
+#   tags = {
+#     Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
+#   }
+# }
 
-resource "aws_security_group" "internal_elb" {
+# resource "aws_security_group" "internal_elb" {
 
-  name        = "internal-lb-${local.application_name}"
-  description = "Allow inbound traffic to internal load balancer"
-  vpc_id      = local.vpc_id
+#   name        = "internal-lb-${local.application_name}"
+#   description = "Allow inbound traffic to internal load balancer"
+#   vpc_id      = local.vpc_id
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "internal-loadbalancer-sg"
-    },
-  )
-}
+#   tags = merge(
+#     local.tags,
+#     {
+#       Name = "internal-loadbalancer-sg"
+#     },
+#   )
+# }
 
-resource "aws_security_group_rule" "internal_lb_ingress_1" {
+# resource "aws_security_group_rule" "internal_lb_ingress_1" {
 
-  description       = "allow 443 inbound from PTTP devices"
-  security_group_id = aws_security_group.internal_elb.id
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["10.184.0.0/16"] # Global Protect PTTP devices
-}
+#   description       = "allow 443 inbound from PTTP devices"
+#   security_group_id = aws_security_group.internal_elb.id
+#   type              = "ingress"
+#   from_port         = 443
+#   to_port           = 443
+#   protocol          = "tcp"
+#   cidr_blocks       = ["10.184.0.0/16"] # Global Protect PTTP devices
+# }
 
-resource "aws_security_group_rule" "internal_lb_ingress_2" {
+# resource "aws_security_group_rule" "internal_lb_ingress_2" {
 
-  description              = "allow 443 inbound from Jump Server"
-  security_group_id        = aws_security_group.internal_elb.id
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.jumpserver-windows.id
-}
+#   description              = "allow 443 inbound from Jump Server"
+#   security_group_id        = aws_security_group.internal_elb.id
+#   type                     = "ingress"
+#   from_port                = 443
+#   to_port                  = 443
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.jumpserver-windows.id
+# }
 
-resource "aws_security_group_rule" "internal_lb_ingress_3" {
+# resource "aws_security_group_rule" "internal_lb_ingress_3" {
 
-  description       = "allow 80 inbound from PTTP devices"
-  security_group_id = aws_security_group.internal_elb.id
-  type              = "ingress"
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
-  cidr_blocks       = ["10.184.0.0/16"] # Global Protect PTTP devices
-}
+#   description       = "allow 80 inbound from PTTP devices"
+#   security_group_id = aws_security_group.internal_elb.id
+#   type              = "ingress"
+#   from_port         = 80
+#   to_port           = 80
+#   protocol          = "tcp"
+#   cidr_blocks       = ["10.184.0.0/16"] # Global Protect PTTP devices
+# }
 
-resource "aws_security_group_rule" "internal_lb_ingress_4" {
+# resource "aws_security_group_rule" "internal_lb_ingress_4" {
 
-  description              = "allow 80 inbound from Jump Server"
-  security_group_id        = aws_security_group.internal_elb.id
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.jumpserver-windows.id
-}
+#   description              = "allow 80 inbound from Jump Server"
+#   security_group_id        = aws_security_group.internal_elb.id
+#   type                     = "ingress"
+#   from_port                = 80
+#   to_port                  = 80
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.jumpserver-windows.id
+# }
 
-resource "aws_security_group_rule" "internal_lb_egress_1" {
+# resource "aws_security_group_rule" "internal_lb_egress_1" {
 
-  description              = "allow outbound to weblogic targets"
-  security_group_id        = aws_security_group.internal_elb.id
-  type                     = "egress"
-  from_port                = 7777
-  to_port                  = 7777
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.weblogic_common.id
-}
+#   description              = "allow outbound to weblogic targets"
+#   security_group_id        = aws_security_group.internal_elb.id
+#   type                     = "egress"
+#   from_port                = 7777
+#   to_port                  = 7777
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.weblogic_common.id
+# }
 
-resource "aws_lb" "internal" {
-  #checkov:skip=CKV_AWS_91:skip "Ensure the ELBv2 (Application/Network) has access logging enabled". Logging can be considered when the MP load balancer module is available
-  name                       = "lb-internal-${local.application_name}"
-  internal                   = true
-  load_balancer_type         = "application"
-  security_groups            = [aws_security_group.internal_elb.id]
-  subnets                    = data.aws_subnets.private.ids
-  enable_deletion_protection = true
-  drop_invalid_header_fields = true
+# resource "aws_lb" "internal" {
+#   #checkov:skip=CKV_AWS_91:skip "Ensure the ELBv2 (Application/Network) has access logging enabled". Logging can be considered when the MP load balancer module is available
+#   name                       = "lb-internal-${local.application_name}"
+#   internal                   = true
+#   load_balancer_type         = "application"
+#   security_groups            = [aws_security_group.internal_elb.id]
+#   subnets                    = data.aws_subnets.private.ids
+#   enable_deletion_protection = true
+#   drop_invalid_header_fields = true
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "internal-loadbalancer"
-    },
-  )
-}
+#   tags = merge(
+#     local.tags,
+#     {
+#       Name = "internal-loadbalancer"
+#     },
+#   )
+# }
 
 resource "aws_lb_listener" "internal" {
   load_balancer_arn = aws_lb.internal.arn

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -78,7 +78,6 @@ resource "aws_security_group_rule" "internal_lb_egress_1" {
 # module in nomis-test is complete.
 resource "aws_lb" "internal" {
   #checkov:skip=CKV_AWS_91:skip "Ensure the ELBv2 (Application/Network) has access logging enabled". Logging can be considered when the MP load balancer module is available
-  count                      = local.environment == "test" ? 0 : 1
   name                       = "lb-internal-${local.application_name}"
   internal                   = true
   load_balancer_type         = "application"

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -99,7 +99,9 @@
 # }
 
 resource "aws_lb_listener" "internal" {
-  load_balancer_arn = aws_lb.internal.arn
+  # TODO: Add an ARN output to the MP load balancer module. Hardcoding as a
+  # string for now.
+  load_balancer_arn = "arn:aws:elasticloadbalancing:eu-west-2:612659970365:loadbalancer/app/jbtest-lb/7e3d2cc41770e409"
   port              = "443"
   protocol          = "HTTPS"
   #checkov:skip=CKV_AWS_103:the application does not support tls 1.2
@@ -127,7 +129,9 @@ resource "aws_lb_listener" "internal_http" {
     aws_acm_certificate_validation.internal_lb
   ]
 
-  load_balancer_arn = aws_lb.internal.arn
+  # TODO: Add an ARN output to the MP load balancer module. Hardcoding as a
+  # string for now.
+  load_balancer_arn = "arn:aws:elasticloadbalancing:eu-west-2:612659970365:loadbalancer/app/jbtest-lb/7e3d2cc41770e409"
   port              = "80"
   protocol          = "HTTP"
 

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -99,7 +99,7 @@ data "aws_subnets" "private" {
 # }
 
 resource "aws_lb_listener" "internal" {
-  # TODO: Add an ARN output to the MP load balancer module. Hardcoding as a
+  # TODO: Add an 'arn' output to the MP load balancer module. Hardcoding as a
   # string for now.
   load_balancer_arn = "arn:aws:elasticloadbalancing:eu-west-2:612659970365:loadbalancer/app/jbtest-lb/7e3d2cc41770e409"
   port              = "443"
@@ -129,7 +129,7 @@ resource "aws_lb_listener" "internal_http" {
     aws_acm_certificate_validation.internal_lb
   ]
 
-  # TODO: Add an ARN output to the MP load balancer module. Hardcoding as a
+  # TODO: Add an 'arn' output to the MP load balancer module. Hardcoding as a
   # string for now.
   load_balancer_arn = "arn:aws:elasticloadbalancing:eu-west-2:612659970365:loadbalancer/app/jbtest-lb/7e3d2cc41770e409"
   port              = "80"
@@ -156,7 +156,9 @@ resource "aws_route53_record" "internal_lb" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.internal.dns_name
+    # TODO: Add a 'dns_name' output to the MP load balancer module. Hardcoding
+    # as a string for now.
+    name                   = "internal-jbtest-lb-1400065058.eu-west-2.elb.amazonaws.com"
     zone_id                = aws_lb.internal.zone_id
     evaluate_target_health = true
   }
@@ -268,7 +270,9 @@ resource "aws_route53_record" "internal_lb_az" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.internal.dns_name
+    # TODO: Add a 'dns_name' output to the MP load balancer module. Hardcoding
+    # as a string for now.    
+    name                   = "internal-jbtest-lb-1400065058.eu-west-2.elb.amazonaws.com"
     zone_id                = aws_lb.internal.zone_id
     evaluate_target_health = true
   }

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -156,10 +156,10 @@ resource "aws_route53_record" "internal_lb" {
   type    = "A"
 
   alias {
-    # TODO: Add a 'dns_name' output to the MP load balancer module. Hardcoding
-    # as a string for now.
+    # TODO: Add outputs 'dns_name' and 'zone_id' to the MP load balancer module.
+    # Hardcoding as strings for now.
     name                   = "internal-jbtest-lb-1400065058.eu-west-2.elb.amazonaws.com"
-    zone_id                = aws_lb.internal.zone_id
+    zone_id                = "ZHURV8PSTC4K8"
     evaluate_target_health = true
   }
 }
@@ -270,10 +270,10 @@ resource "aws_route53_record" "internal_lb_az" {
   type    = "A"
 
   alias {
-    # TODO: Add a 'dns_name' output to the MP load balancer module. Hardcoding
-    # as a string for now.    
+    # TODO: Add outputs 'dns_name' and 'zone_id' to the MP load balancer module.
+    # Hardcoding as strings for now.   
     name                   = "internal-jbtest-lb-1400065058.eu-west-2.elb.amazonaws.com"
-    zone_id                = aws_lb.internal.zone_id
+    zone_id                = "ZHURV8PSTC4K8"
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
I've created new load balancer **jbtest-lb** in **nomis-test** and moved the listeners from existing load balancer **lb-internal-nomis** to **jbtest-lb**. The code changes have already been deployed into **nomis-test** so the Terraform plan should be clear. I've tested connectivity to **jbtest-lb** using the Windows jump server in **nomis-test**. Expect a follow-up PR in the coming days to align the load balancer with our naming standards.