### PR TITLE
Adding an ASG for the Windows 2019 jumpserver

### DIFF
--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -139,11 +139,14 @@ locals {
         }
       }
       jumpserver-2019 = {
-        ami_name = "nomis_windows_server_2019_jumpserver_release_*"
+        ami_name = "nomis_windows_server_2019_jumpserver_test_*"
         tags = {
           server-type       = "jumpserver"
           description       = "Windows Server 2019 Jumpserver for NOMIS"
-          nomis-environment = "jumpserver"
+          monitored         = true
+          os-type           = "Windows"
+          component         = "jumpserver"
+          nomis-environment = "dev"
         }
         autoscaling_group = {
           min_size = 0

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -127,6 +127,18 @@ locals {
           max_size = 1
         }
       }
+      jumpserver-2019 = {
+        ami_name = "nomis_windows_server_2019_jumpserver_release_*"
+        tags = {
+          server-type       = "jumpserver"
+          description       = "Windows Server 2019 Jumpserver for NOMIS"
+          nomis-environment = "jumpserver"
+        }
+        autoscaling_group = {
+          min_size = 0
+          max_size = 1
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
A Windows 2019 jumpserver for **nomis-development**.