### PR TITLE
Fix failing action when test fails

### DIFF
--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -30,6 +30,7 @@ jobs:
 
   plan-dev-test:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - environment: development
@@ -68,6 +69,7 @@ jobs:
     needs: plan-dev-test
     if: success()
     strategy:
+      fail-fast: false
       matrix:
         include:
           - environment: development
@@ -105,6 +107,7 @@ jobs:
   # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - environment: preproduction
@@ -142,6 +145,7 @@ jobs:
     needs: plan-preprod-prod
     if: success()
     strategy:
+      fail-fast: false
       matrix:
         include:
           - environment: preproduction

--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -29,6 +29,7 @@ defaults:
 jobs:
 
   plan-dev-test:
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +69,7 @@ jobs:
   deploy-dev-test:
     needs: plan-dev-test
     if: success()
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +109,6 @@ jobs:
   # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:
     strategy:
-      fail-fast: false
       matrix:
         include:
           - environment: preproduction
@@ -145,7 +146,6 @@ jobs:
     needs: plan-preprod-prod
     if: success()
     strategy:
-      fail-fast: false
       matrix:
         include:
           - environment: preproduction


### PR DESCRIPTION
When the test environment fails it prevents dev deployment from running.

Turning off fail-fast to run the deployment workflows even if the plans fail.