### PR TITLE
IAPS - Use AD to manage access

### DIFF
--- a/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
+++ b/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
@@ -93,7 +93,6 @@ tasks:
         Install-WindowsFeature -Name RSAT-ADDS-Tools
 
         # Allow Domain Users to connect via RDP and give them local admin rights
-        Add-LocalGroupMember -Group "Remote Desktop Users" -Member "Domain Users@${delius_iaps_ad_domain_name}"
         Add-LocalGroupMember -Group "Administrators" -Member "Domain Users@${delius_iaps_ad_domain_name}"
 
         exit 3010 # Reboot instance, see https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-exit-codes-reboots

--- a/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
+++ b/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
@@ -87,6 +87,11 @@ tasks:
         $token = invoke-restmethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
         $instanceId = invoke-restmethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -uri http://169.254.169.254/latest/meta-data/instance-id
         Add-Computer -DomainName "${delius_iaps_ad_domain_name}" -Credential $domainJoinCredential -NewName $instanceId -Force
+
+        # Install AD Management Tools
+        Install-WindowsFeature -Name RSAT-AD-PowerShell
+        Install-WindowsFeature -Name RSAT-ADDS-Tools
+
         exit 3010 # Reboot instance, see https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-exit-codes-reboots
       }
   - frequency: once

--- a/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
+++ b/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
@@ -92,6 +92,10 @@ tasks:
         Install-WindowsFeature -Name RSAT-AD-PowerShell
         Install-WindowsFeature -Name RSAT-ADDS-Tools
 
+        # Allow Domain Users to connect via RDP and give them local admin rights
+        Add-LocalGroupMember -Group "Remote Desktop Users" -Member "Domain Users@${delius_iaps_ad_domain_name}"
+        Add-LocalGroupMember -Group "Administrators" -Member "Domain Users@${delius_iaps_ad_domain_name}"
+
         exit 3010 # Reboot instance, see https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-exit-codes-reboots
       }
   - frequency: once


### PR DESCRIPTION
IAPS Domain Users require local admin rights, as some of the legacy applications they use rely on them. Additionally each IAPS Domain only covers the environment it is in. (AD is hopefully a temporary workaround, and the auth method should change in the future)
