### PR TITLE
Update Example code for AWS v5 provider compliance

### DIFF
--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -4,7 +4,7 @@
 
 # EC2 Created via module
 module "ec2_test_instance" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/example/ec2_autoscaling_group.tf
+++ b/terraform/environments/example/ec2_autoscaling_group.tf
@@ -1,5 +1,5 @@
 module "ec2_test_autoscaling_group" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/example/ec2_bastion_linux.tf
+++ b/terraform/environments/example/ec2_bastion_linux.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v3.0.8"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.0.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/example/ecs.tf
+++ b/terraform/environments/example/ecs.tf
@@ -2,37 +2,8 @@
 #------------------------Comment out file if not required----------------------------------
 ###########################################################################################
 
-module "ecs" {
-
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs?ref=v2.1.3"
-
-  subnet_set_name         = local.subnet_set_name
-  vpc_all                 = local.vpc_all
-  app_name                = local.ecs_application_name
-  container_instance_type = local.application_data.accounts[local.environment].container_os_type
-  ami_image_id            = local.application_data.accounts[local.environment].container_ami_image_id
-  instance_type           = local.application_data.accounts[local.environment].container_instance_type
-  user_data               = base64encode(templatefile("${path.module}/templates/user_data.sh.tftpl", {}))
-  key_name                = local.application_data.accounts[local.environment].ecs_key_name
-  task_definition         = templatefile("${path.module}/templates/task_definition.json.tftpl", {})
-  ec2_desired_capacity    = local.application_data.accounts[local.environment].ec2_desired_capacity
-  ec2_max_size            = local.application_data.accounts[local.environment].ec2_max_size
-  ec2_min_size            = local.application_data.accounts[local.environment].ec2_min_size
-  container_cpu           = local.application_data.accounts[local.environment].container_cpu
-  container_memory        = local.application_data.accounts[local.environment].container_memory
-  task_definition_volume  = local.application_data.accounts[local.environment].task_definition_volume
-  network_mode            = local.application_data.accounts[local.environment].network_mode
-  server_port             = local.application_data.accounts[local.environment].server_port
-  app_count               = local.application_data.accounts[local.environment].app_count
-  ec2_ingress_rules       = local.ec2_ingress_rules
-  ec2_egress_rules        = local.ec2_egress_rules
-  lb_tg_name              = aws_lb_target_group.ecs_target_group.name
-  tags_common             = local.tags
-  depends_on              = [aws_lb_listener.ecs-example]
-}
-
 module "ecs-cluster" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster?ref=v2.0.1"
 
   ec2_capacity_instance_type     = local.application_data.accounts[local.environment].container_instance_type
   ec2_capacity_max_size          = local.application_data.accounts[local.environment].ec2_max_size
@@ -50,7 +21,7 @@ module "ecs-cluster" {
 }
 
 module "service" {
-  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service"
+  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service?ref=v2.0.1"
 
   container_definition_json = templatefile("${path.module}/templates/task_definition.json.tftpl", {})
   ecs_cluster_arn           = module.ecs-cluster.ecs_cluster_arn
@@ -152,7 +123,7 @@ locals {
 
 # Load balancer build using the module
 module "ecs_lb_access_logs_enabled" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v2.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v3.0.0"
   providers = {
     # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
     # Need to pass the provider to the S3 bucket module

--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -192,7 +192,7 @@ resource "aws_wafv2_web_acl_association" "web_acl_association_my_lb" {
 ######################### S3 Bucket required for logs  ##########################
 #################################################################################
 module "s3-bucket-lb" { #tfsec:ignore:aws-s3-enable-versioning
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   bucket_prefix      = "s3-bucket-example-lb"
   versioning_enabled = false

--- a/terraform/environments/example/loadbalancer_module.tf
+++ b/terraform/environments/example/loadbalancer_module.tf
@@ -1,6 +1,6 @@
 # Load balancer build using the module
 module "lb_access_logs_enabled" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v2.1.3"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v3.0.0"
   providers = {
     # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
     # Need to pass the provider to the S3 bucket module

--- a/terraform/environments/example/platform_versions.tf
+++ b/terraform/environments/example/platform_versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/example/s3.tf
+++ b/terraform/environments/example/s3.tf
@@ -6,7 +6,7 @@
 # S3 Bucket
 #------------------------------------------------------------------------------
 module "s3-bucket" { #tfsec:ignore:aws-s3-enable-versioning
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   bucket_prefix      = "s3-bucket-example"
   versioning_enabled = false

--- a/terraform/modules/environment/versions.tf
+++ b/terraform/modules/environment/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = "~> 4.9"
+      version               = ">= 4.9"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.modernisation-platform]
     }


### PR DESCRIPTION
* Set provider version constraint to `~> 5.0`
* Update module references to compliant versions
* Raise ceiling for local module to allow `example` to use it without breaking it for everyone else.