### PR TITLE
Updating bastion version in example-development account

### DIFF
--- a/terraform/environments/example/bastion_linux.tf
+++ b/terraform/environments/example/bastion_linux.tf
@@ -4,7 +4,7 @@ locals {
 
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v3.0.5"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v3.0.6"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts


### PR DESCRIPTION
Version 3.0.6 of the bastion repo uses templatefile terraform function for templates. This is to replace the discontinued hashicorp/template provider.


Linked issue: https://github.com/ministryofjustice/modernisation-platform/issues/2506
Tested  locally with plan/apply.