### PR TITLE
Jitbit: Alerting for high volume of application error logs

### DIFF
--- a/terraform/environments/delius-jitbit/monitoring_app.tf
+++ b/terraform/environments/delius-jitbit/monitoring_app.tf
@@ -1,5 +1,5 @@
 resource aws_cloudwatch_log_group app_logs {
-  name              = "delius-jitbit-ecs"
+  name              = "delius-jitbit-app"
   retention_in_days = 30
 }
 

--- a/terraform/environments/delius-jitbit/monitoring_app.tf
+++ b/terraform/environments/delius-jitbit/monitoring_app.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_log_group" "app_logs" {
   tags = local.tags
 }
 
-// log metric filter for error logs in container that contain the word error or exception
+// log metric filter for error logs in container that contain the phrase "Error in Helpdesk"
 resource "aws_cloudwatch_log_metric_filter" "error" {
   name           = "jitbit-application-error"
   pattern        = "Error in Helpdesk"
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "jitbit_high_error_volume" {
   evaluation_periods  = "1"
   alarm_actions       = [aws_sns_topic.jitbit_alerting.arn]
   ok_actions          = [aws_sns_topic.jitbit_alerting.arn]
-  threshold           = "5"
+  threshold           = "10"
   treat_missing_data  = "missing"
   comparison_operator = "GreaterThanThreshold"
 }

--- a/terraform/environments/delius-jitbit/monitoring_app.tf
+++ b/terraform/environments/delius-jitbit/monitoring_app.tf
@@ -1,6 +1,8 @@
 resource aws_cloudwatch_log_group app_logs {
   name              = "delius-jitbit-app"
   retention_in_days = 30
+
+  tags = local.tags
 }
 
 // log metric filter for error logs in container that contain the word error or exception

--- a/terraform/environments/delius-jitbit/monitoring_app.tf
+++ b/terraform/environments/delius-jitbit/monitoring_app.tf
@@ -1,0 +1,17 @@
+resource aws_cloudwatch_log_group app_logs {
+  name              = "delius-jitbit-ecs"
+  retention_in_days = 30
+}
+
+// log metric filter for error logs in container that contain the word error or exception
+resource "aws_cloudwatch_log_metric_filter" "error" {
+  name           = "jitbit-application-error"
+  pattern        = "Error in Helpdesk"
+  log_group_name = aws_cloudwatch_log_group.app_logs.name
+
+  metric_transformation {
+    name      = "ErrorCount"
+    namespace = "JitbitMetrics"
+    value     = "1"
+  }
+}

--- a/terraform/environments/delius-jitbit/monitoring_app.tf
+++ b/terraform/environments/delius-jitbit/monitoring_app.tf
@@ -1,4 +1,4 @@
-resource aws_cloudwatch_log_group app_logs {
+resource "aws_cloudwatch_log_group" "app_logs" {
   name              = "delius-jitbit-app"
   retention_in_days = 30
 
@@ -16,4 +16,19 @@ resource "aws_cloudwatch_log_metric_filter" "error" {
     namespace = "JitbitMetrics"
     value     = "1"
   }
+}
+
+resource "aws_cloudwatch_metric_alarm" "jitbit_high_error_volume" {
+  alarm_name          = "jitbit-high-error-count"
+  alarm_description   = "Triggers alarm if there are more than 5 errors in the last 5 minutes"
+  namespace           = "JitbitMetrics"
+  metric_name         = "ErrorCount"
+  statistic           = "Sum"
+  period              = "300"
+  evaluation_periods  = "1"
+  alarm_actions       = [aws_sns_topic.jitbit_alerting.arn]
+  ok_actions          = [aws_sns_topic.jitbit_alerting.arn]
+  threshold           = "5"
+  treat_missing_data  = "missing"
+  comparison_operator = "GreaterThanThreshold"
 }

--- a/terraform/environments/delius-jitbit/monitoring_ecs.tf
+++ b/terraform/environments/delius-jitbit/monitoring_ecs.tf
@@ -38,54 +38,56 @@ resource "aws_cloudwatch_dashboard" "jitbit_ecs_dashboard" {
 
   dashboard_body = <<EOF
   {
-  "widgets": [
-    {
-      "type": "metric",
-      "height": 8,
-      "width": 11,
-      "y": 0,
-      "x": 11,
-      "properties": {
-        "metrics": [
-          [
-            "AWS/ECS",
-            "CPUUtilization",
-            "ClusterName",
-            "${format("hmpps-%s-%s", local.environment, local.application_name)}",
-            "ServiceName",
-            "${format("hmpps-%s-%s", local.environment, local.application_name)}"
-          ]
-        ],
-        "period": 60,
-        "stat": "Average",
-        "region": "eu-west-2",
-        "title": "CPU Utilization"
-      }
-    },
-    {
-      "type": "metric",
-      "height": 8,
-      "width": 11,
-      "y": 0,
-      "x": 11,
-      "properties": {
-        "metrics": [
-          [
-            "AWS/ECS",
-            "MemoryUtilization",
-            "ClusterName",
-            "${format("hmpps-%s-%s", local.environment, local.application_name)}",
-            "ServiceName",
-            "${format("hmpps-%s-%s", local.environment, local.application_name)}"
-          ]
-        ],
-        "period": 60,
-        "stat": "Average",
-        "region": "eu-west-2",
-        "title": "Memory Utilization"
-      }
-    }
-  ]
-}
+    "widgets": [
+        {
+            "height": 8,
+            "width": 11,
+            "y": 0,
+            "x": 11,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ECS", "CPUUtilization", "ClusterName", "hmpps-development-delius-jitbit", "ServiceName", "hmpps-development-delius-jitbit" ]
+                ],
+                "period": 60,
+                "stat": "Average",
+                "region": "eu-west-2",
+                "title": "CPU Utilization"
+            }
+        },
+        {
+            "height": 8,
+            "width": 11,
+            "y": 8,
+            "x": 11,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ECS", "MemoryUtilization", "ClusterName", "hmpps-development-delius-jitbit", "ServiceName", "hmpps-development-delius-jitbit" ]
+                ],
+                "period": 60,
+                "stat": "Average",
+                "region": "eu-west-2",
+                "title": "Memory Utilization"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 5,
+            "y": 0,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [ "JitbitMetrics", "ErrorCount" ]
+                ],
+                "region": "eu-west-2",
+                "title": "Jitbit Application Error Count"
+            }
+        }
+    ]
+  }
 EOF
 }

--- a/terraform/environments/delius-jitbit/monitoring_ecs.tf
+++ b/terraform/environments/delius-jitbit/monitoring_ecs.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_dashboard" "jitbit_ecs_dashboard" {
   dashboard_name = "jitbit-ecs-dashboard"
 
   dashboard_body = <<EOF
-  {
+{
     "widgets": [
         {
             "height": 8,
@@ -78,16 +78,18 @@ resource "aws_cloudwatch_dashboard" "jitbit_ecs_dashboard" {
             "width": 6,
             "height": 6,
             "properties": {
+                "metrics": [
+                    [ "JitbitMetrics", "ErrorCount", { "region": "eu-west-2", "color": "#d62728" } ]
+                ],
                 "view": "timeSeries",
                 "stacked": false,
-                "metrics": [
-                    [ "JitbitMetrics", "ErrorCount" ]
-                ],
                 "region": "eu-west-2",
-                "title": "Jitbit Application Error Count"
+                "title": "Jitbit Application Error Count",
+                "period": 300,
+                "stat": "Average"
             }
         }
     ]
-  }
+}
 EOF
 }


### PR DESCRIPTION
- Create new log group for application logs
- Log metric filter to filter error logs "Error in Helpdesk"
- Create alarm hooked into PagerDuty integration for alerting when error count in the last 5 minutes exceeds the threshold of 10 (these examples are PoC and are subject to adjustment)
- Add widget to jitbit dashboard with error count