### PR TITLE
add cwagent log stream for weblogic logs in nomis

### DIFF
--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -21,6 +21,9 @@ locals {
       cwagent-nomis-autologoff = {
         retention_days = 90
       }
+      cwagent-weblogic-logs = {
+        retention_days = 30
+      }
     }
 
     # Add database instances here. They will be created using ec2-database.tf


### PR DESCRIPTION
additional log group for weblogic logs for nomis-test environment only (at the moment) 

assuming this works I'll replicate it to the other nomis environments or revert this if it doesn't