### PR TITLE
Data platform 396 end to end data upload

### DIFF
--- a/terraform/environments/data-platform/lambda_for_code.tf
+++ b/terraform/environments/data-platform/lambda_for_code.tf
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_event_rule" "put_to_code_directory" {
     "detail-type" : ["AWS API Call via CloudTrail"],
     "detail" : {
       "eventSource" : ["s3.amazonaws.com"],
-      "eventName" : ["PutObject"],
+      "eventName" : ["PutObject", "CompleteMultipartUpload"],
       "requestParameters" : {
         "bucketName" : [module.s3-bucket.bucket.id],
         "key" : [{ "prefix" : "code_zips/" }]

--- a/terraform/environments/data-platform/lambda_for_data.tf
+++ b/terraform/environments/data-platform/lambda_for_data.tf
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_event_rule" "put_to_data_directory" {
     "detail-type" : ["AWS API Call via CloudTrail"],
     "detail" : {
       "eventSource" : ["s3.amazonaws.com"],
-      "eventName" : ["PutObject"],
+      "eventName" : ["PutObject", "CompleteMultipartUpload"],
       "requestParameters" : {
         "bucketName" : [module.s3-bucket.bucket.id],
         "key" : [{ "prefix" : "raw_data/" }]

--- a/terraform/environments/data-platform/lambda_for_presigned_url.tf
+++ b/terraform/environments/data-platform/lambda_for_presigned_url.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "iam_policy_document_for_presigned_url_lambda" {
     sid       = "GetPutDataObject"
     effect    = "Allow"
     actions   = ["s3:GetObject", "s3:PutObject"]
-    resources = ["${module.s3-bucket.bucket.arn}/curated_data/*"]
+    resources = ["${module.s3-bucket.bucket.arn}/raw_data/*"]
   }
 }
 

--- a/terraform/environments/data-platform/src/presigned_url/main.py
+++ b/terraform/environments/data-platform/src/presigned_url/main.py
@@ -18,9 +18,9 @@ def handler(event, context):
     md5 = str(event["queryStringParameters"]["contentMD5"])
     uuid_string = str(uuid.uuid4())
     file_name = os.path.join(
-        "curated_data",
-        f"database_name={database}",
-        f"table_name={table}",
+        "raw_data",
+        database,
+        table,
         f"extraction_timestamp={amz_date}",
         uuid_string,
     )


### PR DESCRIPTION
* Presigned URL should now write to the `raw_data` directory
* The glue job has been changed to follow ISO datetime standards eg `20230609T133114Z` rather than with no T and Z as before eg `20230609133114`
* Added new trigger events for cloudwatch to cover multi part data and code uploads