### PR TITLE
Revert "Bump windows-ecs::modernisation-platform-terraform-ecs from 2.1.0 to 2.1.3 in /terraform/environments/performance-hub"

### DIFF
--- a/terraform/environments/performance-hub/main.tf
+++ b/terraform/environments/performance-hub/main.tf
@@ -143,7 +143,7 @@ data "template_file" "task_definition" {
 
 module "windows-ecs" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs?ref=v2.1.3"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs?ref=v2.1.0"
 
   subnet_set_name         = local.subnet_set_name
   vpc_all                 = local.vpc_all


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform-environments#1325

This shouldn't have been merged, it has breaking changes for performance hub reverting so the current code runs.