### PR TITLE
nomis: DSOS-1834: update cloudwatch alarms

### DIFF
--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -183,6 +183,7 @@ locals {
       chronyd-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
@@ -196,6 +197,7 @@ locals {
       sshd-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
@@ -209,6 +211,7 @@ locals {
       cloudwatch-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
@@ -222,6 +225,7 @@ locals {
       ssm-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -1,8 +1,8 @@
-# The cloudwatch_metric_alarms locals provides a standard set of 
-# alarms useful for EC2 instances, autoscaling groups, load balancers etc. 
+# The cloudwatch_metric_alarms locals provides a standard set of
+# alarms useful for EC2 instances, autoscaling groups, load balancers etc.
 # grouped by namespace.
 #
-# The desired alarm_actions are passed in as a parameter to the module and 
+# The desired alarm_actions are passed in as a parameter to the module and
 # appended to the alarms in the output.  The alarms can also be optionally
 # filtered in the output
 #
@@ -49,174 +49,201 @@
 #
 # Add application specific alarms using exactly the same structure
 # as local.cloudwatch_:etric_alarms using the application_alarms option.
+#
+# Example alarm definition with comment.  The statistic may be applied over
+# several instances in the case of auto scaling groups.
+#   cpu-utilization-high-15mins = {
+#     comparison_operator = "GreaterThanOrEqualToThreshold" # threshold to trigger the alarm state
+#     evaluation_periods  = "15"                            # how many periods over which to evaluate the alarm
+#     datapoints_to_alarm = "15"                            # how many datapoints must be breaching the threshold to trigger the alarm
+#     metric_name         = "CPUUtilization"                # name of the alarm's associated metric
+#     namespace           = "AWS/EC2"                       # namespace of the alarm's associated metric
+#     period              = "60"                            # period in seconds over which the specified statistic is applied
+#     statistic           = "Average"                       # could be Average/Minimum/Maximum etc.
+#     threshold           = "95"                            # threshold for the alarm - see comparison_operator for usage
+#     alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes"
+#   }
 
 locals {
 
   cloudwatch_metric_alarms = {
 
     acm = {
+      cert-expires-in-less-than-14-days = {
+        comparison_operator = "LessThanThreshold"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
+        metric_name         = "DaysToExpiry"
+        namespace           = "AWS/CertificateManager"
+        period              = "86400"
+        statistic           = "Minimum"
+        threshold           = "14"
+        alarm_description   = "Triggers if an ACM certificate has not automatically renewed and is expiring soon. Automatic renewal should happen 60 days prior to expiration."
+      }
     }
 
     ec2 = {
-      cpu-utilization = {
-        comparison_operator = "GreaterThanOrEqualToThreshold" # threshold to trigger the alarm state
-        evaluation_periods  = "15"                            # how many periods over which to evaluate the alarm
-        datapoints_to_alarm = "15"                            # how many datapoints must be breaching the threshold to trigger the alarm
-        metric_name         = "CPUUtilization"                # name of the alarm's associated metric   
-        namespace           = "AWS/EC2"                       # namespace of the alarm's associated metric
-        period              = "60"                            # period in seconds over which the specified statistic is applied
-        statistic           = "Average"                       # could be Average/Minimum/Maximum etc.
-        threshold           = "95"                            # threshold for the alarm - see comparison_operator for usage
+      cpu-utilization-high-15mins = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
+        metric_name         = "CPUUtilization"
+        namespace           = "AWS/EC2"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "95"
         alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes"
       }
-      # Key Servers Instance alert - sensitive alert for key servers changing status from healthy. 
-      # If this triggers often then we've got a problem.
-      instance-health-check-failed = {
+      instance-status-check-failed-in-last-hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
+        evaluation_periods  = "60"
+        datapoints_to_alarm = "1"
         metric_name         = "StatusCheckFailed_Instance"
         namespace           = "AWS/EC2"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "Instance status checks monitor the software and network configuration of your individual instance. When an instance status check fails, you typically must address the problem yourself: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
+        alarm_description   = "Triggers if there has been an instance status check failure within last hour. This monitors the software and network configuration of your individual instance. When an instance status check fails, you typically must address the problem yourself: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
       }
-      system-health-check-failed = {
+      system-status-check-failed-in-last-hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
+        evaluation_periods  = "60"
+        datapoints_to_alarm = "1"
         metric_name         = "StatusCheckFailed_System"
         namespace           = "AWS/EC2"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "System status checks monitor the AWS systems on which your instance runs. These checks detect underlying problems with your instance that require AWS involvement to repair: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
+        alarm_description   = "Triggers if there has been a system status check failure within last hour.  This monitors the AWS systems on which your instance runs. These checks detect underlying problems with your instance that require AWS involvement to repair: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html"
       }
     }
 
     ec2_cwagent_windows = {
-      disk-free-windows = {
+      free-disk-space-low-1hour = {
         comparison_operator = "LessThanOrEqualToThreshold"
-        evaluation_periods  = "2"
-        datapoints_to_alarm = "2"
+        evaluation_periods  = "60"
+        datapoints_to_alarm = "60"
         metric_name         = "DISK_FREE"
         namespace           = "CWAgent"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Minimum"
         threshold           = "15"
-        alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
+        alarm_description   = "Triggers if free disk space falls below the threshold for an hour. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
       }
-      high-cpu-windows = {
+      high-memory-usage-15mins = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "PROCESSOR_TIME"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "95"
-        alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space falls below 15% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4305453159/Disk+Free+alarm+-+Windows"
-      }
-      low-available-memory-windows = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "2"
-        datapoints_to_alarm = "2"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
         metric_name         = "Memory % Committed Bytes In Use"
         namespace           = "CWAgent"
         period              = "60"
-        statistic           = "Average"
-        threshold           = "80"
-        alarm_description   = "This metric monitors the amount of available memory. If Committed Bytes in Use is > 80% for 2 minutes, the alarm will trigger."
+        statistic           = "Maximum"
+        threshold           = "90"
+        alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
       }
     }
 
     ec2_cwagent_linux = {
-      high-memory-usage = {
+      free-disk-space-low-1hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "2"
-        datapoints_to_alarm = "2"
+        evaluation_periods  = "60"
+        datapoints_to_alarm = "60"
+        metric_name         = "disk_used_percent"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "85"
+        alarm_description   = "Triggers if free disk space falls below the threshold for an hour. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
+      }
+      high-memory-usage-15mins = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
         metric_name         = "mem_used_percent"
         namespace           = "CWAgent"
         period              = "60"
         statistic           = "Average"
         threshold           = "90"
-        alarm_description   = "This metric monitors the amount of available memory. If the amount of available memory is greater than 90% for 2 minutes, the alarm will trigger."
+        alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
       }
-      cpu-usage-iowait = {
+      cpu-iowait-high-3hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "60"
-        datapoints_to_alarm = "60"
+        evaluation_periods  = "180"
+        datapoints_to_alarm = "180"
         metric_name         = "cpu_usage_iowait"
         namespace           = "CWAgent"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "30"
-        alarm_description   = "This metric monitors the amount of CPU time spent waiting for I/O to complete. If the average CPU time spent waiting for I/O to complete is greater than 30% for 60 minutes, the alarm will trigger."
-      }
-      disk-used-percent = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "2"
-        datapoints_to_alarm = "2"
-        metric_name         = "disk_used_percent"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "85"
-        alarm_description   = "This metric monitors the amount of free disk space on the instance. If the amount of free disk space is above 85% for 2 minutes, the alarm will trigger: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
+        alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 3 hours"
       }
     }
 
     ec2_cwagent_collectd = {
-      chronyd-service = {
+      chronyd-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "chronyd service has stopped"
+        alarm_description   = "Triggers if the chronyd service has stopped"
         dimensions = {
           instance = "chronyd"
         }
       }
-      sshd-service = {
+      sshd-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "sshd service has stopped"
+        alarm_description   = "Triggers if the sshd service has stopped"
         dimensions = {
           instance = "sshd"
         }
       }
-      cloudwatch-agent-status = {
+      cloudwatch-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "cloudwatch agent service has stopped"
+        alarm_description   = "Triggers if the cloudwatch agent service has stopped"
         dimensions = {
           instance = "cloudwatch_agent_status"
         }
       }
-      ssm-agent-status = {
+      ssm-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_exec_value"
         period              = "60"
-        statistic           = "Average"
+        statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "ssm agent service has stopped"
+        alarm_description   = "Triggers if the ssm agent service has stopped"
         dimensions = {
           instance = "ssm_agent_status"
         }
+      }
+    }
+    lb = {
+      unhealthy-hosts-atleast-one = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        metric_name         = "UnHealthyHostCount"
+        namespace           = "AWS/ApplicationELB"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "Triggers if the number of unhealthy hosts in the target table group is at least one for 3 minutes"
       }
     }
   }


### PR DESCRIPTION
Add ACM/LB alarms plus updated existing alarms:
- statistic changes to take into account there could be multiple instances being checked
- updated naming to allow for different variants of same alarm, high-cpu-5mins, high-cpu-15mins etc.
- removed windows CPU alarm as duplicate of the EC2 one
- increased some of the time thresholds 