### PR TITLE
Removing the Windows 2019 ASG

### DIFF
--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -138,21 +138,6 @@ locals {
           max_size = 1
         }
       }
-      jumpserver-2019 = {
-        ami_name = "nomis_windows_server_2019_jumpserver_test_*"
-        tags = {
-          server-type       = "jumpserver"
-          description       = "Windows Server 2019 Jumpserver for NOMIS"
-          monitored         = true
-          os-type           = "Windows"
-          component         = "jumpserver"
-          nomis-environment = "dev"
-        }
-        autoscaling_group = {
-          min_size = 0
-          max_size = 1
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Using the Windows 2019 jumpserver and older version of IE did not resolve the NOMIS access issue.