### PR TITLE
NIT-621 change how nd interface is configured

### DIFF
--- a/terraform/environments/delius-iaps/application_variables.json
+++ b/terraform/environments/delius-iaps/application_variables.json
@@ -50,7 +50,7 @@
       "db_performance_insights_enabled": "false",
       "db_skip_final_snapshot": "true",
       "ec2_iaps_instance_type": "t3.medium",
-      "ec2_iaps_instance_ami_name": "delius_iaps_server_patch_2023-04-13T10-13-38.727Z",
+      "ec2_iaps_instance_ami_name": "delius_iaps_server_patch_2023-04-17T15-40-43.990Z",
       "cloudwatch_agent_log_group_retention_period": "365",
       "iaps_ndelius_interface_url": "interface.stage.probation.service.justice.gov.uk",
       "iaps_im_interface_url": "preprod-im-data.i2ncloud.com",

--- a/terraform/environments/delius-iaps/files/ndelius_interface_ssm_params.yml
+++ b/terraform/environments/delius-iaps/files/ndelius_interface_ssm_params.yml
@@ -4,65 +4,35 @@ parameter:
     type: "String"
     value: "dev-placeholder-ndelius-interface-iapscmsif-interface-user"
     overwrite: false
-  ndelius-interface-iapscmsif-interface-password:
-    name: /NDeliusInterface/IAPSCMSIF/Interface/password
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-iapscmsif-interface-password"
-    overwrite: false
   ndelius-interface-iapscmsif-interface-passwordcoded:
     name: /NDeliusInterface/IAPSCMSIF/Interface/passwordcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-iapscmsif-interface-passwordcoded"
     overwrite: false
-  ndelius-interface-user:
-    name: /NDeliusInterface/Interface/user
+  ndelius-interface-dbuser:
+    name: /NDeliusInterface/Interface/dbuser
+    type: "String"
+    value: "dev-placeholder-ndelius-interface-dbuser"
+    overwrite: false
+  ndelius-interface-dbpwdcoded:
+    name: /NDeliusInterface/Interface/dbpwdcoded
+    type: "SecureString"
+    value: "dev-placeholder-ndelius-interface-dbpasswordcoded"
+    overwrite: false
+  ndelius-interface-soapuser:
+    name: /NDeliusInterface/Interface/soapuser
     type: "String"
     value: "dev-placeholder-ndelius-interface-user"
-    overwrite: false
-  ndelius-interface-password:
-    name: /NDeliusInterface/Interface/password
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-password"
-    overwrite: false
-  ndelius-interface-replicapasswordcoded:
-    name: /NDeliusInterface/Interface/replicapwdcoded
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-replicapasswordcoded"
     overwrite: false
   ndelius-interface-soappasscoded:
     name: /NDeliusInterface/Interface/soappwdcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-soappasscoded"
     overwrite: false
-  ndelius-interface-pwdcoded:
-    name: /NDeliusInterface/Interface/pwdcoded
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-passwordcoded"
-    overwrite: false
-  ndelius-interface-odbc-dsn:
-    name: /NDeliusInterface/Interface/ODBC/dsn
-    type: "String"
-    value: "dev-placeholder-ndelius-interface-odbc-dsn"
-    overwrite: false
-  ndelius-interface-odbc-uid:
-    name: /NDeliusInterface/Interface/ODBC/uid
-    type: "String"
-    value: "dev-placeholder-ndelius-interface-odbc-uid"
-    overwrite: false
-  ndelius-interface-odbc-pwd:
-    name: /NDeliusInterface/Interface/ODBC/pwd
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-odbc-pwd"
-    overwrite: false
   ndelius-interface-email-smtpuser:
     name: /NDeliusInterface/Email/smtpuser
     type: "String"
     value: "dev-placeholder-ndelius-interface-email-smtpuser"
-    overwrite: false
-  ndelius-interface-email-password:
-    name: /NDeliusInterface/Email/password
-    type: "SecureString"
-    value: "dev-placeholder-ndelius-interface-email-password"
     overwrite: false
   ndelius-interface-email-passwordcoded:
     name: /NDeliusInterface/Email/passwordcoded

--- a/terraform/environments/delius-iaps/files/ndelius_interface_ssm_params.yml
+++ b/terraform/environments/delius-iaps/files/ndelius_interface_ssm_params.yml
@@ -3,44 +3,44 @@ parameter:
     name: /NDeliusInterface/IAPSCMSIF/Interface/user
     type: "String"
     value: "dev-placeholder-ndelius-interface-iapscmsif-interface-user"
-    overwrite: false
+    overwrite: true
   ndelius-interface-iapscmsif-interface-passwordcoded:
     name: /NDeliusInterface/IAPSCMSIF/Interface/passwordcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-iapscmsif-interface-passwordcoded"
-    overwrite: false
+    overwrite: true
   ndelius-interface-dbuser:
     name: /NDeliusInterface/Interface/dbuser
     type: "String"
     value: "dev-placeholder-ndelius-interface-dbuser"
-    overwrite: false
+    overwrite: true
   ndelius-interface-dbpwdcoded:
     name: /NDeliusInterface/Interface/dbpwdcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-dbpasswordcoded"
-    overwrite: false
+    overwrite: true
   ndelius-interface-soapuser:
     name: /NDeliusInterface/Interface/soapuser
     type: "String"
     value: "dev-placeholder-ndelius-interface-user"
-    overwrite: false
+    overwrite: true
   ndelius-interface-soappasscoded:
     name: /NDeliusInterface/Interface/soappwdcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-soappasscoded"
-    overwrite: false
+    overwrite: true
   ndelius-interface-email-smtpuser:
     name: /NDeliusInterface/Email/smtpuser
     type: "String"
     value: "dev-placeholder-ndelius-interface-email-smtpuser"
-    overwrite: false
+    overwrite: true
   ndelius-interface-email-passwordcoded:
     name: /NDeliusInterface/Email/passwordcoded
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-email-passwordcoded"
-    overwrite: false
+    overwrite: true
   ndelius-interface-email-fromaddress:
     name: /NDeliusInterface/Email/fromaddress
     type: "SecureString"
     value: "dev-placeholder-ndelius-interface-email-fromaddress"
-    overwrite: false
+    overwrite: true

--- a/terraform/environments/delius-iaps/ssm.tf
+++ b/terraform/environments/delius-iaps/ssm.tf
@@ -3,7 +3,7 @@ resource "aws_ssm_parameter" "im-interface-oracle-user" {
   name      = "/IMInterface/IAPSOracle/user"
   type      = "String"
   value     = "dev-placeholder-iapsoracle-user"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -16,7 +16,7 @@ resource "aws_ssm_parameter" "im-interface-oracle-password" {
   name      = "/IMInterface/IAPSOracle/password"
   type      = "SecureString"
   value     = "dev-placeholder-iapsoracle-password"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -29,7 +29,7 @@ resource "aws_ssm_parameter" "im-interface-soap-odbc-dsn" {
   name      = "/IMInterface/SOAPServer/ODBC/dsn"
   type      = "String"
   value     = "dev-placeholder-soapserver-odbc-dsn"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -42,7 +42,7 @@ resource "aws_ssm_parameter" "im-interface-soap-odbc-server" {
   name      = "/IMInterface/SOAPServer/ODBC/server"
   type      = "String"
   value     = "dev-placeholder-soapserver-odbc-server"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -55,7 +55,7 @@ resource "aws_ssm_parameter" "im-interface-soap-odbc-database" {
   name      = "/IMInterface/SOAPServer/ODBC/database"
   type      = "String"
   value     = "dev-placeholder-soapserver-odbc-database"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -68,7 +68,7 @@ resource "aws_ssm_parameter" "im-interface-soap-odbc-uid" {
   name      = "/IMInterface/SOAPServer/ODBC/uid"
   type      = "String"
   value     = "dev-placeholder-soapserver-odbc-uid"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [
@@ -81,7 +81,7 @@ resource "aws_ssm_parameter" "im-interface-soap-odbc-pwd" {
   name      = "/IMInterface/SOAPServer/ODBC/pwd"
   type      = "SecureString"
   value     = "dev-placeholder-soapserver-odbc-pwd"
-  overwrite = false
+  overwrite = true
 
   lifecycle {
     ignore_changes = [

--- a/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
+++ b/terraform/environments/delius-iaps/templates/iaps-EC2LaunchV2.yaml.tftpl
@@ -167,32 +167,19 @@ tasks:
       $VerbosePreference = "Continue"
 
       $NDeliusIAPSCMSConfigFile = "C:\Program Files (x86)\I2N\IapsNDeliusInterface\Config\IAPSCMSIF.xml"
-      $NDeliusIAPSCMSConfigXML = [xml](Get-Content $NDeliusIAPSCMSConfigFile)
-
-      $NDeliusIAPSCMSConfigXML.DLLDEF.INTERFACES.INTERFACE.USER = (Get-SSMParameter -Name "/NDeliusInterface/IAPSCMSIF/Interface/user" -WithDecryption $true).Value
-      $NDeliusIAPSCMSConfigXML.DLLDEF.INTERFACES.INTERFACE.PASSWORD = (Get-SSMParameter -Name "/NDeliusInterface/IAPSCMSIF/Interface/password" -WithDecryption $true).Value
-      $NDeliusIAPSCMSConfigXML.DLLDEF.INTERFACES.INTERFACE.PASSWORDCODED = (Get-SSMParameter -Name "/NDeliusInterface/IAPSCMSIF/Interface/passwordcoded" -WithDecryption $true).Value
-
-      $NDeliusIAPSCMSConfigXML.save($NDeliusIAPSCMSConfigFile)
+      (Get-Content $NDeliusIAPSCMSConfigFile).replace('[ND_IAPS_CMSIF_DB_USER]', (Get-SSMParameter -Name "/NDeliusInterface/IAPSCMSIF/Interface/user" -WithDecryption $true).Value) | Set-Content $NDeliusIAPSCMSConfigFile
+      (Get-Content $NDeliusIAPSCMSConfigFile).replace('[ND_IAPS_CMSIF_DB_PASSWORDCODED]', (Get-SSMParameter -Name "/NDeliusInterface/IAPSCMSIF/Interface/passwordcoded" -WithDecryption $true).Value) | Set-Content $NDeliusIAPSCMSConfigFile
 
       $NDeliusConfigFile = "C:\Program Files (x86)\I2N\IapsNDeliusInterface\Config\NDELIUSIF.xml"
-      $configXML = [xml](Get-Content $NDeliusConfigFile)
-      $configXML.DLLDEF.INTERFACES.INTERFACE.USER = (Get-SSMParameter -Name "/NDeliusInterface/Interface/user" -WithDecryption $true).Value
-      $configXML.DLLDEF.INTERFACES.INTERFACE.PASSWORD = (Get-SSMParameter -Name "/NDeliusInterface/Interface/password" -WithDecryption $true).Value
-      $configXML.DLLDEF.INTERFACES.INTERFACE.REPLICAPASSWORDCODED = (Get-SSMParameter -Name "/NDeliusInterface/Interface/replicapwdcoded" -WithDecryption $true).Value
-      $configXML.DLLDEF.INTERFACES.INTERFACE.SOAPPASSCODED = (Get-SSMParameter -Name "/NDeliusInterface/Interface/soappwdcoded" -WithDecryption $true).Value
-      $configXML.DLLDEF.INTERFACES.INTERFACE.PASSWORDCODED = (Get-SSMParameter -Name "/NDeliusInterface/Interface/pwdcoded" -WithDecryption $true).Value
+      (Get-Content $NDeliusConfigFile).replace('[ND_IF_DB_USER]', (Get-SSMParameter -Name "/NDeliusInterface/Interface/dbuser" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
+      (Get-Content $NDeliusConfigFile).replace('[ND_IF_DB_PASSWORDCODED]', (Get-SSMParameter -Name "/NDeliusInterface/Interface/dbpwdcoded" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
 
-      $InterfaceODBCdsn = (Get-SSMParameter -Name "/NDeliusInterface/Interface/ODBC/dsn" -WithDecryption $true).Value
-      $InterfaceODBCuid = (Get-SSMParameter -Name "/NDeliusInterface/Interface/ODBC/uid" -WithDecryption $true).Value
-      $InterfaceODBCpwd = (Get-SSMParameter -Name "/NDeliusInterface/Interface/ODBC/pwd" -WithDecryption $true).Value
-      $configXML.DLLDEF.INTERFACES.INTERFACE.ODBC = "DSN=$${InterfaceODBCdsn};uid=$${InterfaceODBCuid};pwd=$${InterfaceODBCpwd}"
+      (Get-Content $NDeliusConfigFile).replace('[ND_SOAP_USER]', (Get-SSMParameter -Name "/NDeliusInterface/Interface/soapuser" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
+      (Get-Content $NDeliusConfigFile).replace('[ND_SOAP_PASSWORDCODED]', (Get-SSMParameter -Name "/NDeliusInterface/Interface/soappwdcoded" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
 
-      $configXML.DLLDEF.EMAIL.SMTPUSER = (Get-SSMParameter -Name "/NDeliusInterface/Email/smtpuser" -WithDecryption $true).Value
-      $configXML.DLLDEF.EMAIL.PASSWORD = (Get-SSMParameter -Name "/NDeliusInterface/Email/password" -WithDecryption $true).Value
-      $configXML.DLLDEF.EMAIL.PASSWORDCODED = (Get-SSMParameter -Name "/NDeliusInterface/Email/passwordcoded" -WithDecryption $true).Value
-      $configXML.DLLDEF.EMAIL.FROMADDRESS = (Get-SSMParameter -Name "/NDeliusInterface/Email/fromaddress" -WithDecryption $true).Value
-      $configXML.save($NDeliusConfigFile)
+      (Get-Content $NDeliusConfigFile).replace('[SMTP_USER]', (Get-SSMParameter -Name "/NDeliusInterface/Email/smtpuser" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
+      (Get-Content $NDeliusConfigFile).replace('[SMTP_PASSWORDCODED]', (Get-SSMParameter -Name "/NDeliusInterface/Email/passwordcoded" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
+      (Get-Content $NDeliusConfigFile).replace('[SMTP_FROMADDRESS]', (Get-SSMParameter -Name "/NDeliusInterface/Email/fromaddress" -WithDecryption $true).Value) | Set-Content $NDeliusConfigFile
 
 %{if environment == "development"}
       $service = Restart-Service -Name IapsNDeliusInterfaceWinService -Force -PassThru


### PR DESCRIPTION
We are choosing to use a find+replace method to configure the interface. Previous method of editing the XML file using PowerShell does not allow us to write certain characters without escaping them. The application does not conform to XML specication and expects some URI characters like & to remain unescaped

Additionally, some parameters we previously set are not required