### PR TITLE
DSOS-1834: Add tags to the cloudwatch alarms

### DIFF
--- a/terraform/modules/acm_certificate/main.tf
+++ b/terraform/modules/acm_certificate/main.tf
@@ -105,5 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   dimensions = merge(each.value.dimensions, {
     "CertificateArn" = aws_acm_certificate.this.arn
   })
-  tags = {}
+  tags = merge(var.tags, {
+    Name = "${var.name}-${each.key}"
+  })
 }

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -34,7 +34,7 @@ variable "tags" {
 }
 
 variable "cloudwatch_metric_alarms" {
-  description = "Map of cloudwatch metric alarms."
+  description = "Map of cloudwatch metric alarms.  The alarm name is set to the cert name plus the map key."
   type = map(object({
     comparison_operator = string
     evaluation_periods  = number
@@ -49,7 +49,6 @@ variable "cloudwatch_metric_alarms" {
     datapoints_to_alarm = optional(number)
     treat_missing_data  = optional(string, "missing")
     dimensions          = optional(map(string), {})
-    tags                = optional(map(string))
   }))
   default = {}
 }

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -318,5 +318,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   dimensions = merge(each.value.dimensions, {
     "AutoScalingGroupName" = aws_autoscaling_group.this.name
   })
-  tags = {}
+  tags = merge(var.tags, {
+    Name = "${aws_autoscaling_group.this.name}-${each.key}"
+  })
 }

--- a/terraform/modules/ec2_autoscaling_group/variables.tf
+++ b/terraform/modules/ec2_autoscaling_group/variables.tf
@@ -231,7 +231,7 @@ variable "lb_target_groups" {
 }
 
 variable "cloudwatch_metric_alarms" {
-  description = "Map of cloudwatch metric alarms."
+  description = "Map of cloudwatch metric alarms.  The alarm name is set to the autoscaling group name plus the map key."
   type = map(object({
     comparison_operator = string
     evaluation_periods  = number
@@ -246,7 +246,6 @@ variable "cloudwatch_metric_alarms" {
     datapoints_to_alarm = optional(number)
     treat_missing_data  = optional(string, "missing")
     dimensions          = optional(map(string), {})
-    tags                = optional(map(string))
   }))
   default = {}
 }

--- a/terraform/modules/ec2_instance/main.tf
+++ b/terraform/modules/ec2_instance/main.tf
@@ -126,10 +126,10 @@ resource "aws_ebs_volume" "this" {
   iops              = try(each.value.iops > 0, false) ? each.value.iops : null
   throughput        = try(each.value.throughput > 0, false) ? each.value.throughput : null
   size              = each.value.size
-  type              = each.value.type
+  type              = lookup(each.value, "type", null)
 
   # you may run into a permission issue if the AMI is not in self account
-  snapshot_id = each.value.snapshot_id
+  snapshot_id = lookup(each.value, "snapshot_id", null)
 
   tags = merge(
     local.tags,
@@ -297,5 +297,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   dimensions = merge(each.value.dimensions, {
     "InstanceId" = aws_instance.this.id
   })
-  tags = {}
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}"
+  })
 }

--- a/terraform/modules/ec2_instance/variables.tf
+++ b/terraform/modules/ec2_instance/variables.tf
@@ -181,7 +181,7 @@ variable "ssm_parameters" {
 }
 
 variable "cloudwatch_metric_alarms" {
-  description = "Map of cloudwatch metric alarms."
+  description = "Map of cloudwatch metric alarms.  The alarm name is set to the ec2 instance name plus the map key."
   type = map(object({
     comparison_operator = string
     evaluation_periods  = number
@@ -196,7 +196,6 @@ variable "cloudwatch_metric_alarms" {
     datapoints_to_alarm = optional(number)
     treat_missing_data  = optional(string, "missing")
     dimensions          = optional(map(string), {})
-    tags                = optional(map(string))
   }))
   default = {}
 }

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -243,7 +243,9 @@ resource "aws_route53_record" "self" {
 #  alarm_description   = each.value.alarm_description
 #  datapoints_to_alarm = each.value.datapoints_to_alarm
 #  treat_missing_data  = each.value.treat_missing_data
-#  tags                = {}
+#  tags                = merge(var.tags, {
+#    Name = "${var.name}-${each.key}"
+#  })
 #  dimensions = merge(each.value.dimensions, {
 #    "LoadBalancer" = data.aws_lb.this.arn_suffix
 #    "TargetGroup"  = local.target_group_arn.arn_suffix

--- a/terraform/modules/lb_listener/variables.tf
+++ b/terraform/modules/lb_listener/variables.tf
@@ -189,7 +189,7 @@ variable "tags" {
 }
 
 variable "cloudwatch_metric_alarms" {
-  description = "Map of cloudwatch metric alarms."
+  description = "Map of cloudwatch metric alarms.  The alarm name is set to the target group name plus the map key."
   type = map(object({
     comparison_operator = string
     evaluation_periods  = number
@@ -204,7 +204,6 @@ variable "cloudwatch_metric_alarms" {
     datapoints_to_alarm = optional(number)
     treat_missing_data  = optional(string, "missing")
     dimensions          = optional(map(string), {})
-    tags                = optional(map(string))
   }))
   default = {}
 }


### PR DESCRIPTION
Ensure cloudwatch alarms are tagged properly.

Note there is a separate repo for ec2-instance/autoscaling group modules but not everyone is using it yet.   I'll do separate PR for those repos.