### PR TITLE
means that 'missing' values appear as green in the AWS UI

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -118,6 +118,7 @@ locals {
         period              = "60"
         statistic           = "Average"
         threshold           = "1"
+        treat_missing_data  = "notBreaching"
         alarm_description   = "Oracle db has recorded a failed batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4295000327/Batch+Failure for remediation steps."
         alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
         dimensions = {
@@ -133,6 +134,7 @@ locals {
         period              = "60"
         statistic           = "Average"
         threshold           = "1"
+        treat_missing_data  = "notBreaching"
         alarm_description   = "Oracle db has recorded a long-running batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325966186/Long+Running+Batch for remediation steps."
         alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
         dimensions = {


### PR DESCRIPTION
These metrics come in as 0 (okay) and 1 (batch is failing) if the db monitor has posted the associated strings into a file.

This isn't guaranteed so change the alarm settings so that 'missing' data doesn't render the metric into an "insufficient data" state once it's been set up