### PR TITLE
Nomis/dsos 1778/linux service alarms

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -141,8 +141,34 @@ locals {
           instance = "nomis_long_running_batch"
         }
       }
-      # oracleasm_service = {}
-      # oracle_ohasd_service = {}
+      oracleasm-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_exec_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "oracleasm service has stopped"
+        alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+        dimensions = {
+          instance = "oracleasm"
+        }
+      }
+      oracle-ohasd-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_exec_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "oracleasm service has stopped"
+        alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+        dimensions = {
+          instance = "oracle_ohasd"
+        }
+      }
     }
   }
 }

--- a/terraform/environments/nomis/locals-alerts-linux.tf
+++ b/terraform/environments/nomis/locals-alerts-linux.tf
@@ -72,9 +72,61 @@ locals {
       alarm_description   = "System status checks monitor the AWS systems on which your instance runs. These checks detect underlying problems with your instance that require AWS involvement to repair: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
       alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
-    # Service alert - chronyd
-    # Service alert - sshd
-    # Service alert - cloudwatch_agent_status
-    # Service alert - ssm_agent_status
+    chronyd-service = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_exec_value"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "chronyd service has stopped"
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+      dimensions = {
+        instance = "chronyd"
+      }
+    }
+    sshd-service = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_exec_value"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "sshd service has stopped"
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+      dimensions = {
+        instance = "sshd"
+      }
+    }
+    cloudwatch-agent-status = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_exec_value"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "cloudwatch agent service has stopped"
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+      dimensions = {
+        instance = "cloudwatch_agent_status"
+      }
+    }
+    ssm-agent-status = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_exec_value"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "ssm agent service has stopped"
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+      dimensions = {
+        instance = "ssm_agent_status"
+      }
+    }
   }
 }

--- a/terraform/environments/nomis/locals-alerts-linux.tf
+++ b/terraform/environments/nomis/locals-alerts-linux.tf
@@ -20,8 +20,8 @@ locals {
       namespace           = "CWAgent"
       period              = "60"
       statistic           = "Average"
-      threshold           = "90"
-      alarm_description   = "This metric monitors the amount of CPU time spent waiting for I/O to complete. If the average CPU time spent waiting for I/O to complete is greater than 90% for 30 minutes, the alarm will trigger."
+      threshold           = "30"
+      alarm_description   = "This metric monitors the amount of CPU time spent waiting for I/O to complete. If the average CPU time spent waiting for I/O to complete is greater than 30% for 30 minutes, the alarm will trigger."
       alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
     disk-used-percent = {

--- a/terraform/environments/nomis/locals-alerts-windows.tf
+++ b/terraform/environments/nomis/locals-alerts-windows.tf
@@ -36,5 +36,17 @@ locals {
       alarm_description   = "This metric monitors the amount of available memory. If Committed Bytes in Use is > 80% for 2 minutes, the alarm will trigger."
       alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
     }
+    cpu-utilization-windows = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "15"
+      datapoints_to_alarm = "15"
+      metric_name         = "CPUUtilization"
+      namespace           = "AWS/EC2"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "95"
+      alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes"
+      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+    }
   }
 }


### PR DESCRIPTION
Introduces a number of new alarms which will trigger on non-running key services
 - ssm agent
 - cloudwatch agent
 - chronyd
 - sshd
 - oracle-ohasd and oracleasm for db machines
 - weblogic-node-manager for web instances

Adds a missing CPUUtilization alarm for windows hosts

Changes the cpu-iowait threshold to bring it in line with settings in dso-monitoring for this metric