### PR TITLE
Nomis: DSOS-1652: ec2 policy update for ansible

### DIFF
--- a/terraform/environments/nomis-combined-reporting/baseline_presets.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline_presets.tf
@@ -8,6 +8,7 @@ module "baseline_presets" {
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
+    enable_ec2_self_provision                    = true
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
   }
 }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -78,6 +78,8 @@ data "aws_iam_policy_document" "ansible_policy" {
     effect = "Allow"
     actions = [
       "ec2:DescribeInstances",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeTags",
     ]
     resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
   }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "ansible_policy" {
     sid    = "Ec2AnsiblePolicy"
     effect = "Allow"
     actions = [
-      "ssm:DescribeInstances",
+      "ec2:DescribeInstances",
     ]
     resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
   }

--- a/terraform/environments/nomis/ec2-common.tf
+++ b/terraform/environments/nomis/ec2-common.tf
@@ -72,6 +72,17 @@ data "aws_iam_policy_document" "ssm_custom" {
   }
 }
 
+data "aws_iam_policy_document" "ansible_policy" {
+  statement {
+    sid    = "Ec2AnsiblePolicy"
+    effect = "Allow"
+    actions = [
+      "ssm:DescribeInstances",
+    ]
+    resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards
+  }
+}
+
 # custom policy document for cloudwatch agent, based on CloudWatchAgentServerPolicy but removed CreateLogGroup permission to enforce all log groups in code
 data "aws_iam_policy_document" "cloud_watch_custom" {
   statement {
@@ -216,7 +227,8 @@ data "aws_iam_policy_document" "ec2_common_combined" {
     data.aws_iam_policy_document.s3_bucket_access.json,
     data.aws_iam_policy_document.cloud_watch_custom.json,
     data.aws_iam_policy_document.hmpps_kms_keys.json,
-    data.aws_iam_policy_document.application_insights.json # TODO: remove this later
+    data.aws_iam_policy_document.application_insights.json, # TODO: remove this later
+    data.aws_iam_policy_document.ansible_policy.json,
   ]
 }
 

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -3,8 +3,9 @@ locals {
   ec2_instance = {
 
     profile_policies = {
-      # remember to add any S3 policy
-      ssm_default = flatten([
+
+      # remember to add the appropriate S3 policy to this
+      default = flatten([
         "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
         local.iam_policies_ec2_default,
       ])
@@ -12,8 +13,7 @@ locals {
 
     config = {
 
-      # example configuration (assumes image builder, business unit kms cmks and
-      # cloud watch agent policies have been created)
+      # example configuration
       default = {
         availability_zone             = "eu-west-2a"
         subnet_name                   = "private"
@@ -23,8 +23,8 @@ locals {
         iam_resource_names_prefix     = "ec2-instance"
         instance_profile_policies = flatten([
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-          "EC2S3BucketWriteAndDeleteAccessPolicy",
           local.iam_policies_ec2_default,
+          "EC2S3BucketWriteAndDeleteAccessPolicy",
         ])
       }
     }

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -2,6 +2,14 @@ locals {
 
   ec2_instance = {
 
+    profile_policies = {
+      # remember to add any S3 policy
+      ssm_default = flatten([
+        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+        local.iam_policies_ec2_default,
+      ])
+    }
+
     config = {
 
       # example configuration (assumes image builder, business unit kms cmks and
@@ -13,12 +21,11 @@ locals {
         user_data_raw                 = null
         ssm_parameters_prefix         = "ec2/"
         iam_resource_names_prefix     = "ec2-instance"
-        instance_profile_policies = [
+        instance_profile_policies = flatten([
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
           "EC2S3BucketWriteAndDeleteAccessPolicy",
-          "BusinessUnitKmsCmkPolicy",
-          "CloudWatchAgentServerReducedPolicy"
-        ]
+          local.iam_policies_ec2_default,
+        ])
       }
     }
 

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -3,7 +3,14 @@ locals {
   iam_policies_filter = flatten([
     var.options.enable_business_unit_kms_cmks ? ["BusinessUnitKmsCmkPolicy"] : [],
     var.options.enable_image_builder ? ["ImageBuilderLaunchTemplatePolicy"] : [],
-    var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : []
+    var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
+    var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
+  ])
+
+  iam_policies_ec2_default = flatten([
+    var.options.enable_business_unit_kms_cmks ? ["BusinessUnitKmsCmkPolicy"] : [],
+    var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
+    var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
   ])
 
   iam_policies = {
@@ -85,6 +92,19 @@ locals {
           "ssm:GetParameters"
         ]
         resources = ["arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"]
+      }]
+    }
+
+    Ec2SelfProvisionPolicy = {
+      description = "Permissions to allow EC2 to self provision by pulling ec2 instance, volume and tag info"
+      statements = [{
+        effect = "Allow"
+        actions = [
+          "ec2:DescribeVolumes",
+          "ec2:DescribeTags",
+          "ec2:DescribeInstances",
+        ]
+        resources = ["*"]
       }]
     }
   }

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -10,6 +10,7 @@ variable "options" {
     enable_business_unit_kms_cmks                = optional(bool, false)
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)
+    enable_ec2_self_provision                    = optional(bool, false)
     s3_iam_policies                              = optional(list(string))
   })
 }


### PR DESCRIPTION
Allow EC2 access to DescribeInstances, required for pulling EC2 volume information when running ansible on provision.
Also added to baseline module