### PR TITLE
Glue job create table

### DIFF
--- a/terraform/environments/data-platform/glue_job_spark.tf
+++ b/terraform/environments/data-platform/glue_job_spark.tf
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "glue-athena-access" {
       "athena:StartQueryExecution",
     ]
     resources = [
-       "arn:aws:athena:*:${data.aws_caller_identity.current.account_id}:workgroup/*"
+      "arn:aws:athena:*:${data.aws_caller_identity.current.account_id}:workgroup/*"
     ]
   }
 }

--- a/terraform/environments/data-platform/glue_job_spark.tf
+++ b/terraform/environments/data-platform/glue_job_spark.tf
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "s3-access" {
 resource "aws_iam_policy" "s3_policy_for_gluejob" {
   name        = "${local.name}-s3-policy-${local.environment}"
   path        = "/"
-  description = "AWS IAM Policy for managing aws lambda role"
+  description = "s3 permissions for data product transform glue job"
   policy      = data.aws_iam_policy_document.s3-access.json
 
 }
@@ -91,6 +91,31 @@ resource "aws_iam_policy" "s3_policy_for_gluejob" {
 resource "aws_iam_role_policy_attachment" "s3_access_for_glue_job" {
   role       = aws_iam_role.glue-service-role.name
   policy_arn = aws_iam_policy.s3_policy_for_gluejob.arn
+}
+
+data "aws_iam_policy_document" "glue-athena-access" {
+  statement {
+    sid = "QueryAccess"
+    actions = [
+      "athena:StartQueryExecution",
+    ]
+    resources = [
+       "arn:aws:athena:*:${data.aws_caller_identity.current.account_id}:workgroup/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "athena_policy_for_gluejob" {
+  name        = "${local.name}-athena-policy-${local.environment}"
+  path        = "/"
+  description = "Athena permissions for data product transform glue job"
+  policy      = data.aws_iam_policy_document.glue-athena-access.json
+
+}
+
+resource "aws_iam_role_policy_attachment" "athena_access_for_glue_job" {
+  role       = aws_iam_role.glue-service-role.name
+  policy_arn = aws_iam_policy.athena_policy_for_gluejob.arn
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {

--- a/terraform/environments/data-platform/lambda_for_authoriser.tf
+++ b/terraform/environments/data-platform/lambda_for_authoriser.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "authoriser" {
   environment {
     variables = {
       authorisationToken = "placeholder"
-      api_resource_arn = "placeholder"
+      api_resource_arn   = "placeholder"
     }
   }
 }

--- a/terraform/environments/data-platform/s3.tf
+++ b/terraform/environments/data-platform/s3.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 module "s3_athena_query_results_bucket" { #tfsec:ignore:aws-s3-enable-versioning
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
 
-  bucket_prefix      = "athena-query-results-${data.aws_caller_identity.current.account_id}"
+  bucket_name      = "athena-data-product-query-results-${data.aws_caller_identity.current.account_id}"
   versioning_enabled = false
   # Refer to the below section "Replication" before enabling replication
   replication_enabled = false

--- a/terraform/environments/data-platform/s3.tf
+++ b/terraform/environments/data-platform/s3.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 module "s3_athena_query_results_bucket" { #tfsec:ignore:aws-s3-enable-versioning
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
 
-  bucket_name      = "athena-data-product-query-results-${data.aws_caller_identity.current.account_id}"
+  bucket_name        = "athena-data-product-query-results-${data.aws_caller_identity.current.account_id}"
   versioning_enabled = false
   # Refer to the below section "Replication" before enabling replication
   replication_enabled = false


### PR DESCRIPTION
Added functionality to glue job so that if an extraction timestamp partition of data is found to already exist the script also checks if the database and table exists and creates if it does not.

As well as the glue job python script changes were needed to:
- the glue job infra terraform to give athena start query execution permissions to the iam role
- the athena query bucket, to drop the timestamp suffix so we can predict the name of the bucket when deployed to accounts other than the dev sandbox