### PR TITLE
Nomis: DSOS-1831: create az zones

### DIFF
--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -10,7 +10,7 @@ module "baseline" {
   environment = module.environment
 
   # security_groups          = local.baseline_security_groups
-  acm_certificates = module.baseline_presets.acm_certificates
+  acm_certificates = merge(module.baseline_presets.acm_certificates, local.baseline_acm_certificates)
   # cloudwatch_log_groups    = module.baseline_presets.cloudwatch_log_groups
   # iam_policies             = module.baseline_presets.iam_policies
   # iam_roles                = module.baseline_presets.iam_roles

--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -21,6 +21,6 @@ module "baseline" {
   # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
   # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
   route53_resolvers = module.baseline_presets.route53_resolvers
-  route53_zones     = lookup(local.baseline_environment_config, "baseline_route53_zones", {})
+  route53_zones     = merge(local.baseline_route53_zones, lookup(local.baseline_environment_config, "baseline_route53_zones", {}))
   lbs               = lookup(local.baseline_environment_config, "baseline_lbs", {})
 }

--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -21,5 +21,6 @@ module "baseline" {
   # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
   # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
   route53_resolvers = module.baseline_presets.route53_resolvers
+  route53_zones     = lookup(local.baseline_environment_config, "baseline_route53_zones", {})
   lbs               = lookup(local.baseline_environment_config, "baseline_lbs", {})
 }

--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -10,7 +10,7 @@ module "baseline" {
   environment = module.environment
 
   # security_groups          = local.baseline_security_groups
-  acm_certificates = merge(module.baseline_presets.acm_certificates, local.baseline_acm_certificates)
+  acm_certificates = module.baseline_presets.acm_certificates
   # cloudwatch_log_groups    = module.baseline_presets.cloudwatch_log_groups
   # iam_policies             = module.baseline_presets.iam_policies
   # iam_roles                = module.baseline_presets.iam_roles

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -50,9 +50,10 @@ locals {
     route53 = {
       route53_records = {
         "$(name).nomis" = {
-          account                = "core-vpc"
-          zone_id                = module.environment.route53_zones[module.environment.domains.public.business_unit_environment].zone_id
-          evaluate_target_health = true
+          zone_name              = module.environment.domains.public.business_unit_environment
+        }
+        "$(name)" = {
+          zone_name              = "${local.environment}.nomis.az.justice.gov.uk"
         }
       }
     }

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -50,10 +50,10 @@ locals {
     route53 = {
       route53_records = {
         "$(name).nomis" = {
-          zone_name              = module.environment.domains.public.business_unit_environment
+          zone_name = module.environment.domains.public.business_unit_environment
         }
         "$(name)" = {
-          zone_name              = "${local.environment}.nomis.az.justice.gov.uk"
+          zone_name = "${local.environment}.nomis.az.justice.gov.uk"
         }
       }
     }
@@ -108,7 +108,10 @@ locals {
           }]
           conditions = [{
             host_header = {
-              values = ["$(name).nomis.${module.environment.vpc_name}.modernisation-platform.service.justice.gov.uk"]
+              values = [
+                "$(name).nomis.${module.environment.domains.public.business_unit_environment}",
+                "$(name).${local.environment}.nomis.az.justice.gov.uk"
+              ]
             }
           }]
         }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -158,14 +158,6 @@ locals {
   # baseline config
   test_config = {
 
-    baseline_route53_zones = {
-      "${local.environment}.nomis.az.justice.gov.uk" = {
-        lb_alias_records = [
-          { name = "t1-nomis-web", type = "A", lbs_map_key = "private" }
-        ]
-      }
-    }
-
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -158,6 +158,14 @@ locals {
   # baseline config
   test_config = {
 
+    baseline_route53_zones = {
+      "${local.environment}.nomis.az.justice.gov.uk" = {
+        lb_alias_records = [
+          { name = "t1-nomis-web", type = "A", lbs_map_key = "private" }
+        ]
+      }
+    }
+
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -16,36 +16,6 @@ locals {
     "${local.environment}.nomis.az.justice.gov.uk" = {}
   }
 
-  baseline_acm_certificates = {
-    nomis_wildcard_cert = {
-      # domain_name limited to 64 chars so use modernisation platform domain for this
-      # and put the wildcard in the san
-      domain_name = module.environment.domains.public.modernisation_platform
-      subject_alternate_names = [
-        "*.${module.environment.domains.public.application_environment}",
-        "*.${local.environment}.nomis.az.justice.gov.uk"
-      ]
-
-      validation = {
-        "${module.environment.domains.public.modernisation_platform}" = {
-          account   = "core-network-services"
-          zone_name = "${module.environment.domains.public.modernisation_platform}."
-        }
-        "*.${module.environment.domains.public.application_environment}" = {
-          account   = "core-vpc"
-          zone_name = "${module.environment.domains.public.business_unit_environment}."
-        }
-        "*.${local.environment}.nomis.az.justice.gov.uk" = {
-          account   = "self"
-          zone_name = "${local.environment}.nomis.az.justice.gov.uk."
-        }
-      }
-      tags = {
-        description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
-      }
-    }
-  }
-
   autoscaling_schedules_default = {
     "scale_up" = {
       recurrence = "0 7 * * Mon-Fri"

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -16,6 +16,36 @@ locals {
     "${local.environment}.nomis.az.justice.gov.uk" = {}
   }
 
+  baseline_acm_certificates = {
+    nomis_wildcard_cert = {
+      # domain_name limited to 64 chars so use modernisation platform domain for this
+      # and put the wildcard in the san
+      domain_name = module.environment.domains.public.modernisation_platform
+      subject_alternate_names = [
+        "*.${module.environment.domains.public.application_environment}",
+        "*.${local.environment}.nomis.az.justice.gov.uk"
+      ]
+
+      validation = {
+        "${module.environment.domains.public.modernisation_platform}" = {
+          account   = "core-network-services"
+          zone_name = "${module.environment.domains.public.modernisation_platform}."
+        }
+        "*.${module.environment.domains.public.application_environment}" = {
+          account   = "core-vpc"
+          zone_name = "${module.environment.domains.public.business_unit_environment}."
+        }
+        "*.${local.environment}.nomis.az.justice.gov.uk" = {
+          account   = "self"
+          zone_name = "${local.environment}.nomis.az.justice.gov.uk."
+        }
+      }
+      tags = {
+        description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
+      }
+    }
+  }
+
   autoscaling_schedules_default = {
     "scale_up" = {
       recurrence = "0 7 * * Mon-Fri"

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -12,6 +12,10 @@ locals {
   }
   baseline_environment_config = local.environment_configs[local.environment]
 
+  baseline_route53_zones = {
+    "${local.environment}.nomis.az.justice.gov.uk" = {}
+  }
+
   autoscaling_schedules_default = {
     "scale_up" = {
       recurrence = "0 7 * * Mon-Fri"

--- a/terraform/environments/nomis/outputs.tf
+++ b/terraform/environments/nomis/outputs.tf
@@ -1,0 +1,4 @@
+output "route53_zone_ns_records" {
+  description = "NS records of created zones"
+  value       = { for key, value in module.baseline.route53_zones : key => value.name_servers }
+}

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -65,6 +65,11 @@ output "route53_resolvers" {
   }
 }
 
+output "route53_zones" {
+  description = "map of any created route53 zones"
+  value       = aws_route53_zone.this
+}
+
 output "s3_buckets" {
   description = "map of s3_bucket outputs cooresponding to var.s3_buckets. Policies can be found in iam_policies output"
   value       = module.s3_bucket

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -1,9 +1,14 @@
 locals {
 
   # exclude any zones that already exist
-  route53_zones = { for zone_name, zone_value in var.route53_zones :
+  route53_zones_to_create = { for zone_name, zone_value in var.route53_zones :
     zone_name => zone_value if !contains(keys(var.environment.route53_zones), zone_name)
   }
+
+  # combine route53 zones into single map
+  route53_zones = merge(var.environment.route53_zones, {
+    for key, value in aws_route53_zone.this : key => merge(value, { provider = "self" })
+  })
 
   route53_records_list = flatten([
     for zone_name, zone_value in var.route53_zones : [
@@ -11,19 +16,80 @@ locals {
         key = "${record.name}.${zone_name}-${record.type}"
         value = merge(record, {
           zone_key = zone_name
-          provider = try(var.environment.route53_zones[zone_name].provider, "self")
+          provider = local.route53_zones[zone_name].provider
+          alias    = null
         })
       }]
     ]
   ])
 
-  route53_records_self = { for item in local.route53_records_list :
+  route53_ns_records_list = flatten([
+    for zone_name, zone_value in var.route53_zones : [
+      for record in zone_value.ns_records : [{
+        key = "${record.name}.${zone_name}-${record.type}"
+        value = merge(record, {
+          zone_key = zone_name
+          provider = local.route53_zones[zone_name].provider
+          type     = "NS"
+          records  = local.route53_zones[zone_name].name_servers
+          alias    = null
+        })
+      }]
+    ]
+  ])
+
+  route53_lb_alias_records_list = flatten([
+    for zone_name, zone_value in var.route53_zones : [
+      for record in zone_value.lb_alias_records : [{
+        key = "${record.name}.${zone_name}-${record.type}"
+        value = merge(record, {
+          zone_key = zone_name
+          provider = local.route53_zones[zone_name].provider
+          ttl      = null
+          records  = null
+          alias = {
+            name                   = module.lb[record.lbs_map_key].load_balancer.dns_name
+            zone_id                = module.lb[record.lbs_map_key].load_balancer.zone_id
+            evaluate_target_health = record.evaluate_target_health
+          }
+        })
+      }]
+    ]
+  ])
+
+  route53_s3_alias_records_list = flatten([
+    for zone_name, zone_value in var.route53_zones : [
+      for record in zone_value.s3_alias_records : [{
+        key = "${record.name}.${zone_name}-${record.type}"
+        value = merge(record, {
+          zone_key = zone_name
+          provider = local.route53_zones[zone_name].provider
+          ttl      = null
+          records  = null
+          alias = {
+            name                   = module.s3_bucket[record.s3_bucket_map_key].bucket.bucket_domain_name
+            zone_id                = module.s3_bucket[record.s3_bucket_map_key].bucket.hosted_zone_id
+            evaluate_target_health = record.evaluate_target_health
+          }
+        })
+      }]
+    ]
+  ])
+
+  route53_records_all = concat(
+    local.route53_records_list,
+    local.route53_ns_records_list,
+    local.route53_lb_alias_records_list,
+    local.route53_s3_alias_records_list
+  )
+
+  route53_records_self = { for item in local.route53_records_all :
     item.key => item.value if item.value.provider == "self"
   }
-  route53_records_core_vpc = { for item in local.route53_records_list :
+  route53_records_core_vpc = { for item in local.route53_records_all :
     item.key => item.value if item.value.provider == "core-vpc"
   }
-  route53_records_core_network_services = { for item in local.route53_records_list :
+  route53_records_core_network_services = { for item in local.route53_records_all :
     item.key => item.value if item.value.provider == "core-network-services"
   }
 
@@ -64,7 +130,7 @@ locals {
 }
 
 resource "aws_route53_zone" "this" {
-  for_each = local.route53_zones
+  for_each = local.route53_zones_to_create
 
   name = each.key
   tags = merge(local.tags, {
@@ -75,11 +141,20 @@ resource "aws_route53_zone" "this" {
 resource "aws_route53_record" "self" {
   for_each = local.route53_records_self
 
-  zone_id = aws_route53_zone.this[each.value.zone_key].zone_id
+  zone_id = local.route53_zones[each.value.zone_key].zone_id
   name    = each.value.name
   type    = each.value.type
   ttl     = each.value.ttl
   records = each.value.records
+
+  dynamic "alias" {
+    for_each = each.value.alias != null ? [each.value.alias] : []
+    content {
+      name                   = alias.value.name
+      zone_id                = alias.value.zone_id
+      evaluate_target_health = alias.value.evaluate_target_health
+    }
+  }
 }
 
 resource "aws_route53_record" "core_vpc" {
@@ -87,7 +162,7 @@ resource "aws_route53_record" "core_vpc" {
 
   provider = aws.core-vpc
 
-  zone_id = var.environment.route53_zones[each.value.zone_key].zone_id
+  zone_id = local.route53_zones[each.value.zone_key].zone_id
   name    = each.value.name
   type    = each.value.type
   ttl     = each.value.ttl
@@ -99,7 +174,7 @@ resource "aws_route53_record" "core_network_services" {
 
   provider = aws.core-network-services
 
-  zone_id = var.environment.route53_zones[each.value.zone_key].zone_id
+  zone_id = local.route53_zones[each.value.zone_key].zone_id
   name    = each.value.name
   type    = each.value.type
   ttl     = each.value.ttl

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -167,6 +167,15 @@ resource "aws_route53_record" "core_vpc" {
   type    = each.value.type
   ttl     = each.value.ttl
   records = each.value.records
+
+  dynamic "alias" {
+    for_each = each.value.alias != null ? [each.value.alias] : []
+    content {
+      name                   = alias.value.name
+      zone_id                = alias.value.zone_id
+      evaluate_target_health = alias.value.evaluate_target_health
+    }
+  }
 }
 
 resource "aws_route53_record" "core_network_services" {
@@ -179,6 +188,15 @@ resource "aws_route53_record" "core_network_services" {
   type    = each.value.type
   ttl     = each.value.ttl
   records = each.value.records
+
+  dynamic "alias" {
+    for_each = each.value.alias != null ? [each.value.alias] : []
+    content {
+      name                   = alias.value.name
+      zone_id                = alias.value.zone_id
+      evaluate_target_health = alias.value.evaluate_target_health
+    }
+  }
 }
 
 # Create single security group to cover all resolvers

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -528,6 +528,23 @@ variable "route53_zones" {
       ttl     = number
       records = list(string)
     })), [])
+    ns_records = optional(list(object({
+      name      = string
+      ttl       = number
+      zone_name = string
+    })), [])
+    lb_alias_records = optional(list(object({
+      name                   = string
+      type                   = string
+      lbs_map_key            = string
+      evaluate_target_health = optional(bool, false)
+    })), [])
+    s3_alias_records = optional(list(object({
+      name                   = string
+      type                   = string
+      s3_bucket_map_key      = string
+      evaluate_target_health = optional(bool, false)
+    })), [])
   }))
   default = {}
 }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -477,9 +477,8 @@ variable "lbs" {
         }))
       })), {})
       route53_records = optional(map(object({
-        account                = string # account to create the record in.  set to core-vpc or self
-        zone_id                = string # id of zone to create the record in
-        evaluate_target_health = bool
+        zone_name              = string
+        evaluate_target_health = optional(bool, false)
       })), {})
       replace = optional(object({
         target_group_name_match       = optional(string, "$(name)")

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -519,6 +519,19 @@ variable "route53_resolvers" {
   default = {}
 }
 
+variable "route53_zones" {
+  description = "map of route53 zones and associated records, where the map key is the name of the zone and the value object contains the records.  Zone is created if it doesn't already exist"
+  type = map(object({
+    records = optional(list(object({
+      name    = string
+      type    = string
+      ttl     = number
+      records = list(string)
+    })), [])
+  }))
+  default = {}
+}
+
 variable "s3_buckets" {
   description = "map of s3 buckets to create where the map key is the bucket prefix.  See s3_bucket module for more variable details.  Use iam_policies to automatically create a iam policies for the bucket where the key is the name of the policy"
   type = map(object({

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -98,8 +98,11 @@ output "domains" {
 }
 
 output "route53_zones" {
-  description = "a map of aws_route53_zone data objects where the key is the domain name"
-  value       = merge(data.aws_route53_zone.core_network_services, data.aws_route53_zone.core_vpc)
+  description = "a map of aws_route53_zone data objects where the key is the domain name.  The data objects have extra provider field so you know which account they are in"
+  value = merge(
+    { for key, value in data.aws_route53_zone.core_network_services : key => merge(value, { provider = "core-network-services" }) },
+    { for key, value in data.aws_route53_zone.core_vpc : key => merge(value, { provider = "core-vpc" })
+  })
 }
 
 output "kms_keys" {

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -218,7 +218,7 @@ resource "aws_route53_record" "self" {
   for_each = { for key, value in var.route53_records : key => value if value.account == "self" }
 
   zone_id = each.value.zone_id
-  name    = replace(each.value.key, var.replace.route53_record_name_match, var.replace.route53_record_name_replace)
+  name    = replace(each.key, var.replace.route53_record_name_match, var.replace.route53_record_name_replace)
   type    = "A"
 
   alias {


### PR DESCRIPTION
Add ability to create route53 zones via baseline module and added additional zones for nomis for Mojo device testing:
- environment module route53 zones output now includes the provider to use for each zone
- baseline module can now create route53 zones and associated records 
- create new domains under "az.justice.gov.uk" so URLs work with Mojo devices without any changes 