### PR TITLE
returned version constraint to ~1

### DIFF
--- a/.github/workflows/apex.yml
+++ b/.github/workflows/apex.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Plan - ${{ matrix.environment }}
 #         run: |
@@ -248,7 +248,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Apply - ${{ matrix.environment }}
 #         run: |

--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -105,7 +105,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -140,7 +140,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -215,7 +215,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -253,7 +253,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/data-and-insights-wepi.yml
+++ b/.github/workflows/data-and-insights-wepi.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -211,7 +211,7 @@ jobs:
        - name: Load and Configure Terraform
          uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
          with:
-           terraform_version: "~1.3"
+           terraform_version: "~1"
            terraform_wrapper: false
        - name: Plan - ${{ matrix.environment }}
          run: |
@@ -249,7 +249,7 @@ jobs:
        - name: Load and Configure Terraform
          uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
          with:
-           terraform_version: "~1.3"
+           terraform_version: "~1"
            terraform_wrapper: false
        - name: Apply - ${{ matrix.environment }}
          run: |

--- a/.github/workflows/delius-core.yml
+++ b/.github/workflows/delius-core.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
   #    - name: Load and Configure Terraform
   #      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #      with:
-  #        terraform_version: "~1.3"
+  #        terraform_version: "~1"
   #        terraform_wrapper: false
   #    - name: Plan - ${{ matrix.environment }}
   #      run: |
@@ -248,7 +248,7 @@ jobs:
   #    - name: Load and Configure Terraform
   #      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #      with:
-  #        terraform_version: "~1.3"
+  #        terraform_version: "~1"
   #        terraform_wrapper: false
   #    - name: Apply - ${{ matrix.environment }}
   #      run: |

--- a/.github/workflows/delius-iaps.yml
+++ b/.github/workflows/delius-iaps.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/delius-jitbit.yml
+++ b/.github/workflows/delius-jitbit.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/digital-prison-reporting.yml
+++ b/.github/workflows/digital-prison-reporting.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Plan - ${{ matrix.environment }}
 #         run: |
@@ -248,7 +248,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Apply - ${{ matrix.environment }}
 #         run: |

--- a/.github/workflows/equip.yml
+++ b/.github/workflows/equip.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -134,7 +134,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -172,7 +172,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/laa-oem.yml
+++ b/.github/workflows/laa-oem.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -138,7 +138,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/long-term-storage.yml
+++ b/.github/workflows/long-term-storage.yml
@@ -62,7 +62,7 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #       with:
-  #         terraform_version: "~1.3"
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Plan - ${{ matrix.environment }}
   #       run: |
@@ -101,7 +101,7 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #       with:
-  #         terraform_version: "~1.3"
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Apply - ${{ matrix.environment }}
   #       run: |
@@ -136,7 +136,7 @@ jobs:
   #      - name: Load and Configure Terraform
   #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #        with:
-  #          terraform_version: "~1.3"
+  #          terraform_version: "~1"
   #          terraform_wrapper: false
   #      - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
   #        run: |
@@ -174,7 +174,7 @@ jobs:
   #      - name: Load and Configure Terraform
   #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #        with:
-  #          terraform_version: "~1.3"
+  #          terraform_version: "~1"
   #          terraform_wrapper: false
   #      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
   #        run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/maatdb.yml
+++ b/.github/workflows/maatdb.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #        with:
-#          terraform_version: "~1.3"
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Plan - ${{ matrix.environment }}
 #        run: |
@@ -248,7 +248,7 @@ jobs:
 #      - name: Load and Configure Terraform
 #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #        with:
-#          terraform_version: "~1.3"
+#          terraform_version: "~1"
 #          terraform_wrapper: false
 #      - name: Apply - ${{ matrix.environment }}
 #        run: |

--- a/.github/workflows/mlra.yml
+++ b/.github/workflows/mlra.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan after nuke - ${{ matrix.nuke_accts }}
         run: |

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Plan - ${{ matrix.environment }}
 #         run: |
@@ -248,7 +248,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Apply - ${{ matrix.environment }}
 #         run: |

--- a/.github/workflows/oasys.yml
+++ b/.github/workflows/oasys.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - ${{ matrix.environment }}
         run: |
@@ -94,7 +94,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Run Terrform Apply
         run: |
@@ -131,7 +131,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - ${{ matrix.environment }}
         run: |
@@ -170,7 +170,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Run Terrform Apply
         run: |

--- a/.github/workflows/performance-hub.yml
+++ b/.github/workflows/performance-hub.yml
@@ -62,7 +62,7 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #       with:
-  #         terraform_version: "~1.3"
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Plan - ${{ matrix.environment }}
   #       run: |
@@ -101,7 +101,7 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #       with:
-  #         terraform_version: "~1.3"
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Apply - ${{ matrix.environment }}
   #       run: |
@@ -136,7 +136,7 @@ jobs:
   #     - name: Load and Configure Terraform
   #       uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #       with:
-  #         terraform_version: "~1.3"
+  #         terraform_version: "~1"
   #         terraform_wrapper: false
   #     - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
   #       run: |
@@ -174,7 +174,7 @@ jobs:
   #      - name: Load and Configure Terraform
   #        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
   #        with:
-  #          terraform_version: "~1.3"
+  #          terraform_version: "~1"
   #          terraform_wrapper: false
   #      - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
   #        run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/ppud.yml
+++ b/.github/workflows/ppud.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/refer-monitor.yml
+++ b/.github/workflows/refer-monitor.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Plan - ${{ matrix.environment }}
 #         run: |
@@ -248,7 +248,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Apply - ${{ matrix.environment }}
 #         run: |

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -134,7 +134,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -172,7 +172,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/tariff.yml
+++ b/.github/workflows/tariff.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -210,7 +210,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Plan - ${{ matrix.environment }}
 #         run: |
@@ -248,7 +248,7 @@ jobs:
 #       - name: Load and Configure Terraform
 #         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
 #         with:
-#           terraform_version: "~1.3"
+#           terraform_version: "~1"
 #           terraform_wrapper: false
 #       - name: Apply - ${{ matrix.environment }}
 #         run: |

--- a/.github/workflows/tipstaff.yml
+++ b/.github/workflows/tipstaff.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -211,7 +211,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Plan - ${{ matrix.environment }}
         run: |
@@ -250,7 +250,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Apply - ${{ matrix.environment }}
         run: |

--- a/.github/workflows/xhibit-portal.yml
+++ b/.github/workflows/xhibit-portal.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - development
         run: |
@@ -86,7 +86,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - development
         run: |
@@ -123,7 +123,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy plan - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -161,7 +161,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform destroy apply - ${{ github.workflow }} - ${{ matrix.environment }}
         run: |
@@ -189,7 +189,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - preproduction
         run: |
@@ -220,7 +220,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - preproduction
         run: |
@@ -250,7 +250,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform plan - production
         run: |
@@ -283,7 +283,7 @@ jobs:
       - name: Load and Configure Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: "~1.3"
+          terraform_version: "~1"
           terraform_wrapper: false
       - name: Terraform apply - production
         run: |


### PR DESCRIPTION
Due to issues with Terraform 1.4.0 breaking some pipeline runs, the version constraint was set to `1.3.x`, but since Terraform 1.4.1 has been released that resolves this issue with pipeline runs, the version constraint can be safely removed.