### PR TITLE
infra for athena load lambda

### DIFF
--- a/terraform/environments/data-platform/lambda_for_athena_load.tf
+++ b/terraform/environments/data-platform/lambda_for_athena_load.tf
@@ -1,0 +1,134 @@
+module "data_product_athena_load_lambda" {
+  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=v1.1.0"
+  application_name               = "data_product_athena_load"
+  tags                           = local.tags
+  description                    = "Lambda to load and transform raw data products landing in s3. Creates partitioned parquet tables"
+  role_name                      = "athena_load_lambda_role_${local.environment}"
+  policy_json                    = data.aws_iam_policy_document.athena-load-lambda-function-policy.json
+  function_name                  = "data_product_athena_load_${local.environment}"
+  create_role                    = true
+  reserved_concurrent_executions = 1
+
+  image_uri    = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/data-platform-athena-load-lambda-ecr-repo:latest"
+  timeout      = 600
+  tracing_mode = "Active"
+  memory_size  = 512
+
+  allowed_triggers = {
+
+    AllowStartExecutionFromCloudWatch = {
+      principal  = "events.amazonaws.com"
+      source_arn = aws_cloudwatch_event_rule.put_to_data_directory.arn
+    }
+  }
+
+}
+
+resource "aws_athena_workgroup" "data_product_athena_workgroup" {
+  name = "data_product_workgroup"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+    engine_version {
+      selected_engine_version = "Athena engine version 3"
+    }
+    result_configuration {
+      output_location = "athena-data-product-query-results-${data.aws_caller_identity.current.account_id}"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "athena-load-lambda-function-policy" {
+  statement {
+    sid    = "AllowLambdaToCreateLogGroup"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup"
+    ]
+    resources = [
+      format("arn:aws:logs:eu-west-2:%s:*", data.aws_caller_identity.current.account_id)
+    ]
+  }
+  statement {
+    sid    = "AllowLambdaToWriteLogsToGroup"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      format("arn:aws:logs:eu-west-2:%s:*", data.aws_caller_identity.current.account_id)
+    ]
+  }
+  statement {
+    sid    = "s3Access"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject*",
+      "s3:PutObject*",
+      "s3:ListBucket*",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      "${module.s3-bucket.bucket.arn}/*",
+      "${module.s3-bucket.bucket.arn}",
+      "${module.s3_athena_query_results_bucket.bucket.arn}",
+      "${module.s3_athena_query_results_bucket.bucket.arn}/*"
+    ]
+  }
+  statement {
+    sid    = "GluePermissions"
+    effect = "Allow"
+    actions = [
+      "glue:BatchCreatePartition",
+      "glue:BatchDeletePartition",
+      "glue:BatchDeleteTable",
+      "glue:BatchDeleteTableVersion",
+      "glue:BatchGetPartition",
+      "glue:CreateDatabase",
+      "glue:CreatePartition",
+      "glue:CreatePartitionIndex",
+      "glue:CreateTable",
+      "glue:DeletePartition",
+      "glue:DeletePartitionIndex",
+      "glue:DeleteSchema",
+      "glue:DeleteTable",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetPartition",
+      "glue:GetPartitionIndexes",
+      "glue:GetPartitions",
+      "glue:GetSchema",
+      "glue:GetSchemaByDefinition",
+      "glue:GetSchemaVersion",
+      "glue:GetSchemaVersionsDiff",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetTableVersion",
+      "glue:GetTableVersions",
+      "glue:ListSchemas",
+      "glue:UpdatePartition",
+      "glue:UpdateRegistry",
+      "glue:UpdateSchema",
+      "glue:UpdateTable"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+  statement {
+    sid = "AthenaQueryAccess"
+    actions = [
+      "athena:StartQueryExecution",
+      "athena:GetQueryExecution"
+    ]
+    resources = [
+      aws_athena_workgroup.data_product_athena_workgroup.arn
+    ]
+  }
+}


### PR DESCRIPTION
lambda code for this function is to be contained within an ecr image.

It's triggered by the same event bridge notification as the spark glue job trigger lambda [lambda_for_data.tf](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/lambda_for_data.tf) and performs the same task other than there is no transformation of data other than an extraction_timestamp being added to use as a partition