### PR TITLE
Nomis: jumpserver bodges

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -145,15 +145,16 @@ module "db_ec2_instance" {
 
   name = each.key
 
-  ami_name              = each.value.ami_name
-  ami_owner             = try(each.value.ami_owner, "core-shared-services-production")
-  instance              = merge(local.database.instance, lookup(each.value, "instance", {}))
-  user_data_cloud_init  = merge(local.database.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
-  ebs_volume_config     = merge(local.database.ebs_volume_config, lookup(each.value, "ebs_volume_config", {}))
-  ebs_volumes           = { for k, v in local.database.ebs_volumes : k => merge(v, try(each.value.ebs_volumes[k], {})) }
-  ssm_parameters_prefix = "database/"
-  ssm_parameters        = merge(local.database.ssm_parameters, lookup(each.value, "ssm_parameters", {}))
-  route53_records       = merge(local.database.route53_records, lookup(each.value, "route53_records", {}))
+  ami_name                      = each.value.ami_name
+  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
+  instance                      = merge(local.database.instance, lookup(each.value, "instance", {}))
+  user_data_cloud_init          = merge(local.database.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
+  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config             = merge(local.database.ebs_volume_config, lookup(each.value, "ebs_volume_config", {}))
+  ebs_volumes                   = { for k, v in local.database.ebs_volumes : k => merge(v, try(each.value.ebs_volumes[k], {})) }
+  ssm_parameters_prefix         = "database/"
+  ssm_parameters                = merge(local.database.ssm_parameters, lookup(each.value, "ssm_parameters", {}))
+  route53_records               = merge(local.database.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-database"
   instance_profile_policies = concat(local.ec2_common_managed_policies, [aws_iam_policy.s3_db_backup_bucket_access.arn])

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -27,7 +27,10 @@ locals {
     ebs_volumes_copy_all_from_ami = false
 
     ebs_volumes = {
-      "/dev/sda1" = {}
+      "/dev/sda1" = {
+        type = "gp3"
+        size = "100"
+      }
     }
 
     user_data_raw = base64encode(templatefile("./templates/jumpserver-user-data.yaml", { SECRET_PREFIX = local.secret_prefix, S3_BUCKET = module.s3-bucket.bucket.id }))

--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -69,15 +69,16 @@ module "ec2_test_instance" {
 
   name = each.key
 
-  ami_name              = each.value.ami_name
-  ami_owner             = try(each.value.ami_owner, "core-shared-services-production")
-  instance              = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  user_data_cloud_init  = merge(local.ec2_test.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
-  ebs_volume_config     = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes           = lookup(each.value, "ebs_volumes", {})
-  ssm_parameters_prefix = lookup(each.value, "ssm_parameters_prefix", "test/")
-  ssm_parameters        = lookup(each.value, "ssm_parameters", null)
-  route53_records       = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
+  ami_name                      = each.value.ami_name
+  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
+  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  user_data_cloud_init          = merge(local.ec2_test.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
+  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
+  route53_records               = merge(local.ec2_test.route53_records, lookup(each.value, "route53_records", {}))
 
   iam_resource_names_prefix = "ec2-test-instance"
   instance_profile_policies = local.ec2_common_managed_policies
@@ -108,16 +109,17 @@ module "ec2_test_autoscaling_group" {
 
   name = each.key
 
-  ami_name              = each.value.ami_name
-  ami_owner             = try(each.value.ami_owner, "core-shared-services-production")
-  instance              = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
-  user_data_cloud_init  = merge(local.ec2_test.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
-  ebs_volume_config     = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes           = lookup(each.value, "ebs_volumes", {})
-  ssm_parameters_prefix = lookup(each.value, "ssm_parameters_prefix", "test/")
-  ssm_parameters        = lookup(each.value, "ssm_parameters", null)
-  autoscaling_group     = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
-  autoscaling_schedules = coalesce(lookup(each.value, "autoscaling_schedules", null), local.ec2_test.autoscaling_schedules)
+  ami_name                      = each.value.ami_name
+  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
+  instance                      = merge(local.ec2_test.instance, lookup(each.value, "instance", {}))
+  user_data_cloud_init          = merge(local.ec2_test.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
+  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
+  ssm_parameters                = lookup(each.value, "ssm_parameters", null)
+  autoscaling_group             = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
+  autoscaling_schedules         = coalesce(lookup(each.value, "autoscaling_schedules", null), local.ec2_test.autoscaling_schedules)
 
   iam_resource_names_prefix = "ec2-test-asg"
   instance_profile_policies = local.ec2_common_managed_policies

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -109,15 +109,16 @@ module "ec2_weblogic_autoscaling_group" {
 
   name = each.key
 
-  ami_name              = each.value.ami_name
-  ami_owner             = try(each.value.ami_owner, "core-shared-services-production")
-  instance              = merge(local.ec2_weblogic.instance, lookup(each.value, "instance", {}))
-  user_data_cloud_init  = merge(local.ec2_weblogic.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
-  ebs_volume_config     = lookup(each.value, "ebs_volume_config", {})
-  ebs_volumes           = lookup(each.value, "ebs_volumes", {})
-  ssm_parameters_prefix = "weblogic/"
-  ssm_parameters        = {}
-  autoscaling_group     = merge(local.ec2_weblogic.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
+  ami_name                      = each.value.ami_name
+  ami_owner                     = try(each.value.ami_owner, "core-shared-services-production")
+  instance                      = merge(local.ec2_weblogic.instance, lookup(each.value, "instance", {}))
+  user_data_cloud_init          = merge(local.ec2_weblogic.user_data_cloud_init, lookup(each.value, "user_data_cloud_init", {}))
+  ebs_volumes_copy_all_from_ami = try(each.value.ebs_volumes_copy_all_from_ami, true)
+  ebs_volume_config             = lookup(each.value, "ebs_volume_config", {})
+  ebs_volumes                   = lookup(each.value, "ebs_volumes", {})
+  ssm_parameters_prefix         = "weblogic/"
+  ssm_parameters                = {}
+  autoscaling_group             = merge(local.ec2_weblogic.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
   autoscaling_schedules = coalesce(lookup(each.value, "autoscaling_schedules", null), {
     # if sizes not set, use the values defined in autoscaling_group
     "scale_up" = {

--- a/terraform/environments/nomis/modules/ec2_autoscaling_group/locals.tf
+++ b/terraform/environments/nomis/modules/ec2_autoscaling_group/locals.tf
@@ -48,7 +48,7 @@ locals {
   }
 
   # merge AMI and var.ebs_volume values, e.g. allow AMI settings to be overridden
-  ebs_volume_names = keys(merge(var.ebs_volumes, local.ami_block_device_mappings))
+  ebs_volume_names = var.ebs_volumes_copy_all_from_ami ? keys(merge(var.ebs_volumes, local.ami_block_device_mappings)) : keys(var.ebs_volumes)
 
   ebs_volumes = {
     for key in local.ebs_volume_names :

--- a/terraform/environments/nomis/modules/ec2_autoscaling_group/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_autoscaling_group/variables.tf
@@ -127,6 +127,12 @@ variable "user_data_cloud_init" {
   default = null
 }
 
+variable "ebs_volumes_copy_all_from_ami" {
+  description = "If true, ensure all volumes in AMI are also present in EC2.  If false, only create volumes specified in ebs_volumes var"
+  type        = bool
+  default     = true
+}
+
 variable "ebs_volume_config" {
   description = "EC2 volume configurations, where key is a label, e.g. flash, which is assigned to the disk in ebs_volumes.  All disks with same label have the same configuration.  If not specified, use values from the AMI.  If total_size specified, the volume size is this divided by the number of drives with the given label"
   type = map(object({

--- a/terraform/environments/nomis/modules/ec2_instance/locals.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/locals.tf
@@ -62,7 +62,8 @@ locals {
   }
 
   # merge AMI and var.ebs_volume values, e.g. allow AMI settings to be overridden
-  ebs_volume_names = keys(merge(var.ebs_volumes, local.ami_block_device_mappings_nonroot))
+  ebs_volume_names = var.ebs_volumes_copy_all_from_ami ? keys(merge(var.ebs_volumes, local.ami_block_device_mappings)) : keys(var.ebs_volumes)
+
   ebs_volumes = {
     for key in local.ebs_volume_names :
     key => merge(

--- a/terraform/environments/nomis/modules/ec2_instance/variables.tf
+++ b/terraform/environments/nomis/modules/ec2_instance/variables.tf
@@ -131,6 +131,12 @@ variable "user_data_cloud_init" {
   default = null
 }
 
+variable "ebs_volumes_copy_all_from_ami" {
+  description = "If true, ensure all volumes in AMI are also present in EC2.  If false, only create volumes specified in ebs_volumes var"
+  type        = bool
+  default     = true
+}
+
 variable "ebs_volume_config" {
   description = "EC2 volume configurations, where key is a label, e.g. flash, which is assigned to the disk in ebs_volumes.  All disks with same label have the same configuration.  If not specified, use values from the AMI.  If total_size specified, the volume size is this divided by the number of drives with the given label"
   type = map(object({

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -112,18 +112,18 @@ locals {
       }
     }
     ec2_jumpservers = {
-      jumpserver0 = {
-        ami_name = "nomis_windows_server_2022_jumpserver_2022*"
-        tags = {
-          server-type = "jumpserver"
-          description = "Jumpserver for NOMIS"
-        }
-        ebs_volumes = {}
-        autoscaling_group = {
-          min_size = 0
-          max_size = 1
-        }
-      }
+      #      jumpserver0 = {
+      #        ami_name = "nomis_windows_server_2022_jumpserver_2022*"
+      #        tags = {
+      #          server-type = "jumpserver"
+      #          description = "Jumpserver for NOMIS"
+      #        }
+      #        ebs_volumes = {}
+      #        autoscaling_group = {
+      #          min_size = 0
+      #          max_size = 1
+      #        }
+      #      }
     }
   }
 }

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -112,18 +112,17 @@ locals {
       }
     }
     ec2_jumpservers = {
-      #      jumpserver0 = {
-      #        ami_name = "nomis_windows_server_2022_jumpserver_2022*"
-      #        tags = {
-      #          server-type = "jumpserver"
-      #          description = "Jumpserver for NOMIS"
-      #        }
-      #        ebs_volumes = {}
-      #        autoscaling_group = {
-      #          min_size = 0
-      #          max_size = 1
-      #        }
-      #      }
+      jumpserver-2022 = {
+        ami_name = "nomis_windows_server_2022_jumpserver_2022*"
+        tags = {
+          server-type = "jumpserver"
+          description = "Windows Server 2022 Jumpserver for NOMIS"
+        }
+        autoscaling_group = {
+          min_size = 0
+          max_size = 1
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Add option to ignore EBS volumes in AMI images and set this for jumpserver.
This is to get rid of the unwanted EBS ephemeral devices in the jumpserver images which is causing terraform problems.