### PR TITLE
Nomis/dsos 1934/switch to new web a nomis test instances

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -301,6 +301,9 @@ locals {
                     values = [
                       "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
                       "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t1.test.nomis.az.justice.gov.uk",
+                      "c-t1.test.nomis.service.justice.gov.uk",
+                      "t1-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -316,9 +319,6 @@ locals {
                     values = [
                       "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
                       "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
-                      "c-t1.test.nomis.az.justice.gov.uk",
-                      "c-t1.test.nomis.service.justice.gov.uk",
-                      "t1-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -327,7 +327,7 @@ locals {
           })
 
           https = merge(local.weblogic_lb_listeners.https, {
-            alarm_target_group_names = ["t1-nomis-web-b-http-7777"]
+            alarm_target_group_names = ["t1-nomis-web-a-http-7777"]
             rules = {
               t1-nomis-web-a-http-7777 = {
                 priority = 300
@@ -340,6 +340,9 @@ locals {
                     values = [
                       "t1-nomis-web-a.test.nomis.az.justice.gov.uk",
                       "t1-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t1.test.nomis.az.justice.gov.uk",
+                      "c-t1.test.nomis.service.justice.gov.uk",
+                      "t1-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -355,9 +358,6 @@ locals {
                     values = [
                       "t1-nomis-web-b.test.nomis.az.justice.gov.uk",
                       "t1-nomis-web-b.test.nomis.service.justice.gov.uk",
-                      "c-t1.test.nomis.az.justice.gov.uk",
-                      "c-t1.test.nomis.service.justice.gov.uk",
-                      "t1-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -373,6 +373,9 @@ locals {
                     values = [
                       "t2-nomis-web-a.test.nomis.az.justice.gov.uk",
                       "t2-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t2.test.nomis.az.justice.gov.uk",
+                      "c-t2.test.nomis.service.justice.gov.uk",
+                      "t2-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -388,9 +391,6 @@ locals {
                     values = [
                       "t2-nomis-web-b.test.nomis.az.justice.gov.uk",
                       "t2-nomis-web-b.test.nomis.service.justice.gov.uk",
-                      "c-t2.test.nomis.az.justice.gov.uk",
-                      "c-t2.test.nomis.service.justice.gov.uk",
-                      "t2-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -406,6 +406,9 @@ locals {
                     values = [
                       "t3-nomis-web-a.test.nomis.az.justice.gov.uk",
                       "t3-nomis-web-a.test.nomis.service.justice.gov.uk",
+                      "c-t3.test.nomis.az.justice.gov.uk",
+                      "c-t3.test.nomis.service.justice.gov.uk",
+                      "t3-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -421,9 +424,6 @@ locals {
                     values = [
                       "t3-nomis-web-b.test.nomis.az.justice.gov.uk",
                       "t3-nomis-web-b.test.nomis.service.justice.gov.uk",
-                      "c-t3.test.nomis.az.justice.gov.uk",
-                      "c-t3.test.nomis.service.justice.gov.uk",
-                      "t3-cn.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -192,7 +192,7 @@ locals {
     # autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
     #  desired_capacity = 0
     # })
-    cloudwatch_metric_alarms = {}
+    # cloudwatch_metric_alarms = {}
     tags = merge(local.weblogic_ec2_default.tags, {
       deployment = "blue"
     })
@@ -211,7 +211,7 @@ locals {
     # autoscaling_group = merge(local.weblogic_ec2_default.autoscaling_group, {
     #   desired_capacity = 0
     # })
-    # cloudwatch_metric_alarms = {}
+    cloudwatch_metric_alarms = {}
     tags = merge(local.weblogic_ec2_default.tags, {
       deployment = "green"
     })


### PR DESCRIPTION
- switch lb rules to point at the newer nomis-web-a instances in nomis-test
- turn monitoring on for the nomis-web-a instances and OFF for the nomis-web-b instances