### PR TITLE
Converting rebuild after nuke to using a GHA secret from hardcoded list.

### DIFF
--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Apply after nuke - ${{ matrix.nuke_accts }}
         run: |
           terraform --version
-          echo "Terraform apply - ${ACCOUNT_NAME%-development}"
+          echo "Terraform apply - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
           bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
           terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
           bash scripts/terraform-apply.sh terraform/environments/${ACCOUNT_NAME%-development}

--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -9,7 +9,7 @@ on:
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
-  NUKE_DO_NOT_RECREATE_ENVIRONMENTS: performance-hub-development,example-development,testing-test-development,
+  NUKE_REDEPLOY_ACCOUNTS: ${{ secrets.MODERNISATION_PLATFORM_AUTONUKE_REBUILD }}
   TF_IN_AUTOMATION: true
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -19,21 +19,26 @@ defaults:
     shell: bash
 
 jobs:
-
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: echo "matrix=$(jq -c '.|sort' <<< $NUKE_REDEPLOY_ACCOUNTS)" >> $GITHUB_OUTPUT
   redeploy-after-nuke:
     strategy:
       fail-fast: false
       matrix:
-        # current content of nuke list: {"COOKER_DEVELOPMENT_ACCID","SPRINKLER_DEVELOPMENT_ACCID","EXAMPLE_DEVELOPMENT_ACCID","TESTING_TEST_DEVELOPMENT_ACCID,"DELIUS_IAPS_DEVELOPMENT_ACCID"}
-        # matrix values are contents of that list minus accounts in the exclusion list defined in NUKE_DO_NOT_RECREATE_ENVIRONMENTS.
-        nuke_accts: [sprinkler, delius-iaps, data-and-insights-wepi, cooker]
+        nuke_accts: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     name: Redeploy after nuke
+    needs: setup-matrix
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}-development" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
@@ -48,9 +53,9 @@ jobs:
       - name: Apply after nuke - ${{ matrix.nuke_accts }}
         run: |
           terraform --version
-          echo "Terraform apply - ${ACCOUNT_NAME}"
-          bash scripts/terraform-init.sh terraform/environments/$ACCOUNT_NAME
-          terraform -chdir="terraform/environments/${ACCOUNT_NAME}" workspace select "${ACCOUNT_NAME}-development"
-          bash scripts/terraform-apply.sh terraform/environments/$ACCOUNT_NAME
+          echo "Terraform apply - ${ACCOUNT_NAME%-development}"
+          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
+          terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
+          bash scripts/terraform-apply.sh terraform/environments/${ACCOUNT_NAME%-development}
     env:
       ACCOUNT_NAME: ${{ matrix.nuke_accts }}


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2400

Refactoring the rebuild-after-nuke workflow to run off a GHA secret rather than a hardcoded list.

Code to generate the contents of the secret: https://github.com/ministryofjustice/modernisation-platform-terraform-environments/pull/23
Code to create the secrets: https://github.com/ministryofjustice/modernisation-platform/pull/2772

* As you can not use secrets or environment variables directly to set the contents of the matrix, this adds an additional `setup-matrix`  job that parses the list into an output.
* Modifies `redeploy-after-nuke` job to consume the output of the `setup-matrix` job rather than a hard-coded list of accounts.

Test run with plan substituted for apply to demonstrate the above: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/3637299214