### PR TITLE
add nomis_nonprod_alarms as sns option

### DIFF
--- a/terraform/environments/nomis/monitoring-setup.tf
+++ b/terraform/environments/nomis/monitoring-setup.tf
@@ -7,10 +7,17 @@ resource "aws_sns_topic" "nomis_alarms" {
   name = "nomis_alarms"
 }
 
-## Pager duty integration
-
 # integration "nomis_alarms" has to be set up manually in pagerduty by the Modernisation Platform team
 # alarms will currently appear in the dso_alerts_modernisation_platform slack channel
+
+resource "aws_sns_topic" "nomis_nonprod_alarms" {
+  name = "nomis_nonprod_alarms"
+}
+
+# integration "nomis_nonprod_alarms" has to be set up manually in pagerduty by the Modernisation Platform team
+# nomis_nonprod_alarms will currently appear in the dso_alerts_devtest_modernisation_platform slack channel
+
+## Pager duty integration
 
 # Get the map of pagerduty integration keys from the modernisation platform account
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
@@ -35,4 +42,13 @@ module "pagerduty_core_alerts" {
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.nomis_alarms.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["nomis_alarms"]
+}
+
+module "pagerduty_core_alerts" {
+  depends_on = [
+    aws_sns_topic.nomis_nonprod_alarms
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.nomis_nonprod_alarms.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["nomis_nonprod_alarms"]
 }


### PR DESCRIPTION
nomis_nonprod_alarms needs to be wired up to #dso_alerts_devtest_modernisation_platform channel as LOW PRIORITY in PagerDuty please 