### PR TITLE
Nomis: DSOS-1816: fixngo dns forwarding

### DIFF
--- a/terraform/environments/nomis-combined-reporting/baseline.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline.tf
@@ -17,6 +17,7 @@ module "baseline" {
   iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
   key_pairs                = module.baseline_presets.key_pairs
   kms_grants               = module.baseline_presets.kms_grants
+  route53_resolvers        = module.baseline_presets.route53_resolvers
   s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
 
   ec2_instances          = lookup(local.environment_config, "baseline_ec2_instances", {})

--- a/terraform/environments/nomis-combined-reporting/baseline_presets.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline_presets.tf
@@ -1,7 +1,8 @@
 module "baseline_presets" {
   source = "../../modules/baseline_presets"
 
-  environment = module.environment
+  environment  = module.environment
+  ip_addresses = module.ip_addresses
 
   options = {
     enable_application_environment_wildcard_cert = true
@@ -10,5 +11,10 @@ module "baseline_presets" {
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+
+    # comment this in if you need to resolve FixNGo hostnames
+    # route53_resolver_rules = {
+    #   outbound-data-and-private-subnets = ["azure-fixngo-domain"]
+    # }
   }
 }

--- a/terraform/environments/nomis-data-hub/baseline.tf
+++ b/terraform/environments/nomis-data-hub/baseline.tf
@@ -17,6 +17,7 @@ module "baseline" {
   iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
   key_pairs                = module.baseline_presets.key_pairs
   kms_grants               = module.baseline_presets.kms_grants
+  route53_resolvers        = module.baseline_presets.route53_resolvers
   s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
 
   ec2_instances          = lookup(local.environment_config, "baseline_ec2_instances", {})

--- a/terraform/environments/nomis-data-hub/baseline_presets.tf
+++ b/terraform/environments/nomis-data-hub/baseline_presets.tf
@@ -1,7 +1,8 @@
 module "baseline_presets" {
   source = "../../modules/baseline_presets"
 
-  environment = module.environment
+  environment  = module.environment
+  ip_addresses = module.ip_addresses
 
   options = {
     enable_application_environment_wildcard_cert = true
@@ -10,5 +11,10 @@ module "baseline_presets" {
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+
+    # comment this in if you need to resolve FixNGo hostnames
+    # route53_resolver_rules = {
+    #   outbound-data-and-private-subnets = ["azure-fixngo-domain"]
+    # }
   }
 }

--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -20,6 +20,6 @@ module "baseline" {
   # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.baseline_environment_config, "baseline_s3_buckets", {}))
   # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
   # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
-  route53_resolvers = lookup(local.baseline_environment_config, "baseline_route53_resolvers", {})
+  route53_resolvers = module.baseline_presets.route53_resolvers
   lbs               = lookup(local.baseline_environment_config, "baseline_lbs", {})
 }

--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -20,5 +20,6 @@ module "baseline" {
   # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.baseline_environment_config, "baseline_s3_buckets", {}))
   # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
   # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
-  lbs = lookup(local.baseline_environment_config, "baseline_lbs", {})
+  route53_resolvers = lookup(local.baseline_environment_config, "baseline_route53_resolvers", {})
+  lbs               = lookup(local.baseline_environment_config, "baseline_lbs", {})
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -1,7 +1,8 @@
 module "baseline_presets" {
   source = "../../modules/baseline_presets"
 
-  environment = module.environment
+  environment  = module.environment
+  ip_addresses = module.ip_addresses
 
   options = {
     enable_application_environment_wildcard_cert = true
@@ -9,6 +10,9 @@ module "baseline_presets" {
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
-    s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+    route53_resolver_rules = {
+      outbound-data-and-private-subnets = ["azure-fixngo-domain"]
+    }
+    s3_iam_policies = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
   }
 }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -158,7 +158,7 @@ locals {
   # baseline config
   test_config = {
     baseline_route53_resolvers = {
-      outbound = {
+      nomis-outbound = {
         forward = {
           "azure.noms.root" = {
             target_ips = module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -157,6 +157,16 @@ locals {
 
   # baseline config
   test_config = {
+    baseline_route53_resolvers = {
+      outbound = {
+        forward = {
+          "azure.noms.root" = {
+            target_ips = module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers
+          }
+        }
+      }
+    }
+
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -157,15 +157,6 @@ locals {
 
   # baseline config
   test_config = {
-    baseline_route53_resolvers = {
-      nomis-outbound = {
-        forward = {
-          "azure.noms.root" = {
-            target_ips = module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers
-          }
-        }
-      }
-    }
 
     baseline_lbs = {
       # AWS doesn't let us call it internal

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -38,6 +38,7 @@ module "baseline" {
   iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
   key_pairs                = module.baseline_presets.key_pairs
   kms_grants               = module.baseline_presets.kms_grants
+  route53_resolvers        = module.baseline_presets.route53_resolvers
   # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
 
   bastion_linux = lookup(local.environment_config, "baseline_bastion_linux", null)
@@ -51,7 +52,8 @@ module "baseline" {
 module "baseline_presets" {
   source = "../../modules/baseline_presets"
 
-  environment = module.environment
+  environment  = module.environment
+  ip_addresses = module.ip_addresses
 
   options = {
     enable_application_environment_wildcard_cert = true
@@ -61,6 +63,11 @@ module "baseline_presets" {
     enable_ec2_self_provision                    = true
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
   }
+
+  # comment this in if you need to resolve FixNGo hostnames
+  # route53_resolver_rules = {
+  #   outbound-data-and-private-subnets = ["azure-fixngo-domain"]
+  # }
 }
 
 

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -49,6 +49,22 @@ output "lbs" {
   }
 }
 
+output "route53_resolvers_security_group" {
+  description = "security group used for route53 resolvers"
+  value       = length(aws_security_group.route53_resolver) != 0 ? aws_security_group.route53_resolver[0] : null
+}
+
+output "route53_resolvers" {
+  description = "map of route53 resolvers and rules corresponding to var.route53_resolvers"
+  value = {
+    for resolver_key, resolver_value in var.route53_resolvers : resolver_key => merge(aws_route53_resolver_endpoint.this[resolver_key], {
+      rules = {
+        for rule_key, rule_value in resolver_value.rules : rule_key => aws_route53_resolver_rule.this["${resolver_key}-${rule_key}"]
+      }
+    })
+  }
+}
+
 output "s3_buckets" {
   description = "map of s3_bucket outputs cooresponding to var.s3_buckets. Policies can be found in iam_policies output"
   value       = module.s3_bucket

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -61,9 +61,9 @@ resource "aws_security_group" "route53_resolver" {
   description = "${each.key} route53 resolver security group"
   vpc_id      = var.environment.vpc.id
 
-  tags = merge(local.tags, {
-    Name = "${each.key}-route53-resolver"
-  })
+  #  tags = merge(local.tags, {
+  #    Name = "${each.key}-route53-resolver"
+  #  })
 }
 
 resource "aws_security_group_rule" "route53_resolver" {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -130,3 +130,12 @@ resource "aws_route53_resolver_rule" "this" {
   #   Name = each.value.name
   # })
 }
+
+resource "aws_route53_resolver_rule_association" "this" {
+  for_each = local.route53_resolver_rules
+
+  provider = aws.core-vpc
+
+  resolver_rule_id = aws_route53_resolver_rule.this[each.key].id
+  vpc_id           = var.environment.vpc.id
+}

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -1,0 +1,91 @@
+locals {
+  route53_security_groups = length(var.route53_resolvers) != 0 ? {
+    route53-resolver = {
+      description = "Security group for Route53 resolver"
+      ingress     = {}
+      egress = {
+        dns-tcp = {
+          description = "Allow tcp/53 egress"
+          from_port   = 53
+          to_port     = 53
+          protocol    = "tcp"
+          cidr_blocks = [var.environment.vpc.cidr_block]
+        }
+        dns-udp = {
+          description = "Allow udp/53 egress"
+          from_port   = 53
+          to_port     = 53
+          protocol    = "udp"
+          cidr_blocks = [var.environment.vpc.cidr_block]
+        }
+      }
+      tags = {}
+    }
+  } : {}
+
+  route53_resolver_rules_list = flatten([
+    for resolver_key, resolver_value in var.route53_resolvers : [
+      for rule_key, rule_value in resolver_value.forward : [{
+        key = "${resolver_key}-${rule_key}"
+        value = merge({
+          resolver_name = resolver_key
+          name          = replace(rule_key, ".", "-")
+          domain_name   = rule_key
+          rule_type     = "FORWARD"
+        }, rule_value)
+      }]
+    ]
+  ])
+
+  route53_resolver_rules = { for item in local.route53_resolver_rules_list :
+    item.key => item.value
+  }
+}
+
+resource "aws_route53_resolver_endpoint" "this" {
+  for_each = var.route53_resolvers
+
+  provider = aws.core-vpc
+
+  name      = each.key
+  direction = each.value.direction
+
+  security_group_ids = [aws_security_group.this["route53-resolver"].id]
+
+  dynamic "ip_address" {
+    for_each = flatten([for subnet_name in each.value.subnet_names :
+      var.environment.subnets[subnet_name].ids
+    ])
+
+    content {
+      subnet_id = ip_address.value
+    }
+  }
+
+  tags = merge(local.tags, {
+    Name = each.key
+  })
+}
+
+resource "aws_route53_resolver_rule" "this" {
+  for_each = local.route53_resolver_rules
+
+  provider = aws.core-vpc
+
+  domain_name = each.value.domain_name
+  name        = each.value.name
+  rule_type   = each.value.rule_type
+
+  resolver_endpoint_id = aws_route53_resolver_endpoint.this[each.value.resolver_name].id
+
+  dynamic "target_ip" {
+    for_each = each.value.target_ips
+    content {
+      ip = target_ip.value
+    }
+  }
+
+  tags = merge(local.tags, {
+    Name = each.value.name
+  })
+}

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -47,10 +47,9 @@ resource "aws_security_group" "route53_resolver" {
   description = "Route53 resolver security group for ${var.environment.application_name}"
   vpc_id      = var.environment.vpc.id
 
-  # member delegation roles can create the security group but can't currently tag it due to missing permissions
-  # tags = merge(local.tags, {
-  #   Name = "${var.environment.application_name}-route53-resolver"
-  # })
+  tags = merge(local.tags, {
+    Name = "${var.environment.application_name}-route53-resolver"
+  })
 }
 
 resource "aws_security_group_rule" "route53_resolver" {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -1,27 +1,37 @@
 locals {
-  route53_security_groups = length(var.route53_resolvers) != 0 ? {
-    route53-resolver = {
-      description = "Security group for Route53 resolver"
-      ingress     = {}
-      egress = {
-        dns-tcp = {
-          description = "Allow tcp/53 egress"
-          from_port   = 53
-          to_port     = 53
-          protocol    = "tcp"
-          cidr_blocks = [var.environment.vpc.cidr_block]
-        }
-        dns-udp = {
-          description = "Allow udp/53 egress"
-          from_port   = 53
-          to_port     = 53
-          protocol    = "udp"
-          cidr_blocks = [var.environment.vpc.cidr_block]
-        }
-      }
-      tags = {}
+  default_route53_resolver_security_groups_rules = {
+    dns-tcp = {
+      type        = "egress"
+      description = "Allow tcp/53 egress"
+      from_port   = 53
+      to_port     = 53
+      protocol    = "tcp"
+      cidr_blocks = [var.environment.vpc.cidr_block]
     }
-  } : {}
+    dns-udp = {
+      type        = "egress"
+      description = "Allow udp/53 egress"
+      from_port   = 53
+      to_port     = 53
+      protocol    = "udp"
+      cidr_blocks = [var.environment.vpc.cidr_block]
+    }
+  }
+
+  route53_resolver_security_groups_list = flatten([
+    for resolver_key, resolver_value in var.route53_resolvers : [
+      for sg_rule_key, sg_rule_value in merge(local.default_route53_resolver_security_groups_rules, resolver_value.security_group_rules) : [{
+        key = "${resolver_key}-${sg_rule_key}"
+        value = merge({
+          resolver_name = resolver_key
+        }, sg_rule_value)
+      }]
+    ]
+  ])
+
+  route53_resolver_security_group_rules = { for item in local.route53_resolver_security_groups_list :
+    item.key => item.value
+  }
 
   route53_resolver_rules_list = flatten([
     for resolver_key, resolver_value in var.route53_resolvers : [
@@ -42,6 +52,34 @@ locals {
   }
 }
 
+resource "aws_security_group" "route53_resolver" {
+  for_each = var.route53_resolvers
+
+  provider = aws.core-vpc
+
+  name        = "${each.key}-route53-resolver"
+  description = "${each.key} route53 resolver security group"
+  vpc_id      = var.environment.vpc.id
+
+  tags = merge(local.tags, {
+    Name = "${each.key}-route53-resolver"
+  })
+}
+
+resource "aws_security_group_rule" "route53_resolver" {
+  for_each = local.route53_resolver_security_group_rules
+
+  provider = aws.core-vpc
+
+  type              = each.value.type
+  description       = each.value.description
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  protocol          = each.value.protocol
+  cidr_blocks       = each.value.cidr_blocks
+  security_group_id = aws_security_group.route53_resolver[each.value.resolver_name].id
+}
+
 resource "aws_route53_resolver_endpoint" "this" {
   for_each = var.route53_resolvers
 
@@ -50,7 +88,7 @@ resource "aws_route53_resolver_endpoint" "this" {
   name      = each.key
   direction = each.value.direction
 
-  security_group_ids = [aws_security_group.this["route53-resolver"].id]
+  security_group_ids = [aws_security_group.route53_resolver[each.key].id]
 
   dynamic "ip_address" {
     for_each = flatten([for subnet_name in each.value.subnet_names :

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -50,7 +50,7 @@ resource "aws_security_group" "route53_resolver" {
   vpc_id      = var.environment.vpc.id
 
   tags = merge(local.tags, {
-    Name = "${each.key}-route53-resolver"
+    Name = "${var.environment.application_name}-route53-resolver"
   })
 }
 

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -61,6 +61,7 @@ resource "aws_security_group" "route53_resolver" {
   description = "${each.key} route53 resolver security group"
   vpc_id      = var.environment.vpc.id
 
+  # No tags as member-delegation roles don't currently have required permission
   #  tags = merge(local.tags, {
   #    Name = "${each.key}-route53-resolver"
   #  })
@@ -124,7 +125,8 @@ resource "aws_route53_resolver_rule" "this" {
     }
   }
 
-  tags = merge(local.tags, {
-    Name = each.value.name
-  })
+  # No tags as member-delegation roles don't currently have route53resolver:TagResource permission
+  # tags = merge(local.tags, {
+  #   Name = each.value.name
+  # })
 }

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -6,7 +6,7 @@ locals {
       from_port   = 53
       to_port     = 53
       protocol    = "tcp"
-      cidr_blocks = [var.environment.vpc.cidr_block]
+      cidr_blocks = ["0.0.0.0/0"]
     }
     dns-udp = {
       type        = "egress"
@@ -14,7 +14,7 @@ locals {
       from_port   = 53
       to_port     = 53
       protocol    = "udp"
-      cidr_blocks = [var.environment.vpc.cidr_block]
+      cidr_blocks = ["0.0.0.0/0"]
     }
   }
 

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -49,10 +49,9 @@ resource "aws_security_group" "route53_resolver" {
   description = "Route53 resolver security group for ${var.environment.application_name}"
   vpc_id      = var.environment.vpc.id
 
-  # No tags as member-delegation roles don't currently have required permission
-  #  tags = merge(local.tags, {
-  #    Name = "${each.key}-route53-resolver"
-  #  })
+  tags = merge(local.tags, {
+    Name = "${each.key}-route53-resolver"
+  })
 }
 
 resource "aws_security_group_rule" "route53_resolver" {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -62,9 +62,10 @@ resource "aws_route53_resolver_endpoint" "this" {
     }
   }
 
-  tags = merge(local.tags, {
-    Name = each.key
-  })
+  # No tags as member-delegation roles don't currently have route53resolver:TagResource permission
+  # tags = merge(local.tags, {
+  #   Name = each.key
+  # })
 }
 
 resource "aws_route53_resolver_rule" "this" {

--- a/terraform/modules/baseline/security_groups.tf
+++ b/terraform/modules/baseline/security_groups.tf
@@ -6,12 +6,10 @@ locals {
   # groups, and additional rules can be added elsewhere.
   # Unfortunately, the individual aws_security_group_rule doesn't allow combined 
   # self/cidr/security_groups to we split them out here.
-  #
-  security_groups = merge(local.route53_security_groups, var.security_groups)
 
   # flatten security group rules
   security_group_rule_list = [[
-    for sg_key, sg_value in local.security_groups : [
+    for sg_key, sg_value in var.security_groups : [
       for rule_key, rule_value in sg_value.ingress : {
         key = "${sg_key}-ingress-${rule_key}"
         value = merge(rule_value, {
@@ -20,7 +18,7 @@ locals {
         })
       }
     ]], [
-    for sg_key, sg_value in local.security_groups : [
+    for sg_key, sg_value in var.security_groups : [
       for rule_key, rule_value in sg_value.egress : {
         key = "${sg_key}-egress-${rule_key}"
         value = merge(rule_value, {
@@ -37,7 +35,7 @@ locals {
         cidr_blocks              = null
         source_security_group_id = null
       })
-    } if lookup(item.value, "self", null) != null
+    } if item.value.self != null
   ]
   security_group_rule_list_cidrs = [
     for item in flatten(local.security_group_rule_list) : {
@@ -46,18 +44,18 @@ locals {
         self                     = null
         source_security_group_id = null
       })
-    } if lookup(item.value, "cidr_blocks", null) != null
+    } if item.value.cidr_blocks != null
   ]
   security_group_rule_list_sgs = [
     for item in flatten(local.security_group_rule_list) : [
-      for security_group in lookup(item.value, "security_groups", null) != null ? item.value.security_groups : [] : {
+      for security_group in item.value.security_groups != null ? item.value.security_groups : [] : {
         key = "${item.key}-${security_group}"
         value = merge(item.value, {
           self                     = null
           cidr_blocks              = null
           source_security_group_id = security_group
         })
-      } if lookup(item.value, "security_groups", null) != null
+      } if item.value.security_groups != null
     ]
   ]
   security_group_rule_list_others = [
@@ -66,7 +64,7 @@ locals {
       value = merge(item.value, {
         source_security_group_id = null
       })
-    } if lookup(item.value, "self", null) == null && lookup(item.value, "cidr_blocks", null) == null && lookup(item.value, "security_groups", null) == null
+    } if item.value.self == null && item.value.cidr_blocks == null && item.value.security_groups == null
   ]
   security_group_rules = { for item in flatten([
     local.security_group_rule_list_self,
@@ -85,7 +83,7 @@ locals {
 }
 
 resource "aws_security_group" "this" {
-  for_each = local.security_groups
+  for_each = var.security_groups
 
   name        = each.key
   description = each.value.description
@@ -107,6 +105,6 @@ resource "aws_security_group_rule" "this" {
   cidr_blocks              = each.value.cidr_blocks
   source_security_group_id = each.value.source_security_group_id == null ? null : lookup(local.security_group_ids, each.value.source_security_group_id, each.value.source_security_group_id)
   self                     = each.value.self
-  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
+  prefix_list_ids          = each.value.prefix_list_ids
   security_group_id        = resource.aws_security_group.this[each.value.security_group_name].id
 }

--- a/terraform/modules/baseline/security_groups.tf
+++ b/terraform/modules/baseline/security_groups.tf
@@ -6,10 +6,12 @@ locals {
   # groups, and additional rules can be added elsewhere.
   # Unfortunately, the individual aws_security_group_rule doesn't allow combined 
   # self/cidr/security_groups to we split them out here.
+  #
+  security_groups = merge(local.route53_security_groups, var.security_groups)
 
   # flatten security group rules
   security_group_rule_list = [[
-    for sg_key, sg_value in var.security_groups : [
+    for sg_key, sg_value in local.security_groups : [
       for rule_key, rule_value in sg_value.ingress : {
         key = "${sg_key}-ingress-${rule_key}"
         value = merge(rule_value, {
@@ -18,7 +20,7 @@ locals {
         })
       }
     ]], [
-    for sg_key, sg_value in var.security_groups : [
+    for sg_key, sg_value in local.security_groups : [
       for rule_key, rule_value in sg_value.egress : {
         key = "${sg_key}-egress-${rule_key}"
         value = merge(rule_value, {
@@ -35,7 +37,7 @@ locals {
         cidr_blocks              = null
         source_security_group_id = null
       })
-    } if item.value.self != null
+    } if lookup(item.value, "self", null) != null
   ]
   security_group_rule_list_cidrs = [
     for item in flatten(local.security_group_rule_list) : {
@@ -44,18 +46,18 @@ locals {
         self                     = null
         source_security_group_id = null
       })
-    } if item.value.cidr_blocks != null
+    } if lookup(item.value, "cidr_blocks", null) != null
   ]
   security_group_rule_list_sgs = [
     for item in flatten(local.security_group_rule_list) : [
-      for security_group in item.value.security_groups != null ? item.value.security_groups : [] : {
+      for security_group in lookup(item.value, "security_groups", null) != null ? item.value.security_groups : [] : {
         key = "${item.key}-${security_group}"
         value = merge(item.value, {
           self                     = null
           cidr_blocks              = null
           source_security_group_id = security_group
         })
-      } if item.value.security_groups != null
+      } if lookup(item.value, "security_groups", null) != null
     ]
   ]
   security_group_rule_list_others = [
@@ -64,7 +66,7 @@ locals {
       value = merge(item.value, {
         source_security_group_id = null
       })
-    } if item.value.self == null && item.value.cidr_blocks == null && item.value.security_groups == null
+    } if lookup(item.value, "self", null) == null && lookup(item.value, "cidr_blocks", null) == null && lookup(item.value, "security_groups", null) == null
   ]
   security_group_rules = { for item in flatten([
     local.security_group_rule_list_self,
@@ -83,7 +85,7 @@ locals {
 }
 
 resource "aws_security_group" "this" {
-  for_each = var.security_groups
+  for_each = local.security_groups
 
   name        = each.key
   description = each.value.description
@@ -105,6 +107,6 @@ resource "aws_security_group_rule" "this" {
   cidr_blocks              = each.value.cidr_blocks
   source_security_group_id = each.value.source_security_group_id == null ? null : lookup(local.security_group_ids, each.value.source_security_group_id, each.value.source_security_group_id)
   self                     = each.value.self
-  prefix_list_ids          = each.value.prefix_list_ids
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
   security_group_id        = resource.aws_security_group.this[each.value.security_group_name].id
 }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -519,14 +519,6 @@ variable "route53_resolvers" {
   type = map(object({
     direction    = optional(string, "OUTBOUND")
     subnet_names = optional(list(string), ["data", "private"]) # NOTE: there's a quota of 6 cidrs / resolver
-    security_group_rules = optional(map(object({
-      type        = string
-      description = optional(string)
-      from_port   = number
-      to_port     = number
-      protocol    = string
-      cidr_blocks = optional(list(string))
-    })), {})
     forward = optional(map(object({
       target_ips = list(string) # domain_name is key to the map
     })), {})

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -515,12 +515,14 @@ variable "kms_grants" {
 }
 
 variable "route53_resolvers" {
-  description = "map of resolver endpoints and associated rules to configure"
+  description = "map of resolver endpoints and associated rules to configure, where map keys are the names of the resources.  The application name is automatically added as a prefix to the resource names"
   type = map(object({
     direction    = optional(string, "OUTBOUND")
     subnet_names = optional(list(string), ["data", "private"]) # NOTE: there's a quota of 6 cidrs / resolver
-    forward = optional(map(object({
-      target_ips = list(string) # domain_name is key to the map
+    rules = optional(map(object({
+      domain_name = string
+      rule_type   = optional(string, "FORWARD")
+      target_ips  = list(string)
     })), {})
   }))
   default = {}

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -518,7 +518,7 @@ variable "route53_resolvers" {
   description = "map of resolver endpoints and associated rules to configure"
   type = map(object({
     direction    = optional(string, "OUTBOUND")
-    subnet_names = optional(list(string), ["data", "private"])
+    subnet_names = optional(list(string), ["data", "private", "public"])
     forward = optional(map(object({
       target_ips = list(string) # domain_name is key to the map
     })), {})

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -514,6 +514,18 @@ variable "kms_grants" {
   default = {}
 }
 
+variable "route53_resolvers" {
+  description = "map of resolver endpoints and associated rules to configure"
+  type = map(object({
+    direction    = optional(string, "OUTBOUND")
+    subnet_names = optional(list(string), ["data", "private"])
+    forward = optional(map(object({
+      target_ips = list(string) # domain_name is key to the map
+    })), {})
+  }))
+  default = {}
+}
+
 variable "s3_buckets" {
   description = "map of s3 buckets to create where the map key is the bucket prefix.  See s3_bucket module for more variable details.  Use iam_policies to automatically create a iam policies for the bucket where the key is the name of the policy"
   type = map(object({

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -518,7 +518,7 @@ variable "route53_resolvers" {
   description = "map of resolver endpoints and associated rules to configure"
   type = map(object({
     direction    = optional(string, "OUTBOUND")
-    subnet_names = optional(list(string), ["data", "private", "public"])
+    subnet_names = optional(list(string), ["data", "private"]) # NOTE: there's a quota of 6 cidrs / resolver
     security_group_rules = optional(map(object({
       type        = string
       description = optional(string)

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -519,6 +519,14 @@ variable "route53_resolvers" {
   type = map(object({
     direction    = optional(string, "OUTBOUND")
     subnet_names = optional(list(string), ["data", "private", "public"])
+    security_group_rules = optional(map(object({
+      type        = string
+      description = optional(string)
+      from_port   = number
+      to_port     = number
+      protocol    = string
+      cidr_blocks = optional(list(string))
+    })), {})
     forward = optional(map(object({
       target_ips = list(string) # domain_name is key to the map
     })), {})

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -68,6 +68,16 @@ output "kms_grants" {
   }
 }
 
+output "route53_resolver_rules" {
+  description = "Map of route53 resolver rules depending on options provided"
+  value       = local.route53_resolver_rules
+}
+
+output "route53_resolvers" {
+  description = "Map of route53 resolvers to create depending on options provided"
+  value       = local.route53_resolvers
+}
+
 output "s3_bucket_policies" {
   description = "Map of common bucket policies to use on s3_buckets"
 

--- a/terraform/modules/baseline_presets/route53.tf
+++ b/terraform/modules/baseline_presets/route53.tf
@@ -1,0 +1,75 @@
+# Return resolver endpoint configuration depending on what has been passed in
+# via var.options.route53_resolver_rules.  For example, if you want to create 
+# a resolver for both data and private subnets with a forwarded to the 
+# azure-fixngo-domain, then configure like this
+#
+# options.route53_resolver_rules = {
+#   outbound-data-and-private-subnets = ["azure-fixngo-domain"]
+# }
+#
+# If you just want to forward on private subnets, configure like this
+#
+# options.route53_resolver_rules = {
+#   outbound-private-subnets = ["azure-fixngo-domain"]
+# }
+
+locals {
+
+  route53_resolver_rules_all = {
+    azure-fixngo-devtest-domain = {
+      domain_name = "azure.noms.root"
+      target_ips  = var.ip_addresses.azure_fixngo_ips.devtest.domain_controllers
+      rule_type   = "FORWARD"
+    }
+    azure-fixngo-production-domain = {
+      domain_name = "azure.hmpp.root"
+      target_ips  = var.ip_addresses.azure_fixngo_ips.prod.domain_controllers
+      rule_type   = "FORWARD"
+    }
+  }
+
+  route53_resolvers_rules_by_environment = {
+    development = {
+      azure-fixngo-domain = local.route53_resolver_rules_all.azure-fixngo-devtest-domain
+    }
+    test = {
+      azure-fixngo-domain = local.route53_resolver_rules_all.azure-fixngo-devtest-domain
+    }
+    preproduction = {
+      azure-fixngo-domain = local.route53_resolver_rules_all.azure-fixngo-production-domain
+    }
+    production = {
+      azure-fixngo-domain = local.route53_resolver_rules_all.azure-fixngo-production-domain
+    }
+  }
+
+  route53_resolver_rules = {
+    for rule_key, rules_filter in var.options.route53_resolver_rules : rule_key => {
+      for key, value in local.route53_resolvers_rules_by_environment[var.environment.environment] : key => value if contains(rules_filter, key)
+    }
+  }
+
+  route53_resolver_list = flatten([
+    try(length(local.route53_resolver_rules["outbound-data-and-private-subnets"]), 0) != 0 ? [{
+      key = "outbound-data-and-private-subnets"
+      value = {
+        direction    = "OUTBOUND"
+        subnet_names = ["data", "private"]
+        rules        = local.route53_resolver_rules["outbound-data-and-private-subnets"]
+      }
+    }] : [],
+    try(length(local.route53_resolver_rules["outbound-private-subnets"]), 0) != 0 ? [{
+      key = "outbound-private-subnets"
+      value = {
+        direction    = "OUTBOUND"
+        subnet_names = ["private"]
+        rules        = local.route53_resolver_rules["outbound-private-subnets"]
+      }
+    }] : [],
+  ])
+
+  route53_resolvers = {
+    for item in local.route53_resolver_list : item.key => item.value
+  }
+}
+

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -2,6 +2,10 @@ variable "environment" {
   description = "Standard environmental data resources from the environment module"
 }
 
+variable "ip_addresses" {
+  description = "ip address resources from the ip_address module"
+}
+
 variable "options" {
   description = "Map of options controlling what resources to return"
   type = object({
@@ -11,6 +15,7 @@ variable "options" {
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)
     enable_ec2_self_provision                    = optional(bool, false)
+    route53_resolver_rules                       = optional(map(list(string)), {})
     s3_iam_policies                              = optional(list(string))
   })
 }

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -1,5 +1,36 @@
 locals {
 
+  azure_fixngo_ip = {
+    # Prod Domain Controllers
+    PCMCW0011 = "10.40.128.196"
+    PCMCW0012 = "10.40.0.133"
+    pcmcw1011 = "10.40.144.196"
+    pcmcw1012 = "10.40.64.133"
+
+    # DevTest Domain Controllers
+    MGMCW0002    = "10.102.0.196"
+    tc_mgt_dc_01 = "10.102.0.199"
+    tc_mgt_dc_02 = "10.102.0.200"
+  }
+
+  azure_fixngo_ips = {
+    devtest = {
+      domain_controllers = [
+        local.azure_fixngo_ip.MGMCW0002,
+        local.azure_fixngo_ip.tc_mgt_dc_01,
+        local.azure_fixngo_ip.tc_mgt_dc_02,
+      ]
+    }
+    prod = {
+      domain_controllers = [
+        local.azure_fixngo_ip.PCMCW0011,
+        local.azure_fixngo_ip.PCMCW0012,
+        local.azure_fixngo_ip.pcmcw1011,
+        local.azure_fixngo_ip.pcmcw1012,
+      ]
+    }
+  }
+
   azure_fixngo_cidr = {
     noms_live_vnet            = "10.40.0.0/18"
     noms_live_dr_vnet         = "10.40.64.0/18"

--- a/terraform/modules/ip_addresses/outputs.tf
+++ b/terraform/modules/ip_addresses/outputs.tf
@@ -8,6 +8,16 @@ output "moj_cidrs" {
   description = "MoJ Infrastructure aggregate cidrs: map(list(string))"
 }
 
+output "azure_fixngo_ip" {
+  value       = local.azure_fixngo_ip
+  description = "Azure FixNGo ips: map(string)"
+}
+
+output "azure_fixngo_ips" {
+  value       = local.azure_fixngo_ips
+  description = "Azure FixNGo aggregate ips: map(list(string))"
+}
+
 output "azure_fixngo_cidr" {
   value       = local.azure_fixngo_cidr
   description = "Azure FixNGo cidrs: map(string)"


### PR DESCRIPTION
Added configuration to forward DNS requests for Azure hosts to Azure domain controllers via baseline module.
- added FixNGo domain controller details into ip_addresses module
- baseline presets now takes ip_addresses module output as a parameter, so it can use common IPs
- added route53 forwarding configuration to baseline
- added FixNGo route53 forwarding config into baseline_presets
- enable for nomis account only at the moment, but likely to be needed for other accounts.
