### PR TITLE
remove file_error alert

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -126,21 +126,6 @@ locals {
         # oracleasm_service = {}
         # oracle_ohasd_service = {}
       }
-      oracle-monitoring-file_error = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "20"
-        datapoints_to_alarm = "20"
-        metric_name         = "collectd_exec_value"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "Oracle db monitoring file doesn't exist. Usually indicates that the oracle setup hasn't completed fully."
-        alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
-        dimensions = {
-          instance = "file_error"
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
remove this alarm 'cause it will trigger whenever a test db instance is created and is not particularly useful

the metric exists for debugging purposes so that's fine - it should be incorporated into a "db dashboard" later but having this as an alert is too shouty