### PR TITLE
Remove deprecated provider attribute from apps

### DIFF
--- a/terraform/environments/apex/providers.tf
+++ b/terraform/environments/apex/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/ccms-ebs/providers.tf
+++ b/terraform/environments/ccms-ebs/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/data-and-insights-wepi/providers.tf
+++ b/terraform/environments/data-and-insights-wepi/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "core-vpc"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
 #   }
@@ -79,7 +74,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "core-network-services"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
 #   }

--- a/terraform/environments/delius-iaps/providers.tf
+++ b/terraform/environments/delius-iaps/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/delius-jitbit/providers.tf
+++ b/terraform/environments/delius-jitbit/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/digital-prison-reporting/providers.tf
+++ b/terraform/environments/digital-prison-reporting/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/equip/providers.tf
+++ b/terraform/environments/equip/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/maatdb/providers.tf
+++ b/terraform/environments/maatdb/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/mlra/providers.tf
+++ b/terraform/environments/mlra/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
 #   }
@@ -80,7 +75,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"
 #   }

--- a/terraform/environments/nomis/providers.tf
+++ b/terraform/environments/nomis/providers.tf
@@ -15,9 +15,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -25,9 +24,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -35,9 +33,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }

--- a/terraform/environments/oasys/providers.tf
+++ b/terraform/environments/oasys/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = can(regex("modernisation-platform-developer", data.aws_iam_session_context.whoami.issuer_arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/performance-hub/providers.tf
+++ b/terraform/environments/performance-hub/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/ppud/providers.tf
+++ b/terraform/environments/ppud/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/refer-monitor/providers.tf
+++ b/terraform/environments/refer-monitor/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/tariff/providers.tf
+++ b/terraform/environments/tariff/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/threat-and-vulnerability-mgmt/providers.tf
+++ b/terraform/environments/threat-and-vulnerability-mgmt/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/xhibit-portal/providers.tf
+++ b/terraform/environments/xhibit-portal/providers.tf
@@ -14,9 +14,8 @@ provider "aws" {
 
 # AWS provider for the Modernisation Platform, to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -24,9 +23,8 @@ provider "aws" {
 
 # AWS provider for core-vpc-<environment>, to share VPCs into this account
 provider "aws" {
-  alias                  = "core-vpc"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-vpc"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -34,9 +32,8 @@ provider "aws" {
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
 provider "aws" {
-  alias                  = "core-network-services"
-  region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
+  alias  = "core-network-services"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/xhibit-portal/providers.tf.gh
+++ b/terraform/environments/xhibit-portal/providers.tf.gh
@@ -16,7 +16,6 @@ provider "aws" {
 provider "aws" {
   alias                  = "modernisation-platform"
   region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -26,7 +25,6 @@ provider "aws" {
 provider "aws" {
   alias                  = "core-vpc"
   region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
@@ -36,7 +34,6 @@ provider "aws" {
 provider "aws" {
   alias                  = "core-network-services"
   region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
@@ -60,7 +57,6 @@ provider "aws" {
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -70,7 +66,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-vpc"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 # provider "aws" {
 #   alias  = "core-network-services"
 #   region = "eu-west-2"
-#   skip_get_ec2_platforms = true
 
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"

--- a/terraform/environments/xhibit-portal/providers.tf.local
+++ b/terraform/environments/xhibit-portal/providers.tf.local
@@ -16,7 +16,6 @@
 # provider "aws" {
 #   alias                  = "modernisation-platform"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
 #   }
@@ -26,7 +25,6 @@
 # provider "aws" {
 #   alias                  = "core-vpc"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
 #   }
@@ -36,7 +34,6 @@
 # provider "aws" {
 #   alias                  = "core-network-services"
 #   region                 = "eu-west-2"
-#   skip_get_ec2_platforms = true
 #   assume_role {
 #     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
 #   }
@@ -60,7 +57,6 @@ provider "aws" {
 provider "aws" {
   alias                  = "modernisation-platform"
   region                 = "eu-west-2"
-  skip_get_ec2_platforms = true
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
@@ -70,7 +66,6 @@ provider "aws" {
 provider "aws" {
   alias  = "core-vpc"
   region = "eu-west-2"
-  skip_get_ec2_platforms = true
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only"
@@ -81,7 +76,6 @@ provider "aws" {
 provider "aws" {
   alias  = "core-network-services"
   region = "eu-west-2"
-  skip_get_ec2_platforms = true
 
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-dns-records"


### PR DESCRIPTION
```
Warning: Argument is deprecated

  with provider["registry.terraform.io/hashicorp/aws"].modernisation-platform,
  on providers.tf line 19, in provider "aws":
  19:   skip_get_ec2_platforms = true

With the retirement of EC2-Classic the skip_get_ec2_platforms attribute has
been deprecated and will be removed in a future version.
```

Resolves the above warning.