### PR TITLE
nomis: DSOS-1866: add route53 query logging

### DIFF
--- a/terraform/environments/nomis-combined-reporting/baseline.tf
+++ b/terraform/environments/nomis-combined-reporting/baseline.tf
@@ -5,6 +5,7 @@ module "baseline" {
     aws                       = aws
     aws.core-network-services = aws.core-network-services
     aws.core-vpc              = aws.core-vpc
+    aws.us-east-1             = aws.us-east-1
   }
 
   environment = module.environment

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -5,6 +5,7 @@ module "baseline" {
     aws                       = aws
     aws.core-network-services = aws.core-network-services
     aws.core-vpc              = aws.core-vpc
+    aws.us-east-1             = aws.us-east-1
   }
 
   environment = module.environment

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -37,6 +37,7 @@ module "baseline" {
     aws                       = aws
     aws.core-network-services = aws.core-network-services
     aws.core-vpc              = aws.core-vpc
+    aws.us-east-1             = aws.us-east-1
   }
 
   environment = module.environment

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -58,6 +58,7 @@ module "baseline" {
     aws                       = aws
     aws.core-network-services = aws.core-network-services
     aws.core-vpc              = aws.core-vpc
+    aws.us-east-1             = aws.us-east-1
   }
 
   # bastion_linux = lookup(local.environment_config, "baseline_bastion_linux", null)

--- a/terraform/modules/baseline/iam_policies.tf
+++ b/terraform/modules/baseline/iam_policies.tf
@@ -1,5 +1,5 @@
 locals {
-  iam_policies = merge(local.s3_buckets_iam_policies, local.route53_iam_policies, var.iam_policies)
+  iam_policies = merge(local.s3_buckets_iam_policies, var.iam_policies)
 }
 
 data "aws_iam_policy_document" "this" {

--- a/terraform/modules/baseline/iam_policies.tf
+++ b/terraform/modules/baseline/iam_policies.tf
@@ -1,5 +1,5 @@
 locals {
-  iam_policies = merge(local.s3_buckets_iam_policies, var.iam_policies)
+  iam_policies = merge(local.s3_buckets_iam_policies, local.route53_iam_policies, var.iam_policies)
 }
 
 data "aws_iam_policy_document" "this" {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -153,18 +153,18 @@ resource "aws_route53_zone" "this" {
   })
 }
 
-#resource "aws_cloudwatch_log_group" "route53" {
-#  for_each = local.route53_zones_to_create
-#
-#  provider = aws.us-east-1
-#
-#  name              = "route53/${each.key}"
-#  retention_in_days = 30
-#
-#  tags = merge(local.tags, {
-#    Name = "route53/${each.key}"
-#  })
-#}
+resource "aws_cloudwatch_log_group" "route53" {
+  for_each = local.route53_zones_to_create
+
+  provider = aws.us-east-1
+
+  name              = "route53/${each.key}"
+  retention_in_days = 30
+
+  tags = merge(local.tags, {
+    Name = "route53/${each.key}"
+  })
+}
 
 #resource "aws_route53_query_log" "this" {
 #  for_each = local.route53_zones_to_create

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -170,7 +170,10 @@ resource "aws_route53_query_log" "this" {
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
   zone_id                  = aws_route53_zone.this[each.key].zone_id
 
-  depends_on = [aws_iam_policy.this]
+  depends_on = [
+    aws_cloudwatch_log_group.route53,
+    aws_iam_policy.this,
+  ]
 }
 
 resource "aws_route53_record" "self" {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -153,6 +153,19 @@ resource "aws_route53_zone" "this" {
   })
 }
 
+resource "aws_cloudwatch_log_group" "route53" {
+  for_each = local.route53_zones_to_create
+
+  provider = aws.us-east-1
+
+  name              = "aws/route53/${each.key}"
+  retention_in_days = 30
+
+  tags = merge(local.tags, {
+    Name = "aws/route53/${each.key}"
+  })
+}
+
 data "aws_iam_policy_document" "route53_query_logging_policy" {
   statement {
     actions = [
@@ -160,7 +173,7 @@ data "aws_iam_policy_document" "route53_query_logging_policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/route53/*"]
+    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
 
     principals {
       identifiers = ["route53.amazonaws.com"]
@@ -176,18 +189,6 @@ resource "aws_cloudwatch_log_resource_policy" "route53_query_logging_policy" {
   policy_name     = "CloudWatchRoute53QueryLoggingPolicy"
 }
 
-resource "aws_cloudwatch_log_group" "route53" {
-  for_each = local.route53_zones_to_create
-
-  provider = aws.us-east-1
-
-  name              = "route53/${each.key}"
-  retention_in_days = 30
-
-  tags = merge(local.tags, {
-    Name = "route53/${each.key}"
-  })
-}
 
 resource "aws_route53_query_log" "this" {
   for_each = local.route53_zones_to_create

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -157,7 +157,6 @@ resource "aws_cloudwatch_log_group" "route53" {
   for_each = local.route53_zones_to_create
 
   name              = "route53/${each.key}"
-  kms_key_id        = var.environment.kms_keys["general"].arn
   retention_in_days = 30
 
   tags = merge(local.tags, {

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -153,29 +153,29 @@ resource "aws_route53_zone" "this" {
   })
 }
 
-resource "aws_cloudwatch_log_group" "route53" {
-  for_each = local.route53_zones_to_create
+#resource "aws_cloudwatch_log_group" "route53" {
+#  for_each = local.route53_zones_to_create
+#
+#  provider = aws.us-east-1
+#
+#  name              = "route53/${each.key}"
+#  retention_in_days = 30
+#
+#  tags = merge(local.tags, {
+#    Name = "route53/${each.key}"
+#  })
+#}
 
-  provider = aws.us-east-1
-
-  name              = "route53/${each.key}"
-  retention_in_days = 30
-
-  tags = merge(local.tags, {
-    Name = "route53/${each.key}"
-  })
-}
-
-resource "aws_route53_query_log" "this" {
-  for_each = local.route53_zones_to_create
-
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
-  zone_id                  = aws_route53_zone.this[each.key].zone_id
-
-  depends_on = [
-    aws_iam_policy.this,
-  ]
-}
+#resource "aws_route53_query_log" "this" {
+#  for_each = local.route53_zones_to_create
+#
+#  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
+#  zone_id                  = aws_route53_zone.this[each.key].zone_id
+#
+#  depends_on = [
+#    aws_iam_policy.this,
+#  ]
+#}
 
 resource "aws_route53_record" "self" {
   for_each = local.route53_records_self

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -158,7 +158,7 @@ resource "aws_cloudwatch_log_group" "route53" {
 
   provider = aws.us-east-1
 
-  name              = "aws/route53/${each.key}"
+  name              = "/route53/${each.key}"
   retention_in_days = 30
 
   tags = merge(local.tags, {
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "route53_query_logging_policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+    resources = ["arn:aws:logs:*:*:log-group:/route53/*"]
 
     principals {
       identifiers = ["route53.amazonaws.com"]
@@ -189,17 +189,16 @@ resource "aws_cloudwatch_log_resource_policy" "route53_query_logging_policy" {
   policy_name     = "CloudWatchRoute53QueryLoggingPolicy"
 }
 
-
-resource "aws_route53_query_log" "this" {
-  for_each = local.route53_zones_to_create
-
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
-  zone_id                  = aws_route53_zone.this[each.key].zone_id
-
-  depends_on = [
-    aws_cloudwatch_log_resource_policy.route53_query_logging_policy,
-  ]
-}
+#resource "aws_route53_query_log" "this" {
+#  for_each = local.route53_zones_to_create
+#
+#  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
+#  zone_id                  = aws_route53_zone.this[each.key].zone_id
+#
+#  depends_on = [
+#    aws_cloudwatch_log_resource_policy.route53_query_logging_policy,
+#  ]
+#}
 
 resource "aws_route53_record" "self" {
   for_each = local.route53_records_self

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -189,16 +189,16 @@ resource "aws_cloudwatch_log_resource_policy" "route53_query_logging_policy" {
   policy_name     = "CloudWatchRoute53QueryLoggingPolicy"
 }
 
-#resource "aws_route53_query_log" "this" {
-#  for_each = local.route53_zones_to_create
-#
-#  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
-#  zone_id                  = aws_route53_zone.this[each.key].zone_id
-#
-#  depends_on = [
-#    aws_cloudwatch_log_resource_policy.route53_query_logging_policy,
-#  ]
-#}
+resource "aws_route53_query_log" "this" {
+  for_each = local.route53_zones_to_create
+
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
+  zone_id                  = aws_route53_zone.this[each.key].zone_id
+
+  depends_on = [
+    aws_cloudwatch_log_resource_policy.route53_query_logging_policy,
+  ]
+}
 
 resource "aws_route53_record" "self" {
   for_each = local.route53_records_self

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "route53_query_logging_policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/route53/*"]
+    resources = ["arn:aws:logs:us-east-1:*:log-group:*"]
 
     principals {
       identifiers = ["route53.amazonaws.com"]

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -156,6 +156,8 @@ resource "aws_route53_zone" "this" {
 resource "aws_cloudwatch_log_group" "route53" {
   for_each = local.route53_zones_to_create
 
+  provider = aws.us-east-1
+
   name              = "route53/${each.key}"
   retention_in_days = 30
 
@@ -171,7 +173,6 @@ resource "aws_route53_query_log" "this" {
   zone_id                  = aws_route53_zone.this[each.key].zone_id
 
   depends_on = [
-    aws_cloudwatch_log_group.route53,
     aws_iam_policy.this,
   ]
 }

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -25,6 +25,7 @@ locals {
           identifiers = ["route53.amazonaws.com"]
           type        = "Service"
         }
+        conditions = []
       }]
     }
   } : {}

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -11,7 +11,7 @@ locals {
   })
 
   # create route53 policy for query logs
-  route53_iam_policies = length(route53_zones_to_create) != 0 ? {
+  route53_iam_policies = length(local.route53_zones_to_create) != 0 ? {
     CloudWatchRoute53Policy = {
       description = "Allow Route53 to write CloudWatch logs"
       statements = [{

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -166,16 +166,16 @@ resource "aws_cloudwatch_log_group" "route53" {
   })
 }
 
-#resource "aws_route53_query_log" "this" {
-#  for_each = local.route53_zones_to_create
-#
-#  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
-#  zone_id                  = aws_route53_zone.this[each.key].zone_id
-#
-#  depends_on = [
-#    aws_iam_policy.this,
-#  ]
-#}
+resource "aws_route53_query_log" "this" {
+  for_each = local.route53_zones_to_create
+
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53[each.key].arn
+  zone_id                  = aws_route53_zone.this[each.key].zone_id
+
+  depends_on = [
+    aws_iam_policy.this,
+  ]
+}
 
 resource "aws_route53_record" "self" {
   for_each = local.route53_records_self

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -13,6 +13,7 @@ locals {
   # create route53 policy for query logs
   route53_iam_policies = length(local.route53_zones_to_create) != 0 ? {
     CloudWatchRoute53Policy = {
+      path        = "/"
       description = "Allow Route53 to write CloudWatch logs"
       statements = [{
         effect = "Allow"

--- a/terraform/modules/baseline/versions.tf
+++ b/terraform/modules/baseline/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       version               = "~> 4.9"
       source                = "hashicorp/aws"
-      configuration_aliases = [aws.core-vpc, aws.core-network-services]
+      configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.us-east-1]
     }
   }
   required_version = ">= 1.1.7"


### PR DESCRIPTION
Mod platform have done their bit so we can merge this now
- add us-east-1 provider so we can create loggroup in correct place
- enable force_destroy on route53 zones to avoid dangling resources (i.e. what happened in oasys)
- automatically setup route53 query logging for all zones created via baseline