### PR TITLE
reroute nomis-web-b traffic to web-a in nomis-production and pre-prod

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -60,7 +60,7 @@ locals {
 
           https = merge(
             local.weblogic_lb_listeners.https, {
-              alarm_target_group_names = ["preprod-nomis-web-b-http-7777"]
+              alarm_target_group_names = ["preprod-nomis-web-a-http-7777"]
               rules = {
                 preprod-nomis-web-a-http-7777 = {
                   priority = 200
@@ -73,6 +73,9 @@ locals {
                       values = [
                         "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk",
                         "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk",
+                        "c.preproduction.nomis.az.justice.gov.uk",
+                        "c.preproduction.nomis.service.justice.gov.uk",
+                        "c.pp-nomis.service.justice.gov.uk",
                       ]
                     }
                   }]
@@ -88,9 +91,6 @@ locals {
                       values = [
                         "preprod-nomis-web-b.preproduction.nomis.az.justice.gov.uk",
                         "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk",
-                        "c.preproduction.nomis.az.justice.gov.uk",
-                        "c.preproduction.nomis.service.justice.gov.uk",
-                        "c.pp-nomis.service.justice.gov.uk",
                       ]
                     }
                   }]

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -151,7 +151,7 @@ locals {
 
           https = merge(
             local.weblogic_lb_listeners.https, {
-              alarm_target_group_names = ["prod-nomis-web-b-http-7777"]
+              alarm_target_group_names = ["prod-nomis-web-a-http-7777"]
               rules = {
                 prod-nomis-web-a-http-7777 = {
                   priority = 200
@@ -164,6 +164,9 @@ locals {
                       values = [
                         "prod-nomis-web-a.production.nomis.az.justice.gov.uk",
                         "prod-nomis-web-a.production.nomis.service.justice.gov.uk",
+                        "c.production.nomis.az.justice.gov.uk",
+                        "c.production.nomis.service.justice.gov.uk",
+                        "c.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]
@@ -179,9 +182,6 @@ locals {
                       values = [
                         "prod-nomis-web-b.production.nomis.az.justice.gov.uk",
                         "prod-nomis-web-b.production.nomis.service.justice.gov.uk",
-                        "c.production.nomis.az.justice.gov.uk",
-                        "c.production.nomis.service.justice.gov.uk",
-                        "c.nomis.az.justice.gov.uk",
                       ]
                     }
                   }]


### PR DESCRIPTION
re-route prod and pre-prod web traffic to the new web-a instances

deploying this will also remove the web-b instances as 'deployments' haven't been run in nomis-production and nomis-preproduction environments yet