### PR TITLE
Disable megalinter reports

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -52,6 +52,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
+          REPORT_OUTPUT_FOLDER: none
 
       - name: Check for changes
         run: |


### PR DESCRIPTION
Following configuration guidance here - https://github.com/marketplace/actions/megalinter#quick-start
Setting the report folder to none 

> REPORT_OUTPUT_FOLDER | ${GITHUB_WORKSPACE}/megalinter-reports | Directory for generating report files. Set to none to not generate reports



