### PR TITLE
DSOS-1611: migrate weblogic ami to ansible

### DIFF
--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -43,17 +43,6 @@ locals {
       max_size         = 2
       min_size         = 0
     }
-
-    autoscaling_schedules = {
-      # if sizes not set, use the values defined in autoscaling_group
-      "scale_up" = {
-        recurrence = "0 7 * * Mon-Fri"
-      }
-      "scale_down" = {
-        desired_capacity = 0
-        recurrence       = "0 19 * * Mon-Fri"
-      }
-    }
   }
 }
 
@@ -119,7 +108,16 @@ module "ec2_test_autoscaling_group" {
   ssm_parameters_prefix         = lookup(each.value, "ssm_parameters_prefix", "test/")
   ssm_parameters                = lookup(each.value, "ssm_parameters", null)
   autoscaling_group             = merge(local.ec2_test.autoscaling_group, lookup(each.value, "autoscaling_group", {}))
-  autoscaling_schedules         = coalesce(lookup(each.value, "autoscaling_schedules", null), local.ec2_test.autoscaling_schedules)
+  autoscaling_schedules = coalesce(lookup(each.value, "autoscaling_schedules", null), {
+    # if sizes not set, use the values defined in autoscaling_group
+    "scale_up" = {
+      recurrence = "0 7 * * Mon-Fri"
+    }
+    "scale_down" = {
+      desired_capacity = lookup(each.value, "offpeak_desired_capacity", 0)
+      recurrence       = "0 19 * * Mon-Fri"
+    }
+  })
 
   iam_resource_names_prefix = "ec2-test-asg"
   instance_profile_policies = local.ec2_common_managed_policies

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -164,7 +164,6 @@ locals {
         # NOTE: setting desired capacity to 0 until fully working
         autoscaling_group = {
           desired_capacity = 0
-          warm_pool        = null
         }
         offpeak_desired_capacity = 0
       }

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -158,13 +158,12 @@ locals {
           oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
           oracle-db-name     = "CNOMT1"
         }
-        ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_test_2022-12-22T17-25-08.543Z"
+        ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2022-12-23T13-04-38.814Z"
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
-        # NOTE: setting desired capacity to 0 as this is not fully working yet
-        # See DSOS-1570 and DSOS-1571
+        # NOTE: setting desired capacity to 0 until fully working
         autoscaling_group = {
-          desired_capacity = 1
+          desired_capacity = 0
           warm_pool        = null
         }
         offpeak_desired_capacity = 0

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -180,6 +180,34 @@ locals {
     }
 
     ec2_test_instances = {}
+    ec2_test_autoscaling_groups = {
+      t1-ndh-app = {
+        tags = {
+          server-type = "ndh-app"
+          description = "Standalone EC2 for testing RHEL7.9 NDH App"
+        }
+        ami_name = "nomis_rhel_7_9_baseimage_2022-11-01T13-43-46.384Z"
+        # branch   = var.BRANCH_NAME # comment in if testing ansible
+        autoscaling_group = {
+          desired_capacity = 1
+        }
+        autoscaling_schedules = {}
+        subnet_name           = "data"
+      }
+      t1-ndh-ems = {
+        tags = {
+          server-type = "ndh-ems"
+          description = "Standalone EC2 for testing RHEL7.9 NDH EMS"
+        }
+        ami_name = "nomis_rhel_7_9_baseimage_2022-11-01T13-43-46.384Z"
+        # branch   = var.BRANCH_NAME # comment in if testing ansible
+        autoscaling_group = {
+          desired_capacity = 1
+        }
+        autoscaling_schedules = {}
+        subnet_name           = "data"
+      }
+    }
     ec2_jumpservers    = {}
   }
 }

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -153,16 +153,19 @@ locals {
     weblogic_autoscaling_groups = {
       t1-nomis-web = {
         tags = {
+          ami                = "nomis_rhel_6_10_weblogic_appserver_10_3"
+          description        = "T1 nomis weblogic 10.3"
           oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
-          oracle-sid         = "CNOMT1"
+          oracle-db-name     = "CNOMT1"
         }
-        ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2022-11-02T00-00-24.828Z"
+        ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_test_2022-12-22T17-25-08.543Z"
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
         # NOTE: setting desired capacity to 0 as this is not fully working yet
         # See DSOS-1570 and DSOS-1571
         autoscaling_group = {
-          desired_capacity = 0
+          desired_capacity = 1
+          warm_pool        = null
         }
         offpeak_desired_capacity = 0
       }

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -161,7 +161,7 @@ locals {
         ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2022-12-23T13-04-38.814Z"
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
-        # NOTE: setting desired capacity to 0 until fully working
+        # NOTE: setting desired capacity to 0 until fully working DSOS-1611
         autoscaling_group = {
           desired_capacity = 0
         }

--- a/terraform/environments/nomis/nomis-test.tf
+++ b/terraform/environments/nomis/nomis-test.tf
@@ -206,6 +206,6 @@ locals {
         subnet_name           = "data"
       }
     }
-    ec2_jumpservers    = {}
+    ec2_jumpservers = {}
   }
 }


### PR DESCRIPTION
Update t1-nomis-web to use the newer, shinier, and hopefully working version of weblogic
Aligned ec2-test ASG with the weblogic one by adding "offpeak_desired_capacity" option.

Also added Tony's NDH ASGs which were applied via a branch but forgot to make its way into main
