### PR TITLE
Removed the null resource as we're rebuilding dev.

### DIFF
--- a/terraform/environments/mlra/modules/alb/main.tf
+++ b/terraform/environments/mlra/modules/alb/main.tf
@@ -526,11 +526,6 @@ resource "aws_waf_web_acl" "waf_acl" {
 
 ## ALB Listener
 
-# TODO This resource is required because otherwise Error: failed to read schema for module.alb.null_resource.always_run in registry.terraform.io/hashicorp/null: failed to instantiate provider
-# When the whole stack is recreated this can be removed
-resource "null_resource" "always_run" {
-}
-
 resource "aws_lb_listener" "alb_listener" {
 
   load_balancer_arn = aws_lb.loadbalancer.arn


### PR DESCRIPTION
As per title. This resource can now be deleted as we're rebuilding each environment.