### PR TITLE
Nit476 allow asg module to support multi az

### DIFF
--- a/terraform/environments/delius-iaps/ec2-iaps-server.tf
+++ b/terraform/environments/delius-iaps/ec2-iaps-server.tf
@@ -275,16 +275,11 @@ module "ec2_iaps_server" {
   # })
 
   instance_profile_policies = local.iaps_server.iam_policies
-  business_unit             = local.vpc_name
   application_name          = local.application_name
-  environment               = local.environment
   region                    = data.aws_region.current.name
-  # availability_zone         = local.availability_zone 
-  # This defaults to a single zone in the module, we need to span this across multiple AZ
-  subnet_set         = local.subnet_set
-  subnet_name        = local.application_data.ec2_iaps_instance_subnet_name
-  tags               = local.ec2_tags
-  account_ids_lookup = local.environment_management.account_ids
+  subnet_ids                = data.aws_subnets.private-public.ids
+  tags                      = local.ec2_tags
+  account_ids_lookup        = local.environment_management.account_ids
 }
 
 

--- a/terraform/environments/nomis/data.tf
+++ b/terraform/environments/nomis/data.tf
@@ -1,0 +1,10 @@
+# Derive private subnet ids
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+  tags = {
+    Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
+  }
+}

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -78,13 +78,9 @@ module "ec2_jumpserver" {
 
   iam_resource_names_prefix = "ec2-jumpserver"
   instance_profile_policies = concat(local.ec2_common_managed_policies, [aws_iam_policy.jumpserver_users.arn])
-  business_unit             = local.vpc_name
   application_name          = local.application_name
-  environment               = local.environment
   region                    = local.region
-  availability_zone         = local.availability_zone
-  subnet_set                = local.subnet_set
-  subnet_name               = "private"
+  subnet_ids                = data.aws_subnets.private.ids
   tags                      = merge(local.tags, local.ec2_jumpserver.tags, try(each.value.tags, {}))
   account_ids_lookup        = local.environment_management.account_ids
   ansible_repo              = "modernisation-platform-configuration-management"

--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -122,20 +122,14 @@ module "ec2_test_autoscaling_group" {
 
   iam_resource_names_prefix = "ec2-test-asg"
   instance_profile_policies = local.ec2_common_managed_policies
-
-  business_unit      = local.vpc_name
-  application_name   = local.application_name
-  environment        = local.environment
-  region             = local.region
-  availability_zone  = local.availability_zone
-  subnet_set         = local.subnet_set
-  subnet_name        = lookup(each.value, "subnet_name", "private")
-  tags               = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
-  account_ids_lookup = local.environment_management.account_ids
-
-  ansible_repo         = "modernisation-platform-configuration-management"
-  ansible_repo_basedir = "ansible"
-  branch               = try(each.value.branch, "main")
+  application_name          = local.application_name
+  region                    = local.region
+  subnet_ids                = data.aws_subnets.private.ids
+  tags                      = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
+  account_ids_lookup        = local.environment_management.account_ids
+  ansible_repo              = "modernisation-platform-configuration-management"
+  ansible_repo_basedir      = "ansible"
+  branch                    = try(each.value.branch, "main")
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -134,13 +134,9 @@ module "ec2_weblogic_autoscaling_group" {
   iam_resource_names_prefix = "ec2-weblogic-asg"
   instance_profile_policies = local.ec2_common_managed_policies
 
-  business_unit      = local.vpc_name
   application_name   = local.application_name
-  environment        = local.environment
   region             = local.region
-  availability_zone  = local.availability_zone
-  subnet_set         = local.subnet_set
-  subnet_name        = "private"
+  subnet_ids         = data.aws_subnets.private.ids
   tags               = merge(local.tags, local.ec2_weblogic.tags, try(each.value.tags, {}))
   account_ids_lookup = local.environment_management.account_ids
 

--- a/terraform/environments/nomis/loadbalancer.tf
+++ b/terraform/environments/nomis/loadbalancer.tf
@@ -1,16 +1,6 @@
 #------------------------------------------------------------------------------
 # Load Balancer - Internal
 #------------------------------------------------------------------------------
-data "aws_subnets" "private" {
-  filter {
-    name   = "vpc-id"
-    values = [local.vpc_id]
-  }
-  tags = {
-    Name = "${local.vpc_name}-${local.environment}-${local.subnet_set}-private-${local.region}*"
-  }
-}
-
 resource "aws_security_group" "internal_elb" {
   name        = "internal-lb-${local.application_name}"
   description = "Allow inbound traffic to internal load balancer"

--- a/terraform/modules/ec2_autoscaling_group/data.tf
+++ b/terraform/modules/ec2_autoscaling_group/data.tf
@@ -1,17 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_vpc" "shared_vpc" {
-  tags = {
-    Name = "${var.business_unit}-${var.environment}"
-  }
-}
-
-data "aws_subnet" "this" {
-  tags = {
-    Name = "${var.business_unit}-${var.environment}-${var.subnet_set}-${var.subnet_name}-${var.availability_zone}"
-  }
-}
-
 data "aws_ami" "this" {
   most_recent = true
   owners      = [try(var.account_ids_lookup[var.ami_owner], var.ami_owner)]

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -95,7 +95,7 @@ resource "aws_autoscaling_group" "this" {
   force_delete              = var.autoscaling_group.force_delete
   termination_policies      = var.autoscaling_group.termination_policies
   target_group_arns         = var.autoscaling_group.target_group_arns
-  vpc_zone_identifier       = [data.aws_subnet.this.id]
+  vpc_zone_identifier       = var.subnet_ids
   wait_for_capacity_timeout = var.autoscaling_group.wait_for_capacity_timeout
 
   launch_template {

--- a/terraform/modules/ec2_autoscaling_group/variables.tf
+++ b/terraform/modules/ec2_autoscaling_group/variables.tf
@@ -1,10 +1,3 @@
-variable "business_unit" {
-  type        = string
-  description = "This corresponds to the VPC in which the application resides"
-  default     = "hmpps"
-  nullable    = false
-}
-
 variable "application_name" {
   type        = string
   description = "The name of the application.  This will be name of the environment in Modernisation Platform"
@@ -15,32 +8,15 @@ variable "application_name" {
   }
 }
 
-variable "environment" {
-  type        = string
-  description = "Application environment - i.e. the terraform workspace"
-}
-
 variable "region" {
   type        = string
   description = "Destination AWS Region for the infrastructure"
   default     = "eu-west-2"
 }
 
-variable "availability_zone" {
-  type        = string
-  description = "The availability zone in which to deploy the infrastructure"
-  default     = "eu-west-2a"
-  nullable    = false
-}
-
-variable "subnet_set" {
-  type        = string
-  description = "Fixed variable to specify subnet-set for RAM shared subnets"
-}
-
-variable "subnet_name" {
-  type        = string
-  description = "Name of subnet within the given subnet-set"
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet ids given to the ASG to set the associated AZs (and therefore redundancy of the ASG instances)"
 }
 
 variable "tags" {


### PR DESCRIPTION
Work item nit-476: Changes to the local ASG module to receive a set of subnet_ids that are then applied to the ASG. It allows module consumes to be in charge of which subnets that want the ASG to operate over (and therefore adding AZ redundancy)