### PR TITLE
Adding security group back in

### DIFF
--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -191,7 +191,7 @@ resource "aws_security_group" "weblogic_common" {
     protocol    = "TCP"
     security_groups = [
       aws_security_group.jumpserver-windows.id,
-      local.environment == "test" ? module.jb_load_balancer_test[0].security_group.id : aws_security_group.internal_elb.id
+      local.environment == "test" ? module.lb_internal_nomis[0].security_group.id : aws_security_group.internal_elb.id
     ]
   }
 

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -191,7 +191,7 @@ resource "aws_security_group" "weblogic_common" {
     protocol    = "TCP"
     security_groups = [
       aws_security_group.jumpserver-windows.id,
-      # local.environment == "test" ? module.jb_load_balancer_test[0].security_group.id : aws_security_group.internal_elb.id
+      local.environment == "test" ? module.jb_load_balancer_test[0].security_group.id : aws_security_group.internal_elb.id
     ]
   }
 


### PR DESCRIPTION
Now that the old load balancer and other related resources, including a security group, have been destroyed and rebuilt, I can add this back in.