### PR TITLE
DPR-498 add contract registry name parameter to DataHubJob

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -52,7 +52,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
-    "--dpr.contract.registryName"               = module.glue_registry_avro.registry_name
+    "--dpr.contract.registryName"               = split("/", module.glue_registry_avro.registry_name)
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -56,7 +56,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
-    "--dpr.contract.registryName"               = trimprefix(module.glue_registry_avro.registry_name, local.glue_avro_registry[0])
+    "--dpr.contract.registryName"               = trimprefix(module.glue_registry_avro.registry_name, "${local.glue_avro_registry[0]}/")
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -52,7 +52,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
-    "--dpr.contract.registryName"               = "${module.glue_registry_avro.name}"
+    "--dpr.contract.registryName"               = "${module.glue_registry_avro.registry_name}"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -56,7 +56,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
-    "--dpr.contract.registryName"               = trimprefix(local.glue_avro_registry, local.glue_avro_registry[0])
+    "--dpr.contract.registryName"               = trimprefix(module.glue_registry_avro.registry_name, local.glue_avro_registry[0])
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -52,6 +52,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
+    "--dpr.contract.registryName"               = "${module.glue_registry_avro.name}"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -3,6 +3,10 @@
 ###############################################
 ## Glue Job, Reporting Hub
 ## Glue Cloud Platform Ingestion Job (Load, Reload, CDC)
+locals {
+  glue_avro_registry = split("/", module.glue_registry_avro.registry_name)
+}
+    
 module "glue_reporting_hub_job" {
   source                        = "./modules/glue_job"
   create_job                    = local.create_job
@@ -52,7 +56,7 @@ module "glue_reporting_hub_job" {
     "--enable-spark-ui"                         = false
     "--enable-job-insights"                     = true
     "--dpr.aws.kinesis.endpointUrl"             = "https://kinesis.${local.account_region}.amazonaws.com"
-    "--dpr.contract.registryName"               = split("/", module.glue_registry_avro.registry_name)
+    "--dpr.contract.registryName"               = trimprefix(local.glue_avro_registry, local.glue_avro_registry[0])
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/glue_registry/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_registry/outputs.tf
@@ -1,0 +1,4 @@
+output "registry_name" {
+  description = "Registry Name"
+  value = aws_glue_registry.glue_registry[0].id
+}


### PR DESCRIPTION
Summary of changes
* added new `dpr.contract.registryName` parameter to the DataHubJob so that the contract registry name can be passed to the job. 