### PR TITLE
Generating strategy matrix using environment files and updating relevant pipelines

### DIFF
--- a/.github/workflows/nomis-combined-reporting.yml
+++ b/.github/workflows/nomis-combined-reporting.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     if: inputs.action != 'destroy'
     with:
-      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
+      application: "${{ github.workflow }}"
 
   terraform:
     needs: strategy

--- a/.github/workflows/nomis-data-hub.yml
+++ b/.github/workflows/nomis-data-hub.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     if: inputs.action != 'destroy'
     with:
-      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
+      application: "${{ github.workflow }}"
 
   terraform:
     needs: strategy

--- a/.github/workflows/nomis.yml
+++ b/.github/workflows/nomis.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     if: inputs.action != 'destroy'
     with:
-      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
+      application: "${{ github.workflow }}"
 
   terraform:
     needs: strategy

--- a/.github/workflows/oasys.yml
+++ b/.github/workflows/oasys.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/reusable_terraform_strategy.yml
     if: inputs.action != 'destroy'
     with:
-      strategy_type: "standard_four_accounts"  # allow apply to dev/test from branch
+      application: "${{ github.workflow }}"
 
   terraform:
     needs: strategy

--- a/.github/workflows/reusable_terraform_strategy.yml
+++ b/.github/workflows/reusable_terraform_strategy.yml
@@ -45,6 +45,7 @@ jobs:
           echo ']}' >> matrix.out
           matrix=$(cat matrix.out | jq -r)
           echo $matrix
-          echo '${matrix}' >> $GITHUB_OUTPUT
+          echo 'matrix<<EOF' >> $GITHUB_OUTPUT
+          echo "${matrix}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           echo "${matrix}"

--- a/.github/workflows/reusable_terraform_strategy.yml
+++ b/.github/workflows/reusable_terraform_strategy.yml
@@ -17,10 +17,10 @@ name: terraform strategy
 on:
   workflow_call:
     inputs:
-      strategy_type:
+      application:
         type: string
         required: true
-        description: "Set to the a string representing the desired workflow strategy, e.g. standard_four_accounts, see comments for more info"
+        description: "Application name for which this strategy matrix pipeline should run. This is later used to identify environments from the JSON environments files in the MP repo: https://github.com/ministryofjustice/modernisation-platform/tree/main/environments."
     outputs:
       matrix:
         description: "Matrix json string to feed that can be used as strategy in separate terraform job"
@@ -35,52 +35,16 @@ jobs:
     steps:
       - name: Set Strategy Matrix
         id: strategy
-        run: |
-          if [[ "${{ inputs.strategy_type }}" == "standard_four_accounts" ]]; then
-            if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-              matrix=$(cat << EOF
-              {
-                "include": [{
-                  "target": "development",
-                  "action": "plan_apply"
-                }, {
-                  "target": "test",
-                  "action": "plan_apply"
-                }, {
-                  "target": "preproduction",
-                  "action": "plan"
-                }, {
-                  "target": "production",
-                  "action": "plan"
-                }]
-              }
-          EOF
-          )
-            else
-              matrix=$(cat << EOF
-              {
-                "include": [{
-                  "target": "development",
-                  "action": "plan_apply"
-                }, {
-                  "target": "test",
-                  "action": "plan_apply"
-                }, {
-                  "target": "preproduction",
-                  "action": "plan_apply"
-                }, {
-                  "target": "production",
-                  "action": "plan_apply"
-                }]
-              }
-          EOF
-          )
-            fi
+        run: | 
+          echo '{"include":[' > matrix.out
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/"${{ inputs.application }}".json' | jq -r '.environments[]' | jq '.name' | jq 'if contains("production") then {"target": ., "action":"plan"} else {"target": ., "action":"plan_apply"} end' -j | sed s"/}{/},{/g" >> matrix.out
           else
-            echo "Unexpected value for inputs.strategy_type [${{ inputs.strategy_type }}]"
-            exit 1
+            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/"${{ inputs.application }}".json' | jq  -r '.environments[] | {"target" : .name, "action" : "plan_apply"}' -j | sed s"/}{/},{/g" >> matrix.out
           fi
-          echo 'matrix<<EOF' >> $GITHUB_OUTPUT
-          echo "${matrix}" >> $GITHUB_OUTPUT
+          echo ']}' >> matrix.out
+          matrix=$(cat matrix.out)
+          echo '$matrix | jq -r'
+          echo '${matrix} | jq -r' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           echo "${matrix}"

--- a/.github/workflows/reusable_terraform_strategy.yml
+++ b/.github/workflows/reusable_terraform_strategy.yml
@@ -38,9 +38,9 @@ jobs:
         run: | 
           echo '{"include":[' > matrix.out
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/"${{ inputs.application }}".json' | jq -r '.environments[]' | jq '.name' | jq 'if contains("production") then {"target": ., "action":"plan"} else {"target": ., "action":"plan_apply"} end' -j | sed s"/}{/},{/g" >> matrix.out
+            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json' | jq -r '.environments[]' | jq '.name' | jq 'if contains("production") then {"target": ., "action":"plan"} else {"target": ., "action":"plan_apply"} end' -j | sed s"/}{/},{/g" >> matrix.out
           else
-            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/"${{ inputs.application }}".json' | jq  -r '.environments[] | {"target" : .name, "action" : "plan_apply"}' -j | sed s"/}{/},{/g" >> matrix.out
+            curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json' | jq  -r '.environments[] | {"target" : .name, "action" : "plan_apply"}' -j | sed s"/}{/},{/g" >> matrix.out
           fi
           echo ']}' >> matrix.out
           matrix=$(cat matrix.out | jq -r)

--- a/.github/workflows/reusable_terraform_strategy.yml
+++ b/.github/workflows/reusable_terraform_strategy.yml
@@ -43,8 +43,8 @@ jobs:
             curl -X GET 'https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/"${{ inputs.application }}".json' | jq  -r '.environments[] | {"target" : .name, "action" : "plan_apply"}' -j | sed s"/}{/},{/g" >> matrix.out
           fi
           echo ']}' >> matrix.out
-          matrix=$(cat matrix.out)
-          echo '$matrix | jq -r'
-          echo '${matrix} | jq -r' >> $GITHUB_OUTPUT
+          matrix=$(cat matrix.out | jq -r)
+          echo $matrix
+          echo '${matrix}' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           echo "${matrix}"

--- a/.github/workflows/reusable_terraform_strategy.yml
+++ b/.github/workflows/reusable_terraform_strategy.yml
@@ -44,7 +44,6 @@ jobs:
           fi
           echo ']}' >> matrix.out
           matrix=$(cat matrix.out | jq -r)
-          echo $matrix
           echo 'matrix<<EOF' >> $GITHUB_OUTPUT
           echo "${matrix}" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR is part of the https://github.com/ministryofjustice/modernisation-platform/issues/3452 ticket.

The original reusable terraform strategy pipeline only accepts standard four accounts, which is no good, if a team has a random number of environments (e.g. only development and production and not test and preproduction).

This change is to dynamically generate the strategy matrix by reading an application's [json environment file](https://github.com/ministryofjustice/modernisation-platform/tree/main/environments) and generating the matrix based on the environments found in that file.

Updating the workflows that already use the reusable terraform pipelines.