### PR TITLE
mlra/workspace-access

### DIFF
--- a/terraform/environments/mlra/alb.tf
+++ b/terraform/environments/mlra/alb.tf
@@ -18,6 +18,7 @@ module "alb" {
   security_group_ingress_to_port   = 80
   security_group_ingress_protocol  = "tcp"
   ingress_cidr_block               = local.application_data.accounts[local.environment].lz_vpc_cidr
+  lz_workspace_ingress_cidr        = local.application_data.accounts[local.environment].lz_workspace_ingress_cidr 
 
   listener_protocol = "HTTP"
   listener_port     = 80

--- a/terraform/environments/mlra/application_variables.json
+++ b/terraform/environments/mlra/application_variables.json
@@ -30,6 +30,7 @@
       "ecs_scaling_mem_threshold": 80,
       "mp_vpc_id": "vpc-06febffe7b87ab37f",
       "lz_vpc_cidr": "10.202.0.0/20",
+      "lz_workspace_ingress_cidr": "10.200.0.0/20",
       "mp_laa_int_endpoint_security_group": "sg-0754d9a309704addd",
       "mp_private_2a_subnet_id": "subnet-06594eda5221bd3c9"
     },
@@ -63,6 +64,7 @@
       "ecs_scaling_mem_threshold": 80,
       "mp_vpc_id": "vpc-03b493ca0dc364b78",
       "lz_vpc_cidr": "10.203.0.0/20",
+      "lz_workspace_ingress_cidr": "10.200.0.0/20",
       "mp_laa_int_endpoint_security_group": "sg-0a8e105b2345a1840",
       "mp_private_2a_subnet_id": "subnet-082f917f7abd1cd68"
     },
@@ -96,6 +98,7 @@
       "ecs_scaling_mem_threshold": 80,
       "mp_vpc_id": "vpc-045c1efc32aa54598",
       "lz_vpc_cidr": "10.206.0.0/20",
+      "lz_workspace_ingress_cidr": "10.200.16.0/20",
       "mp_laa_int_endpoint_security_group": "sg-0607158c98d5df1bb",
       "mp_private_2a_subnet_id": "subnet-063bec8ad1ef41959"
     },
@@ -129,6 +132,7 @@
       "ecs_scaling_mem_threshold": 80,
       "mp_vpc_id": "vpc-0fe62e6799b319460",
       "lz_vpc_cidr": "10.205.0.0/20",
+      "lz_workspace_ingress_cidr": "10.200.16.0/20",
       "mp_laa_int_endpoint_security_group": "sg-0e7c18081199d1cf1",
       "mp_private_2a_subnet_id": "subnet-04740cd676f9d84bc"
     }

--- a/terraform/environments/mlra/modules/alb/main.tf
+++ b/terraform/environments/mlra/modules/alb/main.tf
@@ -27,6 +27,14 @@ locals {
       cidr_blocks     = [var.ingress_cidr_block]
       security_groups = []
     }
+    "lb_workspace_ingress" = {
+      description     = "Loadbalancer ingress rule"
+      from_port       = var.security_group_ingress_from_port
+      to_port         = var.security_group_ingress_to_port
+      protocol        = var.security_group_ingress_protocol
+      cidr_blocks     = [var.lz_workspace_ingress_cidr]
+      security_groups = []
+    }
   }
   loadbalancer_egress_rules = {
     "lb_egress" = {

--- a/terraform/environments/mlra/modules/alb/variables.tf
+++ b/terraform/environments/mlra/modules/alb/variables.tf
@@ -54,6 +54,10 @@ variable "ingress_cidr_block" {
   type        = string
   description = "The cidr block for the lb ingress rules"
 }
+variable "lz_workspace_ingress_cidr" {
+  type        = string
+  description = "The cidr block for direct access from workspaces to the app via nlb ip"
+}
 variable "listener_port" {
   type        = string
   description = "The port number for the ALB Listener"


### PR DESCRIPTION
Adds ingress from workspaces in laa-shared-services to access the application directly for Ops system testing purposes.