### PR TITLE
nomis: DSOS-1647: Remove unused security groups

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -174,22 +174,6 @@ module "db_ec2_instance" {
   branch               = try(each.value.branch, "main")
 }
 
-# Delete in next PR
-resource "aws_security_group" "database_common" {
-  #checkov:skip=CKV2_AWS_5:skip "Ensure that Security Groups are attached to another resource" - attached in nomis-stack module
-  description = "Common security group for database instances"
-  name        = "database-common"
-  vpc_id      = module.environment.vpc.id
-
-  ingress {
-    description = "Internal access to self on all ports"
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    self        = true
-  }
-}
-
 #------------------------------------------------------------------------------
 # Policy for PUT, GET, LIST access to database backups
 #------------------------------------------------------------------------------

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -79,21 +79,6 @@ module "ec2_jumpserver" {
   branch                        = try(each.value.branch, "main")
 }
 
-# Delete in next PR
-resource "aws_security_group" "jumpserver-windows" {
-  description = "Configure Windows jumpserver egress"
-  name        = "jumpserver-windows-${local.application_name}"
-  vpc_id      = module.environment.vpc.id
-
-  ingress {
-    description = "Internal access to self on all ports"
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    self        = true
-  }
-}
-
 #------
 # Jumpserver specific
 #------

--- a/terraform/environments/nomis/ec2-test.tf
+++ b/terraform/environments/nomis/ec2-test.tf
@@ -120,20 +120,3 @@ module "ec2_test_autoscaling_group" {
   account_ids_lookup        = local.environment_management.account_ids
   branch                    = try(each.value.branch, "main")
 }
-
-# Delete in next PR
-resource "aws_security_group" "ec2_test" {
-  #checkov:skip=CKV2_AWS_5:skip "Ensure that Security Groups are attached to another resource" - attached in nomis-stack module
-  description = "Security group for ec2_test instances"
-  name        = "ec2_test"
-  vpc_id      = module.environment.vpc.id
-
-  ingress {
-    description = "Internal access to self on all ports"
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    self        = true
-  }
-}
-

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -150,19 +150,3 @@ module "ec2_weblogic_autoscaling_group" {
   account_ids_lookup = local.environment_management.account_ids
   branch             = try(each.value.branch, "main")
 }
-
-# Delete in next PR
-resource "aws_security_group" "weblogic_common" {
-  #checkov:skip=CKV2_AWS_5:skip "Ensure that Security Groups are attached to another resource" - attached in nomis-stack module
-  description = "Common security group for weblogic instances"
-  name        = "weblogic-common"
-  vpc_id      = module.environment.vpc.id
-
-  ingress {
-    description = "Internal access to self on all ports"
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    self        = true
-  }
-}

--- a/terraform/environments/nomis/security-groups.tf
+++ b/terraform/environments/nomis/security-groups.tf
@@ -18,6 +18,7 @@ resource "aws_security_group" "public" {
       protocol        = lookup(ingress.value, "protocol", null)
       cidr_blocks     = lookup(ingress.value, "cidr_blocks", null)
       security_groups = lookup(ingress.value, "security_groups", null)
+      self            = lookup(ingress.value, "self", null)
     }
   }
 
@@ -30,6 +31,7 @@ resource "aws_security_group" "public" {
       protocol        = lookup(egress.value, "protocol", null)
       cidr_blocks     = lookup(egress.value, "cidr_blocks", null)
       security_groups = lookup(egress.value, "security_groups", null)
+      self            = lookup(egress.value, "self", null)
     }
   }
 
@@ -53,6 +55,7 @@ resource "aws_security_group" "private" {
       protocol        = lookup(ingress.value, "protocol", null)
       cidr_blocks     = lookup(ingress.value, "cidr_blocks", null)
       security_groups = lookup(ingress.value, "security_groups", null)
+      self            = lookup(ingress.value, "self", null)
     }
   }
 
@@ -65,6 +68,7 @@ resource "aws_security_group" "private" {
       protocol        = lookup(egress.value, "protocol", null)
       cidr_blocks     = lookup(egress.value, "cidr_blocks", null)
       security_groups = lookup(egress.value, "security_groups", null)
+      self            = lookup(egress.value, "self", null)
     }
   }
 
@@ -88,6 +92,7 @@ resource "aws_security_group" "data" {
       protocol        = lookup(ingress.value, "protocol", null)
       cidr_blocks     = lookup(ingress.value, "cidr_blocks", null)
       security_groups = lookup(ingress.value, "security_groups", null)
+      self            = lookup(ingress.value, "self", null)
     }
   }
 
@@ -100,6 +105,7 @@ resource "aws_security_group" "data" {
       protocol        = lookup(egress.value, "protocol", null)
       cidr_blocks     = lookup(egress.value, "cidr_blocks", null)
       security_groups = lookup(egress.value, "security_groups", null)
+      self            = lookup(egress.value, "self", null)
     }
   }
 
@@ -123,6 +129,7 @@ resource "aws_security_group" "jumpserver" {
       protocol        = lookup(ingress.value, "protocol", null)
       cidr_blocks     = lookup(ingress.value, "cidr_blocks", null)
       security_groups = lookup(ingress.value, "security_groups", null)
+      self            = lookup(ingress.value, "self", null)
     }
   }
 
@@ -135,6 +142,7 @@ resource "aws_security_group" "jumpserver" {
       protocol        = lookup(egress.value, "protocol", null)
       cidr_blocks     = lookup(egress.value, "cidr_blocks", null)
       security_groups = lookup(egress.value, "security_groups", null)
+      self            = lookup(egress.value, "self", null)
     }
   }
 


### PR DESCRIPTION
Now everything has switched over to the new groups, should be possible to zap the old ones