### PR TITLE
Allow Equip hosts to send traffic to 3rd party monitoring solution

### DIFF
--- a/terraform/environments/equip/application_variables.json
+++ b/terraform/environments/equip/application_variables.json
@@ -946,6 +946,11 @@
       "to_port": 4119,
       "protocol": "TCP"
     },
+    "TCP_5721": {
+      "from_port": 5721,
+      "to_port": 5721,
+      "protocol": "TCP"
+    },
     "TCP_4952-65535": {
       "from_port": 4952,
       "to_port": 65535,


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/3339, this PR adds a common outbound access rule to all hosts, allowing them to send traffic to their 3rd party monitoring solution over the agent check-in port.