### PR TITLE
Adding resource_explorer Baseline Module argument for OASys environments

### DIFF
--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -140,7 +140,7 @@ locals {
     instance              = module.baseline_presets.ec2_instance.instance.default_db
     autoscaling_schedules = {}
     autoscaling_group     = module.baseline_presets.ec2_autoscaling_group
-    user_data_cloud_init  = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags, {
+    user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags, {
       args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags.args, {
         branch = "ccfe2d0becae50d1ff706442b52a6c9fe01d5a7c" # 2023-04-12
       })

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -49,25 +49,23 @@ module "baseline" {
     aws.core-vpc              = aws.core-vpc
   }
 
-  security_groups       = local.baseline_security_groups
-  acm_certificates      = module.baseline_presets.acm_certificates
-  cloudwatch_log_groups = module.baseline_presets.cloudwatch_log_groups
-  iam_policies          = module.baseline_presets.iam_policies
-  iam_roles             = module.baseline_presets.iam_roles
+  # bastion_linux = lookup(local.environment_config, "baseline_bastion_linux", null)
   # iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
-  key_pairs         = module.baseline_presets.key_pairs
-  kms_grants        = module.baseline_presets.kms_grants
-  route53_resolvers = module.baseline_presets.route53_resolvers
-  route53_zones     = lookup(local.environment_config, "baseline_route53_zones", {})
-  s3_buckets        = merge(local.baseline_s3_buckets, module.baseline_presets.s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
   # rds_instances
-  #sns_topics
-
-  #bastion_linux = lookup(local.environment_config, "baseline_bastion_linux", null)
-
-  environment = module.environment
-
-  ec2_instances          = lookup(local.environment_config, "baseline_ec2_instances", {})
+  # sns_topics
+  acm_certificates       = module.baseline_presets.acm_certificates
+  cloudwatch_log_groups  = module.baseline_presets.cloudwatch_log_groups
   ec2_autoscaling_groups = lookup(local.environment_config, "baseline_ec2_autoscaling_groups", {})
+  ec2_instances          = lookup(local.environment_config, "baseline_ec2_instances", {})
+  environment            = module.environment
+  iam_policies           = module.baseline_presets.iam_policies
+  iam_roles              = module.baseline_presets.iam_roles
+  key_pairs              = module.baseline_presets.key_pairs
+  kms_grants             = module.baseline_presets.kms_grants
   lbs                    = lookup(local.environment_config, "baseline_lbs", {})
+  resource_explorer      = true
+  route53_resolvers      = module.baseline_presets.route53_resolvers
+  route53_zones          = lookup(local.environment_config, "baseline_route53_zones", {})
+  s3_buckets             = merge(local.baseline_s3_buckets, module.baseline_presets.s3_buckets, lookup(local.environment_config, "baseline_s3_buckets", {}))
+  security_groups        = local.baseline_security_groups
 }


### PR DESCRIPTION
I've also applied an alphabetical sort for the Baseline Module arguments which is why the diff looks a bit of a mess.