### PR TITLE
Add automation to tidy old PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,27 @@
+name: Close stale PRs
+
+permissions: {}
+
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '17 1 * * *'
+
+jobs:
+  stale:
+    permissions:
+      contents: write # only for delete-branch option
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # v6.0.1
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 40 days with no activity.'
+          days-before-issue-stale: 90
+          days-before-pr-stale: 30
+          days-before-issue-close: -1
+          days-before-pr-close: 10
+          delete-branch: true


### PR DESCRIPTION
Using this action - https://github.com/actions/stale we can automate the tidying up of old PRs.

After 30 days of no activity, the PR will be marked as stale.  If no body comments or removes the stale tag, after a further 10 days the PR will be closed and the branch deleted.  This includes draft PRs.