### PR TITLE
Nomis: DSOS-1613: test new base amis

### DIFF
--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -25,6 +25,7 @@ locals {
         lifecycle_hook_name = "ready-hook"
       }
       scripts = [
+        "install-ssm-agent.sh.tftpl",
         "ansible-ec2provision.sh.tftpl",
         "post-ec2provision.sh.tftpl"
       ]

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -60,43 +60,7 @@ locals {
       # *-nomis-db-2: MIS, AUDIT
       # *-nomis-db-3: HA
 
-      # For ad-hoc testing.  Comment in and out as needed
-      #      dev-nomis-db-1 = {
-      #        tags = {
-      #          server-type       = "nomis-db"
-      #          description       = "Dev database using T1 data set"
-      #          oracle-sids       = "CNOMT1"
-      #          monitored         = false
-      #          s3-db-restore-dir = "CNOMT1_20211214"
-      #        }
-      #        ami_name  = "nomis_rhel_7_9_oracledb_11_2_*"
-      #        ami_owner = "self"
-      #        ebs_volume_config = {
-      #          app = {
-      #            iops       = 300   # Temporary. See DSOS-1561
-      #            throughput = 0     # Temporary. See DSOS-1561
-      #            type       = "gp2" # Temporary. See DSOS-1561
-      #          }
-      #          data = {
-      #            iops       = 120   # Temporary. See DSOS-1561
-      #            throughput = 0     # Temporary. See DSOS-1561
-      #            type       = "gp2" # Temporary. See DSOS-1561
-      #            total_size = 200
-      #          }
-      #          flash = {
-      #            iops       = 100   # Temporary. See DSOS-1561
-      #            throughput = 0     # Temporary. See DSOS-1561
-      #            type       = "gp2" # Temporary. See DSOS-1561
-      #            total_size = 2
-      #          }
-      #          swap = {
-      #            iops       = 100   # Temporary. See DSOS-1561
-      #            throughput = 0     # Temporary. See DSOS-1561
-      #            type       = "gp2" # Temporary. See DSOS-1561
-      #          }
-      #        }
-      #        # branch = var.BRANCH_NAME # comment in if testing ansible
-      #      }
+      # add databases here as needed
     }
     weblogics          = {}
     ec2_test_instances = {}
@@ -114,18 +78,18 @@ locals {
       }
       dev-base-rhel79 = {
         tags = {
-          ami               = "nomis_rhel_7_9_baseimage"
+          ami               = "base_rhel_7_9"
           description       = "For testing our base RHEL7.9 base image"
           monitored         = false
           nomis-environment = "dev"
           server-type       = "base-rhel79"
         }
-        ami_name = "nomis_rhel_7_9_baseimage*"
+        ami_name = "base_rhel_7_9_*"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
       }
       dev-base-rhel610 = {
         tags = {
-          ami               = "nomis_rhel_6_10_baseimage"
+          ami               = "base_rhel_6_10"
           description       = "For testing our base RHEL6.10 base image"
           monitored         = false
           nomis-environment = "dev"
@@ -135,7 +99,7 @@ locals {
           instance_type                = "t2.medium"
           metadata_options_http_tokens = "optional"
         }
-        ami_name = "nomis_rhel_6_10_baseimage*"
+        ami_name = "base_rhel_6_10*"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
       }
     }

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -65,12 +65,23 @@ locals {
     weblogics          = {}
     ec2_test_instances = {}
     ec2_test_autoscaling_groups = {
+      dev-redhat-rhel610 = {
+        tags = {
+          description = "For testing official RedHat RHEL6.10 image"
+          monitored   = false
+        }
+        instance = {
+          instance_type                = "t2.medium"
+          metadata_options_http_tokens = "optional"
+        }
+        ami_name  = "RHEL-6.10_HVM-*"
+        ami_owner = "309956199498"
+        # branch   = var.BRANCH_NAME # comment in if testing ansible
+      }
       dev-redhat-rhel79 = {
         tags = {
-          description       = "For testing official RedHat RHEL7.9 base image"
-          server-type       = "base-rhel79"
-          monitored         = false
-          nomis-environment = "dev"
+          description = "For testing official RedHat RHEL7.9 image"
+          monitored   = false
         }
         ami_name  = "RHEL-7.9_HVM-*"
         ami_owner = "309956199498"

--- a/terraform/environments/nomis/templates/ansible-ec2provision.sh.tftpl
+++ b/terraform/environments/nomis/templates/ansible-ec2provision.sh.tftpl
@@ -13,6 +13,16 @@ run_ansible() {
     set -x
   fi
 
+  if ! command -v aws > /dev/null; then
+    echo "aws cli must be installed, not installing any ansible" >&2
+    exit 0
+  fi
+
+  if ! command -v git > /dev/null; then
+    echo "git must be installed, not installing any ansible" >&2
+    exit 0
+  fi
+
   echo "# Retrieving API Token"
   token=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 

--- a/terraform/environments/nomis/templates/ansible-ec2provisiondata.sh.tftpl
+++ b/terraform/environments/nomis/templates/ansible-ec2provisiondata.sh.tftpl
@@ -12,6 +12,16 @@ run_ansible() {
     set -x
   fi
 
+  if ! command -v aws > /dev/null; then
+    echo "aws cli must be installed, not installing any ansible" >&2
+    exit 0
+  fi
+
+  if ! command -v git > /dev/null; then
+    echo "git must be installed, not installing any ansible" >&2
+    exit 0
+  fi
+
   echo "# Retrieving API Token"
   token=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 

--- a/terraform/environments/nomis/templates/install-ssm-agent.sh.tftpl
+++ b/terraform/environments/nomis/templates/install-ssm-agent.sh.tftpl
@@ -1,0 +1,26 @@
+#!/bin/bash
+install_ssm_agent_rhel6() {
+  echo "Installing amazon-ssm-agent for RHEL6"
+  yum install -y https://s3.eu-west-2.amazonaws.com/amazon-ssm-eu-west-2/3.0.1390.0/linux_amd64/amazon-ssm-agent.rpm
+  start amazon-ssm-agent
+}
+install_ssm_agent_rhel() {
+  echo "Installing latest version of amazon-ssm-agent"
+  yum install -y https://s3.eu-west-2.amazonaws.com/amazon-ssm-eu-west-2/latest/linux_amd64/amazon-ssm-agent.rpm
+  systemctl start amazon-ssm-agent
+}
+install_ssm_agent() {
+  if [[ -f /etc/redhat-release ]]; then
+    if grep " 6" /etc/redhat-release > /dev/null; then
+      install_ssm_agent_rhel6
+    else
+      install_ssm_agent_rhel
+    fi
+  else
+    echo "Only implemented for RedHat"
+  fi
+}
+
+echo "install_ssm_agent start" | logger -p local3.info -t user-data
+install_ssm_agent 2>&1 | logger -p local3.info -t user-data
+echo "install_ssm_agent end" | logger -p local3.info -t user-data


### PR DESCRIPTION
Some minor improvements for testing images:
- allow testing directly on base RedHat image  (added ssm-agent cloud-init script to support)
- ansible component bails out if aws cli or git not installed
- use new base AMI images in the ASG