### PR TITLE
nomis: DSOS-1893: enable warm pools

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -57,11 +57,7 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
-          })
-        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
@@ -83,11 +79,7 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
-          })
-        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
@@ -109,11 +101,7 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
-          })
-        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
@@ -141,8 +129,7 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 100 }
         }
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-        })
+        autoscaling_group     = module.baseline_presets.ec2_autoscaling_group.default
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "Windows Server 2022 Jumpserver for NOMIS"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -38,11 +38,9 @@ locals {
           vpc_security_group_ids = ["private-web"]
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        autoscaling_group = {
-          desired_capacity    = 0
-          max_size            = 2
-          vpc_zone_identifier = module.environment.subnets["private"].ids
-        }
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+          desired_capacity = 0
+        })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "For testing official RedHat RHEL7.9 image"
@@ -59,12 +57,14 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        autoscaling_group = {
-          desired_capacity    = 0
-          max_size            = 2
-          vpc_zone_identifier = module.environment.subnets["private"].ids
-        }
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+          })
+        })
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+          desired_capacity = 0
+        })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "For testing our base RHEL8.5 base image"
@@ -83,12 +83,14 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        autoscaling_group = {
-          desired_capacity    = 0
-          max_size            = 2
-          vpc_zone_identifier = module.environment.subnets["private"].ids
-        }
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+          })
+        })
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+          desired_capacity = 0
+        })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "For testing our base RHEL7.9 base image"
@@ -107,12 +109,14 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {
           vpc_security_group_ids = ["private-web"]
         })
-        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        autoscaling_group = {
-          desired_capacity    = 0
-          max_size            = 2
-          vpc_zone_identifier = module.environment.subnets["private"].ids
-        }
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+          })
+        })
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+          desired_capacity = 0
+        })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "For testing our base RHEL6.10 base image"
@@ -137,11 +141,8 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 100 }
         }
-        autoscaling_group = {
-          desired_capacity    = 1
-          max_size            = 2
-          vpc_zone_identifier = module.environment.subnets["private"].ids
-        }
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+        })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "Windows Server 2022 Jumpserver for NOMIS"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -90,11 +90,6 @@ locals {
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 0
-          warm_pool = {
-            reuse_on_scale_in           = true
-            min_size                    = 1
-            max_group_prepared_capacity = 2
-          }
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
@@ -121,10 +116,6 @@ locals {
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 0
-          warm_pool = {
-            reuse_on_scale_in           = true
-            max_group_prepared_capacity = 2
-          }
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -62,7 +62,7 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -59,7 +59,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+            branch = "main"
           })
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
@@ -85,7 +85,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+            branch = "main"
           })
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
@@ -111,7 +111,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-1893/re-enable-warm-pools"
+            branch = "main"
           })
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -62,7 +62,7 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
@@ -88,7 +88,7 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
@@ -114,7 +114,7 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -62,7 +62,7 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
@@ -88,8 +88,13 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 0
+          warm_pool = {
+            reuse_on_scale_in           = true
+            min_size                    = 1
+            max_group_prepared_capacity = 2
+          }
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
@@ -114,8 +119,12 @@ locals {
             branch = "nomis/DSOS-1893/re-enable-warm-pools"
           })
         })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook, {
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 0
+          warm_pool = {
+            reuse_on_scale_in           = true
+            max_group_prepared_capacity = 2
+          }
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -89,25 +89,25 @@ locals {
         cloudwatch_metric_alarms = {} # disabled until migration
       })
 
-      t1-nomis-db-1-b = merge(local.database_ec2_b, {
-        tags = merge(local.database_ec2_b.tags, {
-          nomis-environment   = "t1"
-          description         = "T1 NOMIS database"
-          instance-scheduling = "skip-scheduling"
-        })
-        config = merge(local.database_ec2_b.config, {
-          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
-        })
-        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
-          data  = { total_size = 100 }
-          flash = { total_size = 50 }
-        })
-        cloudwatch_metric_alarms = {} # disabled until migration
-      })
+#      t1-nomis-db-1-b = merge(local.database_ec2_b, {
+#        tags = merge(local.database_ec2_b.tags, {
+#          nomis-environment   = "t1"
+#          description         = "T1 NOMIS database"
+#          instance-scheduling = "skip-scheduling"
+#        })
+#        config = merge(local.database_ec2_b.config, {
+#          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
+#        })
+#        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
+#          "/dev/sdb" = { label = "app", size = 100 }
+#          "/dev/sdc" = { label = "app", size = 100 }
+#        })
+#        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
+#          data  = { total_size = 100 }
+#          flash = { total_size = 50 }
+#        })
+#        cloudwatch_metric_alarms = {} # disabled until migration
+#      })
 
       t1-nomis-db-2 = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -93,6 +93,7 @@ locals {
         tags = merge(local.database_ec2_b.tags, {
           nomis-environment   = "t1"
           description         = "T1 NOMIS database"
+          oracle-sids         = "T1TRDS1"
           instance-scheduling = "skip-scheduling"
         })
         config = merge(local.database_ec2_b.config, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -89,25 +89,25 @@ locals {
         cloudwatch_metric_alarms = {} # disabled until migration
       })
 
-#      t1-nomis-db-1-b = merge(local.database_ec2_b, {
-#        tags = merge(local.database_ec2_b.tags, {
-#          nomis-environment   = "t1"
-#          description         = "T1 NOMIS database"
-#          instance-scheduling = "skip-scheduling"
-#        })
-#        config = merge(local.database_ec2_b.config, {
-#          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
-#        })
-#        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
-#          "/dev/sdb" = { label = "app", size = 100 }
-#          "/dev/sdc" = { label = "app", size = 100 }
-#        })
-#        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
-#          data  = { total_size = 100 }
-#          flash = { total_size = 50 }
-#        })
-#        cloudwatch_metric_alarms = {} # disabled until migration
-#      })
+      t1-nomis-db-1-b = merge(local.database_ec2_b, {
+        tags = merge(local.database_ec2_b.tags, {
+          nomis-environment   = "t1"
+          description         = "T1 NOMIS database"
+          instance-scheduling = "skip-scheduling"
+        })
+        config = merge(local.database_ec2_b.config, {
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
+        })
+        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 100 }
+        })
+        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
+          data  = { total_size = 100 }
+          flash = { total_size = 50 }
+        })
+        cloudwatch_metric_alarms = {} # disabled until migration
+      })
 
       t1-nomis-db-2 = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -89,27 +89,6 @@ locals {
         cloudwatch_metric_alarms = {} # disabled until migration
       })
 
-      t1-nomis-db-1-b = merge(local.database_ec2_b, {
-        tags = merge(local.database_ec2_b.tags, {
-          nomis-environment   = "t1"
-          description         = "T1 NOMIS database"
-          oracle-sids         = "T1TRDS1"
-          instance-scheduling = "skip-scheduling"
-        })
-        config = merge(local.database_ec2_b.config, {
-          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
-        })
-        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
-          data  = { total_size = 100 }
-          flash = { total_size = 50 }
-        })
-        cloudwatch_metric_alarms = {} # disabled until migration
-      })
-
       t1-nomis-db-2 = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {
           nomis-environment   = "t1"
@@ -272,7 +251,6 @@ locals {
           { name = "t1nomis", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1nomis-a", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1nomis-b", type = "A", ttl = "300", records = ["10.101.3.132"] },
-          { name = "t1-nomis-db-1-b", type = "CNAME", ttl = "3600", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
           { name = "t1ndh", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1ndh-a", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1ndh-b", type = "A", ttl = "300", records = ["10.101.3.132"] },

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -26,7 +26,7 @@ locals {
     baseline_ec2_autoscaling_groups = {
       # blue deployment
       t1-nomis-web-a = merge(local.weblogic_ec2_a, {
-        autoscaling_group = merge(local.weblogic_ec2_a.ec2_autoscaling_group, {
+        autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
           desired_capacity = 1
         })
         tags = merge(local.weblogic_ec2_a.tags, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -27,7 +27,7 @@ locals {
       # blue deployment
       t1-nomis-web-a = merge(local.weblogic_ec2_a, {
         autoscaling_group = merge(local.weblogic_ec2_a.autoscaling_group, {
-          desired_capacity = 1
+          desired_capacity = 0
         })
         tags = merge(local.weblogic_ec2_a.tags, {
           nomis-environment    = "t1"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -26,6 +26,9 @@ locals {
     baseline_ec2_autoscaling_groups = {
       # blue deployment
       t1-nomis-web-a = merge(local.weblogic_ec2_a, {
+        autoscaling_group = merge(local.weblogic_ec2_a.ec2_autoscaling_group, {
+          desired_capacity = 1
+        })
         tags = merge(local.weblogic_ec2_a.tags, {
           nomis-environment    = "t1"
           oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
@@ -80,6 +83,26 @@ locals {
           "/dev/sdc" = { label = "app", size = 100 }
         })
         ebs_volume_config = merge(local.database_ec2_a.ebs_volume_config, {
+          data  = { total_size = 100 }
+          flash = { total_size = 50 }
+        })
+        cloudwatch_metric_alarms = {} # disabled until migration
+      })
+
+      t1-nomis-db-1-b = merge(local.database_ec2_b, {
+        tags = merge(local.database_ec2_b.tags, {
+          nomis-environment   = "t1"
+          description         = "T1 NOMIS database"
+          instance-scheduling = "skip-scheduling"
+        })
+        config = merge(local.database_ec2_b.config, {
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-04-02T00-00-40.059Z"
+        })
+        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 100 }
+        })
+        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
           data  = { total_size = 100 }
           flash = { total_size = 50 }
         })
@@ -248,6 +271,7 @@ locals {
           { name = "t1nomis", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1nomis-a", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1nomis-b", type = "A", ttl = "300", records = ["10.101.3.132"] },
+          { name = "t1-nomis-db-1-b", type = "CNAME", ttl = "3600", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
           { name = "t1ndh", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1ndh-a", type = "A", ttl = "300", records = ["10.101.3.132"] },
           { name = "t1ndh-b", type = "A", ttl = "300", records = ["10.101.3.132"] },

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -142,39 +142,7 @@ locals {
     })
 
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-
-    autoscaling_group = {
-      desired_capacity = 1
-      max_size         = 2
-      vpc_zone_identifier = [
-        module.environment.subnets["private"].ids
-      ]
-      health_check_grace_period = 300
-      health_check_type         = "EC2"
-      force_delete              = true
-      termination_policies      = ["OldestInstance"]
-      wait_for_capacity_timeout = 0
-
-      # this hook is triggered by the post-ec2provision.sh
-      initial_lifecycle_hooks = {
-        "ready-hook" = {
-          default_result       = "ABANDON"
-          heartbeat_timeout    = 7200
-          lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
-        }
-      }
-
-      instance_refresh = {
-        strategy               = "Rolling"
-        min_healthy_percentage = 90 # seems that instances in the warm pool are included in the % health count so this needs to be set fairly high
-        instance_warmup        = 300
-      }
-
-      # warm_pool = {
-      #   reuse_on_scale_in           = true
-      #   max_group_prepared_capacity = 1
-      # }
-    }
+    autoscaling_group    = module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook
 
     lb_target_groups = {
       http-7777 = local.weblogic_target_group_http_7777

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -170,10 +170,10 @@ locals {
     })
     user_data_cloud_init = merge(local.weblogic_ec2_default.user_data_cloud_init, {
       args = merge(local.weblogic_ec2_default.user_data_cloud_init.args, {
-        branch = "a5c69245a3e30ca8d44ab269062479e1768e2f5c" # 2023-04-25
+        branch = "nomis/DSOS-1893/re-enable-warm-pools"
       })
     })
-    autoscaling_group = merge(local.weblogic_ec2_default.autoscaling_group, {
+    autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
       desired_capacity = 0
     })
     cloudwatch_metric_alarms = {}

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -142,7 +142,7 @@ locals {
     })
 
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-    autoscaling_group    = module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook
+    autoscaling_group    = module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool
 
     lb_target_groups = {
       http-7777 = local.weblogic_target_group_http_7777
@@ -170,10 +170,10 @@ locals {
     })
     user_data_cloud_init = merge(local.weblogic_ec2_default.user_data_cloud_init, {
       args = merge(local.weblogic_ec2_default.user_data_cloud_init.args, {
-        branch = "nomis/DSOS-1893/re-enable-warm-pools"
+        branch = "main"
       })
     })
-    autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
+    autoscaling_group = merge(local.weblogic_ec2_default.autoscaling_group, {
       desired_capacity = 0
     })
     cloudwatch_metric_alarms = {}

--- a/terraform/environments/nomis/templates/post-ec2provision.sh.tftpl
+++ b/terraform/environments/nomis/templates/post-ec2provision.sh.tftpl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Any generic post ansible steps, e.g. calling lifecycle hook
 set -e
+PATH=$PATH:/usr/local/bin
 
 main() {
   # call lifecycle script if one has been configured by ansible

--- a/terraform/environments/nomis/templates/post-ec2provision.sh.tftpl
+++ b/terraform/environments/nomis/templates/post-ec2provision.sh.tftpl
@@ -1,10 +1,23 @@
 #!/bin/bash
 # Any generic post ansible steps, e.g. calling lifecycle hook
+set -e
 
 main() {
+  # call lifecycle script if one has been configured by ansible
   if [[ -x /usr/local/bin/autoscaling-lifecycle-${lifecycle_hook_name}.sh ]]; then
     echo "# running: /usr/local/bin/autoscaling-lifecycle-${lifecycle_hook_name}.sh"
     /usr/local/bin/autoscaling-lifecycle-${lifecycle_hook_name}.sh
+  else
+    # otherwise, check if part of lifecycle.
+    token=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+    state=$(curl -f -sS -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state 2>/dev/null) || exitcode=$?
+    if [[ $exitcode -eq 0 ]]; then
+      echo "# no autoscaling lifecycle script found, run aws autoscaling complete-lifecycle-action --lifecycle-action-result ABANDON"
+      instance_id=$(curl -sS -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id)
+      region=$(curl -sS -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/placement/region)
+      name=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=Name" --output=text | cut -f5)
+      aws autoscaling complete-lifecycle-action --lifecycle-action-result "ABANDON" --instance-id "$instance_id" --lifecycle-hook-name "$name-${lifecycle_hook_name}" --auto-scaling-group-name "$name" --region "$region" || true
+    fi
   fi
 }
 

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -77,7 +77,7 @@ locals {
     cloudwatch_metric_alarms = {}
     user_data_cloud_init     = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags
     autoscaling_schedules    = module.baseline_presets.ec2_autoscaling_schedules.working_hours
-    autoscaling_group        = module.baseline_presets.ec2_autoscaling_group
+    autoscaling_group        = module.baseline_presets.ec2_autoscaling_group.default
     lb_target_groups = {
       http-8080 = {
         port                 = 8080
@@ -123,7 +123,7 @@ locals {
     })
     instance              = module.baseline_presets.ec2_instance.instance.default_db
     autoscaling_schedules = {}
-    autoscaling_group     = module.baseline_presets.ec2_autoscaling_group
+    autoscaling_group     = module.baseline_presets.ec2_autoscaling_group.default
     user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags, {
       args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags.args, {
         branch = "05c85c8f1ef86637e1f65347c2af10741cec0578"

--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -4,13 +4,13 @@ locals {
 
     default = {
       desired_capacity    = 1
-      max_size            = 2
+      max_size            = 1
       vpc_zone_identifier = var.environment.subnets["private"].ids
     }
 
     default_with_ready_hook = {
       desired_capacity    = 1
-      max_size            = 2
+      max_size            = 1
       vpc_zone_identifier = var.environment.subnets["private"].ids
 
       initial_lifecycle_hooks = {
@@ -24,7 +24,7 @@ locals {
 
     default_with_ready_hook_and_warm_pool = {
       desired_capacity    = 1
-      max_size            = 2
+      max_size            = 1
       vpc_zone_identifier = var.environment.subnets["private"].ids
 
       initial_lifecycle_hooks = {

--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -1,9 +1,45 @@
 locals {
 
   ec2_autoscaling_group = {
-    desired_capacity    = 1
-    max_size            = 2
-    vpc_zone_identifier = var.environment.subnets["private"].ids
+
+    default = {
+      desired_capacity    = 1
+      max_size            = 2
+      vpc_zone_identifier = var.environment.subnets["private"].ids
+    }
+
+    default_with_ready_hook = {
+      desired_capacity    = 1
+      max_size            = 2
+      vpc_zone_identifier = var.environment.subnets["private"].ids
+
+      initial_lifecycle_hooks = {
+        "ready-hook" = {
+          default_result       = "ABANDON"
+          heartbeat_timeout    = 7200
+          lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+        }
+      }
+    }
+
+    default_with_ready_hook_and_warm_pool = {
+      desired_capacity    = 1
+      max_size            = 2
+      vpc_zone_identifier = var.environment.subnets["private"].ids
+
+      initial_lifecycle_hooks = {
+        "ready-hook" = {
+          default_result       = "ABANDON"
+          heartbeat_timeout    = 7200
+          lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+        }
+      }
+
+      warm_pool = {
+        reuse_on_scale_in           = true
+        max_group_prepared_capacity = 1
+      }
+    }
   }
 
   ec2_autoscaling_schedules = {

--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -10,10 +10,11 @@ locals {
     }
 
     default_with_ready_hook = {
-      desired_capacity    = 1
-      max_size            = 1
-      force_delete        = true
-      vpc_zone_identifier = var.environment.subnets["private"].ids
+      desired_capacity          = 1
+      max_size                  = 1
+      force_delete              = true
+      vpc_zone_identifier       = var.environment.subnets["private"].ids
+      wait_for_capacity_timeout = 0
 
       initial_lifecycle_hooks = {
         "ready-hook" = {
@@ -25,10 +26,11 @@ locals {
     }
 
     default_with_ready_hook_and_warm_pool = {
-      desired_capacity    = 1
-      max_size            = 1
-      force_delete        = true
-      vpc_zone_identifier = var.environment.subnets["private"].ids
+      desired_capacity          = 1
+      max_size                  = 1
+      force_delete              = true
+      vpc_zone_identifier       = var.environment.subnets["private"].ids
+      wait_for_capacity_timeout = 0
 
       initial_lifecycle_hooks = {
         "ready-hook" = {

--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -5,12 +5,14 @@ locals {
     default = {
       desired_capacity    = 1
       max_size            = 1
+      force_delete        = true
       vpc_zone_identifier = var.environment.subnets["private"].ids
     }
 
     default_with_ready_hook = {
       desired_capacity    = 1
       max_size            = 1
+      force_delete        = true
       vpc_zone_identifier = var.environment.subnets["private"].ids
 
       initial_lifecycle_hooks = {
@@ -25,6 +27,7 @@ locals {
     default_with_ready_hook_and_warm_pool = {
       desired_capacity    = 1
       max_size            = 1
+      force_delete        = true
       vpc_zone_identifier = var.environment.subnets["private"].ids
 
       initial_lifecycle_hooks = {


### PR DESCRIPTION
Enable warm pools for NOMIS since weblogic takes forever to build
- add a number of different autoscaling configurations to baseline presets
- update oasys to use the default one 
- update nomis to use the warm pool one