### PR TITLE
DSOS-1570: allow ec2s to access imagebuilder s3 bucket

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -131,6 +131,21 @@ data "aws_iam_policy_document" "s3_bucket_access" {
       "${module.nomis-audit-archives.bucket.arn}/*"
     ]
   }
+
+  statement {
+    sid    = "AccessToImageBuilderBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.nomis-image-builder-bucket.bucket.arn,
+      "${module.nomis-image-builder-bucket.bucket.arn}/*"
+    ]
+  }
 }
 
 # combine ec2-common policy documents

--- a/terraform/environments/nomis/s3.tf
+++ b/terraform/environments/nomis/s3.tf
@@ -108,17 +108,19 @@ data "aws_iam_policy_document" "cross-account-s3" {
       "s3:PutObject",
       "s3:PutObjectAcl",
       "s3:ListBucket"
-
     ]
 
     resources = ["${module.nomis-image-builder-bucket.bucket.arn}/*",
     module.nomis-image-builder-bucket.bucket.arn, ]
     principals {
       type = "AWS"
-      identifiers = sort([ # sort to avoid plan changes
-        "arn:aws:iam::${local.account_id}:root",
-        "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root"
-      ])
+      identifiers = [
+        "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root",
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-development"]}:root",
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-test"]}:root",
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-preproduction"]}:root",
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-production"]}:root"
+      ]
     }
   }
 }
@@ -173,11 +175,9 @@ module "nomis-image-builder-bucket" {
   ]
 
   tags = local.tags
-
 }
 
 #  Audit Archive dumps bucket
-
 data "aws_iam_policy_document" "nomis-all-environments-access" {
   statement {
     sid = "all-nomis-environments-access-for-archiving"
@@ -193,10 +193,12 @@ data "aws_iam_policy_document" "nomis-all-environments-access" {
     module.nomis-audit-archives.bucket.arn, ]
     principals {
       type = "AWS"
-      identifiers = sort([ # sort to avoid plan changes
+      identifiers = [
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-development"]}:root",
         "arn:aws:iam::${local.environment_management.account_ids["nomis-test"]}:root",
+        "arn:aws:iam::${local.environment_management.account_ids["nomis-preproduction"]}:root",
         "arn:aws:iam::${local.environment_management.account_ids["nomis-production"]}:root"
-      ])
+      ]
     }
   }
 }


### PR DESCRIPTION
Allow EC2s to access imagebuilder S3 bucket within the same account.  This is for weblogic patch testing