### PR TITLE
Nomis/dsos 1755/nomis nonprod alarm

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -104,7 +104,7 @@ locals {
         statistic           = "Average"
         threshold           = "1"
         alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
-        alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+        alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
         dimensions = {
           instance = "db_connected"
         }
@@ -119,7 +119,7 @@ locals {
         statistic           = "Average"
         threshold           = "1"
         alarm_description   = "Oracle db is either in long-running batch or failed batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4295000327/Oracle+Batch+alert for remediation steps."
-        alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+        alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
         dimensions = {
           instance = "batch_error"
         }

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -85,7 +85,11 @@ module "ec2_jumpserver" {
   subnet_ids                    = module.environment.subnets["private"].ids
   tags                          = merge(local.tags, local.ec2_jumpserver.tags, try(each.value.tags, {}))
   account_ids_lookup            = local.environment_management.account_ids
-  cloudwatch_metric_alarms      = local.cloudwatch_metric_alarms_windows
+  cloudwatch_metric_alarms = {
+    for key, value in local.cloudwatch_metric_alarms_windows :
+    key => merge(value, {
+      alarm_actions = [lookup(each.value, "sns_topic", aws_sns_topic.nomis_nonprod_alarms.arn)]
+  }) }
 }
 
 #------

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -150,10 +150,14 @@ module "ec2_weblogic_autoscaling_group" {
   iam_resource_names_prefix = "ec2-weblogic-asg"
   instance_profile_policies = local.ec2_common_managed_policies
 
-  application_name         = local.application_name
-  region                   = local.region
-  subnet_ids               = module.environment.subnets["private"].ids
-  tags                     = merge(local.tags, local.ec2_weblogic.tags, try(each.value.tags, {}))
-  account_ids_lookup       = local.environment_management.account_ids
-  cloudwatch_metric_alarms = local.cloudwatch_metric_alarms_linux
+  application_name   = local.application_name
+  region             = local.region
+  subnet_ids         = module.environment.subnets["private"].ids
+  tags               = merge(local.tags, local.ec2_weblogic.tags, try(each.value.tags, {}))
+  account_ids_lookup = local.environment_management.account_ids
+  cloudwatch_metric_alarms = {
+    for key, value in local.cloudwatch_metric_alarms_linux :
+    key => merge(value, {
+      alarm_actions = [lookup(each.value, "sns_topic", aws_sns_topic.nomis_nonprod_alarms.arn)]
+  }) }
 }

--- a/terraform/environments/nomis/locals-alerts-linux.tf
+++ b/terraform/environments/nomis/locals-alerts-linux.tf
@@ -10,7 +10,7 @@ locals {
       statistic           = "Average"
       threshold           = "90"
       alarm_description   = "This metric monitors the amount of available memory. If the amount of available memory is greater than 90% for 2 minutes, the alarm will trigger."
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     cpu-usage-iowait = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -22,7 +22,7 @@ locals {
       statistic           = "Average"
       threshold           = "90"
       alarm_description   = "This metric monitors the amount of CPU time spent waiting for I/O to complete. If the average CPU time spent waiting for I/O to complete is greater than 90% for 30 minutes, the alarm will trigger."
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     disk-used-percent = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -34,7 +34,7 @@ locals {
       statistic           = "Average"
       threshold           = "85"
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space is above 85% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     cpu-utilization = {
       comparison_operator = "GreaterThanOrEqualToThreshold" # threshold to trigger the alarm state
@@ -46,7 +46,7 @@ locals {
       statistic           = "Average"                       # could be Average/Minimum/Maximum etc.
       threshold           = "95"                            # threshold for the alarm - see comparison_operator for usage
       alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn] # SNS topic to send the alarm to
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn] # SNS topic to send the alarm to
     }
     # Key Servers Instance alert - sensitive alert for key servers changing status from healthy. 
     # If this triggers often then we've got a problem.
@@ -59,7 +59,7 @@ locals {
       statistic           = "Average"
       threshold           = "1"
       alarm_description   = "Instance status checks monitor the software and network configuration of your individual instance. When an instance status check fails, you typically must address the problem yourself: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     system-health-check-failed = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -70,7 +70,7 @@ locals {
       statistic           = "Average"
       threshold           = "1"
       alarm_description   = "System status checks monitor the AWS systems on which your instance runs. These checks detect underlying problems with your instance that require AWS involvement to repair: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     # Service alert - chronyd
     # Service alert - sshd

--- a/terraform/environments/nomis/locals-alerts-windows.tf
+++ b/terraform/environments/nomis/locals-alerts-windows.tf
@@ -10,7 +10,7 @@ locals {
       statistic           = "Average"
       threshold           = "15"
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     high-cpu-windows = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -22,7 +22,7 @@ locals {
       statistic           = "Average"
       threshold           = "95"
       alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     low-available-memory-windows = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -34,7 +34,7 @@ locals {
       statistic           = "Average"
       threshold           = "80"
       alarm_description   = "This metric monitors the amount of available memory. If Committed Bytes in Use is > 80% for 2 minutes, the alarm will trigger."
-      alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
   }
 }

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -1,6 +1,8 @@
 # nomis-production environment settings
 locals {
   nomis_production = {
+    # production SNS channel for alarms
+    sns_topic = aws_sns_topic.nomis_alarms.arn
     # Details of OMS Manager in FixNGo (only needs defining if databases in the environment are managed)
     database_oracle_manager = {
       oms_ip_address = "10.40.0.136"
@@ -66,6 +68,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         }
+        sns_topic = aws_sns_topic.nomis_alarms.arn
       }
 
       prod-nomis-db-2 = {
@@ -95,6 +98,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         }
+        sns_topic = aws_sns_topic.nomis_alarms.arn
       }
 
       prod-nomis-db-3 = {
@@ -120,6 +124,7 @@ locals {
           data  = { total_size = 3000, iops = 3750, throughput = 750 }
           flash = { total_size = 500 }
         }
+        sns_topic = aws_sns_topic.nomis_alarms.arn
       }
     }
 

--- a/terraform/environments/nomis/monitoring-alerts.tf
+++ b/terraform/environments/nomis/monitoring-alerts.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_routing" {
   statistic           = "Average"
   threshold           = "1"
   alarm_description   = "This metric monitors the number of unhealthy hosts in the routing table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
-  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_dns" {
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_dns" {
   statistic           = "Average"
   threshold           = "1"
   alarm_description   = "This metric monitors the number of unhealthy hosts in the DNS table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
-  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
 }
 
 # This may be overkill as unhealthy hosts will trigger an alert themselves (or should do) independently.
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "load_balancer_unhealthy_state_target" {
   statistic           = "Average"
   threshold           = "1"
   alarm_description   = "This metric monitors the number of unhealthy hosts in the target table for the load balancer. If the number of unhealthy hosts is greater than 0 for 3 minutes."
-  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
 }
 
 # ==============================================================================
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_30_days" {
   statistic           = "Average"
   threshold           = "30"
   alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 30."
-  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
   /* dimensions = {
     "CertificateArn" = "value"
   } */
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_metric_alarm" "cert_expires_in_2_days" {
   statistic           = "Average"
   threshold           = "2"
   alarm_description   = "This metric monitors the number of days until the certificate expires. If the number of days is less than 2."
-  alarm_actions       = [aws_sns_topic.nomis_alarms.arn]
+  alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
   /* dimensions = {
     "CertificateArn" = "value"
   } */

--- a/terraform/environments/nomis/monitoring-setup.tf
+++ b/terraform/environments/nomis/monitoring-setup.tf
@@ -32,24 +32,23 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 # Add a local to get the keys
 locals {
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  sns_topics                 = ["nomis_alarms", "nomis_nonprod_alarms"]
 }
 
 # link the sns topic to the service
 
 module "pagerduty_integration_prod" {
-  /* depends_on = [
+  depends_on = [
     aws_sns_topic.nomis_alarms
-  ] */
+  ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.nomis_alarms.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["nomis_alarms"]
 }
 
 module "pagerduty_integration_nonprod" {
-  /* depends_on = [
+  depends_on = [
     aws_sns_topic.nomis_nonprod_alarms
-  ] */
+  ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.nomis_nonprod_alarms.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["nomis_nonprod_alarms"]

--- a/terraform/environments/nomis/monitoring-setup.tf
+++ b/terraform/environments/nomis/monitoring-setup.tf
@@ -7,14 +7,17 @@ resource "aws_sns_topic" "nomis_alarms" {
   name = "nomis_alarms"
 }
 
+# integration "nomis_alarms" has to be set up manually in pagerduty by the Modernisation Platform team
+# alarms will currently appear in the dso_alerts_modernisation_platform slack channel
+
 resource "aws_sns_topic" "nomis_nonprod_alarms" {
   name = "nomis_nonprod_alarms"
 }
 
-## Pager duty integration
+# integration "nomis_nonprod_alarms" has to be set up manually in pagerduty by the Modernisation Platform team
+# nomis_nonprod_alarms will currently appear in the dso_alerts_devtest_modernisation_platform slack channel
 
-# integration "nomis_alarms" has to be set up manually in pagerduty by the Modernisation Platform team
-# alarms will currently appear in the dso_alerts_modernisation_platform slack channel
+## Pager duty integration
 
 # Get the map of pagerduty integration keys from the modernisation platform account
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
@@ -29,14 +32,25 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 # Add a local to get the keys
 locals {
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  sns_topics                 = ["nomis_alarms", "nomis_nonprod_alarms"]
 }
 
 # link the sns topic to the service
-module "pagerduty_core_alerts" {
-  depends_on = [
+
+module "pagerduty_integration_prod" {
+  /* depends_on = [
     aws_sns_topic.nomis_alarms
-  ]
+  ] */
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
   sns_topics                = [aws_sns_topic.nomis_alarms.name]
   pagerduty_integration_key = local.pagerduty_integration_keys["nomis_alarms"]
+}
+
+module "pagerduty_integration_nonprod" {
+  /* depends_on = [
+    aws_sns_topic.nomis_nonprod_alarms
+  ] */
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v1.0.0"
+  sns_topics                = [aws_sns_topic.nomis_nonprod_alarms.name]
+  pagerduty_integration_key = local.pagerduty_integration_keys["nomis_nonprod_alarms"]
 }


### PR DESCRIPTION
Introduces a non-production alerts channel into slack for everything to send notifications to `#dso_alerts_devtest_modernisation_platform` unless specifically over-ridden

You can over-ride this and send alarms to #dso_alerts_modernisation_platform by adding the `sns_topic = aws_sns_topic.nomis_alarms.arn` to the instance config in locals-production.tf (for example) 

Further config options to come but at this point we will be able to differentiate between 'production' and everything else

- changed alarm names to appear as instance-name-alarm-name
- database, jumpserver and weblogic instances can send alarms to 'prod' channel
- alarms go to non-prod channel by default
- existing pagerduty subscription is being re-created as its module call has been renamed