### PR TITLE
Make example destroyable

### DIFF
--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -36,7 +36,7 @@ resource "aws_lb" "external" {
   name                       = "${local.application_name}-loadbalancer"
   load_balancer_type         = "application"
   subnets                    = data.aws_subnets.shared-public.ids
-  enable_deletion_protection = true
+  enable_deletion_protection = false
   # allow 60*4 seconds before 504 gateway timeout for long-running DB operations
   idle_timeout               = 240
   drop_invalid_header_fields = true

--- a/terraform/environments/example/loadbalancer_using_module.tf
+++ b/terraform/environments/example/loadbalancer_using_module.tf
@@ -41,7 +41,7 @@ module "lb_access_logs_enabled" { #tfsec:ignore:aws-ec2-no-public-egress-sgr
   }
   vpc_all = "${local.vpc_name}-${local.environment}"
   #existing_bucket_name               = "my-bucket-name"
-  force_destroy_bucket = true # enables destruction of logging bucket
+  force_destroy_bucket       = true # enables destruction of logging bucket
   application_name           = local.application_name
   public_subnets             = [data.aws_subnet.data_subnets_a.id, data.aws_subnet.data_subnets_b.id, data.aws_subnet.data_subnets_c.id]
   loadbalancer_ingress_rules = local.loadbalancer_ingress_rules

--- a/terraform/environments/example/loadbalancer_using_module.tf
+++ b/terraform/environments/example/loadbalancer_using_module.tf
@@ -41,6 +41,7 @@ module "lb_access_logs_enabled" { #tfsec:ignore:aws-ec2-no-public-egress-sgr
   }
   vpc_all = "${local.vpc_name}-${local.environment}"
   #existing_bucket_name               = "my-bucket-name"
+  force_destroy_bucket = true # enables destruction of logging bucket
   application_name           = local.application_name
   public_subnets             = [data.aws_subnet.data_subnets_a.id, data.aws_subnet.data_subnets_b.id, data.aws_subnet.data_subnets_c.id]
   loadbalancer_ingress_rules = local.loadbalancer_ingress_rules

--- a/terraform/environments/example/s3.tf
+++ b/terraform/environments/example/s3.tf
@@ -8,6 +8,8 @@ module "s3-bucket" { #tfsec:ignore:aws-s3-enable-versioning
   versioning_enabled = false
   bucket_policy      = [data.aws_iam_policy_document.bucket_policy.json]
 
+  # Enable bucket to be destroyed when not empty
+  force_destroy = true
   # Refer to the below section "Replication" before enabling replication
   replication_enabled = false
   # Below three variables and providers configuration are only relevant if 'replication_enabled' is set to true


### PR DESCRIPTION
Whilst trouble shooting a failed plan on a dependabot PR in example, it became clear that you cannot easily destroy example without a lot of manual work.

These changes mean you can build and destroy the example account easily.