### PR TITLE
Nomis: DSOS-1847: simplify lb listener module

### DIFF
--- a/terraform/modules/baseline/lb.tf
+++ b/terraform/modules/baseline/lb.tf
@@ -45,10 +45,6 @@ module "lb_listener" {
 
   source = "../../modules/lb_listener"
 
-  providers = {
-    aws.core-vpc = aws.core-vpc
-  }
-
   name                      = each.key
   business_unit             = var.environment.business_unit
   environment               = var.environment.environment
@@ -62,13 +58,6 @@ module "lb_listener" {
   default_action            = each.value.default_action
   rules                     = each.value.rules
 
-  route53_records = {
-    for key, value in each.value.route53_records : key => merge(value, {
-      account = local.route53_zones[value.zone_name].provider
-      zone_id = local.route53_zones[value.zone_name].zone_id
-    })
-  }
-
   cloudwatch_metric_alarms = {
     for key, value in each.value.cloudwatch_metric_alarms : key => merge(value, {
       alarm_actions = [
@@ -77,8 +66,7 @@ module "lb_listener" {
     })
   }
 
-  replace = each.value.replace
-  tags    = merge(local.tags, each.value.tags)
+  tags = merge(local.tags, each.value.tags)
 
   depends_on = [
     module.acm_certificate,       # ensure certs are created first

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -520,10 +520,6 @@ variable "lbs" {
           }))
         }))
       })), {})
-      route53_records = optional(map(object({
-        zone_name              = string
-        evaluate_target_health = optional(bool, false)
-      })), {})
       cloudwatch_metric_alarms = optional(map(object({
         comparison_operator = string
         evaluation_periods  = number
@@ -539,14 +535,6 @@ variable "lbs" {
         treat_missing_data  = optional(string, "missing")
         dimensions          = optional(map(string), {})
       })), {})
-      replace = optional(object({
-        target_group_name_match       = optional(string, "$(name)")
-        target_group_name_replace     = optional(string, "")
-        condition_host_header_match   = optional(string, "$(name)")
-        condition_host_header_replace = optional(string, "")
-        route53_record_name_match     = optional(string, "$(name)")
-        route53_record_name_replace   = optional(string, "")
-      }), {})
       tags = optional(map(string), {})
     })), {})
   }))

--- a/terraform/modules/lb_listener/locals.tf
+++ b/terraform/modules/lb_listener/locals.tf
@@ -1,16 +1,7 @@
 locals {
   aws_lb = var.load_balancer_arn != null ? data.aws_lb.this[0] : var.load_balancer
 
-  target_group_attachments = flatten([
-    for target_group_name, target_group_value in var.target_groups : [
-      for attachment_value in target_group_value.attachments : {
-        name       = target_group_name
-        attachment = attachment_value
-      }
-    ]
-  ])
-
-  target_groups = merge(var.existing_target_groups, aws_lb_target_group.this)
+  target_groups = var.existing_target_groups
 
   cloudwatch_metric_alarms_list = flatten([
     for target_group_name in var.alarm_target_group_names : [

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -10,7 +10,7 @@ resource "aws_lb_listener" "this" {
 
     content {
       type             = default_action.value.type
-      target_group_arn = default_action.value.target_group_name != null ? local.target_groups[replace(default_action.value.target_group_name, var.replace.target_group_name_match, var.replace.target_group_name_replace)].arn : default_action.value.target_group_arn
+      target_group_arn = default_action.value.target_group_name != null ? local.target_groups[default_action.value.target_group_name].arn : default_action.value.target_group_arn
 
       dynamic "fixed_response" {
         for_each = default_action.value.fixed_response != null ? [default_action.value.fixed_response] : []
@@ -68,7 +68,7 @@ resource "aws_lb_listener_rule" "this" {
 
     content {
       type             = action.value.type
-      target_group_arn = action.value.target_group_name != null ? local.target_groups[replace(action.value.target_group_name, var.replace.target_group_name_match, var.replace.target_group_name_replace)].arn : action.value.target_group_arn
+      target_group_arn = action.value.target_group_name != null ? local.target_groups[action.value.target_group_name].arn : action.value.target_group_arn
 
       dynamic "fixed_response" {
         for_each = action.value.fixed_response != null ? [action.value.fixed_response] : []
@@ -116,10 +116,7 @@ resource "aws_lb_listener_rule" "this" {
       dynamic "host_header" {
         for_each = condition.value.host_header != null ? [condition.value.host_header] : []
         content {
-          values = [
-            for value in host_header.value.values :
-            replace(value, var.replace.condition_host_header_match, var.replace.condition_host_header_replace)
-          ]
+          values = host_header.value.values
         }
       }
       dynamic "path_pattern" {
@@ -141,59 +138,6 @@ resource "aws_lb_listener_certificate" "this" {
   listener_arn    = aws_lb_listener.this.arn
   certificate_arn = lookup(var.certificate_arn_lookup, each.value, each.value)
 }
-
-resource "aws_route53_record" "core_vpc" {
-  for_each = { for key, value in var.route53_records : key => value if value.account == "core-vpc" }
-  provider = aws.core-vpc
-
-  zone_id = each.value.zone_id
-  name    = replace(each.key, var.replace.route53_record_name_match, var.replace.route53_record_name_replace)
-  type    = "A"
-
-  alias {
-    name                   = local.aws_lb.dns_name
-    zone_id                = local.aws_lb.zone_id
-    evaluate_target_health = each.value.evaluate_target_health
-  }
-}
-
-resource "aws_route53_record" "self" {
-  for_each = { for key, value in var.route53_records : key => value if value.account == "self" }
-
-  zone_id = each.value.zone_id
-  name    = replace(each.key, var.replace.route53_record_name_match, var.replace.route53_record_name_replace)
-  type    = "A"
-
-  alias {
-    name                   = local.aws_lb.dns_name
-    zone_id                = local.aws_lb.zone_id
-    evaluate_target_health = each.value.evaluate_target_health
-  }
-}
-
-#resource "aws_cloudwatch_metric_alarm" "this" {
-#  for_each = { for key, value in var.cloudwatch_metric_alarms : key => value if local.target_group_arn.arn_suffix != null }
-#
-#  alarm_name          = "${var.name}-${each.key}"
-#  comparison_operator = each.value.comparison_operator
-#  evaluation_periods  = each.value.evaluation_periods
-#  metric_name         = each.value.metric_name
-#  namespace           = each.value.namespace
-#  period              = each.value.period
-#  statistic           = each.value.statistic
-#  threshold           = each.value.threshold
-#  alarm_actions       = each.value.alarm_actions
-#  alarm_description   = each.value.alarm_description
-#  datapoints_to_alarm = each.value.datapoints_to_alarm
-#  treat_missing_data  = each.value.treat_missing_data
-#  tags                = merge(var.tags, {
-#    Name = "${var.name}-${each.key}"
-#  })
-#  dimensions = merge(each.value.dimensions, {
-#    "LoadBalancer" = data.aws_lb.this.arn_suffix
-#    "TargetGroup"  = local.target_group_arn.arn_suffix
-#  })
-#}
 
 resource "aws_cloudwatch_metric_alarm" "this" {
   for_each = local.cloudwatch_metric_alarms

--- a/terraform/modules/lb_listener/outputs.tf
+++ b/terraform/modules/lb_listener/outputs.tf
@@ -1,8 +1,3 @@
-output "aws_lb_target_group" {
-  value       = aws_lb_target_group.this
-  description = "map of created aws_lb_target_groups"
-}
-
 output "aws_lb_listener" {
   value       = aws_lb_listener.this
   description = "the aws_lb_listener object"

--- a/terraform/modules/lb_listener/variables.tf
+++ b/terraform/modules/lb_listener/variables.tf
@@ -24,38 +24,6 @@ variable "load_balancer_arn" {
   default     = null
 }
 
-variable "target_groups" {
-  description = "Map of target groups, where key is the name"
-  type = map(object({
-    port                 = optional(number)
-    protocol             = optional(string)
-    target_type          = string
-    deregistration_delay = optional(number)
-    health_check = optional(object({
-      enabled             = optional(bool)
-      interval            = optional(number)
-      healthy_threshold   = optional(number)
-      matcher             = optional(string)
-      path                = optional(string)
-      port                = optional(number)
-      timeout             = optional(number)
-      unhealthy_threshold = optional(number)
-    }))
-    stickiness = optional(object({
-      enabled         = optional(bool)
-      type            = string
-      cookie_duration = optional(number)
-      cookie_name     = optional(string)
-    }))
-    attachments = optional(list(object({
-      target_id         = string
-      port              = optional(number)
-      availability_zone = optional(string)
-    })), [])
-  }))
-  default = {}
-}
-
 variable "existing_target_groups" {
   description = "Map of existing aws_lb_target_groups, if looking up target group by name (map key)"
   default     = {}

--- a/terraform/modules/lb_listener/variables.tf
+++ b/terraform/modules/lb_listener/variables.tf
@@ -128,29 +128,6 @@ variable "rules" {
   }))
 }
 
-variable "route53_records" {
-  description = "Map of route53 records to associate with load balancer, where key is the DNS name"
-  type = map(object({
-    account                = string # account to create the record in.  set to core-vpc or self
-    zone_id                = string # id of zone to create the record in
-    evaluate_target_health = bool
-  }))
-  default = {}
-}
-
-variable "replace" {
-  description = "A bit of a bodge to make definition of rules and default_action reusable.  Does a search/replace on the target_group_name field in rules/default_action contains with target_group_name_match/target_group_name_replace.  Likewise with the condition host header.  Useful when you have multiple environments with same config"
-  type = object({
-    target_group_name_match       = optional(string, "$(name)")
-    target_group_name_replace     = optional(string, "")
-    condition_host_header_match   = optional(string, "$(name)")
-    condition_host_header_replace = optional(string, "")
-    route53_record_name_match     = optional(string, "$(name)")
-    route53_record_name_replace   = optional(string, "")
-  })
-  default = {}
-}
-
 variable "tags" {
   type        = map(any)
   description = "Default tags to be applied to resources"

--- a/terraform/modules/lb_listener/versions.tf
+++ b/terraform/modules/lb_listener/versions.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version               = "~> 4.9"
-      source                = "hashicorp/aws"
-      configuration_aliases = [aws.core-vpc]
+      version = "~> 4.9"
+      source  = "hashicorp/aws"
     }
   }
   required_version = ">= 1.1.7"


### PR DESCRIPTION
Try and simplify lb-listener a bit:
- remove support for target groups being created within the module (this is done within ASG)
- remove support for adding route53 entries (this can be done via baseline module)
- remove the replace logic (it's too confusing)
Should be zero plan changes as these features are not currently in use.