### PR TITLE
Nomis: DSOS-1843: new weblogic asgs

### DIFF
--- a/terraform/environments/nomis/baseline.tf
+++ b/terraform/environments/nomis/baseline.tf
@@ -19,9 +19,9 @@ module "baseline" {
   # kms_grants               = module.baseline_presets.kms_grants
   # s3_buckets               = merge(local.baseline_s3_buckets, lookup(local.baseline_environment_config, "baseline_s3_buckets", {}))
   # ec2_instances          = lookup(local.baseline_environment_config, "baseline_ec2_instances", {})
-  # ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
-  route53_resolvers = module.baseline_presets.route53_resolvers
-  route53_zones     = merge(local.baseline_route53_zones, lookup(local.baseline_environment_config, "baseline_route53_zones", {}))
-  lbs               = lookup(local.baseline_environment_config, "baseline_lbs", {})
-  sns_topics        = module.baseline_presets.sns_topics
+  ec2_autoscaling_groups = lookup(local.baseline_environment_config, "baseline_ec2_autoscaling_groups", {})
+  route53_resolvers      = module.baseline_presets.route53_resolvers
+  route53_zones          = merge(local.baseline_route53_zones, lookup(local.baseline_environment_config, "baseline_route53_zones", {}))
+  lbs                    = lookup(local.baseline_environment_config, "baseline_lbs", {})
+  sns_topics             = module.baseline_presets.sns_topics
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -24,7 +24,7 @@ locals {
     }
     s3_iam_policies = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     # sns_topics_pagerduty_integrations = {
-    #   nomis_alarms         = "nomis_alarms"
+    #   nomis_alarms         = "nomis_alarms"
     #   nomis_nonprod_alarms = "nomis_nonprod_alarms"
     # }
   }

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -192,6 +192,12 @@ locals {
     config = merge(local.ec2_weblogic_default.config, {
       availability_zone = "${local.region}a"
     })
+    user_data_cloud_init = merge(local.ec2_weblogic_default.user_data_cloud_init, {
+      args = merge(local.ec2_weblogic_default.user_data_cloud_init.args, {
+        branch = "nomis/DSOS-1843/new-weblogic-asgs"
+      })
+    })
+    warm_pool = null
   })
   ec2_weblogic_zone_b = merge(local.ec2_weblogic_default, {
     config = merge(local.ec2_weblogic_default.config, {

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -153,15 +153,10 @@ locals {
       vpc_zone_identifier = [
         module.environment.subnets["private"].ids
       ]
-      warm_pool = {
-        reuse_on_scale_in           = true
-        max_group_prepared_capacity = 1
-      }
       health_check_grace_period = 300
       health_check_type         = "EC2"
       force_delete              = true
       termination_policies      = ["OldestInstance"]
-      target_group_arns         = []
       wait_for_capacity_timeout = 0
 
       # this hook is triggered by the post-ec2provision.sh
@@ -178,6 +173,11 @@ locals {
         min_healthy_percentage = 90 # seems that instances in the warm pool are included in the % health count so this needs to be set fairly high
         instance_warmup        = 300
       }
+
+      warm_pool = {
+        reuse_on_scale_in           = true
+        max_group_prepared_capacity = 1
+      }
     }
 
     tags = {
@@ -188,18 +188,14 @@ locals {
       component   = "web"
     }
   }
-  ec2_weblogic_eu_west_2a = merge(local.ec2_weblogic_default, {
-    autoscaling_group = merge(local.ec2_weblogic_default.autoscaling_group, {
-      vpc_zone_identifier = [
-        module.environment.subnet["private"]["eu-west-2a"].id
-      ]
+  ec2_weblogic_zone_a = merge(local.ec2_weblogic_default, {
+    config = merge(local.ec2_weblogic_default.config, {
+      availability_zone = "${local.region}a"
     })
   })
-  ec2_weblogic_eu_west_2b = merge(local.ec2_weblogic_default, {
-    autoscaling_group = merge(local.ec2_weblogic_default.autoscaling_group, {
-      vpc_zone_identifier = [
-        module.environment.subnet["private"]["eu-west-2b"].id
-      ]
+  ec2_weblogic_zone_b = merge(local.ec2_weblogic_default, {
+    config = merge(local.ec2_weblogic_default.config, {
+      availability_zone = "${local.region}b"
     })
   })
 

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -194,10 +194,13 @@ locals {
     })
     user_data_cloud_init = merge(local.ec2_weblogic_default.user_data_cloud_init, {
       args = merge(local.ec2_weblogic_default.user_data_cloud_init.args, {
-        branch = "nomis/DSOS-1843/new-weblogic-asgs"
+        branch = "main"
+        #        branch = "nomis/DSOS-1843/new-weblogic-asgs"
       })
     })
-    warm_pool = null
+    autoscaling_group = merge(local.ec2_weblogic_default.autoscaling_group, {
+      warm_pool = null
+    })
   })
   ec2_weblogic_zone_b = merge(local.ec2_weblogic_default, {
     config = merge(local.ec2_weblogic_default.config, {

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -174,10 +174,10 @@ locals {
         instance_warmup        = 300
       }
 
-      warm_pool = {
-        reuse_on_scale_in           = true
-        max_group_prepared_capacity = 1
-      }
+      # warm_pool = {
+      #   reuse_on_scale_in           = true
+      #   max_group_prepared_capacity = 1
+      # }
     }
 
     tags = {
@@ -191,15 +191,6 @@ locals {
   ec2_weblogic_zone_a = merge(local.ec2_weblogic_default, {
     config = merge(local.ec2_weblogic_default.config, {
       availability_zone = "${local.region}a"
-    })
-    user_data_cloud_init = merge(local.ec2_weblogic_default.user_data_cloud_init, {
-      args = merge(local.ec2_weblogic_default.user_data_cloud_init.args, {
-        branch = "main"
-        #        branch = "nomis/DSOS-1843/new-weblogic-asgs"
-      })
-    })
-    autoscaling_group = merge(local.ec2_weblogic_default.autoscaling_group, {
-      warm_pool = null
     })
   })
   ec2_weblogic_zone_b = merge(local.ec2_weblogic_default, {

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -1,4 +1,4 @@
-# nomis-test environment settings
+#se nomis-test environment settings
 locals {
   nomis_test = {
     # vars common across ec2 instances
@@ -157,6 +157,17 @@ locals {
 
   # baseline config
   test_config = {
+
+    baseline_ec2_autoscaling_groups = {
+      t1-nomis-web-a = merge(local.ec2_weblogic_eu_west_2a, {
+        tags = merge(local.ec2_weblogic_eu_west_2a.tags, {
+          oracle-db-hostname = "t1-nomis-db-1"
+          nomis-environment  = "t1"
+          oracle-db-name     = "CNOMT1"
+        })
+        autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
+      })
+    }
 
     baseline_lbs = {
       # AWS doesn't let us call it internal

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -159,8 +159,8 @@ locals {
   test_config = {
 
     baseline_ec2_autoscaling_groups = {
-      t1-nomis-web-a = merge(local.ec2_weblogic_eu_west_2a, {
-        tags = merge(local.ec2_weblogic_eu_west_2a.tags, {
+      t1-nomis-web-a = merge(local.ec2_weblogic_zone_a, {
+        tags = merge(local.ec2_weblogic_zone_a.tags, {
           oracle-db-hostname = "t1-nomis-db-1"
           nomis-environment  = "t1"
           oracle-db-name     = "CNOMT1"

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -1,4 +1,4 @@
-#se nomis-test environment settings
+# nomis-test environment settings
 locals {
   nomis_test = {
     # vars common across ec2 instances

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -67,7 +67,7 @@ module "ec2_autoscaling_group" {
     })
   }
 
-  tags = each.value.tags
+  tags = merge(local.tags, each.value.tags)
 
   # ensure service linked role is created first if defined in code
   depends_on = [

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -36,7 +36,7 @@ module "ec2_autoscaling_group" {
   })
 
   availability_zone             = each.value.config.availability_zone
-  subnet_ids                    = each.value.config.availability_zone != null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnets[each.value.config.subnet_name][each.value.config.availability_zone].id]
+  subnet_ids                    = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnets[each.value.config.subnet_name][each.value.config.availability_zone].id]
   ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
   ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
   ebs_volume_config             = each.value.ebs_volume_config

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -36,7 +36,7 @@ module "ec2_autoscaling_group" {
   })
 
   availability_zone             = each.value.config.availability_zone
-  subnet_ids                    = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnets[each.value.config.subnet_name][each.value.config.availability_zone].id]
+  subnet_ids                    = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id]
   ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
   ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
   ebs_volume_config             = each.value.ebs_volume_config

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -35,7 +35,8 @@ module "ec2_autoscaling_group" {
     ]
   })
 
-  subnet_ids                    = var.environment.subnets[each.value.config.subnet_name].ids
+  availability_zone             = each.value.config.availability_zone
+  subnet_ids                    = each.value.config.availability_zone != null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnets[each.value.config.subnet_name][each.value.config.availability_zone].id]
   ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
   ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
   ebs_volume_config             = each.value.ebs_volume_config

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -68,10 +68,8 @@ variable "ec2_autoscaling_groups" {
       iam_resource_names_prefix     = optional(string, "ec2")
       instance_profile_policies     = list(string)
       ssm_parameters_prefix         = optional(string, "")
-
-      # below are unused but are defined so same object can be used with ec2_instance
-      subnet_name       = optional(string)
-      availability_zone = optional(string)
+      subnet_name                   = optional(string)
+      availability_zone             = optional(string)
     })
     instance = object({
       disable_api_termination      = bool

--- a/terraform/modules/ec2_autoscaling_group/main.tf
+++ b/terraform/modules/ec2_autoscaling_group/main.tf
@@ -53,6 +53,14 @@ resource "aws_launch_template" "this" {
     delete_on_termination       = true
   }
 
+  dynamic "placement" {
+    for_each = var.availability_zone != null ? [var.availability_zone] : []
+
+    content {
+      availability_zone = placement.value
+    }
+  }
+
   dynamic "private_dns_name_options" {
     for_each = var.instance.private_dns_name_options != null ? [var.instance.private_dns_name_options] : []
     content {

--- a/terraform/modules/ec2_autoscaling_group/variables.tf
+++ b/terraform/modules/ec2_autoscaling_group/variables.tf
@@ -53,6 +53,12 @@ variable "name" {
   description = "Provide a unique name for the auto scale group"
 }
 
+variable "availability_zone" {
+  type        = string
+  description = "Optionally associated the ASG with a single availability zone"
+  default     = null
+}
+
 variable "instance" {
   description = "EC2 launch template / instance settings, see aws_instance documentation"
   type = object({


### PR DESCRIPTION
Use baseline module to create new T1 ASG in prep for preprod/prod changes:
- autoscaling group module supports specific availability zone
- fixed tags for baseline module for ASGS
- add a t1-nomis-web-a autoscaling group (idea is for green/blue deployments swapping between -a and -b availability zones)