### PR TITLE
nomis: DSOS-1847: remove references to old security groups

### DIFF
--- a/terraform/environments/nomis/ec2-database.tf
+++ b/terraform/environments/nomis/ec2-database.tf
@@ -139,10 +139,7 @@ locals {
       disable_api_termination      = true
       metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
       monitoring                   = true
-      vpc_security_group_ids = [
-        aws_security_group.data.id, # TODO: remove once weblogic servers refreshed
-        "data-db"
-      ]
+      vpc_security_group_ids       = ["data-db"]
     })
 
     user_data_cloud_init = {

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -69,10 +69,7 @@ locals {
         force_destroy_bucket     = true
         idle_timeout             = 3600
         public_subnets           = module.environment.subnets["private"].ids
-        security_groups = [
-          aws_security_group.public.id, # TODO: remove once weblogic servers refreshed
-          "private-lb"
-        ]
+        security_groups          = ["private-lb"]
 
         listeners = {
           https = merge(

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -165,10 +165,7 @@ locals {
         force_destroy_bucket     = true
         idle_timeout             = 3600
         public_subnets           = module.environment.subnets["private"].ids
-        security_groups = [
-          aws_security_group.public.id, # TODO: remove once weblogic servers refreshed
-          "private-lb"
-        ]
+        security_groups          = ["private-lb"]
 
         listeners = {
           https = merge(

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -154,10 +154,7 @@ locals {
         force_destroy_bucket     = true
         idle_timeout             = 3600
         public_subnets           = module.environment.subnets["private"].ids
-        security_groups = [
-          aws_security_group.public.id, # TODO: remove once weblogic servers refreshed
-          "private-lb",
-        ]
+        security_groups          = ["private-lb"]
 
         listeners = {
           https = merge(


### PR DESCRIPTION
All weblogic servers have been rebuilt so we can get remove these remaining security references in preparation for deleting the old groups