### PR TITLE
Temp fix for opa tests

### DIFF
--- a/scripts/tests/validate/opa.sh
+++ b/scripts/tests/validate/opa.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-files=$(find . -type f -name *.tf -not -path "*/.terraform/*" -not -path "*/providers.tf" -not -path "*/backend.tf")
+files=$(find . -type f -name *.tf -not -path "*/.terraform/*" -not -path "*/*providers.tf" -not -path "*/*backend.tf")
 
 terraform(){
   for file in $files

--- a/scripts/tests/validate/run-opa-tests.sh
+++ b/scripts/tests/validate/run-opa-tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-files=$(find . -type f -name *.tf -not -path "*/.terraform/*" -not -path "*/providers.tf" -not -path "*/backend.tf")
+files=$(find . -type f -name *.tf -not -path "*/.terraform/*" -not -path "*/*providers.tf" -not -path "*/*backend.tf")
 
 terraform(){
   for file in $files


### PR DESCRIPTION
A bit of a dirty fix, as it would be better if we checked for the whole file name, but the changes needed for https://github.com/ministryofjustice/modernisation-platform/issues/2521 will be rolled out in batches, so this can be fixed properly after all of the accounts have the changes.