### PR TITLE
Nomis: DSOS-1795: pipeline tweaks to fix acm module issue

### DIFF
--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -38,7 +38,7 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: true
+      do_state_refresh_on_plan: false
       post_plan_to_pr: true
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"

--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -26,7 +26,7 @@ jobs:
   strategy:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     with:
-      strategy_type: "standard_four_accounts" # allow apply to dev/test from branch
+      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
 
   terraform:
     needs: strategy
@@ -38,8 +38,8 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: false
-      post_plan_to_pr: true
+      do_state_refresh_on_plan: false  # doesn't work with ACM module
+      post_plan_to_pr: false  # pipeline can be triggered by other teams so avoid posting into their PRs for now
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -26,7 +26,7 @@ jobs:
   strategy:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     with:
-      strategy_type: "standard_four_accounts" # allow apply to dev/test from branch
+      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
 
   terraform:
     needs: strategy
@@ -38,8 +38,8 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: true
-      post_plan_to_pr: true
+      do_state_refresh_on_plan: false  # doesn't work with ACM module
+      post_plan_to_pr: false  # pipeline can be triggered by other teams so avoid posting into their PRs for now
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"

--- a/terraform/environments/nomis-combined-reporting/baseline.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline.tf
@@ -9,11 +9,8 @@ module "baseline" {
 
   environment = module.environment
 
-  security_groups = local.baseline_security_groups
-
-  # commenting out certs for now - needs some work to do enable in a single pass
-  # acm_certificates         = module.baseline_presets.acm_certificates
-
+  security_groups          = local.baseline_security_groups
+  acm_certificates         = module.baseline_presets.acm_certificates
   cloudwatch_log_groups    = module.baseline_presets.cloudwatch_log_groups
   iam_policies             = module.baseline_presets.iam_policies
   iam_roles                = module.baseline_presets.iam_roles


### PR DESCRIPTION
A couple of pipeline fixes (to workaround ACM module issue) plus enabling ACM wildcard cert in combined reporting.
- terraform refresh step doesn't work with ACM validation resources (for_each issue) so disabling this for now
- I've noticed our pipelines are sometimes triggered by other teams (e.g. when merging in latest changes) so I'm disabling the PR posting also