### PR TITLE
Replacing debug value for matrix with dynamically generated matrix value

### DIFF
--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -54,8 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
-        nuke_accts: [cooker-development,sprinkler-development]
+        nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
     name: Sandbox Nuke
     permissions:
       id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2400


Removing the debug version of the matrix variable and adding in the generated version instead.

Related PR: https://github.com/ministryofjustice/modernisation-platform-environments/pull/1153
