### PR TITLE
Add a env repo label to everything

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,3 +6,7 @@ dependencies:
 
 github-workflow:
   - "github/workflows/**"
+
+environments-repository:
+  - "**/*.*"
+  - "**/*"


### PR DESCRIPTION
Currently we can't exclude the environments repo from our PR notifications on slack.  By adding a label we can exclude based on label.