### PR TITLE
Nomis: DSOS-1758: rebuild load balancer part2

### DIFF
--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -10,16 +10,15 @@ module "baseline" {
   environment = module.environment
 
   # security_groups          = local.baseline_security_groups
-  # acm_certificates         = module.baseline_presets.acm_certificates
+  acm_certificates = module.baseline_presets.acm_certificates
   # cloudwatch_log_groups    = module.baseline_presets.cloudwatch_log_groups
-  # iam_policies             = module.baseline_presets.iam_policies
+  # iam_policies             = module.baseline_presets.iam_policies
   # iam_roles                = module.baseline_presets.iam_roles
-  # iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
-  # key_pairs                = module.baseline_presets.key_pairs
-  # kms_grants               = module.baseline_presets.kms_grants
-  # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
-
-  # ec2_instances          = lookup(local.environment_config, "baseline_ec2_instances", {})
-  # ec2_autoscaling_groups = lookup(local.environment_config, "baseline_ec2_autoscaling_groups", {})
-  lbs = lookup(local.environment_config, "baseline_lbs", {})
+  # iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
+  # key_pairs                = module.baseline_presets.key_pairs
+  # kms_grants               = module.baseline_presets.kms_grants
+  # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.baseline_environment_config, "baseline_s3_buckets", {}))
+  # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
+  # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
+  lbs = lookup(local.baseline_environment_config, "baseline_lbs", {})
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -1,0 +1,14 @@
+module "baseline_presets" {
+  source = "../../modules/baseline_presets"
+
+  environment = module.environment
+
+  options = {
+    enable_application_environment_wildcard_cert = true
+    enable_business_unit_kms_cmks                = true
+    enable_image_builder                         = true
+    enable_ec2_cloud_watch_agent                 = true
+    enable_ec2_self_provision                    = true
+    s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+  }
+}

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -148,4 +148,8 @@ locals {
       }
     }
   }
+
+  # baseline config
+  development_config = {
+  }
 }

--- a/terraform/environments/nomis/locals-lb-listeners.tf
+++ b/terraform/environments/nomis/locals-lb-listeners.tf
@@ -1,12 +1,6 @@
 locals {
 
   lb_listener_defaults = {
-    nomis_public = {
-      lb_application_name = "nomis-public"
-    }
-    nomis_internal = {
-      lb_application_name = "nomis-internal"
-    }
     route53 = {
       route53_records = {
         "$(name).nomis" = {
@@ -46,10 +40,10 @@ locals {
       }
     }
     https = {
-      port       = 443
-      protocol   = "HTTPS"
-      ssl_policy = "ELBSecurityPolicy-2016-08"
-      # certificate_arns = [module.acm_certificate["star.${module.environment.domains.public.application_environment}"].arn]
+      port             = 443
+      protocol         = "HTTPS"
+      ssl_policy       = "ELBSecurityPolicy-2016-08"
+      certificate_arns = ["application_environment_wildcard_cert"]
       default_action = {
         type = "fixed-response"
         fixed_response = {
@@ -93,76 +87,6 @@ locals {
     }
   }
 
-  lb_listeners = {
-
-    #--------------------------------------------------------------------------
-    # define environment specific load balancer listeners here
-    #--------------------------------------------------------------------------
-    development = {}
-
-    test = {
-      #      nomis-internal-t1-nomis-web-http-7001 = merge(
-      #        local.lb_listener_defaults.http-7001,
-      #        local.lb_listener_defaults.nomis_internal, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-internal"
-      #            condition_host_header_replace = "t1-nomis-web-internal"
-      #          }
-      #        }
-      #      )
-      #      nomis-internal-t1-nomis-web-http-7777 = merge(
-      #        local.lb_listener_defaults.http-7777,
-      #        local.lb_listener_defaults.nomis_internal, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-internal"
-      #            condition_host_header_replace = "t1-nomis-web-internal"
-      #          }
-      #        }
-      #      )
-      #      nomis-internal-t1-nomis-web-https = merge(
-      #        local.lb_listener_defaults.https,
-      #        local.lb_listener_defaults.nomis_internal,
-      #        local.lb_listener_defaults.route53, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-internal"
-      #            condition_host_header_replace = "t1-nomis-web-internal"
-      #            route53_record_name_replace   = "t1-nomis-web-internal"
-      #          }
-      #      })
-      #
-      #      nomis-public-t1-nomis-web-http-7001 = merge(
-      #        local.lb_listener_defaults.http-7001,
-      #        local.lb_listener_defaults.nomis_public, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-public"
-      #            condition_host_header_replace = "t1-nomis-web"
-      #          }
-      #        }
-      #      )
-      #      nomis-public-t1-nomis-web-http-7777 = merge(
-      #        local.lb_listener_defaults.http-7777,
-      #        local.lb_listener_defaults.nomis_public, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-public"
-      #            condition_host_header_replace = "t1-nomis-web"
-      #          }
-      #        }
-      #      )
-      #      nomis-public-t1-nomis-web-https = merge(
-      #        local.lb_listener_defaults.https,
-      #        local.lb_listener_defaults.nomis_public,
-      #        local.lb_listener_defaults.route53, {
-      #          replace = {
-      #            target_group_name_replace     = "t1-nomis-web-public"
-      #            condition_host_header_replace = "t1-nomis-web"
-      #            route53_record_name_replace   = "t1-nomis-web"
-      #          }
-      #      })
-    }
-
-    preproduction = {}
-    production    = {}
-  }
   # allows an over-ride on where to send alarms (which sns topic) based on environment
   lb_listeners_sns_topic = {
     development = {}

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -38,4 +38,8 @@ locals {
     weblogics       = {}
     ec2_jumpservers = {}
   }
+
+  # baseline config
+  preproduction_config = {
+  }
 }

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -132,4 +132,8 @@ locals {
     weblogics       = {}
     ec2_jumpservers = {}
   }
+
+  # baseline config
+  production_config = {
+  }
 }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -212,37 +212,58 @@ locals {
         }
       }
     }
+  }
 
+  # baseline config
+  test_config = {
     baseline_lbs = {
-      # AWS doesn't let us call it internal
+      # AWS doesn't let us call it internal
       private = {
         internal_lb              = true
         enable_delete_protection = false
+        existing_target_groups   = local.existing_target_groups
         force_destroy_bucket     = true
         idle_timeout             = 3600
         public_subnets           = module.environment.subnets["private"].ids
         security_groups          = [aws_security_group.public.id]
 
-        # listeners = {
-        #   t1-nomis-web-http-7001 = merge(
-        #      local.lb_listener_defaults.http-7001, {
-        #       replace = {
-        #         target_group_name_replace     = "t1-nomis-web-internal"
-        #         condition_host_header_replace = "t1-nomis-web-internal"
-        #       }
-        #   })
+        listeners = {
+          #          t1-nomis-web-http-7001 = merge(
+          #            local.lb_listener_defaults.http-7001, {
+          #              replace = {
+          #                target_group_name_replace     = "t1-nomis-web-internal"
+          #                condition_host_header_replace = "t1-nomis-web-internal"
+          #              }
+          #          })
+          #          t1-nomis-web-http-7777 = merge(
+          #            local.lb_listener_defaults.http-7777, {
+          #              replace = {
+          #                target_group_name_replace     = "t1-nomis-web-internal"
+          #                condition_host_header_replace = "t1-nomis-web-internal"
+          #              }
+          #            }
+          #          )
+          #          t1-nomis-web-https = merge(
+          #            local.lb_listener_defaults.https,
+          #            local.lb_listener_defaults.route53, {
+          #              replace = {
+          #                target_group_name_replace     = "t1-nomis-web-internal"
+          #                condition_host_header_replace = "t1-nomis-web-internal"
+          #                route53_record_name_replace   = "t1-nomis-web-internal"
+          #              }
+          #          })
+        }
+
+        # public LB not needed right now
+        # public = {
+        #   internal_lb              = false
+        #   enable_delete_protection = false
+        #   force_destroy_bucket     = true
+        #   idle_timeout             = 3600
+        #   public_subnets           = module.environment.subnets["public"].ids
+        #   security_groups          = [aws_security_group.public.id]
         # }
       }
-
-      # public LB not needed right now
-      # public = {
-      #   internal_lb              = false
-      #   enable_delete_protection = false
-      #   force_destroy_bucket     = true
-      #   idle_timeout             = 3600
-      #   public_subnets           = module.environment.subnets["public"].ids
-      #   security_groups          = [aws_security_group.public.id]
-      # }
     }
   }
 }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -3,6 +3,15 @@ locals {
   region              = "eu-west-2"
   availability_zone_1 = "eu-west-2a"
   availability_zone_2 = "eu-west-2b"
+
+  environment_configs = {
+    development   = local.development_config
+    test          = local.test_config
+    preproduction = local.preproduction_config
+    production    = local.production_config
+  }
+  baseline_environment_config = local.environment_configs[local.environment]
+
   autoscaling_schedules_default = {
     "scale_up" = {
       recurrence = "0 7 * * Mon-Fri"

--- a/terraform/modules/baseline/lb.tf
+++ b/terraform/modules/baseline/lb.tf
@@ -53,7 +53,7 @@ module "lb_listener" {
   business_unit          = var.environment.business_unit
   environment            = var.environment.environment
   load_balancer_arn      = module.lb[each.value.lb_application_name].load_balancer.arn
-  existing_target_groups = local.asg_target_groups
+  existing_target_groups = merge(local.asg_target_groups, var.lbs[each.value.lb_application_name].existing_target_groups)
   port                   = each.value.port
   protocol               = each.value.protocol
   ssl_policy             = each.value.ssl_policy
@@ -61,6 +61,7 @@ module "lb_listener" {
   default_action         = each.value.default_action
   rules                  = each.value.rules
   route53_records        = each.value.route53_records
+  replace                = each.value.replace
   tags                   = merge(local.tags, each.value.tags)
 
   depends_on = [

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -309,6 +309,7 @@ variable "lbs" {
     internal_lb              = optional(bool, false)
     security_groups          = list(string)
     public_subnets           = list(string)
+    existing_target_groups   = optional(map(any), {})
     tags                     = optional(map(string), {})
     listeners = optional(map(object({
       port             = number


### PR DESCRIPTION
Create ACM certs via baseline module.
Allow target groups created outside of baseline module to be referenced.
Created separate config block for baseline to avoid circular dependencies (only required until ASGs moved across)