### PR TITLE
Nomis/dsos 1650/fixngo connectivity alarm

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -209,7 +209,7 @@ module "db_ec2_instance" {
   tags               = merge(local.tags, local.database.tags, try(each.value.tags, {}))
   account_ids_lookup = local.environment_management.account_ids
   cloudwatch_metric_alarms = {
-    for key, value in merge(local.database.cloudwatch_metric_alarms_database, local.cloudwatch_metric_alarms_linux) :
+    for key, value in merge(local.cloudwatch_metric_alarms_linux, local.database.cloudwatch_metric_alarms_database, lookup(each.value, "cloudwatch_metric_alarms", {})) :
     key => merge(value, {
       alarm_actions = [lookup(each.value, "sns_topic", aws_sns_topic.nomis_nonprod_alarms.arn)]
   }) }

--- a/terraform/environments/nomis/ec2-jumpserver.tf
+++ b/terraform/environments/nomis/ec2-jumpserver.tf
@@ -86,7 +86,7 @@ module "ec2_jumpserver" {
   tags                          = merge(local.tags, local.ec2_jumpserver.tags, try(each.value.tags, {}))
   account_ids_lookup            = local.environment_management.account_ids
   cloudwatch_metric_alarms = {
-    for key, value in local.cloudwatch_metric_alarms_windows :
+    for key, value in merge(local.cloudwatch_metric_alarms_windows, lookup(each.value, "cloudwatch_metric_alarms", {})) :
     key => merge(value, {
       alarm_actions = [lookup(each.value, "sns_topic", aws_sns_topic.nomis_nonprod_alarms.arn)]
   }) }

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -172,7 +172,7 @@ module "ec2_weblogic_autoscaling_group" {
   tags               = merge(local.tags, local.ec2_weblogic.tags, try(each.value.tags, {}))
   account_ids_lookup = local.environment_management.account_ids
   cloudwatch_metric_alarms = {
-    for key, value in merge(local.ec2_weblogic.cloudwatch_metric_alarms_weblogic, local.cloudwatch_metric_alarms_linux) :
+    for key, value in merge(local.ec2_weblogic.cloudwatch_metric_alarms_weblogic, local.cloudwatch_metric_alarms_linux, lookup(each.value, "cloudwatch_metric_alarms", {})) :
     key => merge(value, {
       alarm_actions = [lookup(each.value, "sns_topic", aws_sns_topic.nomis_nonprod_alarms.arn)]
   }) }

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -36,38 +36,40 @@ locals {
       # *-nomis-db-3: HA
 
       # add databases here as needed
-      t3-nomis-db-3 = {
-        tags = {
-          server-type         = "nomis-db"
-          description         = "Test database for monitoring automation development"
-          oracle-sids         = "CNOMT1"
-          monitored           = false
-          s3-db-restore-dir   = "CNOMT1_20211214"
-          # instance-scheduling = "skip-scheduling"
-          fixngo-connection-target = "10.40.0.136"
-        }
-        ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"
-        ami_owner = "self" # remove this line next time AMI is updated so core-shared-services-production used instead
-        instance = {
-          disable_api_termination = true
-        }
-        cloudwatch_metric_alarms = {
-          fixngo-connection = {
-            comparison_operator = "GreaterThanOrEqualToThreshold"
-            evaluation_periods  = "3"
-            namespace           = "CWAgent"
-            metric_name         = "collectd_exec_value"
-            period              = "60"
-            statistic           = "Average"
-            threshold           = "1"
-            alarm_description   = "ssm agent service has stopped"
-            alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
-            dimensions = {
-              instance = "fixngo_connected"
-            }
-          }
-        }
-      }
+
+      # NOTE: Example includes settings for an alarm to check wether the database can connect to the Oracle Enterprise Manager in FixNGo
+      # t3-nomis-db-3 = {
+      #   tags = {
+      #    server-type         = "nomis-db"
+      #    description         = "Test database for monitoring automation development"
+      #    oracle-sids         = "CNOMT1"
+      #    monitored           = false
+      #    s3-db-restore-dir   = "CNOMT1_20211214"
+      #    # instance-scheduling = "skip-scheduling"
+      #    fixngo-connection-target = "10.40.0.136"
+      #  }
+      #  ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"
+      #  ami_owner = "self" # remove this line next time AMI is updated so core-shared-services-production used instead
+      #  instance = {
+      #    disable_api_termination = true
+      #  }
+      #  cloudwatch_metric_alarms = {
+      #    fixngo-connection = {
+      #      comparison_operator = "GreaterThanOrEqualToThreshold"
+      #      evaluation_periods  = "3"
+      #      namespace           = "CWAgent"
+      #      metric_name         = "collectd_exec_value"
+      #      period              = "60"
+      #      statistic           = "Average"
+      #      threshold           = "1"
+      #      alarm_description   = "this EC2 instance no longer has a connection to the Oracle Enterprise Manager in FixNGo of the connection-target machine"
+      #      alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+      #      dimensions = {
+      #        instance = "fixngo_connected" # required dimension value for this metric
+      #      }
+      #    }
+      #  }
+      #}
     }
     weblogics          = {}
     ec2_test_instances = {}

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -36,6 +36,41 @@ locals {
       # *-nomis-db-3: HA
 
       # add databases here as needed
+      test-nomis-db-3 = {
+        tags = {
+          server-type         = "nomis-db"
+          description         = "Test database for monitoring automation development"
+          oracle-sids         = "CNOMT1"
+          monitored           = false
+          s3-db-restore-dir   = "CNOMT1_20211214"
+          # instance-scheduling = "skip-scheduling"
+          fixngo-connection-target = "10.40.0.136"
+        }
+        ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"
+        ami_owner = "self" # remove this line next time AMI is updated so core-shared-services-production used instead
+        instance = {
+          disable_api_termination = true
+        }
+        cloudwatch_metric_alarms = {
+          fixngo-connection = {
+            comparison_operator = "GreaterThanOrEqualToThreshold"
+            evaluation_periods  = "3"
+            namespace           = "CWAgent"
+            metric_name         = "collectd_exec_value"
+            period              = "60"
+            statistic           = "Average"
+            threshold           = "1"
+            alarm_description   = "ssm agent service has stopped"
+            alarm_actions       = [aws_sns_topic.nomis_nonprod_alarms.arn]
+            dimensions = {
+              instance = "fixngo_connected"
+            }
+          }
+        }
+      }
+    }
+
+
     }
     weblogics          = {}
     ec2_test_instances = {}

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -69,9 +69,6 @@ locals {
         }
       }
     }
-
-
-    }
     weblogics          = {}
     ec2_test_instances = {}
     ec2_test_autoscaling_groups = {

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -36,7 +36,7 @@ locals {
       # *-nomis-db-3: HA
 
       # add databases here as needed
-      /* t3-nomis-db-3 = {
+      t3-nomis-db-3 = {
         tags = {
           server-type         = "nomis-db"
           description         = "Test database for monitoring automation development"
@@ -67,7 +67,7 @@ locals {
             }
           }
         }
-      } */
+      }
     }
     weblogics          = {}
     ec2_test_instances = {}

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -36,7 +36,7 @@ locals {
       # *-nomis-db-3: HA
 
       # add databases here as needed
-      test-nomis-db-3 = {
+      /* t3-nomis-db-3 = {
         tags = {
           server-type         = "nomis-db"
           description         = "Test database for monitoring automation development"
@@ -67,7 +67,7 @@ locals {
             }
           }
         }
-      }
+      } */
     }
     weblogics          = {}
     ec2_test_instances = {}


### PR DESCRIPTION
- example in nomis-development for setting up an alarm on a single instance
- includes use of fixngo-connection-target tag to set up metric with amazon-cloudwatch-agent role is run on it
- allows web, jumpservers and database instances to set up their own unique alarms if included in the instance configs