### PR TITLE
add lambda function and api gateway to retrieve glue catalog metadata

### DIFF
--- a/terraform/environments/data-platform/lambda_for_glue_metadata.tf
+++ b/terraform/environments/data-platform/lambda_for_glue_metadata.tf
@@ -12,10 +12,14 @@ resource "aws_iam_role" "get_glue_metadata_lambda_role" {
 
 data "aws_iam_policy_document" "iam_policy_document_for_get_glue_metadata_lambda" {
   statement {
-    sid       = "GlueReadOnly"
-    effect    = "Allow"
-    actions   = ["glue:Get*"]
-    resources = ["*"]
+    sid     = "GlueReadOnly"
+    effect  = "Allow"
+    actions = ["glue:GetTable", "glue:GetDatabase"]
+    resources = [
+      "arn:aws:glue:${local.region}:${local.account_id}:catalog",
+      "arn:aws:glue:${local.region}:${local.account_id}:database/*",
+      "arn:aws:glue:${local.region}:${local.account_id}:table/*"
+    ]
   }
   statement {
     sid       = "LambdaLogGroup"

--- a/terraform/environments/data-platform/lambda_for_glue_metadata.tf
+++ b/terraform/environments/data-platform/lambda_for_glue_metadata.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "iam_policy_document_for_get_glue_metadata_lambda
   statement {
     sid     = "GlueReadOnly"
     effect  = "Allow"
-    actions = ["glue:GetTable", "glue:GetDatabase"]
+    actions = ["glue:GetTable", "glue:GetTables", "glue:GetDatabase", "glue:GetDatabases"]
     resources = [
       "arn:aws:glue:${local.region}:${local.account_id}:catalog",
       "arn:aws:glue:${local.region}:${local.account_id}:database/*",

--- a/terraform/environments/data-platform/lambda_for_glue_metadata.tf
+++ b/terraform/environments/data-platform/lambda_for_glue_metadata.tf
@@ -1,0 +1,120 @@
+data "archive_file" "get_glue_metadata_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/get_glue_metadata"
+  output_path = "${path.module}/src/get_glue_metadata_${local.environment}/get_glue_metadata_lambda.zip"
+}
+
+resource "aws_iam_role" "get_glue_metadata_lambda_role" {
+  name               = "get_glue_metadata_role_${local.environment}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_trust_policy_doc.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "iam_policy_document_for_get_glue_metadata_lambda" {
+  statement {
+    sid       = "GlueReadOnly"
+    effect    = "Allow"
+    actions   = ["glue:Get*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "LambdaLogGroup"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/*"]
+  }
+}
+
+resource "aws_iam_policy" "get_glue_metadata_lambda_policy" {
+  name        = "get_glue_metadata_policy_${local.environment}"
+  path        = "/"
+  description = "AWS IAM Policy for managing get_glue_metadata lambda role"
+  policy      = data.aws_iam_policy_document.iam_policy_document_for_get_glue_metadata_lambda.json
+  tags        = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "attach_get_glue_metadata_lambda_policy_to_iam_role" {
+  role       = aws_iam_role.get_glue_metadata_lambda_role.name
+  policy_arn = aws_iam_policy.get_glue_metadata_lambda_policy.arn
+}
+
+resource "aws_lambda_function" "get_glue_metadata" {
+  function_name    = "get_glue_metadata_${local.environment}"
+  description      = "api gateway get_glue_metadata"
+  handler          = "main.handler"
+  runtime          = local.lambda_runtime
+  filename         = data.archive_file.get_glue_metadata_zip.output_path
+  source_code_hash = data.archive_file.get_glue_metadata_zip.output_base64sha256
+  role             = aws_iam_role.get_glue_metadata_lambda_role.arn
+  depends_on       = [aws_iam_role_policy_attachment.attach_code_lambda_policy_to_iam_role]
+  tags             = local.tags
+}
+
+resource "aws_lambda_permission" "get_glue_metadata" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_glue_metadata.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.get_glue_metadata.id}/*/${aws_api_gateway_method.get_glue_metadata.http_method}${aws_api_gateway_resource.get_glue_metadata.path}"
+}
+
+resource "aws_api_gateway_rest_api" "get_glue_metadata" {
+  name = "get_glue_metadata"
+}
+
+resource "aws_api_gateway_resource" "get_glue_metadata" {
+  parent_id   = aws_api_gateway_rest_api.get_glue_metadata.root_resource_id
+  path_part   = "get_glue_metadata"
+  rest_api_id = aws_api_gateway_rest_api.get_glue_metadata.id
+}
+
+resource "aws_api_gateway_method" "get_glue_metadata" {
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.authorizer.id
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.get_glue_metadata.id
+  rest_api_id   = aws_api_gateway_rest_api.get_glue_metadata.id
+}
+
+resource "aws_api_gateway_integration" "get_glue_metadata" {
+  http_method             = aws_api_gateway_method.get_glue_metadata.http_method
+  resource_id             = aws_api_gateway_resource.get_glue_metadata.id
+  rest_api_id             = aws_api_gateway_rest_api.get_glue_metadata.id
+  integration_http_method = "GET"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.get_glue_metadata.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "get_glue_metadata" {
+  rest_api_id = aws_api_gateway_rest_api.get_glue_metadata.id
+
+  triggers = {
+    # NOTE: The configuration below will satisfy ordering considerations,
+    #       but not pick up all future REST API changes. More advanced patterns
+    #       are possible, such as using the filesha1() function against the
+    #       Terraform configuration file(s) or removing the .id references to
+    #       calculate a hash against whole resources. Be aware that using whole
+    #       resources will show a difference after the initial implementation.
+    #       It will stabilize to only change when resources change afterwards.
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.get_glue_metadata.id,
+      aws_api_gateway_method.get_glue_metadata.id,
+      aws_api_gateway_integration.get_glue_metadata.id,
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "get_glue_metadata" {
+  deployment_id = aws_api_gateway_deployment.get_glue_metadata.id
+  rest_api_id   = aws_api_gateway_rest_api.get_glue_metadata.id
+  stage_name    = "sandbox"
+}
+
+output "base_url" {
+  value = aws_api_gateway_deployment.get_glue_metadata.invoke_url
+}

--- a/terraform/environments/data-platform/src/get_glue_metadata/main.py
+++ b/terraform/environments/data-platform/src/get_glue_metadata/main.py
@@ -1,0 +1,15 @@
+import json
+import boto3
+
+def handler(event, context):
+    request_body = json.loads(event['body'])
+    database = request_body['database']
+    table = request_body['table']
+
+    glue_client = boto3.client("glue")
+    resp = glue_client.get_table(DatabaseName=database, Name=table)
+
+    return {
+       'statusCode': 200,
+       'body': json.dumps(resp, default=str)
+   }


### PR DESCRIPTION
Adds a simple Lambda function that retrieves a Glue catalog metadata via an API Gateway request.

The database and table are passed via the request body in this format:

```
{
  "database": "<glue_database_name>",
  "table": "<glue_table_name>"
}
```

For the moment the function retrieves all the available metadata from a specific table in a specific database. The funciton will need further refinement to suit our needs, this could be treated as an initial working POC.