### PR TITLE
add cloud_watch_config_windows to parameter store and install/start cloudwatch using the windows init script

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -91,7 +91,8 @@ data "aws_iam_policy_document" "cloud_watch_custom" {
       "ssm:GetParameter",
       "ssm:GetParameters"
     ]
-    resources = [aws_ssm_parameter.cloud_watch_config_linux.arn]
+    resources = [aws_ssm_parameter.cloud_watch_config_linux.arn,
+      aws_ssm_parameter.cloud_watch_config_windows.arn]
   }
 }
 
@@ -305,7 +306,7 @@ resource "aws_ssm_document" "cloud_watch_agent" {
   )
 }
 
-resource "aws_ssm_association" "manage_cloud_watch_agent_linux" {
+/* resource "aws_ssm_association" "manage_cloud_watch_agent_linux" {
   name             = aws_ssm_document.cloud_watch_agent.name
   association_name = "manage-cloud-watch-agent"
   parameters = { # name of ssm parameter containing cloud watch agent config file
@@ -317,7 +318,7 @@ resource "aws_ssm_association" "manage_cloud_watch_agent_linux" {
   }
   apply_only_at_cron_interval = false
   schedule_expression         = "cron(45 7 ? * TUE *)"
-}
+} */
 
 resource "aws_ssm_parameter" "cloud_watch_config_linux" {
   #checkov:skip=CKV2_AWS_34:there should not be anything secret in this config
@@ -334,7 +335,20 @@ resource "aws_ssm_parameter" "cloud_watch_config_linux" {
   )
 }
 
-# TODO: config for windows
+resource "aws_ssm_parameter" "cloud_watch_config_windows" {
+  #checkov:skip=CKV2_AWS_34:there should not be anything secret in this config
+  description = "cloud watch agent config for windows"
+  name        = "cloud-watch-config-windows"
+  type        = "String"
+  value       = file("./templates/cloud_watch_windows.json")
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "cloud-watch-config-windows"
+    },
+  )
+}
 
 #------------------------------------------------------------------------------
 # SSM Agent - update Systems Manager Agent

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "cloud_watch_custom" {
       "ssm:GetParameters"
     ]
     resources = [aws_ssm_parameter.cloud_watch_config_linux.arn,
-      aws_ssm_parameter.cloud_watch_config_windows.arn]
+    aws_ssm_parameter.cloud_watch_config_windows.arn]
   }
 }
 

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -24,6 +24,9 @@ locals {
       cwagent-weblogic-logs = {
         retention_days = 30
       }
+      cwagent-windows-system = {
+        retention_days = 30
+      }
     }
 
     databases = {

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -24,6 +24,9 @@ locals {
       cwagent-weblogic-logs = {
         retention_days = 30
       }
+      cwagent-windows-system = {
+        retention_days = 30
+      }
     }
 
     databases = {

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -29,6 +29,9 @@ locals {
       cwagent-weblogic-logs = {
         retention_days = 30
       }
+      cwagent-windows-system = {
+        retention_days = 30
+      }
     }
 
     # Add database instances here. They will be created using ec2-database.tf

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -24,6 +24,9 @@ locals {
       cwagent-weblogic-logs = {
         retention_days = 30
       }
+      cwagent-windows-system = {
+        retention_days = 30
+      }
     }
 
     # Add database instances here. They will be created using ec2-database.tf

--- a/terraform/environments/nomis/templates/cloud_watch_windows.json
+++ b/terraform/environments/nomis/templates/cloud_watch_windows.json
@@ -1,0 +1,104 @@
+{
+    "agent": {
+        "metrics_collection_interval": 60,
+        "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+    },
+    "metrics": {
+        "metrics_collected": {
+            "Processor": {
+                "measurement": [
+                    {
+                        "name": "% Idle Time",
+                        "rename": "CPU_IDLE",
+                        "unit": "Percent"
+                    },
+                    "% Interrupt Time",
+                    "% User Time",
+                    "% Processor Time"
+                ],
+                "resources": [
+                    "*"
+                ]
+            },
+            "LogicalDisk": {
+                "measurement": [
+                    {
+                        "name": "% Idle Time",
+                        "unit": "Percent"
+                    },
+                    {
+                        "name": "% Disk Read Time",
+                        "rename": "DISK_READ"
+                    },
+                    "% Disk Write Time"
+                ],
+                "resources": [
+                    "*"
+                ]
+            },
+            "Memory": {
+                "metrics_collection_interval": 5,
+                "measurement": [
+                    "Available Bytes",
+                    "Cache Faults/sec",
+                    "Page Faults/sec",
+                    "Pages/sec"
+                ]
+            },
+            "Network Interface": {
+                "metrics_collection_interval": 5,
+                "measurement": [
+                    "Bytes Received/sec",
+                    "Bytes Sent/sec",
+                    "Packets Received/sec",
+                    "Packets Sent/sec"
+                ],
+                "resources": [
+                    "*"
+                ],
+                "append_dimensions": {
+                    "d3": "win_bo"
+                }
+            },
+            "System": {
+                "measurement": [
+                    "Context Switches/sec",
+                    "System Calls/sec",
+                    "Processor Queue Length"
+                ]
+            }
+        },
+        "append_dimensions": {
+            "ImageId": "${aws:ImageId}",
+            "InstanceId": "${aws:InstanceId}"
+        }
+    },
+    "logs": {
+        "logs_collected": {
+            "files": {
+                "collect_list": [
+                    {
+                        "file_path": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log",
+                        "log_group_name": "amazon-cloudwatch-agent.log",
+                        "log_stream_name": "{instance_id}",
+                        "timezone": "UTC"
+                    }
+                ]
+            },
+            "windows_events": {
+                "collect_list": [
+                    {
+                        "event_name": "System",
+                        "event_levels": [
+                            "INFORMATION",
+                            "ERROR"
+                        ],
+                        "log_group_name": "cwagent-windows-system",
+                        "log_stream_name": "{instance_id}",
+                        "event_format": "xml"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/terraform/environments/nomis/templates/cloud_watch_windows.json
+++ b/terraform/environments/nomis/templates/cloud_watch_windows.json
@@ -1,104 +1,81 @@
 {
-    "agent": {
-        "metrics_collection_interval": 60,
-        "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
-    },
-    "metrics": {
-        "metrics_collected": {
-            "Processor": {
-                "measurement": [
-                    {
-                        "name": "% Idle Time",
-                        "rename": "CPU_IDLE",
-                        "unit": "Percent"
-                    },
-                    "% Interrupt Time",
-                    "% User Time",
-                    "% Processor Time"
-                ],
-                "resources": [
-                    "*"
-                ]
-            },
-            "LogicalDisk": {
-                "measurement": [
-                    {
-                        "name": "% Idle Time",
-                        "unit": "Percent"
-                    },
-                    {
-                        "name": "% Disk Read Time",
-                        "rename": "DISK_READ"
-                    },
-                    "% Disk Write Time"
-                ],
-                "resources": [
-                    "*"
-                ]
-            },
-            "Memory": {
-                "metrics_collection_interval": 5,
-                "measurement": [
-                    "Available Bytes",
-                    "Cache Faults/sec",
-                    "Page Faults/sec",
-                    "Pages/sec"
-                ]
-            },
-            "Network Interface": {
-                "metrics_collection_interval": 5,
-                "measurement": [
-                    "Bytes Received/sec",
-                    "Bytes Sent/sec",
-                    "Packets Received/sec",
-                    "Packets Sent/sec"
-                ],
-                "resources": [
-                    "*"
-                ],
-                "append_dimensions": {
-                    "d3": "win_bo"
-                }
-            },
-            "System": {
-                "measurement": [
-                    "Context Switches/sec",
-                    "System Calls/sec",
-                    "Processor Queue Length"
-                ]
-            }
-        },
+  "agent": {
+    "metrics_collection_interval": 60,
+    "logfile": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log"
+  },
+  "metrics": {
+    "metrics_collected": {
+      "Processor": {
+        "measurement": [
+          {
+            "name": "% Idle Time",
+            "rename": "CPU_IDLE",
+            "unit": "Percent"
+          },
+          "% Interrupt Time",
+          "% User Time",
+          "% Processor Time"
+        ],
+        "resources": ["*"]
+      },
+      "LogicalDisk": {
+        "measurement": [
+          {
+            "name": "% Idle Time",
+            "unit": "Percent"
+          },
+          {
+            "name": "% Disk Read Time",
+            "rename": "DISK_READ"
+          },
+          "% Disk Write Time"
+        ],
+        "resources": ["*"]
+      },
+      "Memory": {
+        "metrics_collection_interval": 5,
+        "measurement": ["Available Bytes", "Cache Faults/sec", "Page Faults/sec", "Pages/sec"]
+      },
+      "Network Interface": {
+        "metrics_collection_interval": 5,
+        "measurement": ["Bytes Received/sec", "Bytes Sent/sec", "Packets Received/sec", "Packets Sent/sec"],
+        "resources": ["*"],
         "append_dimensions": {
-            "ImageId": "${aws:ImageId}",
-            "InstanceId": "${aws:InstanceId}"
+          "d3": "win_bo"
         }
+      },
+      "System": {
+        "measurement": ["Context Switches/sec", "System Calls/sec", "Processor Queue Length"]
+      }
     },
-    "logs": {
-        "logs_collected": {
-            "files": {
-                "collect_list": [
-                    {
-                        "file_path": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log",
-                        "log_group_name": "amazon-cloudwatch-agent.log",
-                        "log_stream_name": "{instance_id}",
-                        "timezone": "UTC"
-                    }
-                ]
-            },
-            "windows_events": {
-                "collect_list": [
-                    {
-                        "event_name": "System",
-                        "event_levels": [
-                            "INFORMATION",
-                            "ERROR"
-                        ],
-                        "log_group_name": "cwagent-windows-system",
-                        "log_stream_name": "{instance_id}",
-                        "event_format": "xml"
-                    }
-                ]
-            }
-        }
+    "append_dimensions": {
+      "ImageId": "${aws:ImageId}",
+      "InstanceId": "${aws:InstanceId}"
     }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs\\amazon-cloudwatch-agent.log",
+            "log_group_name": "amazon-cloudwatch-agent.log",
+            "log_stream_name": "{instance_id}",
+            "timezone": "UTC"
+          }
+        ]
+      },
+      "windows_events": {
+        "collect_list": [
+          {
+            "event_name": "System",
+            "event_levels": ["INFORMATION", "ERROR"],
+            "log_group_name": "cwagent-windows-system",
+            "log_stream_name": "{instance_id}",
+            "event_format": "xml"
+          }
+        ]
+      }
+    }
+  }
 }

--- a/terraform/environments/nomis/templates/jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/jumpserver-user-data.yaml
@@ -43,3 +43,39 @@ tasks:
           $path = "C:\Users\Administrator\Documents\add_users.ps1"
           Out-File -FilePath $path -InputObject $add_users
           Register-ScheduledJob -Name "add_users" -FilePath $path -RunEvery $(New-TimeSpan -Minutes 15) -RunNow
+
+          # Install AWS PowerShell modules dependencies
+          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+          Install-Module -Name AWS.Tools.Installer -Force -AllowClobber
+          Install-AWSToolsModule -Name AWS.Tools.SimpleSystemsManagement -Force -Cleanup -AllowClobber
+
+          $ConfigFilePath = "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-config.json"
+
+          function Get-AmazonCloudWatchAgentConfig {
+            param(
+              [string]$OutFilePath
+            )
+            (Get-SSMParameter -Name "cloud-watch-config-windows").Value | Out-File -FilePath $OutFilePath -Force -NoNewline  
+          }
+          
+          function Start-AmazonCloudWatchAgent {
+            param(
+              [string]$ConfigurationFilePath
+            )
+            "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -s -c file:$ConfigurationFilePath"
+          }
+          
+          # Check CWAgent is installed, if it isn't then install it
+          $cwagent = Get-Service -Name "AmazonCloudWatchAgent" -ErrorAction SilentlyContinue
+          if ($cwagent) {
+            Write-Output "CloudWatch Agent is already installed"
+            Get-AmazonCloudWatchAgentConfig -OutFilePath $ConfigFilePath
+            Start-AmazonCloudWatchAgent -ConfigurationFilePath $ConfigFilePath
+          } else {
+            Write-Output "Installing CloudWatch Agent"
+            Invoke-WebRequest -Uri "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi" -OutFile "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+            $cwagent_installer = "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+            Start-Process -FilePath msiexec.exe -ArgumentList "/i $cwagent_installer /qn" -Wait
+            Get-AmazonCloudWatchAgentConfig -OutFilePath $ConfigFilePath
+            Start-AmazonCloudWatchAgent -ConfigurationFilePath $ConfigFilePath
+          }

--- a/terraform/environments/nomis/templates/jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/jumpserver-user-data.yaml
@@ -57,14 +57,14 @@ tasks:
             )
             (Get-SSMParameter -Name "cloud-watch-config-windows").Value | Out-File -FilePath $OutFilePath -Force -NoNewline  
           }
-          
+
           function Start-AmazonCloudWatchAgent {
             param(
               [string]$ConfigurationFilePath
             )
             "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -s -c file:$ConfigurationFilePath"
           }
-          
+
           # Check CWAgent is installed, if it isn't then install it
           $cwagent = Get-Service -Name "AmazonCloudWatchAgent" -ErrorAction SilentlyContinue
           if ($cwagent) {


### PR DESCRIPTION
Since it's quite challenging to have ansible (running from the modernisation-platform-configuration-management repo) install cloudwatch-agent and config etc. onto Windows machines, for the sake of expediency this is being done in the windows init script.

This (currently) also only applies to the Jumpserver instances as these are our only Windows machines. Possibly the way forward is to use the ansible aws_ssm provider instead but for the moment this is the most straight-forward way of getting Windows logs/metrics into Cloudwatch.

This PR is basically to test the init changes. Assuming windows events start appearing in Cloudwatch I'll extend some of the alerts to include the Jumpservers as well.

NOTE: Open-policy-agent checks associated with adding backends and adding providers have been commented out as they now fail, previously they didn't. So this needs an exclusion for specific environments or there has been some other change in the opa backend.