### PR TITLE
Update code-scanning.yml

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf # v3.0.0
         name: Setup TFLint
         with:
-          tflint_version: latest
+          tflint_version: 0.46
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint


### PR DESCRIPTION
Related to the issue regarding command line arguments support was dropped in v0.47. Use --chdir or --filter instead