### PR TITLE
DSOS-1586: backout checkov policy fixes as they don't work

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -27,6 +27,8 @@ data "aws_iam_policy_document" "ssm_custom" {
       "ssm:GetDeployablePatchSnapshotForInstance",
       "ssm:GetDocument",
       "ssm:GetManifest",
+      "ssm:GetParameter",
+      "ssm:GetParameters",
       "ssm:ListAssociations",
       "ssm:ListInstanceAssociations",
       "ssm:PutInventory",
@@ -50,18 +52,6 @@ data "aws_iam_policy_document" "ssm_custom" {
 
     #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
     resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
-  }
-}
-
-# add custom policy to SSM role to allow Ansible to run
-data "aws_iam_policy_document" "ssm_custom_ansible" {
-  statement {
-    sid    = "CustomSsmPolicyAnsible"
-    effect = "Allow"
-    actions = [
-      "ssm:GetParameters",
-    ]
-    resources = ["arn:aws:ec2:*:*:instance/*"]
   }
 }
 
@@ -164,7 +154,6 @@ data "aws_iam_policy_document" "s3_bucket_access" {
 data "aws_iam_policy_document" "ec2_common_combined" {
   source_policy_documents = [
     data.aws_iam_policy_document.ssm_custom.json,
-    data.aws_iam_policy_document.ssm_custom_ansible.json,
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json
   ]

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -48,9 +48,10 @@ data "aws_iam_policy_document" "ssm_custom" {
       "ec2messages:GetMessages",
       "ec2messages:SendReply"
     ]
-    # skiping these as policy is a scoped down version of Amazon provided AmazonSSMManagedInstanceCore managed policy.  Permissions required for SSM function
+    # skipping these as policy is a scoped down version of Amazon provided AmazonSSMManagedInstanceCore managed policy.  Permissions required for SSM function
 
     #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+    #checkov:skip=CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
     resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
   }
 }


### PR DESCRIPTION
Back this out as EC2s are unable to access SSM parameters