### PR TITLE
Adding an web-identity-assumable role to be used instead of cicd-member-user keys.

### DIFF
--- a/terraform/environments/data-platform/data-platform-labs-oidc.tf
+++ b/terraform/environments/data-platform/data-platform-labs-oidc.tf
@@ -1,8 +1,0 @@
-module "github_actions_roles" {
-  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
-  github_repositories = local.oidc_repositories
-  role_name           = "data-platform-labs-github-actions"
-  policy_arns         = local.oidc_default_policy_arns
-  policy_jsons        = [data.aws_iam_policy.cicd_member_policy.policy]
-  tags                = local.tags
-}

--- a/terraform/environments/data-platform/data-platform-labs-oidc.tf
+++ b/terraform/environments/data-platform/data-platform-labs-oidc.tf
@@ -1,6 +1,6 @@
 module "github_actions_roles" {
   source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
-  github_repositories = local.repositories
+  github_repositories = local.oidc_repositories
   role_name           = "data-platform-labs-github-actions"
   policy_arns         = local.oidc_default_policy_arns
   policy_jsons        = [data.aws_iam_policy.cicd_member_policy.policy]

--- a/terraform/environments/data-platform/data-platform-labs-oidc.tf
+++ b/terraform/environments/data-platform/data-platform-labs-oidc.tf
@@ -1,0 +1,8 @@
+module "github_actions_roles" {
+  source              = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
+  github_repositories = local.repositories
+  role_name           = "data-platform-labs-github-actions"
+  policy_arns         = local.oidc_default_policy_arns
+  policy_jsons        = [data.aws_iam_policy.cicd_member_policy.policy]
+  tags                = local.tags
+}

--- a/terraform/environments/data-platform/data.tf
+++ b/terraform/environments/data-platform/data.tf
@@ -1,1 +1,4 @@
 #### This file can be used to store data specific to the member account ####
+data "aws_iam_policy" "cicd_member_policy" {
+  name = "cicd-member-policy"
+}

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -1,1 +1,5 @@
 #### This file can be used to store locals specific to the member account ####
+locals {
+  oidc_repositories        = ["ministryofjustice/data-platform-products:*"]
+  oidc_default_policy_arns = ["arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"]
+}


### PR DESCRIPTION
This PR creates a web-identity-assumable role with the cicd-member-policy and the AmazonEC2ReadOnlyAccess managed policies. It utilises the modernisation platform oidc role 
module to create the needed resources. The repositories are listed in a local.
