### PR TITLE
Nomis: DSOS-1587: more cmk changes

### DIFF
--- a/terraform/environments/nomis/cmk.tf
+++ b/terraform/environments/nomis/cmk.tf
@@ -1,83 +1,9 @@
 #------------------------------------------------------------------------------
-# Customer Managed Key for AMI sharing
-# Only created in Test account currently as AMIs encrypted using this key
-# should be shared with Production account, hence Prod account requires permissions
-# to use this key
+# Customer Managed Keys
 #------------------------------------------------------------------------------
 
 data "aws_kms_key" "default_ebs" {
   key_id = "alias/aws/ebs"
-}
-
-resource "aws_kms_key" "nomis-cmk" {
-  count                   = local.environment == "test" ? 1 : 0
-  description             = "Nomis Managed Key for AMI Sharing"
-  deletion_window_in_days = 10
-  policy                  = data.aws_iam_policy_document.shared_image_builder_cmk_policy[0].json
-  enable_key_rotation     = true
-}
-
-resource "aws_kms_alias" "nomis-key" {
-  count         = local.environment == "test" ? 1 : 0
-  name          = "alias/nomis-image-builder"
-  target_key_id = aws_kms_key.nomis-cmk[0].key_id
-}
-
-data "aws_iam_policy_document" "shared_image_builder_cmk_policy" {
-  count = local.environment == "test" ? 1 : 0
-  statement {
-    effect = "Allow"
-    actions = ["kms:Encrypt",
-      "kms:Decrypt",
-      "kms:Encrypt",
-      "kms:ReEncrypt*",
-      "kms:ReEncryptFrom",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-      "kms:CreateGrant"
-    ]
-    # these can be ignored as this policy is being applied to a specific key resource. ["*"] in this case refers to this key
-    #tfsec:ignore:aws-iam-no-policy-wildcards
-    #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
-    #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
-    resources = ["*"]
-    principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${local.account_id}:root",
-        "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:root",
-        "arn:aws:iam::${local.environment_management.account_ids["nomis-development"]}:root",
-        "arn:aws:iam::${local.environment_management.account_ids["nomis-preproduction"]}:root",
-        "arn:aws:iam::${local.environment_management.account_ids["nomis-production"]}:root",
-        "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
-      ]
-    }
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Update*",
-      "kms:Revoke*",
-      "kms:Disable*",
-      "kms:Get*",
-      "kms:Delete*",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion"
-    ]
-    # these can be ignored as this policy is being applied to a specific key resource. ["*"] in this case refers to this key
-    #tfsec:ignore:aws-iam-no-policy-wildcards
-    #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
-    #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
-    resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.account_id}:root"]
-    }
-  }
 }
 
 data "aws_iam_policy_document" "sns_topic_key_policy" {

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -406,8 +406,8 @@ data "aws_iam_policy_document" "ssm_ec2_start_stop_kms" {
       "kms:ListGrants",
       "kms:RevokeGrant"
     ]
-    # we have a legacy CMK that's used in production that will be retired but in the meantime requires permissions
-    resources = [local.environment == "test" ? aws_kms_key.nomis-cmk[0].arn : data.aws_kms_key.nomis_key.arn, module.environment.kms_keys["ebs"].arn]
+    # Allow access to the AMI encryption key
+    resources = [module.environment.kms_keys["ebs"].arn]
   }
 
   statement {

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -5,11 +5,6 @@ data "aws_caller_identity" "mod-platform" {
   provider = aws.modernisation-platform
 }
 
-data "aws_kms_key" "nomis_key" {
-  # Look up the CMK used to create AMIs, which is in the test account (maybe it should be in prod?)
-  key_id = "arn:aws:kms:${local.region}:${local.environment_management.account_ids["nomis-test"]}:alias/nomis-image-builder"
-}
-
 data "aws_iam_policy_document" "image-builder-distro-assume-role" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -78,8 +73,8 @@ data "aws_iam_policy_document" "image-builder-distro-kms-policy" {
       "kms:ListGrants",
       "kms:RevokeGrant"
     ]
-    # we use the same AMIs in test and production, which are encrypted with a single key that only exists in test, hence the below
-    resources = [local.environment == "test" ? aws_kms_key.nomis-cmk[0].arn : data.aws_kms_key.nomis_key.arn, module.environment.kms_keys["ebs"].arn]
+    # Allow access to the AMI encryption key
+    resources = [module.environment.kms_keys["ebs"].arn]
   }
 }
 

--- a/terraform/environments/nomis/s3.tf
+++ b/terraform/environments/nomis/s3.tf
@@ -7,6 +7,7 @@ module "s3-bucket" {
   }
   bucket_prefix       = "s3-bucket"
   replication_enabled = false
+  custom_kms_key      = module.environment.kms_keys["general"].id
 
   lifecycle_rule = [
     {
@@ -57,6 +58,7 @@ module "nomis-db-backup-bucket" {
   }
   bucket_prefix       = "nomis-db-backup-bucket"
   replication_enabled = false
+  custom_kms_key      = module.environment.kms_keys["general"].id
 
   lifecycle_rule = [
     {
@@ -133,6 +135,7 @@ module "nomis-image-builder-bucket" {
   }
   bucket_prefix       = "ec2-image-builder-nomis"
   replication_enabled = false
+  custom_kms_key      = module.environment.kms_keys["general"].id
 
   bucket_policy = [data.aws_iam_policy_document.cross-account-s3.json]
 
@@ -211,6 +214,7 @@ module "nomis-audit-archives" {
   }
   bucket_prefix       = "nomis-audit-archives"
   replication_enabled = false
+  custom_kms_key      = module.environment.kms_keys["general"].id
 
   bucket_policy = [data.aws_iam_policy_document.nomis-all-environments-access.json]
 


### PR DESCRIPTION
Remove old nomis CMK (we now use hmpps key from core-shared-services-production instead)
Set default S3 bucket encryption keys to hmpps general.  This will make sharing between accounts easier - particularly relevant for image builder / db backup buckets. 