### PR TITLE
Nomis: DSOS-1587: fix asg shared kms key access

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -6,6 +6,13 @@ resource "aws_kms_grant" "hmpps_ebs_kms_key_for_autoscaling" {
   key_id            = module.environment.kms_keys["ebs"].arn
   grantee_principal = "arn:aws:iam::${module.environment.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [
+    "Encrypt",
+    "Decrypt",
+    "ReEncryptFrom",
+    "ReEncryptTo",
+    "GenerateDataKey",
+    "GenerateDataKeyWithoutPlaintext",
+    "DescribeKey",
     "CreateGrant"
   ]
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -1,6 +1,15 @@
 #------------------------------------------------------------------------------
 # Common IAM policies for all ec2 instance profiles
 #------------------------------------------------------------------------------
+resource "aws_kms_grant" "hmpps_ebs_kms_key_for_autoscaling" {
+  name              = "hmpps-ebs-kms-grant-for-autoscaling"
+  key_id            = module.environment.kms_keys["ebs"].arn
+  grantee_principal = "arn:aws:iam::${module.environment.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+  operations = [
+    "CreateGrant"
+  ]
+}
+
 resource "aws_kms_grant" "ssm-start-stop-shared-cmk-grant" {
   count             = local.environment == "test" ? 1 : 0
   name              = "image-builder-shared-cmk-grant"


### PR DESCRIPTION
Add KMS Grant for autoscaling policy.  This gives access to the shared HMPPS EBS key.  Without this, ASG instances using this key will fail to start