### PR TITLE
Nomis: DSOS-1628: add loadbalancer listeners

### DIFF
--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -182,10 +182,10 @@ resource "aws_security_group" "ec2_test" {
     from_port   = "7777"
     to_port     = "7777"
     protocol    = "TCP"
-    security_groups = [
+    security_groups = concat([
       aws_security_group.jumpserver-windows.id,
       module.bastion_linux.bastion_security_group
-    ]
+    ], local.lb_security_group_ids)
   }
 
   ingress {

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -65,6 +65,18 @@ locals {
       }
     }
   }
+
+  legacy_weblogics = {
+    development = {}
+    test = {
+      CNOMT1 = {
+        ami_name     = "nomis_Weblogic_2022*"
+        asg_max_size = 1
+      }
+    }
+    preproduction = {}
+    production    = {}
+  }
 }
 
 module "weblogic" {
@@ -74,7 +86,7 @@ module "weblogic" {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
   }
 
-  for_each = local.environment_config.weblogics
+  for_each = local.legacy_weblogics[local.environment]
 
   name = each.key
 

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -145,8 +145,6 @@ module "ec2_weblogic_autoscaling_group" {
   branch             = try(each.value.branch, "main")
 }
 
-#  load_balancer_listener_arn = aws_lb_listener.internal.arn
-
 #------------------------------------------------------------------------------
 # Common Security Group for Weblogic Instances
 #------------------------------------------------------------------------------
@@ -200,11 +198,10 @@ resource "aws_security_group" "weblogic_common" {
     from_port   = "7777"
     to_port     = "7777"
     protocol    = "TCP"
-    security_groups = [
+    security_groups = concat([
       aws_security_group.jumpserver-windows.id,
-      module.bastion_linux.bastion_security_group,
-      #      module.lb_internal_nomis[0].security_group.id
-    ]
+      module.bastion_linux.bastion_security_group
+    ], local.lb_security_group_ids)
   }
 
   ingress {

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -41,7 +41,7 @@ locals {
       health_check_type         = "ELB"
       force_delete              = true
       termination_policies      = ["OldestInstance"]
-      target_group_arns         = [] # TODO
+      target_group_arns         = []
       vpc_zone_identifier       = data.aws_subnets.private.ids
       wait_for_capacity_timeout = 0
 

--- a/terraform/environments/nomis/lb-listeners.tf
+++ b/terraform/environments/nomis/lb-listeners.tf
@@ -1,0 +1,23 @@
+module "lb_listener" {
+  for_each = local.lb_listeners[local.environment]
+
+  source = "../../modules/lb_listener"
+
+  providers = {
+    aws.core-vpc = aws.core-vpc
+  }
+
+  name              = each.key
+  business_unit     = local.vpc_name
+  environment       = local.environment
+  load_balancer_arn = module.loadbalancer[each.value.lb_application_name].load_balancer.arn
+  target_groups     = try(each.value.target_groups, {})
+  port              = each.value.port
+  protocol          = each.value.protocol
+  ssl_policy        = try(each.value.ssl_policy, null)
+  certificate_arns  = try(each.value.certificate_arns, [])
+  default_action    = each.value.default_action
+  rules             = try(each.value.rules, {})
+  route53_records   = try(each.value.route53_records, {})
+  tags              = try(each.value.tags, local.tags)
+}

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -1,0 +1,94 @@
+locals {
+
+  lb_listener_defaults = {
+    environment_external_dns_zone = {
+      account                = "core-vpc"
+      zone_id                = data.aws_route53_zone.external-environment.zone_id
+      evaluate_target_health = true
+    }
+    nomis_web_http = {
+      lb_application_name = "nomis-public"
+      port                = 80
+      protocol            = "HTTP"
+      default_action = {
+        type = "redirect"
+        redirect = {
+          status_code = "HTTP_301"
+          port        = 443
+          protocol    = "HTTPS"
+        }
+      }
+    }
+    nomis_web_https = {
+      lb_application_name = "nomis-public"
+      port                = 443
+      protocol            = "HTTPS"
+      ssl_policy          = "ELBSecurityPolicy-2016-08"
+      certificate_arns    = [module.acm_certificate[local.certificate.modernisation_platform_wildcard.name].arn]
+      default_action = {
+        type = "fixed-response"
+        fixed_response = {
+          content_type = "text/plain"
+          message_body = "Fixed response content"
+          status_code  = "503"
+        }
+      }
+      target_groups = {
+        http-7777 = {
+          port                 = 7777
+          protocol             = "HTTP"
+          target_type          = "instance"
+          deregistration_delay = 30
+          health_check = {
+            enabled             = true
+            interval            = 30
+            healthy_threshold   = 3
+            matcher             = "200-399"
+            path                = "/keepalive.htm"
+            port                = 7777
+            timeout             = 5
+            unhealthy_threshold = 5
+          }
+          stickiness = {
+            enabled = true
+            type    = "lb_cookie"
+          }
+        }
+      }
+      rules = {
+        forward-http-7777 = {
+          actions = [{
+            type              = "forward"
+            target_group_name = "http-7777"
+          }]
+          conditions = [{
+            host_header = {
+              values = ["*.nomis.${data.aws_route53_zone.external.name}"]
+            }
+          }]
+        }
+      }
+    }
+  }
+
+  lb_listeners = {
+
+    #--------------------------------------------------------------------------
+    # define environment specific load balancer listeners here
+    #--------------------------------------------------------------------------
+    development = {}
+
+    test = {
+      t1-nomis-web-http = local.lb_listener_defaults.nomis_web_http
+
+      t1-nomis-web-https = merge(local.lb_listener_defaults.nomis_web_https, {
+        route53_records = {
+          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+        }
+      })
+    }
+
+    preproduction = {}
+    production    = {}
+  }
+}

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -82,63 +82,63 @@ locals {
     development = {}
 
     test = {
-#      http = local.lb_listener_defaults.nomis_web_http
-#
-#      https = merge(local.lb_listener_defaults.nomis_web_https, {
-#        target_groups = {
-#          http-7777-asg      = local.lb_http_7777_rule
-#          http-7777-instance = merge(local.lb_http_7777_rule, {
-#            attachments = [
-#              {
-#                # temporary until circular dependencies fixed
-#                target_id = local.environment == "test" ? "i-0983877a07e735688" : null
-#              }
-#            ]
-#          })
-#        }
-#
-#        rules = {
-#          http-7777-asg = {
-#            actions = [{
-#              type              = "forward"
-#              target_group_name = "http-7777-asg"
-#            }]
-#            conditions = [{
-#              host_header = {
-#                values = ["*-nomis-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
-#              }
-#            }]
-#          }
-#          http-7777-instance = {
-#            actions = [{
-#              type              = "forward"
-#              target_group_name = "http-7777-instance"
-#            }]
-#            conditions = [{
-#              host_header = {
-#                values = ["*-nomis-web-instance.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
-#              }
-#            }]
-#          }
-#          http-7777-weblogic-cnomt1 = {
-#            actions = [{
-#              type             = "forward"
-#              target_group_arn = local.environment == "test" ? module.weblogic["CNOMT1"].target_group_arn : null
-#            }]
-#            conditions = [{
-#              host_header = {
-#                values = ["weblogic-cnomt1.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
-#              }
-#            }]
-#          }
-#        }
-#
-#        route53_records = {
-#          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-#          "t1-nomis-web-instance.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-#          "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-#        }
-#      })
+      http = local.lb_listener_defaults.http
+
+      https = merge(local.lb_listener_defaults.https, {
+        target_groups = {
+          http-7777-asg = local.lb_http_7777_rule
+          http-7777-instance = merge(local.lb_http_7777_rule, {
+            attachments = [
+              {
+                # temporary until circular dependencies fixed
+                target_id = local.environment == "test" ? "i-0983877a07e735688" : null
+              }
+            ]
+          })
+        }
+
+        rules = {
+          http-7777-asg = {
+            actions = [{
+              type              = "forward"
+              target_group_name = "http-7777-asg"
+            }]
+            conditions = [{
+              host_header = {
+                values = ["*-nomis-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+              }
+            }]
+          }
+          http-7777-instance = {
+            actions = [{
+              type              = "forward"
+              target_group_name = "http-7777-instance"
+            }]
+            conditions = [{
+              host_header = {
+                values = ["*-nomis-web-instance.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+              }
+            }]
+          }
+          http-7777-weblogic-cnomt1 = {
+            actions = [{
+              type             = "forward"
+              target_group_arn = local.environment == "test" ? module.weblogic["CNOMT1"].target_group_arn : null
+            }]
+            conditions = [{
+              host_header = {
+                values = ["weblogic-cnomt1.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+              }
+            }]
+          }
+        }
+
+        route53_records = {
+          "t1-nomis-web.nomis"          = local.lb_listener_defaults.environment_external_dns_zone
+          "t1-nomis-web-instance.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+          "weblogic-cnomt1.nomis"       = local.lb_listener_defaults.environment_external_dns_zone
+        }
+      })
     }
 
     preproduction = {}

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -63,7 +63,7 @@ locals {
           }]
           conditions = [{
             host_header = {
-              values = ["*.nomis.${data.aws_route53_zone.external.name}"]
+              values = ["*-nomis-web.nomis.${data.aws_route53_zone.external.name}"]
             }
           }]
         }
@@ -84,6 +84,25 @@ locals {
       t1-nomis-web-https = merge(local.lb_listener_defaults.nomis_web_https, {
         route53_records = {
           "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+        }
+      })
+
+      weblogic-cnomt1-https = merge(local.lb_listener_defaults.nomis_web_https, {
+        route53_records = {
+          "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+        }
+        rules = {
+          forward-http-7777 = {
+            actions = [{
+              type             = "forward"
+              target_group_arn = module.weblogic["CNOMT1"].target_group_arn
+            }]
+            conditions = [{
+              host_header = {
+                values = ["weblogic-cnomt1.nomis.${data.aws_route53_zone.external.name}"]
+              }
+            }]
+          }
         }
       })
     }

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -28,7 +28,7 @@ locals {
       zone_id                = data.aws_route53_zone.external-environment.zone_id
       evaluate_target_health = true
     }
-    nomis_web_http = {
+    http = {
       lb_application_name = "nomis-public"
       port                = 80
       protocol            = "HTTP"
@@ -41,7 +41,7 @@ locals {
         }
       }
     }
-    nomis_web_https = {
+    https = {
       lb_application_name = "nomis-public"
       port                = 443
       protocol            = "HTTPS"
@@ -82,50 +82,63 @@ locals {
     development = {}
 
     test = {
-      t1-nomis-web-http = local.lb_listener_defaults.nomis_web_http
-
-      t1-nomis-web-https = merge(local.lb_listener_defaults.nomis_web_https, {
-        route53_records = {
-          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-        }
-      })
-
-      t1-nomis-web-1-https = merge(local.lb_listener_defaults.nomis_web_https, {
-        target_groups = {
-          http-7777 = merge(local.lb_http_7777_rule, {
-            attachments = [
-              {
-                # temporary until circular dependencies fixed
-                target_id = local.environment == "test" ? "i-0983877a07e735688" : null
-              }
-            ]
-          })
-        }
-
-        route53_records = {
-          "t1b-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-        }
-      })
-
-      weblogic-cnomt1-https = merge(local.lb_listener_defaults.nomis_web_https, {
-        target_groups = {}
-        route53_records = {
-          "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-        }
-        rules = {
-          forward-http-7777 = {
-            actions = [{
-              type             = "forward"
-              target_group_arn = local.environment == "test" ? module.weblogic["CNOMT1"].target_group_arn : null
-            }]
-            conditions = [{
-              host_header = {
-                values = ["weblogic-cnomt1.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
-              }
-            }]
-          }
-        }
-      })
+#      http = local.lb_listener_defaults.nomis_web_http
+#
+#      https = merge(local.lb_listener_defaults.nomis_web_https, {
+#        target_groups = {
+#          http-7777-asg      = local.lb_http_7777_rule
+#          http-7777-instance = merge(local.lb_http_7777_rule, {
+#            attachments = [
+#              {
+#                # temporary until circular dependencies fixed
+#                target_id = local.environment == "test" ? "i-0983877a07e735688" : null
+#              }
+#            ]
+#          })
+#        }
+#
+#        rules = {
+#          http-7777-asg = {
+#            actions = [{
+#              type              = "forward"
+#              target_group_name = "http-7777-asg"
+#            }]
+#            conditions = [{
+#              host_header = {
+#                values = ["*-nomis-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+#              }
+#            }]
+#          }
+#          http-7777-instance = {
+#            actions = [{
+#              type              = "forward"
+#              target_group_name = "http-7777-instance"
+#            }]
+#            conditions = [{
+#              host_header = {
+#                values = ["*-nomis-web-instance.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+#              }
+#            }]
+#          }
+#          http-7777-weblogic-cnomt1 = {
+#            actions = [{
+#              type             = "forward"
+#              target_group_arn = local.environment == "test" ? module.weblogic["CNOMT1"].target_group_arn : null
+#            }]
+#            conditions = [{
+#              host_header = {
+#                values = ["weblogic-cnomt1.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+#              }
+#            }]
+#          }
+#        }
+#
+#        route53_records = {
+#          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+#          "t1-nomis-web-instance.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+#          "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+#        }
+#      })
     }
 
     preproduction = {}

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -29,8 +29,8 @@ locals {
         type = "fixed-response"
         fixed_response = {
           content_type = "text/plain"
-          message_body = "Fixed response content"
-          status_code  = "503"
+          message_body = "Not implemented"
+          status_code  = "501"
         }
       }
       target_groups = {
@@ -63,7 +63,7 @@ locals {
           }]
           conditions = [{
             host_header = {
-              values = ["*-nomis-web.nomis.${data.aws_route53_zone.external.name}"]
+              values = ["*-nomis-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
             }
           }]
         }
@@ -99,7 +99,7 @@ locals {
             }]
             conditions = [{
               host_header = {
-                values = ["weblogic-cnomt1.nomis.${data.aws_route53_zone.external.name}"]
+                values = ["weblogic-cnomt1.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
               }
             }]
           }

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -95,7 +95,7 @@ locals {
           forward-http-7777 = {
             actions = [{
               type             = "forward"
-              target_group_arn = module.weblogic["CNOMT1"].target_group_arn
+              target_group_arn = local.environment == "test" ? module.weblogic["CNOMT1"].target_group_arn : null
             }]
             conditions = [{
               host_header = {

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -103,11 +103,12 @@ locals {
         }
 
         route53_records = {
-          "t1-nomis-web-1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+          "t1b-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
         }
       })
 
       weblogic-cnomt1-https = merge(local.lb_listener_defaults.nomis_web_https, {
+        target_groups = {}
         route53_records = {
           "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
         }

--- a/terraform/environments/nomis/locals-lbs.tf
+++ b/terraform/environments/nomis/locals-lbs.tf
@@ -81,3 +81,7 @@ locals {
     production = {}
   }
 }
+
+locals {
+  lb_security_group_ids = [for key, value in module.loadbalancer : value.security_group.id]
+}

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -172,7 +172,7 @@ locals {
 
         # NOTE: using standalone instance until connectivity from FixNGo in place
         autoscaling_group = {
-          desired_capacity  = 0
+          desired_capacity  = 1
           warm_pool         = null
           target_group_arns = local.environment == "test" ? [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn] : []
         }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -174,6 +174,7 @@ locals {
         autoscaling_group = {
           desired_capacity = 0
           warm_pool        = null
+          #          target_group_arns = module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn
         }
       }
     }
@@ -247,7 +248,7 @@ locals {
         ami_name = "nomis_rhel_7_9_baseimage_2022-11-01T13-43-46.384Z"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
         autoscaling_group = {
-          desired_capacity = 1
+          desired_capacity = 0
         }
         autoscaling_schedules = {}
         subnet_name           = "data"
@@ -261,7 +262,7 @@ locals {
         ami_name = "nomis_rhel_7_9_baseimage_2022-11-01T13-43-46.384Z"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
         autoscaling_group = {
-          desired_capacity = 1
+          desired_capacity = 0
         }
         autoscaling_schedules = {}
         subnet_name           = "data"

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -174,7 +174,7 @@ locals {
         autoscaling_group = {
           desired_capacity  = 0
           warm_pool         = null
-          target_group_arns = [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn]
+          target_group_arns = local.environment == "test" ? [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn] : []
         }
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -171,9 +171,9 @@ locals {
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
         autoscaling_group = {
-          desired_capacity = 1
-          warm_pool        = null
-          #         target_group_arns = local.environment == "test" ? [module.lb_listener["https"].aws_lb_target_group["http-7777-asg"].arn] : []
+          desired_capacity  = 1
+          warm_pool         = null
+          target_group_arns = local.environment == "test" ? [module.lb_listener["https"].aws_lb_target_group["http-7777-asg"].arn] : []
         }
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -170,7 +170,6 @@ locals {
         ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
-        # NOTE: using standalone instance until connectivity from FixNGo in place
         autoscaling_group = {
           desired_capacity  = 1
           warm_pool         = null

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -172,9 +172,9 @@ locals {
 
         # NOTE: using standalone instance until connectivity from FixNGo in place
         autoscaling_group = {
-          desired_capacity = 0
-          warm_pool        = null
-          #          target_group_arns = module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn
+          desired_capacity  = 0
+          warm_pool         = null
+          target_group_arns = [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn]
         }
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -179,14 +179,6 @@ locals {
       }
     }
 
-    # Legacy weblogic, to be zapped imminently
-    weblogics = {
-      CNOMT1 = {
-        ami_name     = "nomis_Weblogic_2022*"
-        asg_max_size = 1
-      }
-    }
-
     ec2_test_instances = {
       t1-nomis-web-1 = {
         tags = {

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -171,9 +171,9 @@ locals {
         # branch = var.BRANCH_NAME # comment in if testing ansible
 
         autoscaling_group = {
-          desired_capacity  = 1
-          warm_pool         = null
-#          target_group_arns = local.environment == "test" ? [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn] : []
+          desired_capacity = 1
+          warm_pool        = null
+          #         target_group_arns = local.environment == "test" ? [module.lb_listener["https"].aws_lb_target_group["http-7777-asg"].arn] : []
         }
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -173,7 +173,7 @@ locals {
         autoscaling_group = {
           desired_capacity  = 1
           warm_pool         = null
-          target_group_arns = local.environment == "test" ? [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn] : []
+#          target_group_arns = local.environment == "test" ? [module.lb_listener["t1-nomis-web-https"].aws_lb_target_group["http-7777"].arn] : []
         }
       }
     }

--- a/terraform/environments/nomis/modules/weblogic/outputs.tf
+++ b/terraform/environments/nomis/modules/weblogic/outputs.tf
@@ -1,3 +1,7 @@
 output "launch_template_arn" {
   value = aws_launch_template.weblogic.arn
 }
+
+output "target_group_arn" {
+  value = aws_lb_target_group.weblogic.arn
+}

--- a/terraform/modules/ec2_instance/outputs.tf
+++ b/terraform/modules/ec2_instance/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_instance" {
+  description = "aws_instance resource"
+  value       = aws_instance.this
+}

--- a/terraform/modules/lb_listener/README.md
+++ b/terraform/modules/lb_listener/README.md
@@ -67,7 +67,7 @@ locals {
           }]
           conditions = [{
             host_header = {
-              values = ["*.nomis.${data.aws_route53_zone.external.name}"]
+              values = ["*-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
             }
           }]
         }

--- a/terraform/modules/lb_listener/README.md
+++ b/terraform/modules/lb_listener/README.md
@@ -1,0 +1,115 @@
+Create an `aws_lb_listener` with associated resources such as:
+
+- `aws_lb_target_group`
+- `aws_lb_target_group_attachment`
+- `aws_lb_listener_rule`
+- `aws_lb_listener_certificate`
+- `aws_route53_record`
+
+If associating with an `aws_autoscaling_group`, be sure to create the
+load balancer resource first before populating `target_group_arns`.
+
+Target groups are optional. They can be created externally, or you
+can reference target groups created in another `lb_listener` module
+instance.
+
+Example usage:
+
+```
+locals {
+  lb_listener_defaults = {
+    environment_external_dns_zone = {
+      account                = "core-vpc"
+      zone_id                = data.aws_route53_zone.external-environment.zone_id
+      evaluate_target_health = true
+    }
+    nomis_web_https = {
+      lb_application_name = "nomis-public"
+      port                = 443
+      protocol            = "HTTPS"
+      ssl_policy          = "ELBSecurityPolicy-2016-08"
+      certificate_arns    = [module.acm_certificate[local.certificate.modernisation_platform_wildcard.name].arn]
+      default_action = {
+        type = "fixed-response"
+        fixed_response = {
+          content_type = "text/plain"
+          message_body = "Fixed response content"
+          status_code  = "503"
+        }
+      }
+      target_groups = {
+        http-7777 = {
+          port                 = 7777
+          protocol             = "HTTP"
+          target_type          = "instance"
+          deregistration_delay = 30
+          health_check = {
+            enabled             = true
+            interval            = 30
+            healthy_threshold   = 3
+            matcher             = "200-399"
+            path                = "/keepalive.htm"
+            port                = 7777
+            timeout             = 5
+            unhealthy_threshold = 5
+          }
+          stickiness = {
+            enabled = true
+            type    = "lb_cookie"
+          }
+        }
+      }
+      rules = {
+        forward-http-7777 = {
+          actions = [{
+            type              = "forward"
+            target_group_name = "http-7777"
+          }]
+          conditions = [{
+            host_header = {
+              values = ["*.nomis.${data.aws_route53_zone.external.name}"]
+            }
+          }]
+        }
+      }
+    }
+  }
+
+  lb_listeners = {
+    development = {}
+    test = {
+      t1-nomis-web-https = merge(local.lb_listener_defaults.nomis_web_https, {
+        route53_records = {
+          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
+        }
+      })
+    }
+    preproduction = {}
+    production    = {}
+  }
+}
+
+module "lb_listener" {
+  for_each = local.lb_listeners[local.environment]
+
+  source = "../../modules/lb_listener"
+
+  providers = {
+    aws.core-vpc = aws.core-vpc
+  }
+
+  name              = each.key
+  business_unit     = local.vpc_name
+  environment       = local.environment
+  load_balancer_arn = module.loadbalancer[each.value.lb_application_name].load_balancer.arn
+  target_groups     = try(each.value.target_groups, {})
+  port              = each.value.port
+  protocol          = each.value.protocol
+  ssl_policy        = try(each.value.ssl_policy, null)
+  certificate_arns  = try(each.value.certificate_arns, [])
+  default_action    = each.value.default_action
+  rules             = try(each.value.rules, {})
+  route53_records   = try(each.value.route53_records, {})
+  tags              = try(each.value.tags, local.tags)
+}
+```

--- a/terraform/modules/lb_listener/README.md
+++ b/terraform/modules/lb_listener/README.md
@@ -6,25 +6,58 @@ Create an `aws_lb_listener` with associated resources such as:
 - `aws_lb_listener_certificate`
 - `aws_route53_record`
 
+Note that only one listener is allowed for each protocol/port.  Add
+multiple target groups and listener rules as required.
+
 If associating with an `aws_autoscaling_group`, be sure to create the
 load balancer resource first before populating `target_group_arns`.
-
-Target groups are optional. They can be created externally, or you
-can reference target groups created in another `lb_listener` module
-instance.
 
 Example usage:
 
 ```
 locals {
-  lb_listener_defaults = {
-    environment_external_dns_zone = {
-      account                = "core-vpc"
-      zone_id                = data.aws_route53_zone.external-environment.zone_id
-      evaluate_target_health = true
+
+  lb_http_7777_rule = {
+    port                 = 7777
+    protocol             = "HTTP"
+    target_type          = "instance"
+    deregistration_delay = 30
+    health_check = {
+      enabled             = true
+      interval            = 30
+      healthy_threshold   = 3
+      matcher             = "200-399"
+      path                = "/keepalive.htm"
+      port                = 7777
+      timeout             = 5
+      unhealthy_threshold = 5
     }
-    nomis_web_https = {
-      lb_application_name = "nomis-public"
+    stickiness = {
+      enabled = true
+      type    = "lb_cookie"
+    }
+  }
+  lb_dns_zone = {
+    account                = "core-vpc"
+    zone_id                = data.aws_route53_zone.external-environment.zone_id
+    evaluate_target_health = true
+  }
+  lb_listeners = {
+    http = {
+      lb_application_name = "public"
+      port                = 80
+      protocol            = "HTTP"
+      default_action = {
+        type = "redirect"
+        redirect = {
+          status_code = "HTTP_301"
+          port        = 443
+          protocol    = "HTTPS"
+        }
+      }
+    }
+    https = {
+      lb_application_name = "public"
       port                = 443
       protocol            = "HTTPS"
       ssl_policy          = "ELBSecurityPolicy-2016-08"
@@ -33,64 +66,57 @@ locals {
         type = "fixed-response"
         fixed_response = {
           content_type = "text/plain"
-          message_body = "Fixed response content"
-          status_code  = "503"
+          message_body = "Not implemented"
+          status_code  = "501"
         }
       }
       target_groups = {
-        http-7777 = {
-          port                 = 7777
-          protocol             = "HTTP"
-          target_type          = "instance"
-          deregistration_delay = 30
-          health_check = {
-            enabled             = true
-            interval            = 30
-            healthy_threshold   = 3
-            matcher             = "200-399"
-            path                = "/keepalive.htm"
-            port                = 7777
-            timeout             = 5
-            unhealthy_threshold = 5
-          }
-          stickiness = {
-            enabled = true
-            type    = "lb_cookie"
-          }
-        }
+        http-7777-asg = local.lb_http_7777_rule
+        http-7777-instance = merge(local.lb_http_7777_rule, {
+          attachments = [
+            {
+              target_id = local.my_instance_id_1
+            },
+            {
+              target_id = local.my_instance_id_2
+            }
+          ]
+        })
       }
       rules = {
-        forward-http-7777 = {
+        http-7777-asg = {
           actions = [{
             type              = "forward"
-            target_group_name = "http-7777"
+            target_group_name = "http-7777-asg"
           }]
           conditions = [{
             host_header = {
-              values = ["*-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+              values = ["*-asg.*"]
+            }
+          }]
+        }
+        http-7777-instance = {
+          actions = [{
+            type              = "forward"
+            target_group_name = "http-7777-instance"
+          }]
+          conditions = [{
+            host_header = {
+              values = ["*-instance.*"]
             }
           }]
         }
       }
+      route53_records = {
+        "my-asg"      = local.lb_dns_zone
+        "my-instance" = local.lb_dns_zone
+      }
     }
-  }
-
-  lb_listeners = {
-    development = {}
-    test = {
-      t1-nomis-web-https = merge(local.lb_listener_defaults.nomis_web_https, {
-        route53_records = {
-          "t1-nomis-web.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-        }
-      })
-    }
-    preproduction = {}
-    production    = {}
   }
 }
 
 module "lb_listener" {
-  for_each = local.lb_listeners[local.environment]
+  for_each = local.lb_listeners
 
   source = "../../modules/lb_listener"
 

--- a/terraform/modules/lb_listener/data.tf
+++ b/terraform/modules/lb_listener/data.tf
@@ -1,0 +1,9 @@
+data "aws_lb" "this" {
+  arn = var.load_balancer_arn
+}
+
+data "aws_vpc" "this" {
+  tags = {
+    Name = "${var.business_unit}-${var.environment}"
+  }
+}

--- a/terraform/modules/lb_listener/locals.tf
+++ b/terraform/modules/lb_listener/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  target_group_attachments = flatten([
+    for target_group_name, target_group_value in var.target_groups : [
+      for attachment_value in target_group_value.attachments : {
+        name       = target_group_name
+        attachment = attachment_value
+      }
+    ]
+  ])
+}

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -44,7 +44,7 @@ resource "aws_lb_target_group_attachment" "this" {
     for item in local.target_group_attachments : "${item.name}-${item.attachment.target_id}" => item
   }
 
-  target_group_arn  = aws_lb_target_group.this[each.value.name]
+  target_group_arn  = aws_lb_target_group.this[each.value.name].arn
   target_id         = each.value.attachment.target_id
   port              = each.value.attachment.port
   availability_zone = each.value.attachment.availability_zone

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -1,0 +1,222 @@
+resource "aws_lb_target_group" "this" {
+  for_each = var.target_groups
+
+  name                 = "${var.name}-${each.key}"
+  port                 = each.value.port
+  protocol             = each.value.protocol
+  target_type          = each.value.target_type
+  deregistration_delay = each.value.deregistration_delay
+  vpc_id               = data.aws_vpc.this.id
+
+  dynamic "health_check" {
+    for_each = each.value.health_check != null ? [each.value.health_check] : []
+    content {
+      enabled             = health_check.value.enabled
+      interval            = health_check.value.interval
+      healthy_threshold   = health_check.value.healthy_threshold
+      matcher             = health_check.value.matcher
+      path                = health_check.value.path
+      port                = health_check.value.port
+      timeout             = health_check.value.timeout
+      unhealthy_threshold = health_check.value.unhealthy_threshold
+    }
+  }
+  dynamic "stickiness" {
+    for_each = each.value.stickiness != null ? [each.value.stickiness] : []
+    content {
+      enabled         = stickiness.value.enabled
+      type            = stickiness.value.type
+      cookie_duration = stickiness.value.cookie_duration
+      cookie_name     = stickiness.value.cookie_name
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = merge(var.tags, {
+    Name = "${var.name}-${each.key}"
+  })
+}
+
+resource "aws_lb_target_group_attachment" "this" {
+  for_each = {
+    for item in local.target_group_attachments : "${item.name}-${item.attachment.target_id}" => item
+  }
+
+  target_group_arn  = aws_lb_target_group.this[each.value.name]
+  target_id         = each.value.attachment.target_id
+  port              = each.value.attachment.port
+  availability_zone = each.value.attachment.availability_zone
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = var.load_balancer_arn
+  port              = var.port
+  protocol          = var.protocol
+  ssl_policy        = var.ssl_policy
+  certificate_arn   = try(var.certificate_arns[0], null)
+
+  dynamic "default_action" {
+    for_each = [var.default_action]
+
+    content {
+      type             = default_action.value.type
+      target_group_arn = default_action.value.target_group_name != null ? aws_lb_target_group.this[default_action.value.target_group_name].arn : default_action.value.target_group_arn
+
+      dynamic "fixed_response" {
+        for_each = default_action.value.fixed_response != null ? [default_action.value.fixed_response] : []
+        content {
+          content_type = fixed_response.value.content_type
+          message_body = fixed_response.value.message_body
+          status_code  = fixed_response.value.status_code
+        }
+      }
+
+      dynamic "forward" {
+        for_each = default_action.value.forward != null ? [default_action.value.forward] : []
+        content {
+          dynamic "target_group" {
+            for_each = forward.value.target_group
+            content {
+              arn    = target_group.value.name != null ? aws_lb_target_group.this[target_group.value.name].arn : target_group.value.arn
+              weight = target_group.value.weight
+            }
+          }
+          dynamic "stickiness" {
+            for_each = forward.value.stickiness != null ? [forward.value.stickiness] : []
+            content {
+              duration = stickiness.value.duration
+              enabled  = stickiness.value.enabled
+            }
+          }
+        }
+      }
+
+      dynamic "redirect" {
+        for_each = default_action.value.redirect != null ? [default_action.value.redirect] : []
+        content {
+          status_code = redirect.value.status_code
+          port        = redirect.value.port
+          protocol    = redirect.value.protocol
+        }
+      }
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = var.name
+  })
+
+  depends_on = [
+    aws_lb_target_group.this
+  ]
+}
+
+resource "aws_lb_listener_rule" "this" {
+  for_each = var.rules
+
+  listener_arn = aws_lb_listener.this.arn
+
+  dynamic "action" {
+    for_each = each.value.actions
+
+    content {
+      type             = action.value.type
+      target_group_arn = action.value.target_group_name != null ? aws_lb_target_group.this[action.value.target_group_name].arn : action.value.target_group_arn
+
+      dynamic "fixed_response" {
+        for_each = action.value.fixed_response != null ? [action.value.fixed_response] : []
+        content {
+          content_type = fixed_response.value.content_type
+          message_body = fixed_response.value.message_body
+          status_code  = fixed_response.value.status_code
+        }
+      }
+
+      dynamic "forward" {
+        for_each = action.value.forward != null ? [action.value.forward] : []
+        content {
+          dynamic "target_group" {
+            for_each = forward.value.target_group
+            content {
+              arn    = target_group.value.name != null ? aws_lb_target_group.this[target_group.value.name].arn : target_value.value.arn
+              weight = target_group.value.weight
+            }
+          }
+          dynamic "stickiness" {
+            for_each = forward.value.stickiness != null ? [forward.value.stickiness] : []
+            content {
+              duration = stickiness.value.duration
+              enabled  = stickiness.value.enabled
+            }
+          }
+        }
+      }
+
+      dynamic "redirect" {
+        for_each = action.value.redirect != null ? [action.value.redirect] : []
+        content {
+          status_code = redirect.value.status_code
+          port        = redirect.value.port
+          protocol    = redirect.value.protocol
+        }
+      }
+    }
+  }
+
+  dynamic "condition" {
+    for_each = each.value.conditions
+    content {
+      dynamic "host_header" {
+        for_each = condition.value.host_header != null ? [condition.value.host_header] : []
+        content {
+          values = host_header.value.values
+        }
+      }
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-${each.key}"
+  })
+
+  depends_on = [
+    aws_lb_target_group.this
+  ]
+}
+
+resource "aws_lb_listener_certificate" "this" {
+  for_each        = toset(try(slice(var.certificate_arns, 1, length(var.certificate_arns) - 1), []))
+  listener_arn    = aws_lb_listener.this.arn
+  certificate_arn = each.value
+}
+
+resource "aws_route53_record" "core_vpc" {
+  for_each = { for key, value in var.route53_records : key => value if value.account == "core-vpc" }
+  provider = aws.core-vpc
+
+  zone_id = each.value.zone_id
+  name    = each.key
+  type    = "A"
+
+  alias {
+    name                   = data.aws_lb.this.dns_name
+    zone_id                = data.aws_lb.this.zone_id
+    evaluate_target_health = each.value.evaluate_target_health
+  }
+}
+
+resource "aws_route53_record" "self" {
+  for_each = { for key, value in var.route53_records : key => value if value.account == "self" }
+
+  zone_id = each.value.zone_id
+  name    = each.value.key
+  type    = "A"
+
+  alias {
+    name                   = data.aws_lb.this.dns_name
+    zone_id                = data.aws_lb.this.zone_id
+    evaluate_target_health = each.value.evaluate_target_health
+  }
+}

--- a/terraform/modules/lb_listener/outputs.tf
+++ b/terraform/modules/lb_listener/outputs.tf
@@ -1,0 +1,9 @@
+output "aws_lb_target_group" {
+  value       = aws_lb_target_group.this
+  description = "map of created aws_lb_target_groups"
+}
+
+output "aws_lb_listener" {
+  value       = aws_lb_listener.this
+  description = "the aws_lb_listener object"
+}

--- a/terraform/modules/lb_listener/variables.tf
+++ b/terraform/modules/lb_listener/variables.tf
@@ -1,0 +1,155 @@
+variable "name" {
+  type        = string
+  description = "Name of the listener for tag:Name"
+}
+
+variable "business_unit" {
+  type        = string
+  description = "Modernisation platform business unit, e.g. hmpps"
+}
+
+variable "environment" {
+  type        = string
+  description = "Modernisation platform environment, e.g. development"
+}
+
+variable "load_balancer_arn" {
+  type        = string
+  description = "ARN of the load balancer"
+}
+
+variable "target_groups" {
+  description = "Map of target groups, where key is the name_prefix"
+  type = map(object({
+    port                 = optional(number)
+    protocol             = optional(string)
+    target_type          = string
+    deregistration_delay = optional(number)
+    health_check = optional(object({
+      enabled             = optional(bool)
+      interval            = optional(number)
+      healthy_threshold   = optional(number)
+      matcher             = optional(string)
+      path                = optional(string)
+      port                = optional(number)
+      timeout             = optional(number)
+      unhealthy_threshold = optional(number)
+    }))
+    stickiness = optional(object({
+      enabled         = optional(bool)
+      type            = string
+      cookie_duration = optional(number)
+      cookie_name     = optional(string)
+    }))
+    attachments = optional(list(object({
+      target_id         = string
+      port              = optional(number)
+      availability_zone = optional(string)
+    })), [])
+  }))
+}
+
+variable "port" {
+  type        = number
+  description = "Port on which the load balancer is listening"
+}
+
+variable "protocol" {
+  type        = string
+  description = "Protocol for connections from clients to the load balancer"
+}
+
+variable "ssl_policy" {
+  type        = string
+  description = "Name of the SSL Policy for the listener. Required if protocol is HTTPS"
+  default     = null
+}
+
+variable "certificate_arns" {
+  type        = list(string)
+  description = "List of SSL certificage ARNs to associate with the listener"
+  default     = []
+}
+
+variable "default_action" {
+  description = "Configuration block for default actions"
+  type = object({
+    type              = string
+    target_group_name = optional(string)
+    target_group_arn  = optional(string) # use this if target group defined elsewhere
+    fixed_response = optional(object({
+      content_type = string
+      message_body = optional(string)
+      status_code  = optional(string)
+    }))
+    forward = optional(object({
+      target_group = list(object({
+        name       = optional(string)
+        arn        = optional(string) # use this if target group defined elsewhere
+        stickiness = optional(number)
+      }))
+      stickiness = optional(object({
+        duration = optional(number)
+        enabled  = bool
+      }))
+    }))
+    redirect = optional(object({
+      status_code = string
+      port        = optional(number)
+      protocol    = optional(string)
+    }))
+  })
+}
+
+variable "rules" {
+  description = "Map of additional aws_lb_listener_rules where key is the tag:Name"
+  type = map(object({
+    actions = list(object({
+      type              = string
+      target_group_name = optional(string, null)
+      target_group_arn  = optional(string, null) # use this if target group defined elsewhere
+      fixed_response = optional(object({
+        content_type = string
+        message_body = optional(string)
+        status_code  = optional(string)
+      }))
+      forward = optional(object({
+        target_group = list(object({
+          name       = optional(string)
+          arn        = optional(string) # use this if target group defined elsewhere
+          stickiness = optional(number)
+        }))
+        stickiness = optional(object({
+          duration = optional(number)
+          enabled  = bool
+        }))
+      }))
+      redirect = optional(object({
+        status_code = string
+        port        = optional(number)
+        protocol    = optional(string)
+      }))
+    }))
+    conditions = list(object({
+      host_header = optional(object({
+        values = list(string)
+      }))
+    }))
+  }))
+}
+
+variable "route53_records" {
+  description = "Map of route53 records to associate with load balancer, where key is the DNS name"
+  type = map(object({
+    account                = string # account to create the record in.  set to core-vpc or self
+    zone_id                = string # id of zone to create the record in
+    evaluate_target_health = bool
+  }))
+  default = {}
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Default tags to be applied to resources"
+}
+

--- a/terraform/modules/lb_listener/versions.tf
+++ b/terraform/modules/lb_listener/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version               = "~> 4.9"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.core-vpc]
+    }
+  }
+  required_version = ">= 1.1.7"
+}


### PR DESCRIPTION
Allow addition of multiple loadbalancer listeners and rules for T1, T3 etc.
- moved legacy weblogic locals (soon to be deleted) outside of main locals-test to avoid circular dependency
- added load balancer security groups to the ec2 security groups where necessary
- added a lb-listener module for ease of adding listeners
- added 3 endpoints for T1 nomis for ASG (t1-nomis-web.nomis), standalone instance (t1-nomis-web-instance.nomis), and the legacy EC2 (weblogic-cnomt1.nomis).  The latter 2 will be removed following some testing
- increased the ASG count for weblogic servers while we test