### PR TITLE
turn off high-memory-usage-15mins alarm ref: DSOS-1956

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -126,7 +126,7 @@ locals {
         { key = "ec2", name = "instance-status-check-failed-in-last-hour" },
         { key = "ec2", name = "system-status-check-failed-in-last-hour" },
         { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
-        { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
+        # { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
         { key = "ec2_cwagent_linux", name = "cpu-iowait-high-3hour" },
         { key = "database", name = "oracle-db-disconnected" },
         { key = "database", name = "oracle-batch-failure" },

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -130,17 +130,18 @@ locals {
         threshold           = "85"
         alarm_description   = "Triggers if free disk space falls below the threshold for an hour. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
       }
-      high-memory-usage-15mins = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "15"
-        datapoints_to_alarm = "15"
-        metric_name         = "mem_used_percent"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "90"
-        alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
-      }
+      # NOTE: see DSOS-1956 for why this is commented out temporarily
+      # high-memory-usage-15mins = {
+      #   comparison_operator = "GreaterThanOrEqualToThreshold"
+      #   evaluation_periods  = "15"
+      #   datapoints_to_alarm = "15"
+      #   metric_name         = "mem_used_percent"
+      #   namespace           = "CWAgent"
+      #   period              = "60"
+      #   statistic           = "Average"
+      #   threshold           = "90"
+      #   alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
+      # }
       cpu-iowait-high-3hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "180"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms_lists.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms_lists.tf
@@ -65,7 +65,7 @@ locals {
       parent_keys = ["ec2_default"]
       alarms_list = [
         { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
-        { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
+        # { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
         { key = "ec2_cwagent_linux", name = "cpu-iowait-high-3hour" },
       ]
     }


### PR DESCRIPTION
turn off mem_used_percent alarms as per [DSOS-1956](https://dsdmoj.atlassian.net/browse/DSOS-1956)

[DSOS-1956]: https://dsdmoj.atlassian.net/browse/DSOS-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ