### PR TITLE
Nomis/dsos 1716/fix alarm names

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -94,7 +94,7 @@ locals {
       }
     }
     cloudwatch_metric_alarms_database = {
-      oracle_db_disconnected = {
+      oracle-db-disconnected = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "5"
         datapoints_to_alarm = "5"
@@ -109,7 +109,7 @@ locals {
           instance = "db_connected"
         }
       }
-      oracle_batch_error = {
+      oracle-batch-error = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "5"
         datapoints_to_alarm = "5"
@@ -126,7 +126,7 @@ locals {
         # oracleasm_service = {}
         # oracle_ohasd_service = {}
       }
-      oracle_monitoring_file_error = {
+      oracle-monitoring-file_error = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "20"
         datapoints_to_alarm = "20"

--- a/terraform/environments/nomis/locals-alerts-linux.tf
+++ b/terraform/environments/nomis/locals-alerts-linux.tf
@@ -1,6 +1,6 @@
 locals {
   cloudwatch_metric_alarms_linux = {
-    high_memory_usage = {
+    high-memory-usage = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "2"
       datapoints_to_alarm = "2"
@@ -12,7 +12,7 @@ locals {
       alarm_description   = "This metric monitors the amount of available memory. If the amount of available memory is greater than 90% for 2 minutes, the alarm will trigger."
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    cpu_usage_iowait = {
+    cpu-usage-iowait = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "6"
       datapoints_to_alarm = "5"
@@ -24,7 +24,7 @@ locals {
       alarm_description   = "This metric monitors the amount of CPU time spent waiting for I/O to complete. If the average CPU time spent waiting for I/O to complete is greater than 90% for 30 minutes, the alarm will trigger."
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    disk_used_percent = {
+    disk-used-percent = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "2"
       datapoints_to_alarm = "2"
@@ -36,7 +36,7 @@ locals {
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space is above 85% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    cpu_utilization = {
+    cpu-utilization = {
       comparison_operator = "GreaterThanOrEqualToThreshold" # threshold to trigger the alarm state
       evaluation_periods  = "15"                            # how many periods over which to evaluate the alarm
       datapoints_to_alarm = "15"                            # how many datapoints must be breaching the threshold to trigger the alarm
@@ -50,7 +50,7 @@ locals {
     }
     # Key Servers Instance alert - sensitive alert for key servers changing status from healthy. 
     # If this triggers often then we've got a problem.
-    instance_health_check_failed = {
+    instance-health-check-failed = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "3"
       metric_name         = "StatusCheckFailed_Instance"
@@ -61,7 +61,7 @@ locals {
       alarm_description   = "Instance status checks monitor the software and network configuration of your individual instance. When an instance status check fails, you typically must address the problem yourself: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    system_health_check_failed = {
+    system-health-check-failed = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "3"
       metric_name         = "StatusCheckFailed_System"

--- a/terraform/environments/nomis/locals-alerts-windows.tf
+++ b/terraform/environments/nomis/locals-alerts-windows.tf
@@ -1,6 +1,6 @@
 locals {
   cloudwatch_metric_alarms_windows = {
-    disk_free_windows = {
+    disk-free-windows = {
       comparison_operator = "LessThanOrEqualToThreshold"
       evaluation_periods  = "2"
       datapoints_to_alarm = "2"
@@ -12,7 +12,7 @@ locals {
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    high_cpu_windows = {
+    high-cpu-windows = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "5"
       datapoints_to_alarm = "5"
@@ -24,7 +24,7 @@ locals {
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
       alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
     }
-    low_available_memory_windows = {
+    low-available-memory-windows = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "2"
       datapoints_to_alarm = "2"

--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -2,7 +2,7 @@
 # Load Balancer Alerts - TO BE MOVED
 # ==============================================================================
 resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_routing" {
-  alarm_name          = "load_balancer_unhealthy_state_routing"
+  alarm_name          = "load-balancer-unhealthy-state-routing"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "UnHealthyStateRouting"
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_routing" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_dns" {
-  alarm_name          = "load_balancer_unhealthy_state_dns"
+  alarm_name          = "load-balancer-unhealthy-state-dns"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "UnHealthyStateDNS"
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_dns" {
 
 # This may be overkill as unhealthy hosts will trigger an alert themselves (or should do) independently.
 resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_target" {
-  alarm_name          = "load_balancer_unhealthy_state_target"
+  alarm_name          = "load-balancer-unhealthy-state-target"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "UnHealthyStateTarget"
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_target" {
 # Certificates are managed by AWS Certificate Manager (ACM) so there shouldn't be any reason why these don't renew automatically. 
 # ==============================================================================
 resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
-  alarm_name          = "cert_expires_in_30_days"
+  alarm_name          = "cert-expires-in-30-days"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "DaysToExpiry"
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cert_expires_in_2_days" {
-  alarm_name          = "cert_expires_in_2_days"
+  alarm_name          = "cert-expires-in-2-days"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "DaysToExpiry"

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -299,7 +299,7 @@ resource "aws_lb_target_group" "this" {
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = var.cloudwatch_metric_alarms
 
-  alarm_name          = "${aws_autoscaling_group.this.name}_${each.key}"
+  alarm_name          = "${aws_autoscaling_group.this.name}-${each.key}"
   comparison_operator = each.value.comparison_operator
   evaluation_periods  = each.value.evaluation_periods
   metric_name         = each.value.metric_name

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -299,7 +299,7 @@ resource "aws_lb_target_group" "this" {
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = var.cloudwatch_metric_alarms
 
-  alarm_name          = each.key
+  alarm_name          = "${aws_autoscaling_group.this.name}_${each.key}"
   comparison_operator = each.value.comparison_operator
   evaluation_periods  = each.value.evaluation_periods
   metric_name         = each.value.metric_name

--- a/terraform/modules/ec2_instance/main.tf
+++ b/terraform/modules/ec2_instance/main.tf
@@ -282,7 +282,7 @@ resource "aws_iam_instance_profile" "this" {
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = var.cloudwatch_metric_alarms
 
-  alarm_name          = each.key
+  alarm_name          = "${var.name}_${each.key}"
   comparison_operator = each.value.comparison_operator
   evaluation_periods  = each.value.evaluation_periods
   metric_name         = each.value.metric_name

--- a/terraform/modules/ec2_instance/main.tf
+++ b/terraform/modules/ec2_instance/main.tf
@@ -282,7 +282,7 @@ resource "aws_iam_instance_profile" "this" {
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = var.cloudwatch_metric_alarms
 
-  alarm_name          = "${var.name}_${each.key}"
+  alarm_name          = "${var.name}-${each.key}"
   comparison_operator = each.value.comparison_operator
   evaluation_periods  = each.value.evaluation_periods
   metric_name         = each.value.metric_name


### PR DESCRIPTION
alarm names by instance-name-alarm-name

ec2_instances will have their own alerts on the metrics we're interested in
asg's will have alerts by asg group so this should be fairly sane now!