### PR TITLE
Remove deprecated provider attribute from mp apps

### DIFF
--- a/terraform/environments/cooker/providers.tf
+++ b/terraform/environments/cooker/providers.tf
@@ -13,9 +13,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -23,9 +22,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-sandbox"
   }
@@ -33,9 +31,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }

--- a/terraform/environments/example/providers.tf
+++ b/terraform/environments/example/providers.tf
@@ -13,9 +13,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -23,9 +22,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -33,9 +31,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }

--- a/terraform/environments/sprinkler/providers.tf
+++ b/terraform/environments/sprinkler/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-sandbox"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -63,8 +60,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
-
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
 #   }
@@ -74,8 +69,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
-
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
 #   }
@@ -85,7 +78,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }


### PR DESCRIPTION
```
Warning: Argument is deprecated

  with provider["registry.terraform.io/hashicorp/aws"].modernisation-platform,
  on providers.tf line 19, in provider "aws":
  19:   skip_get_ec2_platforms = true

With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has
been deprecated and will be removed in a future version.
```

Resolves the above warning.