### PR TITLE
Moved sns vars to locals

### DIFF
--- a/terraform/environments/mlra/cloudwatch.tf
+++ b/terraform/environments/mlra/cloudwatch.tf
@@ -1,8 +1,3 @@
-#Get Pagerduty keys from modplatform
-locals {
-  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  sns_topic_name             = "${local.application_name}-${local.environment}-alerting-topic"
-}
 
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   provider = aws.modernisation-platform

--- a/terraform/environments/mlra/locals.tf
+++ b/terraform/environments/mlra/locals.tf
@@ -47,7 +47,9 @@ locals {
 
   is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
   provider_name = "core-vpc-${local.environment}"
-
+  # sns variables
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  sns_topic_name             = "${local.application_name}-${local.environment}-alerting-topic"
   # environment specfic variables
   # example usage:
   # example_data = local.application_data.accounts[local.environment].example_var


### PR DESCRIPTION
To make things more uniform it was decided to move two variables to the locals.tf instead of having them in the cloudwatch.tf
This Pr corrects this issue.