### PR TITLE
LAW-3033 OAS LZ Integration

### DIFF
--- a/terraform/environments/oas/ec2.tf
+++ b/terraform/environments/oas/ec2.tf
@@ -105,6 +105,13 @@ resource "aws_security_group" "ec2" {
     protocol    = "tcp"
     cidr_blocks = [local.application_data.accounts[local.environment].inbound_cidr_lz]
   }
+  ingress {
+    description = "http access from LZ to oas-mp to test connectivity"
+    from_port   = 1389
+    to_port     = 1389
+    protocol    = "tcp"
+    cidr_blocks = [local.application_data.accounts[local.environment].inbound_cidr_lz]
+  }
 
   egress {
     description = "Allow AWS SSM Session Manager"
@@ -175,6 +182,20 @@ resource "aws_security_group" "ec2" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = [local.application_data.accounts[local.environment].outbound_access_cidr]
+  }
+  egress {
+    description = "http access from LZ to oas-mp to test connectivity"
+    from_port   = 1389
+    to_port     = 1389
+    protocol    = "tcp"
+    cidr_blocks = [local.application_data.accounts[local.environment].inbound_cidr_lz]
+  }
+  egress {
+    description = "http access from LZ to oas-mp to test connectivity"
+    from_port   = 1521
+    to_port     = 1521
+    protocol    = "tcp"
+    cidr_blocks = [local.application_data.accounts[local.environment].inbound_cidr_lz]
   }
 }
 


### PR DESCRIPTION
This PR looks at adding in an ingress route in the security group with port 1389 that is needed to integrate with applications in the Dev Landing Zone.
It also adds egress routes in the security group with port 1521 so that it can integrate with databases in the Dev Landing Zone.