### PR TITLE
Testing dynamic provider for us-east-1

### DIFF
--- a/terraform/environments/sprinkler/data.tf
+++ b/terraform/environments/sprinkler/data.tf
@@ -7,3 +7,7 @@ data "aws_caller_identity" "core_vpc" {
 data "aws_caller_identity" "core_network_services" {
   provider = aws.core-network-services
 }
+
+data "aws_caller_identity" "us_east_1" {
+  provider = aws.us-east-1
+}

--- a/terraform/environments/sprinkler/main.tf
+++ b/terraform/environments/sprinkler/main.tf
@@ -812,3 +812,11 @@ resource "aws_cloudwatch_log_group" "app" {
     },
   )
 }
+
+resource "aws_acm_certificate" "us_east_1_test" {
+  domain_name       = "test.platforms-development.modernisation-platform.service.justice.gov.uk"
+  validation_method = "DNS"
+  provider          = aws.us-east-1
+
+  tags = local.tags
+}

--- a/terraform/environments/sprinkler/outputs.tf
+++ b/terraform/environments/sprinkler/outputs.tf
@@ -17,3 +17,7 @@ output "provider_core_network_services" {
 output "provider_modernisation_platform" {
   value = data.aws_caller_identity.modernisation_platform
 }
+
+output "provider_us_east_1" {
+  value = data.aws_caller_identity.us_east_1
+}

--- a/terraform/environments/sprinkler/platform_providers.tf
+++ b/terraform/environments/sprinkler/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }


### PR DESCRIPTION
Adding an ACM resource in US east 1, locally the sso or collaborator role is assumed, but when run on the pipeline the
MemberInfrastructureAccessUSEast role.