### PR TITLE
add missing SIDs to t1-nomis-db-1-b

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -136,7 +136,7 @@ locals {
         tags = merge(local.database_ec2_b.tags, {
           nomis-environment   = "t1"
           description         = "T1 NOMIS database"
-          oracle-sids         = "T1TRDS1"
+          oracle-sids         = "T1TRDS1 T1CNOMS1 T1NDHS1"
           instance-scheduling = "skip-scheduling"
         })
         config = merge(local.database_ec2_b.config, {


### PR DESCRIPTION
part of extending the monitoring to multiple sids on a given host

all the changes will be in re-applying the collectd role from modernisation-platform-configuration-management

this should be the only PR in this repo associated with this