### PR TITLE
nomis: DSOS-1831: remove old wildcard cert

### DIFF
--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -5,7 +5,7 @@ module "baseline_presets" {
   ip_addresses = module.ip_addresses
 
   options = {
-    enable_application_environment_wildcard_cert = true
+    enable_application_environment_wildcard_cert = false
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true


### PR DESCRIPTION
We don't need the standard wildcard cert now we have the new one which includes the nomis.az domains.  So get rid.