### PR TITLE
DSOS-1704: allow access to weblogic servers from Azure 

### DIFF
--- a/terraform/environments/nomis/locals-security-groups.tf
+++ b/terraform/environments/nomis/locals-security-groups.tf
@@ -202,6 +202,7 @@ locals {
           aws_security_group.public.id,
           module.bastion_linux.bastion_security_group
         ]
+        cidr_blocks = local.security_group_cidrs.http7xxx
       },
       {
         description = "Allow http7777 ingress"
@@ -213,6 +214,7 @@ locals {
           aws_security_group.public.id,
           module.bastion_linux.bastion_security_group
         ]
+        cidr_blocks = local.security_group_cidrs.http7xxx
       },
     ]
     egress = [


### PR DESCRIPTION
Allow direct access to individual weblogic server from Azure JumpServers.  This will be required while we figure out how best to provide access to the AWS JumpServers