### PR TITLE
Remove certificate from production

### DIFF
--- a/terraform/environments/performance-hub/application_variables.json
+++ b/terraform/environments/performance-hub/application_variables.json
@@ -2,7 +2,7 @@
   "accounts": {
     "development": {
       "region": "eu-west-2",
-      "ami_image_id": "ami-00ab9c4b796eba4d4",
+      "ami_image_id": "ami-05d3f644a4baadebd",
       "instance_type": "t3.medium",
       "key_name": "performance-hub-ec2",
       "app_count": "1",
@@ -30,7 +30,7 @@
     },
     "preproduction": {
       "region": "eu-west-2",
-      "ami_image_id": "ami-00ab9c4b796eba4d4",
+      "ami_image_id": "ami-05d3f644a4baadebd",
       "instance_type": "t3.medium",
       "key_name": "performance-hub-ec2",
       "app_count": "1",
@@ -58,7 +58,7 @@
     },
     "production": {
       "region": "eu-west-2",
-      "ami_image_id": "ami-00ab9c4b796eba4d4",
+      "ami_image_id": "ami-05d3f644a4baadebd",
       "instance_type": "t3.medium",
       "key_name": "performance-hub-ec2",
       "app_count": "1",

--- a/terraform/environments/performance-hub/locals.tf
+++ b/terraform/environments/performance-hub/locals.tf
@@ -1,10 +1,10 @@
 locals {
-  domain_types = { for dvo in aws_acm_certificate.external.domain_validation_options : dvo.domain_name => {
+  domain_types = try({ for dvo in aws_acm_certificate.external[0].domain_validation_options : dvo.domain_name => {
     name   = dvo.resource_record_name
     record = dvo.resource_record_value
     type   = dvo.resource_record_type
     }
-  }
+  }, [])
 
   domain_name_main   = [for k, v in local.domain_types : v.name if k == "modernisation-platform.service.justice.gov.uk"]
   domain_name_sub    = [for k, v in local.domain_types : v.name if k != "modernisation-platform.service.justice.gov.uk"]

--- a/terraform/environments/performance-hub/route53.tf
+++ b/terraform/environments/performance-hub/route53.tf
@@ -1,3 +1,4 @@
+# Note: The production record is managed by operations engineering and has a CNAME to this record
 resource "aws_route53_record" "external" {
   provider = aws.core-vpc
 
@@ -12,7 +13,9 @@ resource "aws_route53_record" "external" {
   }
 }
 
+# Note: Production certificate is a Gandi cert which is manually imported
 resource "aws_acm_certificate" "external" {
+  count             = local.is-production ? 0 : 1
   domain_name       = "modernisation-platform.service.justice.gov.uk"
   validation_method = "DNS"
 
@@ -27,6 +30,7 @@ resource "aws_acm_certificate" "external" {
 }
 
 resource "aws_route53_record" "external_validation" {
+  count    = local.is-production ? 0 : 1
   provider = aws.core-network-services
 
   allow_overwrite = true
@@ -38,6 +42,7 @@ resource "aws_route53_record" "external_validation" {
 }
 
 resource "aws_route53_record" "external_validation_subdomain" {
+  count    = local.is-production ? 0 : 1
   provider = aws.core-vpc
 
   allow_overwrite = true
@@ -49,6 +54,7 @@ resource "aws_route53_record" "external_validation_subdomain" {
 }
 
 resource "aws_acm_certificate_validation" "external" {
-  certificate_arn         = aws_acm_certificate.external.arn
+  count                   = local.is-production ? 0 : 1
+  certificate_arn         = aws_acm_certificate.external[0].arn
   validation_record_fqdns = [local.domain_name_main[0], local.domain_name_sub[0]]
 }


### PR DESCRIPTION
A recent deployment failed because the certificate in production was expired.  This is an ACM certificate, but because it isn't being used (production uses an imported Gandi certificate), Amazon doesn't renew unused certificates, and the expired certificate caused the apply to fail as the state was unexpected.

This PR adds a count in so that the ACM certificate and the validation records are not created in production.

Also during this change the AMI version was updated so updating here in the same PR to avoid 2 PRs which would implement changes and cause redeployments.  We should see a clean plan with this PR as these changes have been implemented via terraform locally.