### PR TITLE
attach iam policy perms to data role

### DIFF
--- a/terraform/environments/data-platform/glue_script/glue_transform_script.py
+++ b/terraform/environments/data-platform/glue_script/glue_transform_script.py
@@ -39,7 +39,7 @@ def get_database_name() -> str:
     returns database name from the key of the raw data product
     """
     # database name is the data product name pulled from the key
-    m = re.match("^(raw-data)\/(.*)\/(extraction_timestamp=[0-9]{1,14})\/(.*)$", raw_key)
+    m = re.match("^(raw_data)\/(.*)\/(extraction_timestamp=[0-9]{1,14})\/(.*)$", raw_key)
     if m:
         return m.group(2)
     else:
@@ -65,7 +65,7 @@ def get_curated_path(db_name, table_name) -> str:
     creates path for curated data product
     """
     key_list = os.path.join(
-        "s3://", bucket, raw_key.replace("raw-data", "curated-data")
+        "s3://", bucket, raw_key.replace("raw_data", "curated_data")
     ).split("/")
     out_path = "/".join(key_list[:-2])
     out_path = out_path.replace(db_name, f"database_name={db_name}")
@@ -85,7 +85,7 @@ def does_extraction_timestamp_exist(db_name, table_name, timestamp) -> bool:
     paginator = client.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(
         Bucket=bucket,
-        Prefix=os.path.join("curated-data", db_path, table_path)
+        Prefix=os.path.join("curated_data", db_path, table_path)
     )
     response = []
     try:

--- a/terraform/environments/data-platform/lambda_for_data.tf
+++ b/terraform/environments/data-platform/lambda_for_data.tf
@@ -49,9 +49,9 @@ data "aws_iam_policy_document" "iam_policy_document_for_data_lambda" {
   }
 
   statement {
-    sid       = "StartGlueJobRun"
+    sid       = "StartGetGlueJobRun"
     effect    = "Allow"
-    actions   = ["glue:StartJobRun"]
+    actions   = ["glue:StartJobRun", "glue:GetJobRun"]
     resources = [aws_glue_job.glue_job.arn]
   }
 }

--- a/terraform/environments/data-platform/lambda_for_data.tf
+++ b/terraform/environments/data-platform/lambda_for_data.tf
@@ -65,7 +65,7 @@ resource "aws_iam_policy" "data_extractor_lambda_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_data_lambda_policy_to_iam_role" {
-  role       = aws_iam_role.code_extractor_lambda_role.name
+  role       = aws_iam_role.data_extractor_lambda_role.name
   policy_arn = aws_iam_policy.data_extractor_lambda_policy.arn
 }
 

--- a/terraform/environments/data-platform/src/data_extractor/main.py
+++ b/terraform/environments/data-platform/src/data_extractor/main.py
@@ -28,7 +28,7 @@ def handler(event, context):
             "application",
             "transform.py",
         )
-        logging.info("Transform filepath: ", transform_file_path)
+        logging.info(f"Transform filepath: {transform_file_path}")
 
         args = {
             "--bucketName": bucket_name,

--- a/terraform/environments/data-platform/src/data_extractor/main.py
+++ b/terraform/environments/data-platform/src/data_extractor/main.py
@@ -38,7 +38,8 @@ def handler(event, context):
         runId = glue.start_job_run(JobName=gluejobname, Arguments=args)
 
         status = glue.get_job_run(JobName=gluejobname, RunId=runId["JobRunId"])
-        logging.info("Job Status : ", status["JobRun"]["JobRunState"])
+        status_for_log = status["JobRun"]["JobRunState"]
+        logging.info(f"Job Status : {status_for_log}")
 
     except Exception as e:
         logging.info(e)


### PR DESCRIPTION
permissions were attached to the role for code extraction

Have also used this PR to fix minor issues with:
- the lambda and glue job script alignment with regard to s3 path names
- logging in the data lambda python code
- missing glue read permissions to data lambda role so it can get the job status