### PR TITLE
Nit 546 - IAPS Server image specify version

### DIFF
--- a/terraform/environments/delius-iaps/application_variables.json
+++ b/terraform/environments/delius-iaps/application_variables.json
@@ -22,7 +22,8 @@
       "cloudwatch_agent_log_group_retention_period": "7",
       "iaps_ndelius_interface_url": "placeholder.nd.address",
       "iaps_im_interface_url": "placeholder.im.address",
-      "iaps_im_db_url": "placeholder.db.address"
+      "iaps_im_db_url": "placeholder.db.address",
+      "ec2_iaps_instance_ami_name": "delius_iaps_server_patch_2023-03-14T14:36:37.053Z"
     },
     "preproduction": {
       "short_environment_name": "preprod",
@@ -57,7 +58,6 @@
     }
   },
   "ec2_iaps_instance_label": "iaps-server",
-  "ec2_iaps_instance_ami_name": "delius_iaps_server_*",
   "ec2_iaps_instance_ami_owner": "core-shared-services-production",
   "ec2_iaps_instance_subnet_name": "private",
 

--- a/terraform/environments/delius-iaps/ec2-iaps-server.tf
+++ b/terraform/environments/delius-iaps/ec2-iaps-server.tf
@@ -231,8 +231,11 @@ module "ec2_iaps_server" {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
   }
 
-  name                          = local.application_data.ec2_iaps_instance_label
-  ami_name                      = local.application_data.ec2_iaps_instance_ami_name
+  name = local.application_data.ec2_iaps_instance_label
+  ami_name = try(
+    local.application_data.accounts[local.environment].ec2_iaps_instance_ami_name,
+    "delius_iaps_server_*"
+  )
   ami_owner                     = local.application_data.ec2_iaps_instance_ami_owner
   instance                      = local.iaps_server.instance
   user_data_raw                 = local.iaps_server.user_data_raw

--- a/terraform/environments/delius-iaps/ec2-iaps-server.tf
+++ b/terraform/environments/delius-iaps/ec2-iaps-server.tf
@@ -2,7 +2,6 @@
 # Local vars for ec2
 ##
 locals {
-
   ec2_tags = merge(local.tags, {
     Name = lower(format("%s-%s", local.application_name, local.environment))
   })
@@ -77,25 +76,8 @@ locals {
       aws_iam_policy.ssm_least_privilege_policy.arn,
       "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" # Managed policy for cloudwatch agent to talk to CloudWatch
     ]
-
   }
-
 }
-
-##
-# Data
-## 
-# Can use aws ec2 describe-images --filters "Name=owner-id,Values=374269020027" --filters "Name=description,Values='Delius IAPS server'" --query 'reverse(sort_by(Images, &CreationDate))[0].[Name,ImageId]' to test
-# data "aws_ami" "delius_iaps_server" {
-#   most_recent = true
-
-#   filter {
-#     name   = "name"
-#     values = ["${local.application_data.accounts}*"]
-#   }
-
-#   owners = [local.environment_management.account_ids["core-shared-services-production"]]
-# }
 
 ##
 # Resources - Dependencies for ASG and launch template
@@ -237,28 +219,6 @@ resource "aws_iam_policy" "ssm_least_privilege_policy" {
     },
   )
 }
-# resource "aws_iam_role" "iaps_ec2_role" {
-#   name                = "iaps_ec2_role"
-#   assume_role_policy  = data.aws_iam_policy_document.iaps_ec2_assume_role_policy.json
-#   managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-#   inline_policy {
-#     name   = "IapsEc2Policy"
-#     policy = data.aws_iam_policy_document.iaps_ec2_policy.json
-#   }
-#   tags = merge(
-#     local.ec2_tags,
-#     {
-#       Name = "iaps_ec2_role"
-#     },
-#   )
-# }
-
-# resource "aws_iam_instance_profile" "iaps_ec2_profile" {
-#   name = "iaps_ec2_profile"
-#   role = aws_iam_role.iaps_ec2_role.name
-# }
-
-
 
 ##
 # Resources - Create ASG and launch template using module
@@ -282,17 +242,6 @@ module "ec2_iaps_server" {
   ssm_parameters                = null
   autoscaling_group             = local.iaps_server.autoscaling_group
   autoscaling_schedules         = {}
-  # NOMIS example 
-  # autoscaling_schedules = coalesce(lookup(each.value, "autoscaling_schedules", null), {
-  #   # if sizes not set, use the values defined in autoscaling_group
-  #   "scale_up" = {
-  #     recurrence = "0 7 * * Mon-Fri"
-  #   }
-  #   "scale_down" = {
-  #     desired_capacity = lookup(each.value, "offpeak_desired_capacity", 0)
-  #     recurrence       = "0 19 * * Mon-Fri"
-  #   }
-  # })
 
   instance_profile_policies = local.iaps_server.iam_policies
   application_name          = local.application_name


### PR DESCRIPTION
NIT-546 -  Specify version for IAPS server AMI.
Time stamp information already included in the name, so we can use that.

Set the version as an application variable per environment. If it's not specified, then use the latest using _*