### PR TITLE
Nomis: DSOS-1874: reporting fix

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -39,12 +39,13 @@ locals {
       })
       preprod-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
-          oracle-db-hostname = "PPPDL00016.azure.hmpp.root"
-          nomis-environment  = "preprod"
-          oracle-db-name     = "CNOMPP"
+          nomis-environment    = "preprod"
+          oracle-db-hostname-a = "ppnomis-a.preproduction.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "ppnomis-b.preproduction.nomis.service.justice.gov.uk"
+          oracle-db-name       = "PPCNOM"
         })
         autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
-          desired_capacity = 0
+          desired_capacity = 1
         })
         # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
@@ -60,6 +61,8 @@ locals {
         security_groups          = ["private-lb"]
 
         listeners = {
+          http = local.weblogic_lb_listeners.http
+
           https = merge(
             local.weblogic_lb_listeners.https, {
               alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -25,6 +25,7 @@ locals {
     }
 
     baseline_ec2_autoscaling_groups = {
+      # blue deployment
       preprod-nomis-web-a = merge(local.weblogic_ec2_a, {
         tags = merge(local.weblogic_ec2_a.tags, {
           nomis-environment    = "preprod"
@@ -37,6 +38,8 @@ locals {
         })
         cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
+
+      # green deployment
       preprod-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
           nomis-environment    = "preprod"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -46,6 +46,7 @@ locals {
     }
 
     baseline_ec2_autoscaling_groups = {
+      # blue deployment
       prod-nomis-web-a = merge(local.weblogic_ec2_a, {
         tags = merge(local.weblogic_ec2_a.tags, {
           nomis-environment    = "prod"
@@ -58,6 +59,8 @@ locals {
         })
         cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
+
+      # green deployment
       prod-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
           nomis-environment    = "prod"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -60,12 +60,13 @@ locals {
       })
       prod-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
-          oracle-db-hostname = "PDPDL00035.azure.hmpp.root"
-          nomis-environment  = "prod"
-          oracle-db-name     = "CNOMP"
+          nomis-environment    = "prod"
+          oracle-db-hostname-a = "pnomis-a.production.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "pnomis-b.production.nomis.service.justice.gov.uk"
+          oracle-db-name       = "PCNOM"
         })
         autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
-          desired_capacity = 0
+          desired_capacity = 1
         })
         # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
@@ -151,6 +152,8 @@ locals {
         security_groups          = ["private-lb"]
 
         listeners = {
+          http = local.weblogic_lb_listeners.http
+
           https = merge(
             local.weblogic_lb_listeners.https, {
               alarm_target_group_names = ["prod-nomis-web-b-http-7777"]

--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -66,6 +66,17 @@ locals {
           protocol    = -1
           self        = true
         }
+        http = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+            "bastion-linux",
+          ]
+          cidr_blocks = local.security_group_cidrs.https
+        }
         https = {
           description = "Allow https ingress"
           from_port   = 443

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -39,9 +39,10 @@ locals {
 
       t1-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
-          oracle-db-hostname = "t1-nomis-db-1"
-          nomis-environment  = "t1"
-          oracle-db-name     = "CNOMT1"
+          nomis-environment    = "t1"
+          oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
+          oracle-db-name       = "T1CNOM"
         })
         autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
           desired_capacity = 1

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -158,45 +158,86 @@ locals {
         security_groups          = ["private-lb"]
 
         listeners = {
-          https = merge(
-            local.weblogic_lb_listeners.https, {
-              # alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
-              # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
-              rules = {
-                t1-nomis-web-a-http-7777 = {
-                  priority = 300
-                  actions = [{
-                    type              = "forward"
-                    target_group_name = "t1-nomis-web-a-http-7777"
-                  }]
-                  conditions = [{
-                    host_header = {
-                      values = [
-                        "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
-                        "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
-                        "c-t1.test.nomis.az.justice.gov.uk",
-                        "c-t1.test.nomis.service.justice.gov.uk",
-                        "t1-cn.hmpp-azdt.justice.gov.uk",
-                      ]
-                    }
-                  }]
-                }
-                t1-nomis-web-b-http-7777 = {
-                  priority = 400
-                  actions = [{
-                    type              = "forward"
-                    target_group_name = "t1-nomis-web-b-http-7777"
-                  }]
-                  conditions = [{
-                    host_header = {
-                      values = [
-                        "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
-                        "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
-                      ]
-                    }
-                  }]
-                }
+
+          http7777 = merge(local.weblogic_lb_listeners.http7777, {
+            rules = {
+              # T1 users in Azure accessed server directly on http 7777
+              # so support this in Mod Platform as well to minimise
+              # disruption.  This isn't needed for other environments.
+              t1-nomis-web-a = {
+                priority = 300
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "t1-nomis-web-a-http-7777"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
+                      "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t1.test.nomis.az.justice.gov.uk",
+                      "c-t1.test.nomis.service.justice.gov.uk",
+                      "t1-cn.hmpp-azdt.justice.gov.uk",
+                    ]
+                  }
+                }]
               }
+              t1-nomis-web-b = {
+                priority = 400
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "t1-nomis-web-b-http-7777"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
+                      "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+            }
+          })
+
+          https = merge(local.weblogic_lb_listeners.https, {
+            # alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
+            # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
+            rules = {
+              t1-nomis-web-a-http-7777 = {
+                priority = 300
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "t1-nomis-web-a-http-7777"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
+                      "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t1.test.nomis.az.justice.gov.uk",
+                      "c-t1.test.nomis.service.justice.gov.uk",
+                      "t1-cn.hmpp-azdt.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+              t1-nomis-web-b-http-7777 = {
+                priority = 400
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "t1-nomis-web-b-http-7777"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
+                      "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+            }
           })
         }
       }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -24,6 +24,7 @@ locals {
     }
 
     baseline_ec2_autoscaling_groups = {
+      # blue deployment
       t1-nomis-web-a = merge(local.weblogic_ec2_a, {
         tags = merge(local.weblogic_ec2_a.tags, {
           nomis-environment    = "t1"
@@ -37,6 +38,7 @@ locals {
         cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })
 
+      # green deployment
       t1-nomis-web-b = merge(local.weblogic_ec2_b, {
         tags = merge(local.weblogic_ec2_b.tags, {
           nomis-environment    = "t1"
@@ -162,9 +164,9 @@ locals {
 
           http7777 = merge(local.weblogic_lb_listeners.http7777, {
             rules = {
-              # T1 users in Azure accessed server directly on http 7777
-              # so support this in Mod Platform as well to minimise
-              # disruption.  This isn't needed for other environments.
+              # T1 users in Azure accessed server directly on http 7777
+              # so support this in Mod Platform as well to minimise
+              # disruption.  This isn't needed for other environments.
               t1-nomis-web-a = {
                 priority = 300
                 actions = [{

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -158,7 +158,6 @@ locals {
         security_groups          = ["private-lb"]
 
         listeners = {
-
           http = local.weblogic_lb_listeners.http
 
           http7777 = merge(local.weblogic_lb_listeners.http7777, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -159,6 +159,8 @@ locals {
 
         listeners = {
 
+          http = local.weblogic_lb_listeners.http
+
           http7777 = merge(local.weblogic_lb_listeners.http7777, {
             rules = {
               # T1 users in Azure accessed server directly on http 7777

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -44,7 +44,7 @@ locals {
           oracle-db-name     = "CNOMT1"
         })
         autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
-          desired_capacity = 0
+          desired_capacity = 1
         })
         # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
       })

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -170,7 +170,7 @@ locals {
     })
     user_data_cloud_init = merge(local.weblogic_ec2_default.user_data_cloud_init, {
       args = merge(local.weblogic_ec2_default.user_data_cloud_init.args, {
-        branch = "a5c69245a3e30ca8d44ab269062479e1768e2f5c" # 2023-04-25
+        branch = "nomis/DSOS-1874/reporting-fix"
       })
     })
   })

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -198,7 +198,7 @@ locals {
     })
     user_data_cloud_init = merge(local.weblogic_ec2_default.user_data_cloud_init, {
       args = merge(local.weblogic_ec2_default.user_data_cloud_init.args, {
-        branch = "nomis/DSOS-1874/reporting-fix"
+        branch = "f8ece8fc507d42c638878ede0f9030455669bb74" # 2023-04-27 reporting fix
       })
     })
   })

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -43,6 +43,19 @@ locals {
   }
 
   weblogic_lb_listeners = {
+    http7777 = {
+      port     = 7777
+      protocol = "HTTP"
+      default_action = {
+        type = "fixed-response"
+        fixed_response = {
+          content_type = "text/plain"
+          message_body = "Not implemented"
+          status_code  = "501"
+        }
+      }
+    }
+
     https = {
       port                      = 443
       protocol                  = "HTTPS"

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -43,6 +43,20 @@ locals {
   }
 
   weblogic_lb_listeners = {
+
+    http = {
+      port     = 80
+      protocol = "HTTP"
+      default_action = {
+        type = "redirect"
+        redirect = {
+          port        = 443
+          protocol    = "HTTPS"
+          status_code = "HTTP_301"
+        }
+      }
+    }
+
     http7777 = {
       port     = 7777
       protocol = "HTTP"
@@ -70,6 +84,7 @@ locals {
         }
       }
     }
+
   }
 
   weblogic_cloudwatch_metric_alarms = {


### PR DESCRIPTION
More T1 migration prep:
- setup green deploying with combined reporting fix (new SHA for config management repo)
- added http 7777 support for T1 (since this is how it is accessed in Azure)
- setup auto redirect from http to https if port 80 used