### PR TITLE
nomis: enable EC2 backup for DBs in nomis-test

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -242,7 +242,7 @@ locals {
       os-version           = "RHEL 7.9"
       licence-requirements = "Oracle Database"
       "Patch Group"        = "RHEL"
-      monitored            = "true"
+      backup               = "true"
     }
   }
 


### PR DESCRIPTION
Enable EC2 backups for databases in nomis-test.  Remove unused monitored tag.