### PR TITLE
allow laa-oem to continue on fail

### DIFF
--- a/.github/workflows/laa-oem.yml
+++ b/.github/workflows/laa-oem.yml
@@ -38,7 +38,9 @@ defaults:
 jobs:
 
   plan-dev-test:
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         include:
           - environment: development


### PR DESCRIPTION
Because of how the `laa-oem` team are using volume snapshots, and because they don't have any snapshots in their `test` environment, `continue-on-fail` is needed for changes to be made to the development environment