### PR TITLE
DSOS-1620: remove standalone weblogic load balancer

### DIFF
--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -87,14 +87,6 @@ locals {
       https = merge(local.lb_listener_defaults.https, {
         target_groups = {
           http-7777-asg = local.lb_http_7777_rule
-          http-7777-instance = merge(local.lb_http_7777_rule, {
-            attachments = [
-              {
-                # temporary until circular dependencies fixed
-                target_id = local.environment == "test" ? "i-0983877a07e735688" : null
-              }
-            ]
-          })
         }
 
         rules = {
@@ -106,17 +98,6 @@ locals {
             conditions = [{
               host_header = {
                 values = ["*-nomis-web.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
-              }
-            }]
-          }
-          http-7777-instance = {
-            actions = [{
-              type              = "forward"
-              target_group_name = "http-7777-instance"
-            }]
-            conditions = [{
-              host_header = {
-                values = ["*-nomis-web-instance.nomis.${local.vpc_name}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
               }
             }]
           }
@@ -134,9 +115,8 @@ locals {
         }
 
         route53_records = {
-          "t1-nomis-web.nomis"          = local.lb_listener_defaults.environment_external_dns_zone
-          "t1-nomis-web-instance.nomis" = local.lb_listener_defaults.environment_external_dns_zone
-          "weblogic-cnomt1.nomis"       = local.lb_listener_defaults.environment_external_dns_zone
+          "t1-nomis-web.nomis"    = local.lb_listener_defaults.environment_external_dns_zone
+          "weblogic-cnomt1.nomis" = local.lb_listener_defaults.environment_external_dns_zone
         }
       })
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -179,37 +179,38 @@ locals {
     }
 
     ec2_test_instances = {
-#      t1-nomis-web-1 = {
-#        tags = {
-#          ami                = "nomis_rhel_6_10_weblogic_appserver_10_3"
-#          description        = "For testing our RHEL6.10 weblogic image"
-#          monitored          = false
-#          server-type        = "nomis-web"
-#          oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
-#          oracle-db-name     = "CNOMT1"
-#        }
-#        instance = {
-#          # set to large for weblogic testing
-#          instance_type                = "t2.large"
-#          metadata_options_http_tokens = "optional"
-#          associate_public_ip_address  = true
-#          ebs_block_device_inline      = true
-#        }
-#        ebs_volumes = {
-#          "/dev/sdb" = { # /u01 (add for weblogic testing)
-#            type       = "gp3"
-#            size       = 150
-#            kms_key_id = data.aws_kms_key.hmpps_key.arn
-#          }
-#        }
-#        route53_records = {
-#          create_internal_record = true
-#          create_external_record = true
-#        }
-#        subnet_name = "public"
-#        ami_name    = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
-#        # branch   = var.BRANCH_NAME # comment in if testing ansible
-#      }
+      t1-nomis-web-1 = {
+        tags = {
+          ami                = "nomis_rhel_6_10_weblogic_appserver_10_3"
+          description        = "For testing our RHEL6.10 weblogic image"
+          monitored          = false
+          server-type        = "nomis-web"
+          oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
+          oracle-db-name     = "CNOMT1"
+        }
+        instance = {
+          # set to large for weblogic testing
+          instance_type                = "t2.large"
+          metadata_options_http_tokens = "optional"
+          associate_public_ip_address  = true
+          ebs_block_device_inline      = true
+        }
+        ebs_volumes = {
+          "/dev/sdb" = { # /u01 (add for weblogic testing)
+            type       = "gp3"
+            size       = 150
+            kms_key_id = data.aws_kms_key.hmpps_key.arn
+          }
+        }
+        route53_records = {
+          create_internal_record = true
+          create_external_record = true
+        }
+        subnet_name = "public"
+        ami_name    = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
+        branch      = "nomis/DSOS-1620/weblogic-tagsar-fix"
+        # branch   = var.BRANCH_NAME # comment in if testing ansible
+      }
       t1-ndh-app-1 = {
         tags = {
           server-type       = "ndh-app"

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -179,37 +179,37 @@ locals {
     }
 
     ec2_test_instances = {
-      t1-nomis-web-1 = {
-        tags = {
-          ami                = "nomis_rhel_6_10_weblogic_appserver_10_3"
-          description        = "For testing our RHEL6.10 weblogic image"
-          monitored          = false
-          server-type        = "nomis-web"
-          oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
-          oracle-db-name     = "CNOMT1"
-        }
-        instance = {
-          # set to large for weblogic testing
-          instance_type                = "t2.large"
-          metadata_options_http_tokens = "optional"
-          associate_public_ip_address  = true
-          ebs_block_device_inline      = true
-        }
-        ebs_volumes = {
-          "/dev/sdb" = { # /u01 (add for weblogic testing)
-            type       = "gp3"
-            size       = 150
-            kms_key_id = data.aws_kms_key.hmpps_key.arn
-          }
-        }
-        route53_records = {
-          create_internal_record = true
-          create_external_record = true
-        }
-        subnet_name = "public"
-        ami_name    = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
-        # branch   = var.BRANCH_NAME # comment in if testing ansible
-      }
+#      t1-nomis-web-1 = {
+#        tags = {
+#          ami                = "nomis_rhel_6_10_weblogic_appserver_10_3"
+#          description        = "For testing our RHEL6.10 weblogic image"
+#          monitored          = false
+#          server-type        = "nomis-web"
+#          oracle-db-hostname = "db.CNOMT1.nomis.hmpps-test.modernisation-platform.internal"
+#          oracle-db-name     = "CNOMT1"
+#        }
+#        instance = {
+#          # set to large for weblogic testing
+#          instance_type                = "t2.large"
+#          metadata_options_http_tokens = "optional"
+#          associate_public_ip_address  = true
+#          ebs_block_device_inline      = true
+#        }
+#        ebs_volumes = {
+#          "/dev/sdb" = { # /u01 (add for weblogic testing)
+#            type       = "gp3"
+#            size       = 150
+#            kms_key_id = data.aws_kms_key.hmpps_key.arn
+#          }
+#        }
+#        route53_records = {
+#          create_internal_record = true
+#          create_external_record = true
+#        }
+#        subnet_name = "public"
+#        ami_name    = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
+#        # branch   = var.BRANCH_NAME # comment in if testing ansible
+#      }
       t1-ndh-app-1 = {
         tags = {
           server-type       = "ndh-app"

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -208,7 +208,6 @@ locals {
         }
         subnet_name = "public"
         ami_name    = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-01-03T17-01-12.128Z"
-        branch      = "nomis/DSOS-1620/weblogic-tagsar-fix"
         # branch   = var.BRANCH_NAME # comment in if testing ansible
       }
       t1-ndh-app-1 = {


### PR DESCRIPTION
Was temporarily used for testing weblogic from FixNGo.  No longer needed, we can use the main load balancer now.