### PR TITLE
Add us-east-1 dynamic provider for local plans

### DIFF
--- a/terraform/environments/apex/platform_providers.tf
+++ b/terraform/environments/apex/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/ccms-ebs/platform_providers.tf
+++ b/terraform/environments/ccms-ebs/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/data-and-insights-wepi/platform_providers.tf
+++ b/terraform/environments/data-and-insights-wepi/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/data-platform/platform_providers.tf
+++ b/terraform/environments/data-platform/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/delius-core/platform_providers.tf
+++ b/terraform/environments/delius-core/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/delius-iaps/platform_providers.tf
+++ b/terraform/environments/delius-iaps/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/delius-jitbit/platform_providers.tf
+++ b/terraform/environments/delius-jitbit/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/digital-prison-reporting/platform_providers.tf
+++ b/terraform/environments/digital-prison-reporting/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/equip/platform_providers.tf
+++ b/terraform/environments/equip/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/example/platform_providers.tf
+++ b/terraform/environments/example/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_providers.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/laa-oem/platform_providers.tf
+++ b/terraform/environments/laa-oem/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/long-term-storage/platform_providers.tf
+++ b/terraform/environments/long-term-storage/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/maatdb/platform_providers.tf
+++ b/terraform/environments/maatdb/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/mojfin/platform_providers.tf
+++ b/terraform/environments/mojfin/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/nomis-combined-reporting/platform_providers.tf
+++ b/terraform/environments/nomis-combined-reporting/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/nomis-data-hub/platform_providers.tf
+++ b/terraform/environments/nomis-data-hub/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/nomis/platform_providers.tf
+++ b/terraform/environments/nomis/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/oas/platform_providers.tf
+++ b/terraform/environments/oas/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/oasys/platform_providers.tf
+++ b/terraform/environments/oasys/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/performance-hub/platform_providers.tf
+++ b/terraform/environments/performance-hub/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/portal/platform_providers.tf
+++ b/terraform/environments/portal/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/ppud/platform_providers.tf
+++ b/terraform/environments/ppud/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/refer-monitor/platform_providers.tf
+++ b/terraform/environments/refer-monitor/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/tariff/platform_providers.tf
+++ b/terraform/environments/tariff/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/tipstaff/platform_providers.tf
+++ b/terraform/environments/tipstaff/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/tribunals/platform_providers.tf
+++ b/terraform/environments/tribunals/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }

--- a/terraform/environments/xhibit-portal/platform_providers.tf
+++ b/terraform/environments/xhibit-portal/platform_providers.tf
@@ -44,6 +44,6 @@ provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
 }


### PR DESCRIPTION
The local user doesn't have permission to assume the MemberInfrastructureAccessUsEast1 role. When running locally using the original session which has readonly access.