### PR TITLE
nomis: DSOS-1815: switch to blue deployment 

### DIFF
--- a/terraform/environments/nomis/ec2-weblogic.tf
+++ b/terraform/environments/nomis/ec2-weblogic.tf
@@ -162,7 +162,7 @@ locals {
     })
     user_data_cloud_init = merge(local.ec2_weblogic_default.user_data_cloud_init, {
       args = merge(local.ec2_weblogic_default.user_data_cloud_init.args, {
-        branch = "nomis/DSOS-1815/update-weblogic-tns"
+        branch = "a5c69245a3e30ca8d44ab269062479e1768e2f5c" # 2023-04-25
       })
     })
   })
@@ -172,7 +172,7 @@ locals {
     })
     user_data_cloud_init = merge(local.ec2_weblogic_default.user_data_cloud_init, {
       args = merge(local.ec2_weblogic_default.user_data_cloud_init.args, {
-        branch = "b7cf97d15687c1fe653ea139a728db642f783a2d" # 2023-04-06
+        branch = "a5c69245a3e30ca8d44ab269062479e1768e2f5c" # 2023-04-25
       })
     })
   })

--- a/terraform/environments/nomis/locals-preproduction.tf
+++ b/terraform/environments/nomis/locals-preproduction.tf
@@ -35,6 +35,7 @@ locals {
         autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
           desired_capacity = 1
         })
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
       preprod-nomis-web-b = merge(local.ec2_weblogic_b, {
         tags = merge(local.ec2_weblogic_b.tags, {
@@ -42,7 +43,10 @@ locals {
           nomis-environment  = "preprod"
           oracle-db-name     = "CNOMPP"
         })
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+        autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
+          desired_capacity = 0
+        })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -72,6 +76,9 @@ locals {
                       values = [
                         "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk",
                         "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk",
+                        "c.preproduction.nomis.az.justice.gov.uk",
+                        "c.preproduction.nomis.service.justice.gov.uk",
+                        "c.pp-nomis.service.justice.gov.uk",
                       ]
                     }
                   }]
@@ -87,9 +94,6 @@ locals {
                       values = [
                         "preprod-nomis-web-b.preproduction.nomis.az.justice.gov.uk",
                         "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk",
-                        "c.preproduction.nomis.az.justice.gov.uk",
-                        "c.preproduction.nomis.service.justice.gov.uk",
-                        "c.pp-nomis.service.justice.gov.uk",
                       ]
                     }
                   }]

--- a/terraform/environments/nomis/locals-production.tf
+++ b/terraform/environments/nomis/locals-production.tf
@@ -56,6 +56,7 @@ locals {
         autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
           desired_capacity = 1
         })
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
       prod-nomis-web-b = merge(local.ec2_weblogic_b, {
         tags = merge(local.ec2_weblogic_b.tags, {
@@ -63,7 +64,10 @@ locals {
           nomis-environment  = "prod"
           oracle-db-name     = "CNOMP"
         })
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+        autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
+          desired_capacity = 0
+        })
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
     }
 
@@ -163,6 +167,9 @@ locals {
                       values = [
                         "prod-nomis-web-a.production.nomis.az.justice.gov.uk",
                         "prod-nomis-web-a.production.nomis.service.justice.gov.uk",
+                        "c.production.nomis.az.justice.gov.uk",
+                        "c.production.nomis.service.justice.gov.uk",
+                        "c.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]
@@ -178,9 +185,6 @@ locals {
                       values = [
                         "prod-nomis-web-b.production.nomis.az.justice.gov.uk",
                         "prod-nomis-web-b.production.nomis.service.justice.gov.uk",
-                        "c.production.nomis.az.justice.gov.uk",
-                        "c.production.nomis.service.justice.gov.uk",
-                        "c.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]

--- a/terraform/environments/nomis/locals-test.tf
+++ b/terraform/environments/nomis/locals-test.tf
@@ -34,6 +34,7 @@ locals {
         autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
           desired_capacity = 1
         })
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
 
       t1-nomis-web-b = merge(local.ec2_weblogic_b, {
@@ -41,6 +42,9 @@ locals {
           oracle-db-hostname = "t1-nomis-db-1"
           nomis-environment  = "t1"
           oracle-db-name     = "CNOMT1"
+        })
+        autoscaling_group = merge(local.ec2_weblogic_a.autoscaling_group, {
+          desired_capacity = 0
         })
         # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
@@ -169,6 +173,9 @@ locals {
                       values = [
                         "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
                         "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
+                        "c-t1.test.nomis.az.justice.gov.uk",
+                        "c-t1.test.nomis.service.justice.gov.uk",
+                        "t1-cn.hmpp-azdt.justice.gov.uk",
                       ]
                     }
                   }]
@@ -184,9 +191,6 @@ locals {
                       values = [
                         "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
                         "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
-                        "c-t1.test.nomis.az.justice.gov.uk",
-                        "c-t1.test.nomis.service.justice.gov.uk",
-                        "t1-cn.hmpp-azdt.justice.gov.uk",
                       ]
                     }
                   }]


### PR DESCRIPTION
Following testing by Sandhya, it seems the new database connection strings are working for weblogic.  Switch to the new deployment:
- Fix ansible code to commit which updates database connection strings.
- Switch alarms to blue deployment (-a)
- Switch load balancer forwarding rules to blue deployment (-a)
- Remove instances on green deployment (-b)
