### PR TITLE
Pinning the MP ECS module version

### DIFF
--- a/terraform/environments/mlra/ecs.tf
+++ b/terraform/environments/mlra/ecs.tf
@@ -4,7 +4,7 @@
 
 module "mlra-ecs" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs?ref=v.2.1.2"
 
   subnet_set_name         = local.subnet_set_name
   vpc_all                 = local.vpc_all


### PR DESCRIPTION
Pinning the MP ECS module version.

Using the latest version `v.2.1.2` . This version has been tested and it currently works with our configuration. 