### PR TITLE
Nomis: DSOS-1587: fix s3 shared kms key access

### DIFF
--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -214,7 +214,7 @@ data "aws_iam_policy_document" "ec2_common_combined" {
     data.aws_iam_policy_document.ssm_custom.json,
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json,
-    data.aws_iam_policy_document.hmpps_kms_keys,
+    data.aws_iam_policy_document.hmpps_kms_keys.json,
     data.aws_iam_policy_document.application_insights.json # TODO: remove this later
   ]
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "ec2_common_combined" {
     data.aws_iam_policy_document.ssm_custom.json,
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json,
-    # data.aws_iam_policy_document.hmpps_kms_keys.json,
+    data.aws_iam_policy_document.hmpps_kms_keys.json,
     data.aws_iam_policy_document.application_insights.json # TODO: remove this later
   ]
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -189,6 +189,7 @@ data "aws_iam_policy_document" "application_insights" {
 
 data "aws_iam_policy_document" "hmpps_kms_keys" {
   statement {
+    sid    = "AllowBusinessUnitSharedKmsKeys"
     effect = "Allow"
     actions = [
       "kms:Encrypt",

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "ec2_common_combined" {
     data.aws_iam_policy_document.ssm_custom.json,
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json,
-    data.aws_iam_policy_document.hmpps_kms_keys.json,
+    # data.aws_iam_policy_document.hmpps_kms_keys.json,
     data.aws_iam_policy_document.application_insights.json # TODO: remove this later
   ]
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -187,12 +187,34 @@ data "aws_iam_policy_document" "application_insights" {
   }
 }
 
+data "aws_iam_policy_document" "hmpps_kms_keys" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
+    ]
+    # Allow access to the AMI encryption key
+    resources = [
+      module.environment.kms_keys["ebs"].arn,
+      module.environment.kms_keys["general"].arn,
+    ]
+  }
+}
+
 # combine ec2-common policy documents
 data "aws_iam_policy_document" "ec2_common_combined" {
   source_policy_documents = [
     data.aws_iam_policy_document.ssm_custom.json,
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json,
+    data.aws_iam_policy_document.hmpps_kms_keys,
     data.aws_iam_policy_document.application_insights.json # TODO: remove this later
   ]
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -4,7 +4,7 @@
 resource "aws_kms_grant" "hmpps_ebs_kms_key_for_autoscaling" {
   name              = "hmpps-ebs-kms-grant-for-autoscaling"
   key_id            = module.environment.kms_keys["ebs"].arn
-  grantee_principal = "arn:aws:iam::${module.environment.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+  grantee_principal = "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
   operations = [
     "Encrypt",
     "Decrypt",

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -74,7 +74,10 @@ data "aws_iam_policy_document" "image-builder-distro-kms-policy" {
       "kms:RevokeGrant"
     ]
     # Allow access to the AMI encryption key
-    resources = [module.environment.kms_keys["ebs"].arn]
+    resources = [
+      module.environment.kms_keys["ebs"].arn,
+      module.environment.kms_keys["general"].arn,
+    ]
   }
 }
 
@@ -157,19 +160,4 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
   policy_arn = aws_iam_policy.launch-template-reader-policy.arn
   role       = aws_iam_role.core-services-launch-template-reader.name
 
-}
-
-resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
-  name              = "image-builder-shared-cmk-grant"
-  key_id            = module.environment.kms_keys["ebs"].arn
-  grantee_principal = "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
-  operations = [
-    "Encrypt",
-    "Decrypt",
-    "ReEncryptFrom",
-    "GenerateDataKey",
-    "GenerateDataKeyWithoutPlaintext",
-    "DescribeKey",
-    "CreateGrant"
-  ]
 }

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -74,10 +74,7 @@ data "aws_iam_policy_document" "image-builder-distro-kms-policy" {
       "kms:RevokeGrant"
     ]
     # Allow access to the AMI encryption key
-    resources = [
-      module.environment.kms_keys["ebs"].arn,
-      module.environment.kms_keys["general"].arn,
-    ]
+    resources = [module.environment.kms_keys["ebs"].arn]
   }
 }
 
@@ -162,7 +159,7 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
 
 }
 
-# duplicate grant which isn't quite right (other is in ec2-common), but no permissions to delete
+# this can be zapped at some point as the correct definition is in ec2-common
 resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
   name              = "image-builder-shared-cmk-grant"
   key_id            = module.environment.kms_keys["ebs"].arn

--- a/terraform/environments/nomis/ec2-image-builder-iam.tf
+++ b/terraform/environments/nomis/ec2-image-builder-iam.tf
@@ -161,3 +161,19 @@ resource "aws_iam_role_policy_attachment" "launch-template-reader-policy-attach"
   role       = aws_iam_role.core-services-launch-template-reader.name
 
 }
+
+# duplicate grant which isn't quite right (other is in ec2-common), but no permissions to delete
+resource "aws_kms_grant" "image-builder-shared-cmk-grant" {
+  name              = "image-builder-shared-cmk-grant"
+  key_id            = module.environment.kms_keys["ebs"].arn
+  grantee_principal = "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+  operations = [
+    "Encrypt",
+    "Decrypt",
+    "ReEncryptFrom",
+    "GenerateDataKey",
+    "GenerateDataKeyWithoutPlaintext",
+    "DescribeKey",
+    "CreateGrant"
+  ]
+}

--- a/terraform/environments/nomis/s3.tf
+++ b/terraform/environments/nomis/s3.tf
@@ -7,7 +7,7 @@ module "s3-bucket" {
   }
   bucket_prefix       = "s3-bucket"
   replication_enabled = false
-  custom_kms_key      = module.environment.kms_keys["general"].id
+  custom_kms_key      = module.environment.kms_keys["general"].arn
 
   lifecycle_rule = [
     {
@@ -58,7 +58,7 @@ module "nomis-db-backup-bucket" {
   }
   bucket_prefix       = "nomis-db-backup-bucket"
   replication_enabled = false
-  custom_kms_key      = module.environment.kms_keys["general"].id
+  custom_kms_key      = module.environment.kms_keys["general"].arn
 
   lifecycle_rule = [
     {
@@ -135,7 +135,7 @@ module "nomis-image-builder-bucket" {
   }
   bucket_prefix       = "ec2-image-builder-nomis"
   replication_enabled = false
-  custom_kms_key      = module.environment.kms_keys["general"].id
+  custom_kms_key      = module.environment.kms_keys["general"].arn
 
   bucket_policy = [data.aws_iam_policy_document.cross-account-s3.json]
 
@@ -214,7 +214,7 @@ module "nomis-audit-archives" {
   }
   bucket_prefix       = "nomis-audit-archives"
   replication_enabled = false
-  custom_kms_key      = module.environment.kms_keys["general"].id
+  custom_kms_key      = module.environment.kms_keys["general"].arn
 
   bucket_policy = [data.aws_iam_policy_document.nomis-all-environments-access.json]
 


### PR DESCRIPTION
Fix S3 KMS keys:
- add access to keys for EC2 and scaling groups
- corrected default key (use ARN instead of ID)