### PR TITLE
certificate expiry alerts

### DIFF
--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -292,7 +292,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
     Name = "cert_expires_in_30_days"
   }
 }
-  
+
 resource "aws_clouwatch_metric_alarm" "cert_expires_in_2_days" {
   alarm_name          = "cert_expires_in_2_days"
   comparison_operator = "LessThanThreshold"

--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -293,7 +293,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
   }
 }
 
-resource "aws_clouwatch_metric_alarm" "cert_expires_in_2_days" {
+resource "aws_cloudwatch_metric_alarm" "cert_expires_in_2_days" {
   alarm_name          = "cert_expires_in_2_days"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -286,7 +286,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
   period              = "60"
   statistic           = "Average"
   threshold           = "30"
-  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 30 for 1 minute."
+  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 30."
   alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
   tags = {
     Name = "cert_expires_in_30_days"
@@ -302,7 +302,7 @@ resource "aws_clouwatch_metric_alarm" "cert_expires_in_2_days" {
   period              = "60"
   statistic           = "Average"
   threshold           = "2"
-  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 2 for 1 minute."
+  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 2."
   alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
   tags = {
     Name = "cert_expires_in_2_days"

--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -271,3 +271,40 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_target" {
     Name = "load_balancer_unhealthy_state_target"
   }
 }
+
+# ==============================================================================
+# Certificate Alerts - Days to Expiry
+# Certificates are managed by AWS Certificate Manager (ACM) so there shouldn't be any reason why these don't renew automatically.
+# ==============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
+  alarm_name          = "cert_expires_in_30_days"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DaysToExpiry"
+  namespace           = "AWS/ACM"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "30"
+  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 30 for 1 minute."
+  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  tags = {
+    Name = "cert_expires_in_30_days"
+  }
+}
+  
+resource "aws_clouwatch_metric_alarm" "cert_expires_in_2_days" {
+  alarm_name          = "cert_expires_in_2_days"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DaysToExpiry"
+  namespace           = "AWS/ACM"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "2"
+  alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 2 for 1 minute."
+  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  tags = {
+    Name = "cert_expires_in_2_days"
+  }
+}


### PR DESCRIPTION
Although AWS Certificate manager should absolutely auto-renew these it'd be useful to get a heads up when things are on their way to expiry. We can always delete or change these alerts later if they turn out to be irrelevant.