### PR TITLE
Add Data Platform development Route 53 zone

### DIFF
--- a/terraform/environments/data-platform/glue_job_spark.tf
+++ b/terraform/environments/data-platform/glue_job_spark.tf
@@ -8,10 +8,10 @@ locals {
 
 # load the glue script to bucket as bucket object
 resource "aws_s3_object" "object" {
-  bucket = module.s3-bucket.bucket.id
-  key    = "glue_script/glue_spark_transform_script.py"
-  source = "glue_script/glue_spark_transform_script.py"
-  etag   = filemd5("glue_script/glue_spark_transform_script.py")
+  bucket      = module.s3-bucket.bucket.id
+  key         = "glue_script/glue_spark_transform_script.py"
+  source      = "glue_script/glue_spark_transform_script.py"
+  source_hash = filemd5("glue_script/glue_spark_transform_script.py")
 }
 
 resource "aws_glue_job" "glue_job" {

--- a/terraform/environments/data-platform/route53.tf
+++ b/terraform/environments/data-platform/route53.tf
@@ -1,0 +1,11 @@
+module "data_platform_development_route53" {
+  source  = "terraform-aws-modules/route53/aws//modules/zones"
+  version = "2.10.2"
+
+  zones = {
+    "development.data-platform.service.justice.gov.uk" = {
+      comment = "Data Platform Development"
+      tags = local.tags
+    }
+  }
+}

--- a/terraform/environments/data-platform/route53.tf
+++ b/terraform/environments/data-platform/route53.tf
@@ -1,11 +1,4 @@
-module "data_platform_development_route53" {
-  source  = "terraform-aws-modules/route53/aws//modules/zones"
-  version = "2.10.2"
-
-  zones = {
-    "development.data-platform.service.justice.gov.uk" = {
-      comment = "Data Platform Development"
-      tags = local.tags
-    }
-  }
+resource "aws_route53_zone" "development_data_platform_service_justice_gov_uk" {
+  name = "development.data-platform.service.justice.gov.uk"
+  tags = local.tags
 }


### PR DESCRIPTION
Once merged, this zone will be delegated out via Cloud Platform https://github.com/ministryofjustice/cloud-platform-environments/pull/12907

Also, replacing `etag` with `source_hash` on `aws_s3_object.object`, see https://stackoverflow.com/a/68886287