### PR TITLE
NIT-589: add ecs:TagResource permission

### DIFF
--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -214,6 +214,7 @@ resource "aws_iam_policy" "ec2_instance_policy" { #tfsec:ignore:aws-iam-no-polic
                 "ecs:StartTelemetrySession",
                 "ecs:UpdateContainerInstancesState",
                 "ecs:Submit*",
+		 "ecs:TagResource",
                 "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
add `ecs:TagResource` permission to allow the Amazon ECS container agent to tag cluster on creation and to tag container instances when they are registered to a cluster.