### PR TITLE
nomis: DSOS-1522: revise security groups

### DIFF
--- a/terraform/environments/nomis/cidrs.tf
+++ b/terraform/environments/nomis/cidrs.tf
@@ -21,6 +21,7 @@ locals {
     nomisapi_prod_root_vnet    = "10.47.0.128/26"
 
     # AWS
-    cloud_platform = "172.20.0.0/16"
+    cloud_platform              = "172.20.0.0/16"
+    analytical_platform_airflow = "10.200.0.0/15"
   }
 }

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -105,15 +105,49 @@ resource "aws_security_group" "jumpserver-windows" {
   vpc_id      = local.vpc_id
 
   ingress {
-    description = "access from Cloud Platform Prometheus server"
+    description = "Internal access to self on all ports"
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    self        = true
+  }
+
+  ingress {
+    description = "Internal access to RDP"
+    from_port   = "3389"
+    to_port     = "3389"
+    protocol    = "TCP"
+    security_groups = [
+      module.bastion_linux.bastion_security_group
+    ]
+  }
+
+  ingress {
+    description = "External access to RDP"
+    from_port   = "3389"
+    to_port     = "3389"
+    protocol    = "TCP"
+    cidr_blocks = local.environment_config.external_remote_access_cidrs
+  }
+
+  ingress {
+    description = "External access to prometheus node exporter"
     from_port   = "9100"
     to_port     = "9100"
     protocol    = "TCP"
     cidr_blocks = [local.cidrs.cloud_platform]
   }
 
+  ingress {
+    description = "External access to prometheus wmi exporter"
+    from_port   = "9182"
+    to_port     = "9182"
+    protocol    = "TCP"
+    cidr_blocks = [local.cidrs.cloud_platform]
+  }
+
   egress {
-    description = "allow all"
+    description = "Allow all egress"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -1,11 +1,22 @@
 # nomis-development environment settings
 locals {
   nomis_development = {
-    # ip ranges for external access to database instances
-    database_external_access_cidr = [
+    # account specific CIDRs for EC2 security groups
+    external_database_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
-      local.cidrs.cloud_platform
+      local.cidrs.cloud_platform,
+      local.cidrs.analytical_platform_airflow,
+      local.cidrs.aks_studio_hosting_dev_1,
+      local.cidrs.nomisapi_t3_root_vnet,
+    ]
+    external_oem_agent_access_cidrs = [
+      local.cidrs.noms_test,
+      local.cidrs.noms_mgmt,
+    ]
+    external_remote_access_cidrs = [
+      local.cidrs.noms_test,
+      local.cidrs.noms_mgmt,
     ]
 
     # vars common across ec2 instances

--- a/terraform/environments/nomis/nomis-development.tf
+++ b/terraform/environments/nomis/nomis-development.tf
@@ -5,6 +5,8 @@ locals {
     external_database_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
       local.cidrs.cloud_platform,
       local.cidrs.analytical_platform_airflow,
       local.cidrs.aks_studio_hosting_dev_1,
@@ -13,10 +15,14 @@ locals {
     external_oem_agent_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
     ]
     external_remote_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
     ]
 
     # vars common across ec2 instances

--- a/terraform/environments/nomis/nomis-preproduction.tf
+++ b/terraform/environments/nomis/nomis-preproduction.tf
@@ -5,6 +5,8 @@ locals {
     external_database_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
       local.cidrs.cloud_platform,
       local.cidrs.analytical_platform_airflow,
       local.cidrs.aks_studio_hosting_live_1,
@@ -14,10 +16,14 @@ locals {
     external_oem_agent_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
     ]
     external_remote_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
     ]
 
     # vars common across ec2 instances

--- a/terraform/environments/nomis/nomis-preproduction.tf
+++ b/terraform/environments/nomis/nomis-preproduction.tf
@@ -1,11 +1,23 @@
 # nomis-preproduction environment settings
 locals {
   nomis_preproduction = {
-    # ip ranges for external access to database instances
-    database_external_access_cidr = [
+    # account specific CIDRs for EC2 security groups
+    external_database_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
-      local.cidrs.cloud_platform
+      local.cidrs.cloud_platform,
+      local.cidrs.analytical_platform_airflow,
+      local.cidrs.aks_studio_hosting_live_1,
+      local.cidrs.nomisapi_preprod_root_vnet,
+      local.cidrs.nomisapi_prod_root_vnet,
+    ]
+    external_oem_agent_access_cidrs = [
+      local.cidrs.noms_live,
+      local.cidrs.noms_mgmt_live,
+    ]
+    external_remote_access_cidrs = [
+      local.cidrs.noms_live,
+      local.cidrs.noms_mgmt_live,
     ]
 
     # vars common across ec2 instances

--- a/terraform/environments/nomis/nomis-production.tf
+++ b/terraform/environments/nomis/nomis-production.tf
@@ -1,11 +1,22 @@
 # nomis-production environment settings
 locals {
   nomis_production = {
-    # ip ranges for external access to database instances
-    database_external_access_cidr = [
+    external_database_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
-      local.cidrs.cloud_platform
+      local.cidrs.cloud_platform,
+      local.cidrs.analytical_platform_airflow,
+      local.cidrs.aks_studio_hosting_live_1,
+      local.cidrs.nomisapi_preprod_root_vnet,
+      local.cidrs.nomisapi_prod_root_vnet,
+    ]
+    external_oem_agent_access_cidrs = [
+      local.cidrs.noms_live,
+      local.cidrs.noms_mgmt_live,
+    ]
+    external_remote_access_cidrs = [
+      local.cidrs.noms_live,
+      local.cidrs.noms_mgmt_live,
     ]
 
     # Details of OMS Manager in FixNGo (only needs defining if databases in the environment are managed)

--- a/terraform/environments/nomis/nomis-production.tf
+++ b/terraform/environments/nomis/nomis-production.tf
@@ -4,6 +4,8 @@ locals {
     external_database_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
       local.cidrs.cloud_platform,
       local.cidrs.analytical_platform_airflow,
       local.cidrs.aks_studio_hosting_live_1,
@@ -13,10 +15,14 @@ locals {
     external_oem_agent_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
     ]
     external_remote_access_cidrs = [
       local.cidrs.noms_live,
       local.cidrs.noms_mgmt_live,
+      local.cidrs.noms_live_dr,
+      local.cidrs.noms_mgmt_live_dr,
     ]
 
     # Details of OMS Manager in FixNGo (only needs defining if databases in the environment are managed)

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -1,11 +1,22 @@
 # nomis-test environment settings
 locals {
   nomis_test = {
-    # ip ranges for external access to database instances
-    database_external_access_cidr = [
+    # account specific CIDRs for EC2 security groups
+    external_database_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
-      local.cidrs.cloud_platform
+      local.cidrs.cloud_platform,
+      local.cidrs.analytical_platform_airflow,
+      local.cidrs.aks_studio_hosting_dev_1,
+      local.cidrs.nomisapi_t3_root_vnet,
+    ]
+    external_oem_agent_access_cidrs = [
+      local.cidrs.noms_test,
+      local.cidrs.noms_mgmt,
+    ]
+    external_remote_access_cidrs = [
+      local.cidrs.noms_test,
+      local.cidrs.noms_mgmt,
     ]
 
     # vars common across ec2 instances

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -5,6 +5,8 @@ locals {
     external_database_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
       local.cidrs.cloud_platform,
       local.cidrs.analytical_platform_airflow,
       local.cidrs.aks_studio_hosting_dev_1,
@@ -13,10 +15,14 @@ locals {
     external_oem_agent_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
     ]
     external_remote_access_cidrs = [
       local.cidrs.noms_test,
       local.cidrs.noms_mgmt,
+      local.cidrs.noms_test_dr,
+      local.cidrs.noms_mgmt_dr,
     ]
 
     # vars common across ec2 instances


### PR DESCRIPTION
Add access for analytical platform and the AKS clusters.
Aligned the rules while I was at it:
- consistent access for ssh / rdp / prometheus across all groups
- consistent naming
- rules are in port order in the terraform