### PR TITLE
create an additional sns topic for non-prod alerting

### DIFF
--- a/terraform/environments/nomis/monitoring-setup.tf
+++ b/terraform/environments/nomis/monitoring-setup.tf
@@ -7,6 +7,10 @@ resource "aws_sns_topic" "nomis_alarms" {
   name = "nomis_alarms"
 }
 
+resource "aws_sns_topic" "nomis_nonprod_alarms" {
+  name = "nomis_nonprod_alarms"
+}
+
 ## Pager duty integration
 
 # integration "nomis_alarms" has to be set up manually in pagerduty by the Modernisation Platform team


### PR DESCRIPTION
Since adding and then referring immediately to an alert_sns_topic resource seems to have some issues - add this first and THEN apply the changes/linking to the pagerduty/slack integration in a separate PR so it can get this from the state