### PR TITLE
rename jumpserver asg to to test-jumpserver-2022 in nomis-test environment

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -47,7 +47,7 @@ locals {
         })
       })
 
-      dev-jumpserver-2022 = {
+      test-jumpserver-2022 = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name                      = "nomis_windows_server_2022_jumpserver_release_*"


### PR DESCRIPTION
name the asg to match the environments it's in