### PR TITLE
NIT-531: Remove Windows installation media from AMI

### DIFF
--- a/terraform/environments/delius-iaps/ec2-iaps-server.tf
+++ b/terraform/environments/delius-iaps/ec2-iaps-server.tf
@@ -38,6 +38,13 @@ locals {
         type = "gp3"
         size = "50"
       }
+
+      // unmount volume from parent AMI
+      // that was used to enable windows features
+      // without needing to go out to the internet.
+      "/dev/xvdf" = {
+        no_device = true
+      }
     }
 
     user_data_raw = base64encode(data.template_file.iaps_ec2_config.rendered)

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -19,14 +19,14 @@ resource "aws_launch_template" "this" {
       dynamic "ebs" {
         for_each = lookup(block_device_mappings.value, "no_device", null) != true ? [block_device_mappings.value] : []
         content {
-          delete_on_termination = ebs.type != null ? true : null
-          encrypted             = ebs.type != null ? true : null
+          delete_on_termination = ebs.value.type != null ? true : null
+          encrypted             = ebs.value.type != null ? true : null
 
-          kms_key_id  = try(ebs.kms_key_id, var.ebs_kms_key_id)
-          iops        = try(ebs.iops > 0, false) ? ebs.iops : null
-          throughput  = try(ebs.throughput > 0, false) ? ebs.throughput : null
-          volume_size = ebs.size
-          volume_type = ebs.type
+          kms_key_id  = try(ebs.value.kms_key_id, var.ebs_kms_key_id)
+          iops        = try(ebs.value.iops > 0, false) ? ebs.value.iops : null
+          throughput  = try(ebs.value.throughput > 0, false) ? ebs.value.throughput : null
+          volume_size = ebs.value.size
+          volume_type = ebs.value.type
         }
       }
       #      ebs {

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -29,16 +29,6 @@ resource "aws_launch_template" "this" {
           volume_type = ebs.value.type
         }
       }
-      #      ebs {
-      #        delete_on_termination = block_device_mappings.value.type != null ? true : null
-      #        encrypted             = block_device_mappings.value.type != null ? true : null
-      #
-      #        kms_key_id  = try(block_device_mappings.value.kms_key_id, var.ebs_kms_key_id)
-      #        iops        = try(block_device_mappings.value.iops > 0, false) ? block_device_mappings.value.iops : null
-      #        throughput  = try(block_device_mappings.value.throughput > 0, false) ? block_device_mappings.value.throughput : null
-      #        volume_size = block_device_mappings.value.size
-      #        volume_type = block_device_mappings.value.type
-      #      }
     }
   }
 

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -15,16 +15,30 @@ resource "aws_launch_template" "this" {
       device_name  = block_device_mappings.key
       no_device    = lookup(block_device_mappings.value, "no_device", null)
       virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
-      ebs {
-        delete_on_termination = block_device_mappings.value.type != null ? true : null
-        encrypted             = block_device_mappings.value.type != null ? true : null
 
-        kms_key_id  = try(block_device_mappings.value.kms_key_id, var.ebs_kms_key_id)
-        iops        = try(block_device_mappings.value.iops > 0, false) ? block_device_mappings.value.iops : null
-        throughput  = try(block_device_mappings.value.throughput > 0, false) ? block_device_mappings.value.throughput : null
-        volume_size = block_device_mappings.value.size
-        volume_type = block_device_mappings.value.type
+      dynamic "ebs" {
+        for_each = lookup(block_device_mappings.value, "no_device", null) != true ? [block_device_mappings.value] : []
+        content {
+          delete_on_termination = ebs.type != null ? true : null
+          encrypted             = ebs.type != null ? true : null
+
+          kms_key_id  = try(ebs.kms_key_id, var.ebs_kms_key_id)
+          iops        = try(ebs.iops > 0, false) ? ebs.iops : null
+          throughput  = try(ebs.throughput > 0, false) ? ebs.throughput : null
+          volume_size = ebs.size
+          volume_type = ebs.type
+        }
       }
+      #      ebs {
+      #        delete_on_termination = block_device_mappings.value.type != null ? true : null
+      #        encrypted             = block_device_mappings.value.type != null ? true : null
+      #
+      #        kms_key_id  = try(block_device_mappings.value.kms_key_id, var.ebs_kms_key_id)
+      #        iops        = try(block_device_mappings.value.iops > 0, false) ? block_device_mappings.value.iops : null
+      #        throughput  = try(block_device_mappings.value.throughput > 0, false) ? block_device_mappings.value.throughput : null
+      #        volume_size = block_device_mappings.value.size
+      #        volume_type = block_device_mappings.value.type
+      #      }
     }
   }
 

--- a/terraform/modules/ec2_autoscaling_group/variables.tf
+++ b/terraform/modules/ec2_autoscaling_group/variables.tf
@@ -124,6 +124,7 @@ variable "ebs_volumes" {
     size        = optional(number)
     type        = optional(string)
     kms_key_id  = optional(string)
+    no_device   = optional(bool)
   }))
 }
 


### PR DESCRIPTION
Remove windows feature volume from IAPs AMI as it was only required during AMI build to enable windows features without going over the internet