### PR TITLE
nomis: DSOS-1847: migrate sns part2

### DIFF
--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -14,9 +14,9 @@ locals {
       local.ec2_weblogic_cloudwatch_metric_alarms_lists,
       local.database_cloudwatch_metric_alarms_lists
     )
-    # cloudwatch_metric_alarms_lists_with_actions = {
-    #   dso = [local.dso_sns_topic_arn]
-    # }
+    cloudwatch_metric_alarms_lists_with_actions = {
+      nomis_pagerduty = ["nomis_pagerduty"]
+    }
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
     }
@@ -24,7 +24,7 @@ locals {
     iam_policies_ec2_default = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     sns_topics_pagerduty_integrations = {
-      pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
+      nomis_pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
     }
   }
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -16,7 +16,7 @@ locals {
           namespace           = "AWS/CertificateManager"
           period              = "86400"
           statistic           = "Minimum"
-          threshold           = "500"
+          threshold           = "5"
           alarm_description   = "Test alarm for ACM Cert"
         }
       }
@@ -34,7 +34,7 @@ locals {
       local.database_cloudwatch_metric_alarms_lists
     )
     cloudwatch_metric_alarms_lists_with_actions = {
-      nomis_pagerduty = ["nomis_pagerduty"]
+      nomis_alarm = ["nomis_pagerduty", "nomis_email"]
     }
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
@@ -42,8 +42,13 @@ locals {
     iam_policies_filter      = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_ec2_default = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
-    sns_topics_pagerduty_integrations = {
-      nomis_pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
+    sns_topics = {
+      pagerduty_integrations = {
+        nomis_pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
+      }
+      emails = {
+        nomis_email = "/monitoring/test"
+      }
     }
   }
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -1,7 +1,5 @@
 locals {
 
-  # dso_sns_topic_arn = contains(["development", "test"], local.environment) ? aws_sns_topic.nomis_nonprod_alarms.arn : aws_sns_topic.nomis_alarms.arn
-
   baseline_presets_options = {
     enable_application_environment_wildcard_cert = false
     enable_business_unit_kms_cmks                = true
@@ -26,8 +24,7 @@ locals {
     iam_policies_ec2_default = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     sns_topics_pagerduty_integrations = {
-      nomis_alarms         = "nomis_alarms"
-      nomis_nonprod_alarms = "nomis_nonprod_alarms"
+      pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
     }
   }
 }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -7,34 +7,15 @@ locals {
     enable_ec2_cloud_watch_agent = true
     enable_ec2_self_provision    = true
     cloudwatch_metric_alarms = {
-      acm = {
-        cert-expiry-alarm-test = {
-          comparison_operator = "LessThanThreshold"
-          evaluation_periods  = "1"
-          datapoints_to_alarm = "1"
-          metric_name         = "DaysToExpiry"
-          namespace           = "AWS/CertificateManager"
-          period              = "86400"
-          statistic           = "Minimum"
-          threshold           = "5"
-          alarm_description   = "Test alarm for ACM Cert"
-        }
-      }
       weblogic = local.ec2_weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
     }
-    cloudwatch_metric_alarms_lists = merge({
-      acm_default = {
-        parent_keys = []
-        alarms_list = [
-          { key = "acm", name = "cert-expiry-alarm-test" }
-        ]
-      } },
+    cloudwatch_metric_alarms_lists = merge(
       local.ec2_weblogic_cloudwatch_metric_alarms_lists,
       local.database_cloudwatch_metric_alarms_lists
     )
     cloudwatch_metric_alarms_lists_with_actions = {
-      nomis_alarm = ["nomis_pagerduty", "nomis_email"]
+      nomis_pagerduty = ["nomis_pagerduty"]
     }
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
@@ -45,9 +26,6 @@ locals {
     sns_topics = {
       pagerduty_integrations = {
         nomis_pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
-      }
-      emails = {
-        nomis_email = "/monitoring/test"
       }
     }
   }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -7,10 +7,29 @@ locals {
     enable_ec2_cloud_watch_agent = true
     enable_ec2_self_provision    = true
     cloudwatch_metric_alarms = {
+      acm = {
+        cert-expiry-alarm-test = {
+          comparison_operator = "LessThanThreshold"
+          evaluation_periods  = "1"
+          datapoints_to_alarm = "1"
+          metric_name         = "DaysToExpiry"
+          namespace           = "AWS/CertificateManager"
+          period              = "86400"
+          statistic           = "Minimum"
+          threshold           = "500"
+          alarm_description   = "Test alarm for ACM Cert"
+        }
+      }
       weblogic = local.ec2_weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
     }
-    cloudwatch_metric_alarms_lists = merge(
+    cloudwatch_metric_alarms_lists = merge({
+      acm_default = {
+        parent_keys = []
+        alarms_list = [
+          { key = "acm", name = "cert-expiry-alarm-test" }
+        ]
+      } },
       local.ec2_weblogic_cloudwatch_metric_alarms_lists,
       local.database_cloudwatch_metric_alarms_lists
     )

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -25,10 +25,10 @@ locals {
     iam_policies_filter      = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_ec2_default = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
-    # sns_topics_pagerduty_integrations = {
-    #   nomis_alarms         = "nomis_alarms"
-    #   nomis_nonprod_alarms = "nomis_nonprod_alarms"
-    # }
+    sns_topics_pagerduty_integrations = {
+      nomis_alarms         = "nomis_alarms"
+      nomis_nonprod_alarms = "nomis_nonprod_alarms"
+    }
   }
 }
 

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -16,7 +16,7 @@ locals {
           namespace           = "AWS/CertificateManager"
           period              = "86400"
           statistic           = "Minimum"
-          threshold           = "5"
+          threshold           = "500"
           alarm_description   = "Test alarm for ACM Cert"
         }
       }

--- a/terraform/environments/nomis/baseline_presets.tf
+++ b/terraform/environments/nomis/baseline_presets.tf
@@ -16,7 +16,7 @@ locals {
           namespace           = "AWS/CertificateManager"
           period              = "86400"
           statistic           = "Minimum"
-          threshold           = "500"
+          threshold           = "5"
           alarm_description   = "Test alarm for ACM Cert"
         }
       }

--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -145,8 +145,6 @@ locals {
       ]
     })
 
-    # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].database
-
     user_data_cloud_init = {
       args = {
         branch               = "main"

--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -52,7 +52,6 @@ locals {
       protocol                  = "HTTPS"
       ssl_policy                = "ELBSecurityPolicy-2016-08"
       certificate_names_or_arns = ["nomis_wildcard_cert"]
-      # cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].lb_default
       default_action = {
         type = "fixed-response"
         fixed_response = {
@@ -110,7 +109,6 @@ locals {
       vpc_security_group_ids = ["private-web"]
     })
 
-    # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].weblogic
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
 
     autoscaling_group = {

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -28,7 +28,7 @@ locals {
           "*.${module.environment.domains.public.application_environment}",
           "*.${local.environment}.nomis.az.justice.gov.uk",
         ]
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
         }

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -28,7 +28,7 @@ locals {
           "*.${module.environment.domains.public.application_environment}",
           "*.${local.environment}.nomis.az.justice.gov.uk",
         ]
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
         }

--- a/terraform/environments/nomis/locals-development.tf
+++ b/terraform/environments/nomis/locals-development.tf
@@ -28,7 +28,7 @@ locals {
           "*.${module.environment.domains.public.application_environment}",
           "*.${local.environment}.nomis.az.justice.gov.uk",
         ]
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
         tags = {
           description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
         }

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -33,7 +33,7 @@ locals {
           "*.lsast-nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -57,7 +57,7 @@ locals {
           nomis-environment  = "preprod"
           oracle-db-name     = "CNOMPP"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -76,8 +76,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
-              # alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
+              alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
+              cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 preprod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -33,7 +33,7 @@ locals {
           "*.lsast-nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -57,7 +57,7 @@ locals {
           nomis-environment  = "preprod"
           oracle-db-name     = "CNOMPP"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
       })
     }
 
@@ -77,7 +77,7 @@ locals {
           https = merge(
             local.lb_weblogic.https, {
               # alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
               rules = {
                 preprod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -33,7 +33,7 @@ locals {
           "*.lsast-nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -57,7 +57,7 @@ locals {
           nomis-environment  = "preprod"
           oracle-db-name     = "CNOMPP"
         })
-        cloudwatch_metric_alarms = {}
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -76,6 +76,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
+              # alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 preprod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -38,7 +38,7 @@ locals {
           "*.nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].acm_default
+        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -83,7 +83,7 @@ locals {
           nomis-environment  = "prod"
           oracle-db-name     = "CNOMP"
         })
-        cloudwatch_metric_alarms = {}
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -109,6 +109,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       prod-nomis-db-2 = merge(local.database_zone_a, {
@@ -129,10 +130,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        # cloudwatch_metric_alarms = merge(
-        #   local.database_zone_a.cloudwatch_metric_alarms,
-        #   module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].fixngo_connection
-        # )
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       prod-nomis-db-3 = merge(local.database_zone_a, {
@@ -152,6 +150,7 @@ locals {
           data  = { total_size = 3000, iops = 3750, throughput = 750 }
           flash = { total_size = 500 }
         })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
     }
 
@@ -170,6 +169,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
+              # alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 prod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -38,7 +38,7 @@ locals {
           "*.nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -83,7 +83,7 @@ locals {
           nomis-environment  = "prod"
           oracle-db-name     = "CNOMP"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
       })
     }
 
@@ -109,7 +109,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
       })
 
       prod-nomis-db-2 = merge(local.database_zone_a, {
@@ -130,7 +130,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
       })
 
       prod-nomis-db-3 = merge(local.database_zone_a, {
@@ -150,7 +150,7 @@ locals {
           data  = { total_size = 3000, iops = 3750, throughput = 750 }
           flash = { total_size = 500 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
       })
     }
 
@@ -170,7 +170,7 @@ locals {
           https = merge(
             local.lb_weblogic.https, {
               # alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
               rules = {
                 prod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -38,7 +38,7 @@ locals {
           "*.nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -83,7 +83,7 @@ locals {
           nomis-environment  = "prod"
           oracle-db-name     = "CNOMP"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -109,7 +109,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       prod-nomis-db-2 = merge(local.database_zone_a, {
@@ -130,7 +130,7 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       prod-nomis-db-3 = merge(local.database_zone_a, {
@@ -150,7 +150,7 @@ locals {
           data  = { total_size = 3000, iops = 3750, throughput = 750 }
           flash = { total_size = 500 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
     }
 
@@ -169,8 +169,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
-              # alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
+              alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
+              cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 prod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -38,7 +38,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -63,8 +63,7 @@ locals {
           nomis-environment  = "t1"
           oracle-db-name     = "CNOMT1"
         })
-        cloudwatch_metric_alarms = {}
-        # autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -85,6 +84,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t1-nomis-db-1-a = merge(local.database_zone_a, {
@@ -105,6 +105,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t1-nomis-db-2 = merge(local.database_zone_a, {
@@ -158,6 +159,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
+              alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 t1-nomis-web-a-http-7777 = {
                   priority = 300

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -38,7 +38,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -38,7 +38,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -63,7 +63,7 @@ locals {
           nomis-environment  = "t1"
           oracle-db-name     = "CNOMT1"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
       })
     }
 
@@ -84,7 +84,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
       })
 
       t1-nomis-db-1-a = merge(local.database_zone_a, {
@@ -105,7 +105,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
       })
 
       t1-nomis-db-2 = merge(local.database_zone_a, {
@@ -160,7 +160,7 @@ locals {
           https = merge(
             local.lb_weblogic.https, {
               alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
               rules = {
                 t1-nomis-web-a-http-7777 = {
                   priority = 300

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -38,7 +38,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -63,7 +63,7 @@ locals {
           nomis-environment  = "t1"
           oracle-db-name     = "CNOMT1"
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].weblogic
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -84,7 +84,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t1-nomis-db-1-a = merge(local.database_zone_a, {
@@ -105,7 +105,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].database
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t1-nomis-db-2 = merge(local.database_zone_a, {
@@ -123,6 +123,7 @@ locals {
           data  = { total_size = 200 }
           flash = { total_size = 2 }
         })
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t3-nomis-db-1 = merge(local.database_zone_a, {
@@ -140,6 +141,7 @@ locals {
           data  = { total_size = 2000 }
           flash = { total_size = 500 }
         })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
     }
 
@@ -159,8 +161,8 @@ locals {
         listeners = {
           https = merge(
             local.lb_weblogic.https, {
-              alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_alarm"].lb_default
+              # alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
+              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 t1-nomis-web-a-http-7777 = {
                   priority = 300

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -260,7 +260,16 @@ locals {
     }
   }
 
-  baseline_sns_topics = {}
+  baseline_sns_topics = {
+    "dba_slack_pagerduty" = {
+      display_name      = "Pager duty integration for dba_slack"
+      kms_master_key_id = "general"
+    }
+    "dba_callout_pagerduty" = {
+      display_name      = "Pager duty integration for dba_callout"
+      kms_master_key_id = "general"
+    }
+  }
 
   autoscaling_schedules_default = {
     "scale_up" = {

--- a/terraform/modules/baseline/sns.tf
+++ b/terraform/modules/baseline/sns.tf
@@ -9,23 +9,8 @@ locals {
     }]
   ])
 
-  sns_topic_subscriptions_pagerduty_list = flatten([
-    for sns_key, sns_value in var.sns_topics : [
-      for subscription_key, subscription_value in sns_value.subscriptions : {
-        key = "${sns_key}-pagerduty-${subscription_key}"
-        value = merge(subscription_value, {
-          sns_topic_name = sns_key
-          protocol       = "https"
-          endpoint       = "https://events.pagerduty.com/integration/${var.environment.pagerduty_integration_keys[subscription_value]}/enqueue"
-        })
-    }]
-  ])
-
   sns_topic_subscriptions = {
-    for item in concat(
-      local.sns_topic_subscriptions_list,
-      local.sns_topic_subscriptions_pagerduty_list
-    ) : item.key => item.value
+    for item in local.sns_topic_subscriptions_list : item.key => item.value
   }
 }
 

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -714,9 +714,6 @@ variable "sns_topics" {
       endpoint      = string
       filter_policy = optional(string)
     })), {})
-    subscriptions_pagerduty = optional(map(object({ # map key is the name of the pagerduty integration key
-      filter_policy = optional(string)
-    })), {})
   }))
   default = {}
 }

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -128,7 +128,7 @@ locals {
           ] : [
           "arn:aws:s3:::devtest-${var.environment.application_name}-*/*",
           "arn:aws:s3:::devtest-${var.environment.application_name}-*"
-        ], [
+          ], [
           "arn:aws:s3:::ec2-image-builder-*/*",
           "arn:aws:s3:::ec2-image-builder-*",
           "arn:aws:s3:::*-software*/*",
@@ -141,7 +141,7 @@ locals {
       }]
     }
 
-    # see corresponding policy in core-shared-services-production
+    # see corresponding policy in core-shared-services-production
     # https://github.com/ministryofjustice/modernisation-platform-ami-builds/blob/main/modernisation-platform/iam.tf
     ImageBuilderS3BucketReadOnlyAccessPolicy = {
       description = "Permissions to access shared ImageBuilder bucket read-only"

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -112,27 +112,7 @@ output "s3_buckets" {
   value       = local.s3_buckets
 }
 
-# Use var.options.sns_topics_pagerduty_integrations to control, where
-# the map key is the sns_topic name and value is the index to use in
-# the modernisation platform managed pagerduty_integration_keys
-# secret,  e.g.
-# var.options.sns_topics_pagerduty_integrations = {
-#   critical     = nomis_alarms
-#   non-critical = nomis_nonprod_alarms
-# }
 output "sns_topics" {
   description = "Map of sns_topics to create depending on options provided"
-
-  value = {
-    for key, value in var.options.sns_topics_pagerduty_integrations : key => {
-      display_name      = "Pager duty integration for ${value}"
-      kms_master_key_id = "general"
-      subscriptions = {
-        "${key}" = {
-          protocol = "https"
-          endpoint = "https://events.pagerduty.com/integration/${var.environment.pagerduty_integration_keys[value]}/enqueue"
-        }
-      }
-    }
-  }
+  value       = local.sns_topic_pagerduty_integrations
 }

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -109,7 +109,7 @@ output "s3_iam_policies" {
 
 output "s3_buckets" {
   description = "Map of s3_buckets"
-  value = local.s3_buckets
+  value       = local.s3_buckets
 }
 
 # Use var.options.sns_topics_pagerduty_integrations to control, where
@@ -127,8 +127,11 @@ output "sns_topics" {
     for key, value in var.options.sns_topics_pagerduty_integrations : key => {
       display_name      = "Pager duty integration for ${value}"
       kms_master_key_id = "general"
-      subscriptions_pagerduty = {
-        value = {}
+      subscriptions = {
+        "${key}" = {
+          protocol = "https"
+          endpoint = "https://events.pagerduty.com/integration/${var.environment.pagerduty_integration_keys[value]}/enqueue"
+        }
       }
     }
   }

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -114,5 +114,5 @@ output "s3_buckets" {
 
 output "sns_topics" {
   description = "Map of sns_topics to create depending on options provided"
-  value       = local.sns_topic_pagerduty_integrations
+  value       = local.sns_topics
 }

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -7,14 +7,14 @@ locals {
         local.s3_bucket_policies.ProdPreprodEnvironmentsWriteAccessBucketPolicy
       ]
       iam_policies = local.s3_iam_policies
-    }} : {},
-    var.options.enable_shared_s3 && var.environment.environment == "test" ? {"devtest-${var.environment.application_name}-" = {
+    } } : {},
+    var.options.enable_shared_s3 && var.environment.environment == "test" ? { "devtest-${var.environment.application_name}-" = {
       bucket_policy_v2 = [
         local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
         local.s3_bucket_policies.DevTestEnvironmentsWriteAndDeleteAccessBucketPolicy
       ]
       iam_policies = local.s3_iam_policies
-    }} : {}
+    } } : {}
   )
 
   s3_bucket_policies = {

--- a/terraform/modules/baseline_presets/sns_topics.tf
+++ b/terraform/modules/baseline_presets/sns_topics.tf
@@ -19,8 +19,8 @@ data "aws_ssm_parameter" "sns_topics_email" {
 locals {
   sns_topics_pagerduty_integrations = {
     for key, value in var.options.sns_topics.pagerduty_integrations : key => {
-      display_name      = "Pager duty integration for ${value}"
-      kms_master_key_id = "general"
+      display_name = "Pager duty integration for ${value}"
+      # kms_master_key_id = "general"  # cloudwatch doesn't have access to the key yet
       subscriptions = {
         "${key}" = {
           protocol = "https"
@@ -32,8 +32,8 @@ locals {
 
   sns_topics_emails = {
     for key, value in var.options.sns_topics.emails : key => {
-      display_name      = "Email integration for ${value}"
-      kms_master_key_id = "general"
+      display_name = "Email integration for ${value}"
+      # kms_master_key_id = "general"  # cloudwatch doesn't have access to the key yet
       subscriptions = {
         "email" = {
           protocol = "email"

--- a/terraform/modules/baseline_presets/sns_topics.tf
+++ b/terraform/modules/baseline_presets/sns_topics.tf
@@ -1,0 +1,23 @@
+# Use var.options.sns_topics_pagerduty_integrations to control, where
+# the map key is the sns_topic name and value is the index to use in
+# the modernisation platform managed pagerduty_integration_keys
+# secret,  e.g.
+# var.options.sns_topics_pagerduty_integrations = {
+#   prod_alarms    = nomis_alarms
+#   nonprod_alarms = nomis_nonprod_alarms
+# }
+
+locals {
+  sns_topic_pagerduty_integrations = {
+    for key, value in var.options.sns_topics_pagerduty_integrations : key => {
+      display_name      = "Pager duty integration for ${value}"
+      kms_master_key_id = "general"
+      subscriptions = {
+        "${key}" = {
+          protocol = "https"
+          endpoint = "https://events.pagerduty.com/integration/${var.environment.pagerduty_integration_keys[value]}/enqueue"
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -46,6 +46,12 @@ variable "options" {
     iam_policies_filter                          = optional(list(string), [])
     iam_policies_ec2_default                     = optional(list(string), [])
     s3_iam_policies                              = optional(list(string))
-    sns_topics_pagerduty_integrations            = optional(map(string), {})
+    sns_topics = optional(object({
+      pagerduty_integrations = optional(map(string), {})
+      emails                 = optional(map(string), {})
+      }), {
+      pagerduty_integrations = {}
+      emails                 = {}
+    })
   })
 }


### PR DESCRIPTION
Re-enable cloudwatch alarms via baseline:
- support email SNS topics for DBAs
- also some terraform fmt

Tested both email + pagerduty in nomis-test.  Although email is disabled for time being.