### PR TITLE
LAA-OEM: Shorter domain_name in aws_acm_certificate.

### DIFF
--- a/terraform/environments/laa-oem/member_certificates.tf
+++ b/terraform/environments/laa-oem/member_certificates.tf
@@ -2,7 +2,7 @@
 # *.modernisation-platform.service.justice.gov.uk #
 ###################################################
 resource "aws_acm_certificate" "laa_cert" {
-  domain_name       = format("x.%s-%s.modernisation-platform.service.justice.gov.uk", "laa", local.environment)
+  domain_name       = format("%s-%s.modernisation-platform.service.justice.gov.uk", "laa", local.environment)
   validation_method = "DNS"
 
   subject_alternative_names = [


### PR DESCRIPTION
LAA-OEM: Shorter domain_name in aws_acm_certificate.