### PR TITLE
Enable ICMP from CP to example

### DIFF
--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -68,6 +68,16 @@ resource "aws_security_group_rule" "egress_traffic" {
   source_security_group_id = aws_security_group.example_ec2_sg.id
 }
 
+resource "aws_security_group_rule" "ingress_traffic_icmp_from_cp" {
+  description       = "Allowing ping from CP"
+  from_port         = 8 //Echo Request
+  protocol          = "ICMP"
+  security_group_id = aws_security_group.example_ec2_sg.id
+  to_port           = 0
+  type              = "ingress"
+  cidr_blocks       = ["172.20.0.0/16"] //Cloud Platform
+}
+
 #  Build EC2 "example-ec2"
 resource "aws_instance" "develop" {
   #checkov:skip=CKV2_AWS_41:"IAM role is not implemented for this example EC2. SSH/AWS keys are not used either."


### PR DESCRIPTION
This PR is part of the https://github.com/ministryofjustice/modernisation-platform/issues/3822 ticket.

This is to enable latency testing between CP nettest namespace and an EC2 in the MP example-development environment. 

Tested with the following:
```[nettest@nettest-57bb9b554-rz2zs /]$ ping 10.26.16.46
PING 10.26.16.46 (10.26.16.46) 56(84) bytes of data.
64 bytes from 10.26.16.46: icmp_seq=1 ttl=58 time=3.82 ms
64 bytes from 10.26.16.46: icmp_seq=2 ttl=58 time=2.11 ms
64 bytes from 10.26.16.46: icmp_seq=3 ttl=58 time=2.20 ms
64 bytes from 10.26.16.46: icmp_seq=4 ttl=58 time=2.21 ms
64 bytes from 10.26.16.46: icmp_seq=5 ttl=58 time=2.06 ms
64 bytes from 10.26.16.46: icmp_seq=6 ttl=58 time=2.15 ms
64 bytes from 10.26.16.46: icmp_seq=7 ttl=58 time=2.10 ms
64 bytes from 10.26.16.46: icmp_seq=8 ttl=58 time=2.11 ms
^C
--- 10.26.16.46 ping statistics ---
8 packets transmitted, 8 received, 0% packet loss, time 7007ms
rtt min/avg/max/mdev = 2.061/2.345/3.821/0.559 ms```