### PR TITLE
nomis: DSOS-1843: tweak DNS entries for nomis

### DIFF
--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -74,10 +74,9 @@ locals {
                   conditions = [{
                     host_header = {
                       values = [
-                        "preprod-nomis-web.${module.environment.domains.public.application_environment}",
-                        "preprod-nomis-web.preproduction.nomis.az.justice.gov.uk",
-                        "preprod-nomis-web-a.${module.environment.domains.public.application_environment}",
+                        "preprod-nomis-web-a.nomis.${module.environment.domains.public.business_unit_environment}",
                         "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk",
+                        "c.preproduction.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]
@@ -91,14 +90,13 @@ locals {
     baseline_route53_zones = {
       "${module.environment.domains.public.business_unit_environment}" = {
         lb_alias_records = [
-          { name = "preprod-nomis-web.nomis", type = "A", lbs_map_key = "private" },
-          { name = "preprod-nomis-web-a.nomis", type = "A", lbs_map_key = "private" }
+          { name = "preprod-nomis-web-a.nomis", type = "A", lbs_map_key = "private" },
         ]
       }
       "preproduction.nomis.az.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "preprod-nomis-web", type = "A", lbs_map_key = "private" },
-          { name = "preprod-nomis-web-a", type = "A", lbs_map_key = "private" }
+          { name = "preprod-nomis-web-a", type = "A", lbs_map_key = "private" },
+          { name = "c", type = "A", lbs_map_key = "private" },
         ]
       }
     }

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -169,10 +169,9 @@ locals {
                   conditions = [{
                     host_header = {
                       values = [
-                        "prod-nomis-web.${module.environment.domains.public.application_environment}",
-                        "prod-nomis-web.production.nomis.az.justice.gov.uk",
-                        "prod-nomis-web-a.${module.environment.domains.public.application_environment}",
+                        "prod-nomis-web-a.${module.environment.domains.public.business_unit_environment}",
                         "prod-nomis-web-a.production.nomis.az.justice.gov.uk",
+                        "c.production.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]
@@ -186,14 +185,13 @@ locals {
     baseline_route53_zones = {
       "${module.environment.domains.public.business_unit_environment}" = {
         lb_alias_records = [
-          { name = "prod-nomis-web.nomis", type = "A", lbs_map_key = "private" },
-          { name = "prod-nomis-web-a.nomis", type = "A", lbs_map_key = "private" }
+          { name = "prod-nomis-web-a.nomis", type = "A", lbs_map_key = "private" },
         ]
       }
       "production.nomis.az.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "prod-nomis-web", type = "A", lbs_map_key = "private" },
-          { name = "prod-nomis-web-a", type = "A", lbs_map_key = "private" }
+          { name = "c", type = "A", lbs_map_key = "private" },
+          { name = "prod-nomis-web-a", type = "A", lbs_map_key = "private" },
         ]
       }
     }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -193,8 +193,9 @@ locals {
                   conditions = [{
                     host_header = {
                       values = [
-                        "t1-nomis-web.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web.nomis.${module.environment.domains.public.business_unit_environment}",
                         "t1-nomis-web.test.nomis.az.justice.gov.uk",
+                        "c-t1.test.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]
@@ -208,7 +209,7 @@ locals {
                   conditions = [{
                     host_header = {
                       values = [
-                        "t1-nomis-web-a.${module.environment.domains.public.application_environment}",
+                        "t1-nomis-web-a.nomis.${module.environment.domains.public.business_unit_environment}",
                         "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
                       ]
                     }
@@ -218,31 +219,22 @@ locals {
           })
         }
       }
-
-      # public LB not needed right now
-      # public = {
-      #   internal_lb              = false
-      #   enable_delete_protection = false
-      #   force_destroy_bucket     = true
-      #   idle_timeout             = 3600
-      #   public_subnets           = module.environment.subnets["public"].ids
-      #   security_groups          = [aws_security_group.public.id]
-      # }
     }
     baseline_route53_zones = {
       "${module.environment.domains.public.business_unit_environment}" = {
         lb_alias_records = [
           { name = "t1-nomis-web.nomis", type = "A", lbs_map_key = "private" },
-          { name = "t1-nomis-web-a.nomis", type = "A", lbs_map_key = "private" }
+          { name = "t1-nomis-web-a.nomis", type = "A", lbs_map_key = "private" },
         ]
       }
       "test.nomis.az.justice.gov.uk" = {
         records = [
-          { name = "cnomt1", type = "A", ttl = "300", records = ["10.101.3.132"] }
+          { name = "cnomt1", type = "A", ttl = "300", records = ["10.101.3.132"] },
         ]
         lb_alias_records = [
           { name = "t1-nomis-web", type = "A", lbs_map_key = "private" },
-          { name = "t1-nomis-web-a", type = "A", lbs_map_key = "private" }
+          { name = "t1-nomis-web-a", type = "A", lbs_map_key = "private" },
+          { name = "c-t1", type = "A", lbs_map_key = "private" },
         ]
       }
     }


### PR DESCRIPTION
Tweak the DNS naming strategy:
- ensure there is a name matching the ASG in both mod platform domain and .az domain (latter for Mojo testing)
- use "c" for the endpoint we give out to people to be consistent with current naming, or c-t1 when we have stacked environments, e.g.
c.production.az.nomis.justice.gov.uk
c.preproduction.az.nomis.justice.gov.uk
c-t1.test.az.nomis.justice.gov.uk