### PR TITLE
nomis: DSOS-1847: add image builder S3 policies for EC2 instances

### DIFF
--- a/terraform/environments/nomis-combined-reporting/baseline_presets.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline_presets.tf
@@ -10,6 +10,8 @@ module "baseline_presets" {
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
+    iam_policies_filter                          = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
+    iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
 
     # comment this in if you need to resolve FixNGo hostnames

--- a/terraform/environments/nomis-data-hub/baseline_presets.tf
+++ b/terraform/environments/nomis-data-hub/baseline_presets.tf
@@ -10,6 +10,8 @@ module "baseline_presets" {
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
+    iam_policies_filter                          = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
+    iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
 
     # comment this in if you need to resolve FixNGo hostnames

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -31,6 +31,7 @@ module "baseline_presets" {
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
+    iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
 
     # comment this in if you need to resolve FixNGo hostnames

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -2,15 +2,6 @@ locals {
 
   ec2_instance = {
 
-    profile_policies = {
-
-      # remember to add the appropriate S3 policy to this
-      default = flatten([
-        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-        local.iam_policies_ec2_default,
-      ])
-    }
-
     config = {
 
       # example configuration
@@ -24,7 +15,6 @@ locals {
         instance_profile_policies = flatten([
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
           local.iam_policies_ec2_default,
-          "EC2S3BucketWriteAndDeleteAccessPolicy",
         ])
       }
 
@@ -38,7 +28,6 @@ locals {
         instance_profile_policies = flatten([
           "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
           local.iam_policies_ec2_default,
-          "EC2S3BucketWriteAndDeleteAccessPolicy"
         ])
       }
     }

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -6,6 +6,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
     var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
+    var.options.iam_policies_filter,
   ])
 
   iam_policies_ec2_default = flatten([
@@ -13,6 +14,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
     var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
+    var.options.iam_policies_ec2_default,
   ])
 
   iam_policies = {
@@ -123,13 +125,79 @@ locals {
         resources = var.environment == "production" || var.environment == "preproduction" ? [
           "arn:aws:s3:::prodpreprod-${var.environment.application_name}-*/*",
           "arn:aws:s3:::prodpreprod-${var.environment.application_name}-*"
-        ] : [
+          ] : [
           "arn:aws:s3:::devtest-${var.environment.application_name}-*/*",
           "arn:aws:s3:::devtest-${var.environment.application_name}-*"
         ]
       }]
     }
 
+    # see corresponding policy in core-shared-services-production
+    # https://github.com/ministryofjustice/modernisation-platform-ami-builds/blob/main/modernisation-platform/iam.tf
+    ImageBuilderS3BucketReadOnlyAccessPolicy = {
+      description = "Permissions to access shared ImageBuilder bucket read-only"
+      statements = [{
+        effect = "Allow"
+        actions = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        resources = [
+          "arn:aws:s3:::ec2-image-builder-*/*",
+          "arn:aws:s3:::ec2-image-builder-*",
+          "arn:aws:s3:::*-software*/*",
+          "arn:aws:s3:::*-software*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*/*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*",
+          "arn:aws:s3:::modernisation-platform-software*/*",
+          "arn:aws:s3:::modernisation-platform-software*"
+        ]
+      }]
+    }
+    ImageBuilderS3BucketWriteAccessPolicy = {
+      description = "Permissions to access shared ImageBuilder bucket read-write"
+      statements = [{
+        effect = "Allow"
+        actions = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+        ]
+        resources = [
+          "arn:aws:s3:::ec2-image-builder-*/*",
+          "arn:aws:s3:::ec2-image-builder-*",
+          "arn:aws:s3:::*-software*/*",
+          "arn:aws:s3:::*-software*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*/*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*",
+          "arn:aws:s3:::modernisation-platform-software*/*",
+          "arn:aws:s3:::modernisation-platform-software*"
+        ]
+      }]
+    }
+    ImageBuilderS3BucketWriteAndDeleteAccessPolicy = {
+      description = "Permissions to access shared ImageBuilder bucket read-write-delete"
+      statements = [{
+        effect = "Allow"
+        actions = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:DeleteObject",
+        ]
+        resources = [
+          "arn:aws:s3:::ec2-image-builder-*/*",
+          "arn:aws:s3:::ec2-image-builder-*",
+          "arn:aws:s3:::*-software*/*",
+          "arn:aws:s3:::*-software*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*/*",
+          "arn:aws:s3:::mod-platform-image-artefact-bucket*",
+          "arn:aws:s3:::modernisation-platform-software*/*",
+          "arn:aws:s3:::modernisation-platform-software*"
+        ]
+      }]
+    }
   }
-
 }

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -43,6 +43,8 @@ variable "options" {
     enable_ec2_self_provision                    = optional(bool, false)
     enable_shared_s3                             = optional(bool, false)
     route53_resolver_rules                       = optional(map(list(string)), {})
+    iam_policies_filter                          = optional(list(string), [])
+    iam_policies_ec2_default                     = optional(list(string), [])
     s3_iam_policies                              = optional(list(string))
     sns_topics_pagerduty_integrations            = optional(map(string), {})
   })


### PR DESCRIPTION
Add S3 policies that allow access to image builder software S3 buckets cross-account.  
Made the default EC2 policy list a little more flexible.