### PR TITLE
Nomis: DSOS-1849: dba alarms

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -23,7 +23,7 @@ locals {
       weblogic = local.weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
       acm = {
-        test = {
+        test2 = {
           comparison_operator = "LessThanThreshold"
           evaluation_periods  = "1"
           datapoints_to_alarm = "1"
@@ -42,7 +42,7 @@ locals {
         acm_test = {
           parent_keys = []
           alarms_list = [
-            { key = "acm", name = "test" },
+            { key = "acm", name = "test2" },
           ]
         }
     })
@@ -63,7 +63,7 @@ locals {
         dso_pagerduty               = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
         dba_pagerduty               = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_low_priority"
         dba_high_priority_pagerduty = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_high_priority"
-        dba_test                    = "hmpps_shef_dba_non_prod"
+        dba_test                    = "hmpps_shef_dba_low_priority"
       }
     }
   }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -23,7 +23,7 @@ locals {
       weblogic = local.weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
       acm = {
-        test2 = {
+        test3 = {
           comparison_operator = "LessThanThreshold"
           evaluation_periods  = "1"
           datapoints_to_alarm = "1"
@@ -42,7 +42,7 @@ locals {
         acm_test = {
           parent_keys = []
           alarms_list = [
-            { key = "acm", name = "test2" },
+            { key = "acm", name = "test3" },
           ]
         }
     })
@@ -63,7 +63,7 @@ locals {
         dso_pagerduty               = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
         dba_pagerduty               = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_low_priority"
         dba_high_priority_pagerduty = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_high_priority"
-        dba_test                    = "hmpps_shef_dba_low_priority"
+        dba_test                    = "hmpps_shef_dba_high_priority"
       }
     }
   }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -22,33 +22,15 @@ locals {
     cloudwatch_metric_alarms = {
       weblogic = local.weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
-      acm = {
-        test-alarm = {
-          comparison_operator = "LessThanThreshold"
-          evaluation_periods  = "1"
-          datapoints_to_alarm = "1"
-          metric_name         = "DaysToExpiry"
-          namespace           = "AWS/CertificateManager"
-          period              = "86400"
-          statistic           = "Minimum"
-          threshold           = "400"
-          alarm_description   = "TEST"
-        }
-      }
     }
     cloudwatch_metric_alarms_lists = merge(
       local.weblogic_cloudwatch_metric_alarms_lists,
-      local.database_cloudwatch_metric_alarms_lists, {
-        acm_default = {
-          parent_keys = []
-          alarms_list = [
-            { key = "acm", name = "cert-expires-in-less-than-14-days" },
-            { key = "acm", name = "test-alarm" },
-          ]
-        }
-    })
+      local.database_cloudwatch_metric_alarms_lists
+    )
     cloudwatch_metric_alarms_lists_with_actions = {
-      nomis_pagerduty = ["nomis_pagerduty"]
+      dso_pagerduty               = ["dso_pagerduty"]
+      dba_pagerduty               = ["dba_pagerduty"]
+      dba_high_priority_pagerduty = ["dba_high_priority_pagerduty"]
     }
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
@@ -58,7 +40,9 @@ locals {
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     sns_topics = {
       pagerduty_integrations = {
-        nomis_pagerduty = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
+        dso_pagerduty               = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
+        dba_pagerduty               = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_low_priority"
+        dba_high_priority_pagerduty = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_high_priority"
       }
     }
   }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -22,11 +22,31 @@ locals {
     cloudwatch_metric_alarms = {
       weblogic = local.weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
+      acm = {
+        test-alarm = {
+          comparison_operator = "LessThanThreshold"
+          evaluation_periods  = "1"
+          datapoints_to_alarm = "1"
+          metric_name         = "DaysToExpiry"
+          namespace           = "AWS/CertificateManager"
+          period              = "86400"
+          statistic           = "Minimum"
+          threshold           = "400"
+          alarm_description   = "TEST"
+        }
+      }
     }
     cloudwatch_metric_alarms_lists = merge(
       local.weblogic_cloudwatch_metric_alarms_lists,
-      local.database_cloudwatch_metric_alarms_lists
-    )
+      local.database_cloudwatch_metric_alarms_lists, {
+        acm_default = {
+          parent_keys = []
+          alarms_list = [
+            { key = "acm", name = "cert-expires-in-less-than-14-days" },
+            { key = "acm", name = "test-alarm" },
+          ]
+        }
+    })
     cloudwatch_metric_alarms_lists_with_actions = {
       nomis_pagerduty = ["nomis_pagerduty"]
     }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -22,35 +22,15 @@ locals {
     cloudwatch_metric_alarms = {
       weblogic = local.weblogic_cloudwatch_metric_alarms
       database = local.database_cloudwatch_metric_alarms
-      acm = {
-        test3 = {
-          comparison_operator = "LessThanThreshold"
-          evaluation_periods  = "1"
-          datapoints_to_alarm = "1"
-          metric_name         = "DaysToExpiry"
-          namespace           = "AWS/CertificateManager"
-          period              = "86400"
-          statistic           = "Minimum"
-          threshold           = "400"
-          alarm_description   = "Test"
-        }
-      }
     }
     cloudwatch_metric_alarms_lists = merge(
       local.weblogic_cloudwatch_metric_alarms_lists,
-      local.database_cloudwatch_metric_alarms_lists, {
-        acm_test = {
-          parent_keys = []
-          alarms_list = [
-            { key = "acm", name = "test3" },
-          ]
-        }
-    })
+      local.database_cloudwatch_metric_alarms_lists
+    )
     cloudwatch_metric_alarms_lists_with_actions = {
       dso_pagerduty               = ["dso_pagerduty"]
       dba_pagerduty               = ["dba_pagerduty"]
       dba_high_priority_pagerduty = ["dba_high_priority_pagerduty"]
-      dba_test                    = ["dba_test"]
     }
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
@@ -63,7 +43,6 @@ locals {
         dso_pagerduty               = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
         dba_pagerduty               = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_low_priority"
         dba_high_priority_pagerduty = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_high_priority"
-        dba_test                    = "hmpps_shef_dba_high_priority"
       }
     }
   }

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -93,18 +93,38 @@ locals {
   }
 
   database_cloudwatch_metric_alarms_lists = {
-    database = {
-      parent_keys = [
-        "ec2_default",
-        "ec2_linux_default",
-        "ec2_linux_with_collectd_default"
-      ]
+    database_dso = {
+      parent_keys = []
       alarms_list = [
+        { key = "ec2", name = "instance-status-check-failed-in-last-hour" },
+        { key = "ec2", name = "system-status-check-failed-in-last-hour" },
+        { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
+        { key = "ec2_cwagent_collectd", name = "chronyd-stopped" },
+        { key = "ec2_cwagent_collectd", name = "sshd-stopped" },
+        { key = "ec2_cwagent_collectd", name = "cloudwatch-agent-stopped" },
+        { key = "ec2_cwagent_collectd", name = "ssm-agent-stopped" },
+      ]
+    }
+    database_dba = {
+      parent_keys = []
+      alarms_list = [
+        { key = "ec2", name = "cpu-utilization-high-15mins" },
+        { key = "ec2", name = "instance-status-check-failed-in-last-hour" },
+        { key = "ec2", name = "system-status-check-failed-in-last-hour" },
+        { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
+        { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
+        { key = "ec2_cwagent_linux", name = "cpu-iowait-high-3hour" },
         { key = "database", name = "oracle-db-disconnected" },
         { key = "database", name = "oracle-batch-failure" },
         { key = "database", name = "oracle-long-running-batch" },
         { key = "database", name = "oracleasm-service" },
         { key = "database", name = "oracle-ohasd-service" },
+      ]
+    }
+    database_dba_high_priority = {
+      parent_keys = []
+      alarms_list = [
+        { key = "database", name = "oracle-db-disconnected" },
       ]
     }
     fixngo_connection = {
@@ -122,6 +142,11 @@ locals {
   }
 
   database_ec2_default = {
+
+    cloudwatch_metric_alarms = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].database_dso,
+      module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dba_pagerduty"].database_dba
+    )
 
     config = merge(module.baseline_presets.ec2_instance.config.db, {
       ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-07T12-48-08.562Z"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -19,7 +19,7 @@ locals {
           "*.${module.environment.domains.public.application_environment}",
           "*.${local.environment}.nomis.az.justice.gov.uk",
         ]
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
         }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -19,7 +19,7 @@ locals {
           "*.${module.environment.domains.public.application_environment}",
           "*.${local.environment}.nomis.az.justice.gov.uk",
         ]
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for ${module.environment.domains.public.application_environment} and ${local.environment}.nomis.az.justice.gov.uk domain"
         }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -17,7 +17,7 @@ locals {
           "*.lsast-nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -61,7 +61,6 @@ locals {
           https = merge(
             local.weblogic_lb_listeners.https, {
               alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
-              cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 preprod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -17,7 +17,7 @@ locals {
           "*.nomis.az.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -89,7 +89,6 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       prod-nomis-db-2 = merge(local.database_ec2_a, {
@@ -110,9 +109,8 @@ locals {
           data  = { total_size = 4000 }
           flash = { total_size = 1000 }
         })
-        cloudwatch_metric_alarms = merge(
-          module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database,
-          module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].fixngo_connection
+        cloudwatch_metric_alarms = merge(local.database_ec2_a.cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].fixngo_connection
         )
       })
 
@@ -133,7 +131,9 @@ locals {
           data  = { total_size = 3000, iops = 3750, throughput = 750 }
           flash = { total_size = 500 }
         })
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        cloudwatch_metric_alarms = merge(local.database_ec2_a.cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dba_high_priority_pagerduty"].database_dba_high_priority
+        )
       })
     }
 
@@ -152,7 +152,6 @@ locals {
           https = merge(
             local.weblogic_lb_listeners.https, {
               alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
-              cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
               rules = {
                 prod-nomis-web-a-http-7777 = {
                   priority = 200

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -16,8 +16,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dba_test"].acm_test
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -16,7 +16,7 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].acm_default
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }
@@ -62,7 +62,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        cloudwatch_metric_alarms = {} # disabled until migration
       })
 
       t1-nomis-db-1-a = merge(local.database_ec2_a, {
@@ -83,7 +83,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        cloudwatch_metric_alarms = {} # disabled until migration
       })
 
       t1-nomis-db-2 = merge(local.database_ec2_a, {
@@ -101,7 +101,6 @@ locals {
           data  = { total_size = 200 }
           flash = { total_size = 2 }
         })
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
       })
 
       t1-nomis-db-2-a = merge(local.database_ec2_a, {
@@ -119,7 +118,7 @@ locals {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        cloudwatch_metric_alarms = {} # disabled until migration
       })
 
       t3-nomis-db-1 = merge(local.database_ec2_a, {
@@ -137,7 +136,7 @@ locals {
           data  = { total_size = 2000 }
           flash = { total_size = 500 }
         })
-        # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].database
+        cloudwatch_metric_alarms = {} # disabled until migration
       })
     }
 
@@ -196,8 +195,7 @@ locals {
           })
 
           https = merge(local.weblogic_lb_listeners.https, {
-            # alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
-            # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].lb_default
+            alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
             rules = {
               t1-nomis-web-a-http-7777 = {
                 priority = 300

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -16,7 +16,8 @@ locals {
           "*.hmpp-azdt.justice.gov.uk",
         ]
         external_validation_records_created = true
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
+        # cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].acm_default
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dba_test"].acm_test
         tags = {
           description = "wildcard cert for nomis ${local.environment} domains"
         }

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -47,6 +47,7 @@ locals {
     http = {
       port     = 80
       protocol = "HTTP"
+
       default_action = {
         type = "redirect"
         redirect = {
@@ -60,6 +61,7 @@ locals {
     http7777 = {
       port     = 7777
       protocol = "HTTP"
+
       default_action = {
         type = "fixed-response"
         fixed_response = {
@@ -75,6 +77,8 @@ locals {
       protocol                  = "HTTPS"
       ssl_policy                = "ELBSecurityPolicy-2016-08"
       certificate_names_or_arns = ["nomis_wildcard_cert"]
+      cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].lb_default
+
       default_action = {
         type = "fixed-response"
         fixed_response = {
@@ -123,6 +127,8 @@ locals {
   }
 
   weblogic_ec2_default = {
+
+    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["dso_pagerduty"].weblogic
 
     config = merge(module.baseline_presets.ec2_instance.config.default, {
       ami_name                  = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
@@ -184,7 +190,7 @@ locals {
   }
 
   # blue/green deployment
-  # - only set cloudwatch_metric_alarms on the active deployment
+  # - set cloudwatch_metric_alarms = {} on the dormant deployment
   # - set desired_capacity = 0 on the dormant deployment unless testing
   # - use user_data_cloud_init.args.branch to set the ansible code for given deployment
   # - use load balancer rules defined in the environment specific locals file to switch between deployments
@@ -202,7 +208,7 @@ locals {
     autoscaling_group = merge(local.weblogic_ec2_default.autoscaling_group, {
       desired_capacity = 0
     })
-    # cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+    cloudwatch_metric_alarms = {}
     tags = merge(local.weblogic_ec2_default.tags, {
       deployment = "blue"
     })
@@ -221,7 +227,7 @@ locals {
     # autoscaling_group = merge(local.weblogic_ec2_default.autoscaling_group, {
     #   desired_capacity = 0
     # })
-    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_lists_with_actions["nomis_pagerduty"].weblogic
+    # cloudwatch_metric_alarms = {}
     tags = merge(local.weblogic_ec2_default.tags, {
       deployment = "green"
     })

--- a/terraform/modules/baseline/sns.tf
+++ b/terraform/modules/baseline/sns.tf
@@ -20,6 +20,10 @@ resource "aws_sns_topic" "this" {
   name              = each.key
   display_name      = each.value.display_name
   kms_master_key_id = try(var.environment.kms_keys[each.value.kms_master_key_id].arn, each.value.kms_master_key_id)
+
+  tags = merge(local.tags, {
+    Name = each.key
+  })
 }
 
 resource "aws_sns_topic_subscription" "this" {

--- a/terraform/modules/baseline_presets/sns_topics.tf
+++ b/terraform/modules/baseline_presets/sns_topics.tf
@@ -19,8 +19,8 @@ data "aws_ssm_parameter" "sns_topics_email" {
 locals {
   sns_topics_pagerduty_integrations = {
     for key, value in var.options.sns_topics.pagerduty_integrations : key => {
-      display_name = "Pager duty integration for ${value}"
-      # kms_master_key_id = "general"  # cloudwatch doesn't have access to the key yet
+      display_name      = "Pager duty integration for ${value}"
+      kms_master_key_id = "general"
       subscriptions = {
         "${key}" = {
           protocol = "https"
@@ -32,8 +32,8 @@ locals {
 
   sns_topics_emails = {
     for key, value in var.options.sns_topics.emails : key => {
-      display_name = "Email integration for ${value}"
-      # kms_master_key_id = "general"  # cloudwatch doesn't have access to the key yet
+      display_name      = "Email integration for ${value}"
+      kms_master_key_id = "general"
       subscriptions = {
         "email" = {
           protocol = "email"


### PR DESCRIPTION
Add DBA alarms with associated pager duty integration.  Tested all variants.  Added high level docs in confluence.
- make use of the 3 new DBA pagerduty integrations (prod callout, prod, devtest)
- setup initial set of alarms for database.  I expect this will be tweaked a bit following further testing.
- added tags and encryption to SNS topics in baseline