### PR TITLE
Allow users ability to destroy development / test environments

### DIFF
--- a/.github/workflows/apex.yml
+++ b/.github/workflows/apex.yml
@@ -15,6 +15,14 @@ on:
       - 'terraform/environments/apex/**'
       - '.github/workflows/apex.yml'
   workflow_dispatch:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -34,9 +42,9 @@ jobs:
         include:
           - environment: development
           # - environment: test
-    name: Plan - ${{  matrix.environment }}
+    name: Terraform plan - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -55,7 +63,7 @@ jobs:
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Plan - ${{ matrix.environment }}
+      - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
           terraform --version
           echo "Terraform plan - ${TF_ENV}"
@@ -66,13 +74,13 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
           - environment: development
           # - environment: test
-    name: Apply - ${{  matrix.environment }}
+    name: Terraform apply - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     env:
       TF_ENV: ${{ matrix.environment }}
@@ -94,13 +102,86 @@ jobs:
         with:
           terraform_version: "~1"
           terraform_wrapper: false
-      - name: Apply - ${{ matrix.environment }}
+      - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
           terraform --version
           echo "Terraform apply - ${TF_ENV}"
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
 #   plan-preprod-prod:

--- a/.github/workflows/apex.yml
+++ b/.github/workflows/apex.yml
@@ -15,6 +15,7 @@ on:
       - 'terraform/environments/apex/**'
       - '.github/workflows/apex.yml'
   workflow_dispatch:
+    inputs:
       action:
         description: 'Set either [deploy|destroy].'
         default: 'deploy'

--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -15,6 +15,14 @@ on:
       - 'terraform/environments/ccms-ebs/**'
       - '.github/workflows/ccms-ebs.yml'
   workflow_dispatch:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -38,7 +46,7 @@ jobs:
           - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -68,7 +76,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -105,6 +113,80 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
 
   # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -15,6 +15,7 @@ on:
       - 'terraform/environments/ccms-ebs/**'
       - '.github/workflows/ccms-ebs.yml'
   workflow_dispatch:
+    inputs:
       action:
         description: 'Set either [deploy|destroy].'
         default: 'deploy'

--- a/.github/workflows/data-and-insights-wepi.yml
+++ b/.github/workflows/data-and-insights-wepi.yml
@@ -15,6 +15,14 @@ on:
       - 'terraform/environments/data-and-insights-wepi/**'
       - '.github/workflows/data-and-insights-wepi.yml'
   workflow_dispatch:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +44,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +74,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +109,80 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
   
   # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/data-and-insights-wepi.yml
+++ b/.github/workflows/data-and-insights-wepi.yml
@@ -15,6 +15,7 @@ on:
       - 'terraform/environments/data-and-insights-wepi/**'
       - '.github/workflows/data-and-insights-wepi.yml'
   workflow_dispatch:
+    inputs:
       action:
         description: 'Set either [deploy|destroy].'
         default: 'deploy'

--- a/.github/workflows/delius-iaps.yml
+++ b/.github/workflows/delius-iaps.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/delius-iaps/**'
       - '.github/workflows/delius-iaps.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
   # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/delius-jitbit.yml
+++ b/.github/workflows/delius-jitbit.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/delius-jitbit/**'
       - '.github/workflows/delius-jitbit.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           #- environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          #- environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          #- environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/digital-prison-reporting.yml
+++ b/.github/workflows/digital-prison-reporting.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/digital-prison-reporting/**'
       - '.github/workflows/digital-prison-reporting.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
 #   plan-preprod-prod:

--- a/.github/workflows/equip.yml
+++ b/.github/workflows/equip.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/equip/**'
       - '.github/workflows/equip.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/example/**'
       - '.github/workflows/example.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -35,7 +44,7 @@ jobs:
           - environment: development
     name: Terraform plan - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -65,7 +74,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -99,3 +108,76 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy

--- a/.github/workflows/laa-oem.yml
+++ b/.github/workflows/laa-oem.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/laa-oem/**'
       - '.github/workflows/laa-oem.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,3 +110,76 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy

--- a/.github/workflows/long-term-storage.yml
+++ b/.github/workflows/long-term-storage.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/long-term-storage/**'
       - '.github/workflows/long-term-storage.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
   #         - environment: test
   #   name: Plan - ${{  matrix.environment }}
   #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+  #   if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
   #   env:
   #     TF_ENV: ${{ matrix.environment }}
   #   steps:
@@ -66,7 +75,7 @@ jobs:
   # # These jobs run when creating a pull request
   # deploy-dev-test:
   #   needs: plan-dev-test
-  #   if: success()
+  #   if: success() && github.event.inputs.action != 'destroy'
   #   strategy:
   #     matrix:
   #       include:
@@ -101,6 +110,79 @@ jobs:
   #         bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
   #         terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
   #         bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+  #
+  #  destroy-plan-dev-test:
+  #    strategy:
+  #      matrix:
+  #        include:
+  #          - environment: development
+  #          # - environment: test
+  #    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+  #    runs-on: ubuntu-latest
+  #    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+  #    env:
+  #      TF_ENV: ${{ matrix.environment }}
+  #    steps:
+  #      - name: Checkout Repository
+  #        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #      - name: Set Account Number
+  #        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+  #      - name: configure aws credentials
+  #        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+  #        with:
+  #          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+  #          role-session-name: githubactionsrolesession
+  #          aws-region: ${{ env.AWS_REGION }}
+  #      - name: Load and Configure Terraform
+  #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+  #        with:
+  #          terraform_version: "~1"
+  #          terraform_wrapper: false
+  #      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+  #        run: |
+  #          terraform --version
+  #          echo "Terraform destroy plan - ${TF_ENV}"
+  #          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+  #          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+  #          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+  #
+  #  destroy-apply-dev-test:
+  #    needs: destroy-plan-dev-test
+  #    if: success()
+  #    strategy:
+  #      matrix:
+  #        include:
+  #          - environment: development
+  #          # - environment: test
+  #    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+  #    runs-on: ubuntu-latest
+  #    env:
+  #      TF_ENV: ${{ matrix.environment }}
+  #    environment:
+  #      name: ${{ github.workflow }}-${{ matrix.environment }}
+  #    steps:
+  #      - name: Checkout Repository
+  #        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #      - name: Set Account Number
+  #        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+  #      - name: configure aws credentials
+  #        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+  #        with:
+  #          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+  #          role-session-name: githubactionsrolesession
+  #          aws-region: ${{ env.AWS_REGION }}
+  #      - name: Load and Configure Terraform
+  #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+  #        with:
+  #          terraform_version: "~1"
+  #          terraform_wrapper: false
+  #      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+  #        run: |
+  #          terraform --version
+  #          echo "Terraform destroy apply - ${TF_ENV}"
+  #          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+  #          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+  #          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/maatdb.yml
+++ b/.github/workflows/maatdb.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/maatdb/**'
       - '.github/workflows/maatdb.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
         #  - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
 #  plan-preprod-prod:

--- a/.github/workflows/mlra.yml
+++ b/.github/workflows/mlra.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/mlra/**'
       - '.github/workflows/mlra.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -15,15 +15,6 @@ on:
       - 'terraform/environments/nomis-combined-reporting/**'
       - '.github/workflows/nomis-combined-reporting.yml'
   workflow_dispatch:
-    inputs:
-      action:
-        description: 'Set either [deploy|destroy].'
-        default: 'deploy'
-        required: true
-        type: string
-        options:
-        - deploy
-        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -45,7 +36,7 @@ jobs:
           - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -75,7 +66,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success() && github.event.inputs.action != 'destroy'
+    if: success()
     strategy:
       matrix:
         include:
@@ -110,79 +101,6 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
-
-  destroy-plan-dev-test:
-    strategy:
-      matrix:
-        include:
-          - environment: development
-          - environment: test
-    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
-    env:
-      TF_ENV: ${{ matrix.environment }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
-        with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
-          role-session-name: githubactionsrolesession
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
-        run: |
-          terraform --version
-          echo "Terraform destroy plan - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
-          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
-          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
-
-  destroy-apply-dev-test:
-    needs: destroy-plan-dev-test
-    if: success()
-    strategy:
-      matrix:
-        include:
-          - environment: development
-          - environment: test
-    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
-    runs-on: ubuntu-latest
-    env:
-      TF_ENV: ${{ matrix.environment }}
-    environment:
-      name: ${{ github.workflow }}-${{ matrix.environment }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Set Account Number
-        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
-        with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
-          role-session-name: githubactionsrolesession
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Load and Configure Terraform
-        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
-        with:
-          terraform_version: "~1"
-          terraform_wrapper: false
-      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
-        run: |
-          terraform --version
-          echo "Terraform destroy apply - ${TF_ENV}"
-          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
-          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
-          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/nomis-combined-reporting/**'
       - '.github/workflows/nomis-combined-reporting.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/oas/**'
       - '.github/workflows/oas.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
          # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 # #  # Plan + deploy for pre-production and production environments, only from main
 #   plan-preprod-prod:

--- a/.github/workflows/performance-hub.yml
+++ b/.github/workflows/performance-hub.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/performance-hub/**'
       - '.github/workflows/performance-hub.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
   #         # - environment: test
   #   name: Plan - ${{  matrix.environment }}
   #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+  #   if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
   #   env:
   #     TF_ENV: ${{ matrix.environment }}
   #   steps:
@@ -66,7 +75,7 @@ jobs:
   # # These jobs run when creating a pull request
   # deploy-dev-test:
   #   needs: plan-dev-test
-  #   if: success()
+  #   if: success() && github.event.inputs.action != 'destroy'
   #   strategy:
   #     matrix:
   #       include:
@@ -101,6 +110,79 @@ jobs:
   #         bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
   #         terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
   #         bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+  #
+  #  destroy-plan-dev-test:
+  #    strategy:
+  #      matrix:
+  #        include:
+  #          - environment: development
+  #          # - environment: test
+  #    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+  #    runs-on: ubuntu-latest
+  #    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+  #    env:
+  #      TF_ENV: ${{ matrix.environment }}
+  #    steps:
+  #      - name: Checkout Repository
+  #        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #      - name: Set Account Number
+  #        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+  #      - name: configure aws credentials
+  #        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+  #        with:
+  #          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+  #         role-session-name: githubactionsrolesession
+  #         aws-region: ${{ env.AWS_REGION }}
+  #     - name: Load and Configure Terraform
+  #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+  #       with:
+  #         terraform_version: "~1"
+  #         terraform_wrapper: false
+  #     - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+  #       run: |
+  #         terraform --version
+  #         echo "Terraform destroy plan - ${TF_ENV}"
+  #         bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+  #         terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+  #         bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+  #
+  # destroy-apply-dev-test:
+  #   needs: destroy-plan-dev-test
+  #   if: success()
+  #   strategy:
+  #     matrix:
+  #       include:
+  #          - environment: development
+  #          # - environment: test
+  #    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+  #    runs-on: ubuntu-latest
+  #    env:
+  #      TF_ENV: ${{ matrix.environment }}
+  #    environment:
+  #      name: ${{ github.workflow }}-${{ matrix.environment }}
+  #    steps:
+  #      - name: Checkout Repository
+  #        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #      - name: Set Account Number
+  #        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+  #      - name: configure aws credentials
+  #        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+  #        with:
+  #          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+  #          role-session-name: githubactionsrolesession
+  #          aws-region: ${{ env.AWS_REGION }}
+  #      - name: Load and Configure Terraform
+  #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+  #        with:
+  #          terraform_version: "~1"
+  #          terraform_wrapper: false
+  #      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+  #        run: |
+  #          terraform --version
+  #          echo "Terraform destroy apply - ${TF_ENV}"
+  #          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+  #          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+  #          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/ppud.yml
+++ b/.github/workflows/ppud.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/ppud/**'
       - '.github/workflows/ppud.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/refer-monitor.yml
+++ b/.github/workflows/refer-monitor.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/refer-monitor/**'
       - '.github/workflows/refer-monitor.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
 #   plan-preprod-prod:

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -114,6 +114,7 @@ jobs:
       matrix:
         include:
           - environment: development
+          # - environment: test
     name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
@@ -150,6 +151,7 @@ jobs:
       matrix:
         include:
           - environment: development
+          # - environment: test
     name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tariff.yml
+++ b/.github/workflows/tariff.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/tariff/**'
       - '.github/workflows/tariff.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
           # - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
 #   plan-preprod-prod:

--- a/.github/workflows/tipstaff.yml
+++ b/.github/workflows/tipstaff.yml
@@ -15,6 +15,15 @@ on:
       - 'terraform/environments/tipstaff/**'
       - '.github/workflows/tipstaff.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -36,7 +45,7 @@ jobs:
     #      - environment: test
     name: Plan - ${{  matrix.environment }}
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     env:
       TF_ENV: ${{ matrix.environment }}
     steps:
@@ -66,7 +75,7 @@ jobs:
   # These jobs run when creating a pull request
   deploy-dev-test:
     needs: plan-dev-test
-    if: success()
+    if: success() && github.event.inputs.action != 'destroy'
     strategy:
       matrix:
         include:
@@ -101,6 +110,79 @@ jobs:
           bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
           terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
           bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
 #  # Plan + deploy for pre-production and production environments, only from main
   plan-preprod-prod:

--- a/.github/workflows/xhibit-portal.yml
+++ b/.github/workflows/xhibit-portal.yml
@@ -15,7 +15,6 @@ on:                                          # Put ALL the triggers for any part
       - 'terraform/environments/xhibit-portal/**'
       - '.github/workflows/xhibit-portal.yml'
   workflow_dispatch:
-  workflow_dispatch:
     inputs:
       action:
         description: 'Set either [deploy|destroy].'

--- a/.github/workflows/xhibit-portal.yml
+++ b/.github/workflows/xhibit-portal.yml
@@ -15,6 +15,16 @@ on:                                          # Put ALL the triggers for any part
       - 'terraform/environments/xhibit-portal/**'
       - '.github/workflows/xhibit-portal.yml'
   workflow_dispatch:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+        - deploy
+        - destroy
 env:
   TF_IN_AUTOMATION: true
   AWS_REGION: "eu-west-2"
@@ -30,7 +40,7 @@ jobs:
   plan-development:
     name: Plan Development - xhibit-portal
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' # job only runs for pull requests
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy' # job only runs for pull requests
     steps:
       - name: Checkout Repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -62,7 +72,7 @@ jobs:
     needs: plan-development # job only runs if plan-development runs successfully
     name: Deploy Development - xhibit-portal
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -88,6 +98,79 @@ jobs:
           bash scripts/terraform-apply.sh terraform/environments/xhibit-portal
     env:
       TF_ENV: development
+
+  destroy-plan-dev-test:
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy plan - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy plan - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-plan.sh terraform/environments/$GITHUB_WORKFLOW -destroy
+
+  destroy-apply-dev-test:
+    needs: destroy-plan-dev-test
+    if: success()
+    strategy:
+      matrix:
+        include:
+          - environment: development
+          # - environment: test
+    name: Terraform destroy apply - ${{ github.workflow }} - ${{  matrix.environment }}
+    runs-on: ubuntu-latest
+    env:
+      TF_ENV: ${{ matrix.environment }}
+    environment:
+      name: ${{ github.workflow }}-${{ matrix.environment }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Set Account Number
+        run: echo "ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${GITHUB_WORKFLOW}-${TF_ENV}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Load and Configure Terraform
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
+        run: |
+          terraform --version
+          echo "Terraform destroy apply - ${TF_ENV}"
+          bash scripts/terraform-init.sh terraform/environments/$GITHUB_WORKFLOW
+          terraform -chdir="terraform/environments/${GITHUB_WORKFLOW}" workspace select "${GITHUB_WORKFLOW}-${TF_ENV}"
+          bash scripts/terraform-apply.sh terraform/environments/$GITHUB_WORKFLOW -destroy
 
   plan-preproduction:
     name: Plan Pre-Production - xhibit-portal


### PR DESCRIPTION
Expands on the work completed in https://github.com/ministryofjustice/modernisation-platform-environments/pull/1465
`nomis` and `oas` workflows have been exluded from this as they show significant customisation from our default workflow file. 