### PR TITLE
nomis: DSOS-1796: add destroy to nomis pipelines

### DIFF
--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -17,6 +17,15 @@ on:
       - '.github/workflows/nomis-combined-reporting.yml'
 
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+          - deploy
+          - destroy
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -25,11 +34,13 @@ permissions:
 jobs:
   strategy:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
+    if: inputs.action != 'destroy'
     with:
       strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
 
   terraform:
     needs: strategy
+    if: inputs.action != 'destroy'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
@@ -38,8 +49,18 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: false  # doesn't work with ACM module
-      post_plan_to_pr: false  # pipeline can be triggered by other teams so avoid posting into their PRs for now
+    secrets:
+      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
+      pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"
+
+  destroy-development:
+    if: inputs.action == 'destroy'
+    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    with:
+      application: "${{ github.workflow }}"
+      environment: "development"
+      action: "plan_apply"
+      plan_apply_tfargs: "-destroy"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"

--- a/.github/workflows/nomis-data-hub.yml
+++ b/.github/workflows/nomis-data-hub.yml
@@ -54,7 +54,6 @@ jobs:
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"
 
   destroy:
-    needs: strategy
     if: inputs.action == 'destroy'
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:

--- a/.github/workflows/nomis-data-hub.yml
+++ b/.github/workflows/nomis-data-hub.yml
@@ -17,6 +17,15 @@ on:
       - '.github/workflows/nomis-data-hub.yml'
 
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+          - deploy
+          - destroy
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -25,11 +34,13 @@ permissions:
 jobs:
   strategy:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
+    if: inputs.action != 'destroy'
     with:
       strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
 
   terraform:
     needs: strategy
+    if: inputs.action != 'destroy'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
@@ -38,8 +49,19 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: false  # doesn't work with ACM module
-      post_plan_to_pr: false  # pipeline can be triggered by other teams so avoid posting into their PRs for now
+    secrets:
+      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
+      pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"
+
+  destroy:
+    needs: strategy
+    if: inputs.action == 'destroy'
+    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    with:
+      application: "${{ github.workflow }}"
+      environment: "nomis-data-hub-development"
+      action: "plan_apply"
+      plan_apply_tfargs: "-destroy"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"

--- a/.github/workflows/nomis-data-hub.yml
+++ b/.github/workflows/nomis-data-hub.yml
@@ -53,7 +53,7 @@ jobs:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"
 
-  destroy:
+  destroy-development:
     if: inputs.action == 'destroy'
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:

--- a/.github/workflows/nomis-data-hub.yml
+++ b/.github/workflows/nomis-data-hub.yml
@@ -58,7 +58,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_plan_apply.yml
     with:
       application: "${{ github.workflow }}"
-      environment: "nomis-data-hub-development"
+      environment: "development"
       action: "plan_apply"
       plan_apply_tfargs: "-destroy"
     secrets:

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -17,6 +17,15 @@ on:
       - '.github/workflows/nomis.yml'
 
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'Set either [deploy|destroy].'
+        default: 'deploy'
+        required: true
+        type: string
+        options:
+          - deploy
+          - destroy
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -25,11 +34,13 @@ permissions:
 jobs:
   strategy:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
+    if: inputs.action != 'destroy'
     with:
       strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
 
   terraform:
     needs: strategy
+    if: inputs.action != 'destroy'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
@@ -38,8 +49,18 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: false  # doesn't work with ACM module
-      post_plan_to_pr: false  # pipeline can be triggered by other teams so avoid posting into their PRs for now
+    secrets:
+      modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
+      pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"
+
+  destroy-development:
+    if: inputs.action == 'destroy'
+    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    with:
+      application: "${{ github.workflow }}"
+      environment: "development"
+      action: "plan_apply"
+      plan_apply_tfargs: "-destroy"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.DSO_GITHUB_AUTOMATION_PAT }}"

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,7 +125,7 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           set -o pipefail
-          tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.additional_tfargs }}"
+          tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           echo "terraform apply -refresh-only -auto-approve ${tf_args}"
           terraform apply -refresh-only -auto-approve ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
 
@@ -137,7 +137,7 @@ jobs:
         run: |
           set -o pipefail
           exitcode=0
-          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.additional_tfargs }}"
+          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           [[ ${POST_PLAN_TO_PR} == 'true' ]] && tf_args="${tf_args} -no-color"
           [[ ${{ inputs.do_state_refresh_on_plan }} == 'true' ]] && tf_args="${tf_args} -refresh=false"
           echo "terraform plan ${tf_args}"
@@ -233,7 +233,7 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           set -o pipefail
-          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.additional_tfargs }}"
+          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           echo "terraform plan ${tf_args}"
           terraform plan ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
 
@@ -241,6 +241,6 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           set -o pipefail
-          tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.additional_tfargs }} x.tfplan"
+          tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} x.tfplan"
           echo "terraform apply ${tf_args}"
           terraform apply ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -37,6 +37,11 @@ on:
         required: false
         description: "Set to plan or plan_apply"
         default: plan
+      terraform_version:
+        type: string
+        required: false
+        description: "The terraform version to use"
+        default: "~1"
       init_plan_apply_tfargs:
         type: string
         required: false
@@ -105,7 +110,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
         with:
-          terraform_version: "~1"
+          terraform_version: "${{ inputs.terraform_version }}"
           terraform_wrapper: false
 
       - name: Terraform Init
@@ -214,7 +219,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1  # v2.0.3
         with:
-          terraform_version: "~1"
+          terraform_version: "${{ inputs.terraform_version }}"
           terraform_wrapper: false
 
       - name: Terraform Init


### PR DESCRIPTION
Retrofitted the new mod platform destroy functionality to the re-usable pipelines, since I need it for NDH.
Tested both destroy and deploy modes in the NDH pipelines