### PR TITLE
NIT-655 IAPS Security Group updates

### DIFF
--- a/terraform/environments/delius-iaps/application_variables.json
+++ b/terraform/environments/delius-iaps/application_variables.json
@@ -128,12 +128,6 @@
       "protocol": "TCP",
       "destination_cidr": "0.0.0.0/0"
     },
-    "TCP_1433": {
-      "from_port": 1433,
-      "to_port": 1433,
-      "protocol": "TCP",
-      "destination_cidr": "0.0.0.0/0"
-    },
     "TCP_1521": {
       "from_port": 1521,
       "to_port": 1521,

--- a/terraform/environments/delius-iaps/application_variables.json
+++ b/terraform/environments/delius-iaps/application_variables.json
@@ -115,6 +115,13 @@
       "protocol": "TCP"
     }
   },
+  "iaps_sg_egress_rules_vpc": {
+    "TCP_1521": {
+      "from_port": 1521,
+      "to_port": 1521,
+      "protocol": "TCP"
+    }
+  },
   "iaps_sg_egress_rules_cidr": {
     "TCP_80": {
       "from_port": 80,
@@ -125,12 +132,6 @@
     "TCP_443": {
       "from_port": 443,
       "to_port": 443,
-      "protocol": "TCP",
-      "destination_cidr": "0.0.0.0/0"
-    },
-    "TCP_1521": {
-      "from_port": 1521,
-      "to_port": 1521,
       "protocol": "TCP",
       "destination_cidr": "0.0.0.0/0"
     }

--- a/terraform/environments/delius-iaps/ec2-iaps-server.tf
+++ b/terraform/environments/delius-iaps/ec2-iaps-server.tf
@@ -119,6 +119,17 @@ resource "aws_security_group_rule" "ingress_traffic_vpc" {
   cidr_blocks       = [data.aws_vpc.shared.cidr_block]
 }
 
+resource "aws_security_group_rule" "egress_traffic_vpc" {
+  for_each          = local.application_data.iaps_sg_egress_rules_vpc
+  description       = format("Traffic for %s %d", each.value.protocol, each.value.from_port)
+  from_port         = each.value.from_port
+  protocol          = each.value.protocol
+  security_group_id = aws_security_group.iaps.id
+  to_port           = each.value.to_port
+  type              = "egress"
+  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+}
+
 #tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "egress_traffic_cidr" {
   for_each          = local.application_data.iaps_sg_egress_rules_cidr


### PR DESCRIPTION
access to port 1433 is removed as we don’t talk to MSSQL dbs directly
access to port 1521 is locked to VPC only  