### PR TITLE
load balancer target alerts

### DIFF
--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -216,3 +216,58 @@ resource "aws_cloudwatch_metric_alarm" "system_health_check" {
     Name = "system_health_check"
   }
 }
+
+# Key Servers Instance alert - sensitive alert for key servers changing status from healthy. If this triggers often then we've got a problem.
+
+# ==============================================================================
+# Load Balancer Alerts
+# ==============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_routing" {
+  alarm_name          = "load_balancer_unhealthy_state_routing"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "UnHealthyStateRouting"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  alarm_description   = "This metric monitors the number of unhealthy hosts in the routing table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
+  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  tags = {
+    Name = "load_balancer_unhealthy_state_routing"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_dns" {
+  alarm_name          = "load_balancer_unhealthy_state_dns"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "UnHealthyStateDNS"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  alarm_description   = "This metric monitors the number of unhealthy hosts in the DNS table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
+  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  tags = {
+    Name = "load_balancer_unhealthy_state_dns"
+  }
+}
+
+# This may be overkill as unhealthy hosts will trigger an alert themselves (or should do) independently.
+resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_target" {
+  alarm_name          = "load_balancer_unhealthy_state_target"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "UnHealthyStateTarget"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  alarm_description   = "This metric monitors the number of unhealthy hosts in the target table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
+  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  tags = {
+    Name = "load_balancer_unhealthy_state_target"
+  }
+}


### PR DESCRIPTION
picks up things moving into 'unhealthy' status after 3 minutes