### PR TITLE
Nomis: DSOS-1843: add prod loadbalancer

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,14 +125,6 @@ jobs:
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
 
-      - name: Terraform State remove
-        working-directory: "terraform/environments/${{ inputs.application }}"
-        run: |
-          if [[ ${{ inputs.application }} == "nomis" && ${{ inputs.environment }} == "test" ]]; then
-            echo terraform import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
-            terraform import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]' 'arn:aws:elasticloadbalancing:eu-west-2:612659970365:listener/app/private-lb/b25fe967864e4a14/c4c0715c4253256c'
-          fi
-
       - name: Terraform State Refresh (Optional)
         if: inputs.do_state_refresh_on_plan == true
         working-directory: "terraform/environments/${{ inputs.application }}"
@@ -246,7 +238,7 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           set -o pipefail
-          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
+          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} -refresh=false"
           echo "terraform plan ${tf_args}"
           terraform plan ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
 

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -129,8 +129,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           if [[ ${{ inputs.application }} == "nomis" && ${{ inputs.environment }} == "test" ]]; then
-            echo terraform state import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
-            terraform state import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]' 'arn:aws:elasticloadbalancing:eu-west-2:612659970365:listener/app/private-lb/b25fe967864e4a14/c4c0715c4253256c'
+            echo terraform import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
+            terraform import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]' 'arn:aws:elasticloadbalancing:eu-west-2:612659970365:listener/app/private-lb/b25fe967864e4a14/c4c0715c4253256c'
           fi
 
       - name: Terraform State Refresh (Optional)

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           set -o pipefail
           exitcode=0
-          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} -refresh=false"
+          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           [[ ${POST_PLAN_TO_PR} == 'true' ]] && tf_args="${tf_args} -no-color"
           [[ ${{ inputs.do_state_refresh_on_plan }} == 'true' ]] && tf_args="${tf_args} -refresh=false"
           echo "terraform plan ${tf_args}"
@@ -238,7 +238,7 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           set -o pipefail
-          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} -refresh=false"
+          tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           echo "terraform plan ${tf_args}"
           terraform plan ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
 

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,6 +125,14 @@ jobs:
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
 
+      - name: Terraform State remove
+        working-directory: "terraform/environments/${{ inputs.application }}"
+        run: |
+          if [[ ${{ inputs.application }} == "nomis" && ${{ inputs.environment }} == "test" ]]; then
+            echo terraform state rm 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
+            terraform state rm 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
+          fi
+
       - name: Terraform State Refresh (Optional)
         if: inputs.do_state_refresh_on_plan == true
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,6 +125,14 @@ jobs:
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
 
+      - name: Terraform State remove
+        working-directory: "terraform/environments/${{ inputs.application }}"
+        run: |
+          if [[ ${{ inputs.application }} == "nomis" && ${{ inputs.environment }} == "test" ]]; then
+            echo terraform state import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
+            terraform state import 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]' 'arn:aws:elasticloadbalancing:eu-west-2:612659970365:listener/app/private-lb/b25fe967864e4a14/c4c0715c4253256c'
+          fi
+
       - name: Terraform State Refresh (Optional)
         if: inputs.do_state_refresh_on_plan == true
         working-directory: "terraform/environments/${{ inputs.application }}"
@@ -142,7 +150,7 @@ jobs:
         run: |
           set -o pipefail
           exitcode=0
-          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
+          tf_args="-detailed-exitcode ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} -refresh=false"
           [[ ${POST_PLAN_TO_PR} == 'true' ]] && tf_args="${tf_args} -no-color"
           [[ ${{ inputs.do_state_refresh_on_plan }} == 'true' ]] && tf_args="${tf_args} -refresh=false"
           echo "terraform plan ${tf_args}"

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -125,14 +125,6 @@ jobs:
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
 
-      - name: Terraform State remove
-        working-directory: "terraform/environments/${{ inputs.application }}"
-        run: |
-          if [[ ${{ inputs.application }} == "nomis" && ${{ inputs.environment }} == "test" ]]; then
-            echo terraform state rm 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
-            terraform state rm 'module.baseline.module.lb_listener["private-t1-nomis-web-https"].aws_lb_listener_rule.this["forward-http-7777"]'
-          fi
-
       - name: Terraform State Refresh (Optional)
         if: inputs.do_state_refresh_on_plan == true
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -180,6 +180,10 @@ locals {
       # }
     }
 
+    lb_target_groups = {
+      http-7777 = local.lb_target_group_http_7777
+    }
+
     tags = {
       ami         = "nomis_rhel_6_10_weblogic_appserver_10_3"
       description = "nomis weblogic appserver 10.3"

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -47,45 +47,6 @@ locals {
   }
 
   lb_weblogic = {
-    route53 = {
-      route53_records = {
-        "$(name).nomis" = {
-          zone_name = module.environment.domains.public.business_unit_environment
-        }
-        "$(name)" = {
-          zone_name = "${local.environment}.nomis.az.justice.gov.uk"
-        }
-      }
-    }
-
-    http = {
-      port     = 80
-      protocol = "HTTP"
-      default_action = {
-        type = "redirect"
-        redirect = {
-          status_code = "HTTP_301"
-          port        = 443
-          protocol    = "HTTPS"
-        }
-      }
-    }
-    http-7001 = {
-      port     = 7001
-      protocol = "HTTP"
-      default_action = {
-        type              = "forward"
-        target_group_name = "$(name)-http-7001"
-      }
-    }
-    http-7777 = {
-      port     = 7777
-      protocol = "HTTP"
-      default_action = {
-        type              = "forward"
-        target_group_name = "$(name)-http-7777"
-      }
-    }
     https = {
       port                      = 443
       protocol                  = "HTTPS"
@@ -98,23 +59,6 @@ locals {
           content_type = "text/plain"
           message_body = "Not implemented"
           status_code  = "501"
-        }
-      }
-      rules = {
-        forward-http-7777 = {
-          priority = 200
-          actions = [{
-            type              = "forward"
-            target_group_name = "$(name)-http-7777"
-          }]
-          conditions = [{
-            host_header = {
-              values = [
-                "$(name).nomis.${module.environment.domains.public.business_unit_environment}",
-                "$(name).${local.environment}.nomis.az.justice.gov.uk"
-              ]
-            }
-          }]
         }
       }
     }

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -50,5 +50,30 @@ locals {
         })
       })
     }
+
+    baseline_lbs = {
+      private = {
+        internal_lb              = true
+        enable_delete_protection = false
+        existing_target_groups   = local.existing_target_groups
+        force_destroy_bucket     = true
+        idle_timeout             = 3600
+        public_subnets           = module.environment.subnets["private"].ids
+        security_groups          = [aws_security_group.public.id]
+
+        listeners = {
+          preprod-nomis-web-https = merge(
+            local.lb_weblogic.https,
+            local.lb_weblogic.route53, {
+              replace = {
+                target_group_name_replace     = "preprod-nomis-web-a"
+                condition_host_header_replace = "preprod-nomis-web-a"
+                route53_record_name_replace   = "preprod-nomis-web-a"
+              }
+              # alarm_target_group_names = ["preprod-nomis-web-a-http-7777"]
+          })
+        }
+      }
+    }
   }
 }

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -145,5 +145,30 @@ locals {
         })
       })
     }
+
+    baseline_lbs = {
+      private = {
+        internal_lb              = true
+        enable_delete_protection = false
+        existing_target_groups   = local.existing_target_groups
+        force_destroy_bucket     = true
+        idle_timeout             = 3600
+        public_subnets           = module.environment.subnets["private"].ids
+        security_groups          = [aws_security_group.public.id]
+
+        listeners = {
+          prod-nomis-web-https = merge(
+            local.lb_weblogic.https,
+            local.lb_weblogic.route53, {
+              replace = {
+                target_group_name_replace     = "prod-nomis-web-a"
+                condition_host_header_replace = "prod-nomis-web-a"
+                route53_record_name_replace   = "prod-nomis-web-a"
+              }
+              # alarm_target_group_names = ["prod-nomis-web-a-http-7777""]
+          })
+        }
+      }
+    }
   }
 }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -206,16 +206,6 @@ locals {
               }
               alarm_target_group_names = ["t1-nomis-web-http-7777", "t1-nomis-web-http-7001"]
           })
-          t1-nomis-web-a-https = merge(
-            local.lb_weblogic.https,
-            local.lb_weblogic.route53, {
-              replace = {
-                target_group_name_replace     = "t1-nomis-web-a"
-                condition_host_header_replace = "t1-nomis-web-a"
-                route53_record_name_replace   = "t1-nomis-web-a"
-              }
-              # alarm_target_group_names = ["t1-nomis-web-a-http-7777"]
-          })
         }
 
         # public LB not needed right now

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -230,9 +230,19 @@ locals {
       # }
     }
     baseline_route53_zones = {
+      "${module.environment.domains.public.business_unit_environment}" = {
+        lb_alias_records = [
+          { name = "t1-nomis-web", type = "A", lbs_map_key = "private" },
+          { name = "t1-nomis-web-a", type = "A", lbs_map_key = "private" }
+        ]
+      }
       "test.nomis.az.justice.gov.uk" = {
         records = [
           { name = "cnomt1", type = "A", ttl = "300", records = ["10.101.3.132"] }
+        ]
+        lb_alias_records = [
+          { name = "t1-nomis-web", type = "A", lbs_map_key = "private" },
+          { name = "t1-nomis-web-a", type = "A", lbs_map_key = "private" }
         ]
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -181,30 +181,40 @@ locals {
         security_groups          = [aws_security_group.public.id]
 
         listeners = {
-          t1-nomis-web-http-7001 = merge(
-            local.lb_weblogic.http-7001, {
-              replace = {
-                target_group_name_replace     = "t1-nomis-web"
-                condition_host_header_replace = "t1-nomis-web"
+          https = merge(
+            local.lb_weblogic.https, {
+              rules = {
+                t1-nomis-web-http-7777 = {
+                  priority = 200
+                  actions = [{
+                    type              = "forward"
+                    target_group_name = "t1-nomis-web-http-7777"
+                  }]
+                  conditions = [{
+                    host_header = {
+                      values = [
+                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web.test.nomis.az.justice.gov.uk",
+                      ]
+                    }
+                  }]
+                }
+                t1-nomis-web-a-http-7777 = {
+                  priority = 300
+                  actions = [{
+                    type              = "forward"
+                    target_group_name = "t1-nomis-web-a-http-7777"
+                  }]
+                  conditions = [{
+                    host_header = {
+                      values = [
+                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
+                      ]
+                    }
+                  }]
+                }
               }
-          })
-          t1-nomis-web-http-7777 = merge(
-            local.lb_weblogic.http-7777, {
-              replace = {
-                target_group_name_replace     = "t1-nomis-web"
-                condition_host_header_replace = "t1-nomis-web"
-              }
-            }
-          )
-          t1-nomis-web-https = merge(
-            local.lb_weblogic.https,
-            local.lb_weblogic.route53, {
-              replace = {
-                target_group_name_replace     = "t1-nomis-web"
-                condition_host_header_replace = "t1-nomis-web"
-                route53_record_name_replace   = "t1-nomis-web"
-              }
-              alarm_target_group_names = ["t1-nomis-web-http-7777", "t1-nomis-web-http-7001"]
           })
         }
 
@@ -220,7 +230,7 @@ locals {
       }
     }
     baseline_route53_zones = {
-      "${local.environment}.nomis.az.justice.gov.uk" = {
+      "test.nomis.az.justice.gov.uk" = {
         records = [
           { name = "cnomt1", type = "A", ttl = "300", records = ["10.101.3.132"] }
         ]

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -219,5 +219,12 @@ locals {
         # }
       }
     }
+    baseline_route53_zones = {
+      "${local.environment}.nomis.az.justice.gov.uk" = {
+        records = [
+          { name = "cnomt1", type = "A", ttl = "300", records = ["10.101.3.132"] }
+        ]
+      }
+    }
   }
 }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -206,6 +206,16 @@ locals {
               }
               alarm_target_group_names = ["t1-nomis-web-http-7777", "t1-nomis-web-http-7001"]
           })
+          t1-nomis-web-a-https = merge(
+            local.lb_weblogic.https,
+            local.lb_weblogic.route53, {
+              replace = {
+                target_group_name_replace     = "t1-nomis-web-a"
+                condition_host_header_replace = "t1-nomis-web-a"
+                route53_record_name_replace   = "t1-nomis-web-a"
+              }
+              # alarm_target_group_names = ["t1-nomis-web-a-http-7777"]
+          })
         }
 
         # public LB not needed right now

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -171,53 +171,53 @@ locals {
 
     baseline_lbs = {
       # AWS doesn't let us call it internal
-      #      private = {
-      #        internal_lb              = true
-      #        enable_delete_protection = false
-      #        existing_target_groups   = local.existing_target_groups
-      #        force_destroy_bucket     = true
-      #        idle_timeout             = 3600
-      #        public_subnets           = module.environment.subnets["private"].ids
-      #        security_groups          = [aws_security_group.public.id]
-      #
-      #        listeners = {
-      #          https = merge(
-      #            local.lb_weblogic.https, {
-      #              rules = {
-      #                t1-nomis-web-http-7777 = {
-      #                  priority = 200
-      #                  actions = [{
-      #                    type              = "forward"
-      #                    target_group_name = "t1-nomis-web-http-7777"
-      #                  }]
-      #                  conditions = [{
-      #                    host_header = {
-      #                      values = [
-      #                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
-      #                        "t1-nomis-web.test.nomis.az.justice.gov.uk",
-      #                      ]
-      #                    }
-      #                  }]
-      #                }
-      #                t1-nomis-web-a-http-7777 = {
-      #                  priority = 300
-      #                  actions = [{
-      #                    type              = "forward"
-      #                    target_group_name = "t1-nomis-web-a-http-7777"
-      #                  }]
-      #                  conditions = [{
-      #                    host_header = {
-      #                      values = [
-      #                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
-      #                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
-      #                      ]
-      #                    }
-      #                  }]
-      #                }
-      #              }
-      #          })
-      #        }
-      #      }
+      private = {
+        internal_lb              = true
+        enable_delete_protection = false
+        existing_target_groups   = local.existing_target_groups
+        force_destroy_bucket     = true
+        idle_timeout             = 3600
+        public_subnets           = module.environment.subnets["private"].ids
+        security_groups          = [aws_security_group.public.id]
+
+        listeners = {
+          https = merge(
+            local.lb_weblogic.https, {
+              rules = {
+                t1-nomis-web-http-7777 = {
+                  priority = 200
+                  actions = [{
+                    type              = "forward"
+                    target_group_name = "t1-nomis-web-http-7777"
+                  }]
+                  conditions = [{
+                    host_header = {
+                      values = [
+                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web.test.nomis.az.justice.gov.uk",
+                      ]
+                    }
+                  }]
+                }
+                t1-nomis-web-a-http-7777 = {
+                  priority = 300
+                  actions = [{
+                    type              = "forward"
+                    target_group_name = "t1-nomis-web-a-http-7777"
+                  }]
+                  conditions = [{
+                    host_header = {
+                      values = [
+                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
+                      ]
+                    }
+                  }]
+                }
+              }
+          })
+        }
+      }
 
       # public LB not needed right now
       # public = {

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -171,63 +171,63 @@ locals {
 
     baseline_lbs = {
       # AWS doesn't let us call it internal
-      private = {
-        internal_lb              = true
-        enable_delete_protection = false
-        existing_target_groups   = local.existing_target_groups
-        force_destroy_bucket     = true
-        idle_timeout             = 3600
-        public_subnets           = module.environment.subnets["private"].ids
-        security_groups          = [aws_security_group.public.id]
+      #      private = {
+      #        internal_lb              = true
+      #        enable_delete_protection = false
+      #        existing_target_groups   = local.existing_target_groups
+      #        force_destroy_bucket     = true
+      #        idle_timeout             = 3600
+      #        public_subnets           = module.environment.subnets["private"].ids
+      #        security_groups          = [aws_security_group.public.id]
+      #
+      #        listeners = {
+      #          https = merge(
+      #            local.lb_weblogic.https, {
+      #              rules = {
+      #                t1-nomis-web-http-7777 = {
+      #                  priority = 200
+      #                  actions = [{
+      #                    type              = "forward"
+      #                    target_group_name = "t1-nomis-web-http-7777"
+      #                  }]
+      #                  conditions = [{
+      #                    host_header = {
+      #                      values = [
+      #                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
+      #                        "t1-nomis-web.test.nomis.az.justice.gov.uk",
+      #                      ]
+      #                    }
+      #                  }]
+      #                }
+      #                t1-nomis-web-a-http-7777 = {
+      #                  priority = 300
+      #                  actions = [{
+      #                    type              = "forward"
+      #                    target_group_name = "t1-nomis-web-a-http-7777"
+      #                  }]
+      #                  conditions = [{
+      #                    host_header = {
+      #                      values = [
+      #                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
+      #                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
+      #                      ]
+      #                    }
+      #                  }]
+      #                }
+      #              }
+      #          })
+      #        }
+      #      }
 
-        listeners = {
-          https = merge(
-            local.lb_weblogic.https, {
-              rules = {
-                t1-nomis-web-http-7777 = {
-                  priority = 200
-                  actions = [{
-                    type              = "forward"
-                    target_group_name = "t1-nomis-web-http-7777"
-                  }]
-                  conditions = [{
-                    host_header = {
-                      values = [
-                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
-                        "t1-nomis-web.test.nomis.az.justice.gov.uk",
-                      ]
-                    }
-                  }]
-                }
-                t1-nomis-web-a-http-7777 = {
-                  priority = 300
-                  actions = [{
-                    type              = "forward"
-                    target_group_name = "t1-nomis-web-a-http-7777"
-                  }]
-                  conditions = [{
-                    host_header = {
-                      values = [
-                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
-                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
-                      ]
-                    }
-                  }]
-                }
-              }
-          })
-        }
-
-        # public LB not needed right now
-        # public = {
-        #   internal_lb              = false
-        #   enable_delete_protection = false
-        #   force_destroy_bucket     = true
-        #   idle_timeout             = 3600
-        #   public_subnets           = module.environment.subnets["public"].ids
-        #   security_groups          = [aws_security_group.public.id]
-        # }
-      }
+      # public LB not needed right now
+      # public = {
+      #   internal_lb              = false
+      #   enable_delete_protection = false
+      #   force_destroy_bucket     = true
+      #   idle_timeout             = 3600
+      #   public_subnets           = module.environment.subnets["public"].ids
+      #   security_groups          = [aws_security_group.public.id]
+      # }
     }
     baseline_route53_zones = {
       "test.nomis.az.justice.gov.uk" = {


### PR DESCRIPTION
No we have things more or less working
- get rid of the test listeners 7001/7777
- create DNS records via baseline module instead of lb-listener module
- explicitly define the lb rules in locals, I think this is simpler overall
-  add preprod and prod load balancer and listeners