### PR TITLE
Nomis: DSOS-1834: add pagerduty data to environment module

### DIFF
--- a/terraform/environments/example/environment.tf
+++ b/terraform/environments/example/environment.tf
@@ -2,8 +2,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/environments/nomis-combined-reporting/environment.tf
+++ b/terraform/environments/nomis-combined-reporting/environment.tf
@@ -2,8 +2,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/environments/nomis-data-hub/environment.tf
+++ b/terraform/environments/nomis-data-hub/environment.tf
@@ -2,8 +2,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/environments/nomis/environment.tf
+++ b/terraform/environments/nomis/environment.tf
@@ -2,8 +2,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/environments/nomis/monitoring-setup.tf
+++ b/terraform/environments/nomis/monitoring-setup.tf
@@ -19,19 +19,9 @@ resource "aws_sns_topic" "nomis_nonprod_alarms" {
 
 ## Pager duty integration
 
-# Get the map of pagerduty integration keys from the modernisation platform account
-data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
-  provider = aws.modernisation-platform
-  name     = "pagerduty_integration_keys"
-}
-data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
-}
-
 # Add a local to get the keys
 locals {
-  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  pagerduty_integration_keys = module.environment.pagerduty_integration_keys
 }
 
 # link the sns topic to the service

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -6,8 +6,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/modules/environment/README.md
+++ b/terraform/modules/environment/README.md
@@ -24,8 +24,9 @@ module "environment" {
   source = "../../modules/environment"
 
   providers = {
-    aws.core-network-services = aws.core-network-services
-    aws.core-vpc              = aws.core-vpc
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
   }
 
   environment_management = local.environment_management

--- a/terraform/modules/environment/data.tf
+++ b/terraform/modules/environment/data.tf
@@ -87,3 +87,17 @@ data "aws_kms_key" "this" {
   key_id   = "arn:aws:kms:eu-west-2:${var.environment_management.account_ids["core-shared-services-production"]}:alias/${each.key}-${var.business_unit}"
 }
 
+#------------------------------------------------------------------------------
+# Pager Duty
+#------------------------------------------------------------------------------
+
+# Get the map of pagerduty integration keys from the modernisation platform account
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -109,3 +109,9 @@ output "kms_keys" {
   description = "a map of business unit customer-managed keys where the map key is the prefix name, e.g. general, ebs, rds"
   value       = data.aws_kms_key.this
 }
+
+output "pagerduty_integration_keys" {
+  description = "pagerduty integration keys managed by modernisation platform"
+  value       = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  sensitive   = true
+}

--- a/terraform/modules/environment/versions.tf
+++ b/terraform/modules/environment/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       version               = "~> 4.9"
       source                = "hashicorp/aws"
-      configuration_aliases = [aws.core-vpc, aws.core-network-services]
+      configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.modernisation-platform]
     }
   }
   required_version = ">= 1.1.7"


### PR DESCRIPTION
Preparation for moving nomis monitoring stuff into baseline module for re-use by oasys/ndh and combined reporting.

Add the pagerduty integration keys into environment module and updated nomis code to use this.  This requires adding modernisation-platform provider so updated all the other places the module is used.