### PR TITLE
nomis: T3 fixes

### DIFF
--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -23,6 +23,8 @@ locals {
       module.ip_addresses.moj_cidr.aws_analytical_platform_aggregate,
       module.ip_addresses.azure_studio_hosting_cidrs.devtest,
       module.ip_addresses.azure_nomisapi_cidrs.devtest,
+      module.ip_addresses.mp_cidr.hmpps-development,
+      module.ip_addresses.mp_cidr.hmpps-test,
     ])
     oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -524,37 +524,41 @@ locals {
       # These are used in Azure DB TNS entries
       "test.nomis.service.justice.gov.uk" = {
         records = [
-          # T1
+          # T1 [B: T1CNOMS1, T1NDHS1, T1TRDS1]
+          { name = "t1nomis", type = "CNAME", ttl = "300", records = ["t1nomis-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1nomis-a", type = "A", ttl = "3600", records = ["10.101.3.132"] },
           { name = "t1nomis-b", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
           { name = "t1-nomis-db-1-b", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t1ndh", type = "CNAME", ttl = "300", records = ["t1ndh-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1ndh-a", type = "A", ttl = "3600", records = ["10.101.3.132"] },
           { name = "t1ndh-b", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t1or", type = "CNAME", ttl = "300", records = ["t1or-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1or-a", type = "A", ttl = "86400", records = ["10.101.3.132"] },
           { name = "t1or-b", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t1trdat", type = "CNAME", ttl = "300", records = ["t1trdat-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1trdat-a", type = "A", ttl = "3600", records = ["10.101.3.132"] },
           { name = "t1trdat-b", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t1audit", type = "CNAME", ttl = "300", records = ["t1audit-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1audit-a", type = "CNAME", ttl = "86400", records = ["t1-nomis-db-2-a.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
           { name = "t1audit-b", type = "CNAME", ttl = "3600", records = ["t1-nomis-db-2.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
-          # T2
+          # T2 [B: T2CNOMS, T2NDHS1, T2TRDS1]
+          { name = "t2nomis", type = "CNAME", ttl = "300", records = ["t2nomis-b.test.nomis.service.justice.gov.uk"] },
           { name = "t2nomis-a", type = "A", ttl = "3600", records = ["10.101.33.132"] },
           { name = "t2nomis-b", type = "CNAME", ttl = "86400", records = ["t2-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
           { name = "t2-nomis-db-1-b", type = "CNAME", ttl = "86400", records = ["t2-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t2ndh", type = "CNAME", ttl = "300", records = ["t2ndh-b.test.nomis.service.justice.gov.uk"] },
           { name = "t2ndh-a", type = "A", ttl = "3600", records = ["10.101.33.132"] },
           { name = "t2ndh-b", type = "CNAME", ttl = "86400", records = ["t2-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t2or", type = "CNAME", ttl = "300", records = ["t2or-b.test.nomis.service.justice.gov.uk"] },
           { name = "t2or-a", type = "A", ttl = "3600", records = ["10.101.33.132"] },
           { name = "t2or-b", type = "CNAME", ttl = "86400", records = ["t2-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
+          { name = "t2trdat", type = "CNAME", ttl = "300", records = ["t2trdat-b.test.nomis.service.justice.gov.uk"] },
           { name = "t2trdat-a", type = "A", ttl = "3600", records = ["10.101.33.132"] },
           { name = "t2trdat-b", type = "CNAME", ttl = "86400", records = ["t2-nomis-db-1-b.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
-          # T3
+          # T3: [B: T3CNOM]
+          { name = "t3nomis", type = "CNAME", ttl = "300", records = ["t3nomis-b.test.nomis.service.justice.gov.uk"] },
           { name = "t3nomis-a", type = "A", ttl = "3600", records = ["10.101.63.135"] },
           { name = "t3nomis-b", type = "CNAME", ttl = "86400", records = ["t3-nomis-db-1.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
-          { name = "t3ndh-a", type = "A", ttl = "3600", records = ["10.101.63.135"] },
-          { name = "t3ndh-b", type = "CNAME", ttl = "86400", records = ["t3-nomis-db-1.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
-          { name = "t3or-a", type = "A", ttl = "3600", records = ["10.101.63.135"] },
-          { name = "t3or-b", type = "CNAME", ttl = "86400", records = ["t3-nomis-db-1.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
-          { name = "t3trdat-a", type = "A", ttl = "3600", records = ["10.101.63.135"] },
-          { name = "t3trdat-b", type = "CNAME", ttl = "86400", records = ["t3-nomis-db-1.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },
         ]
         lb_alias_records = [
           # T1


### PR DESCRIPTION
Create additional DNS records for users that are connecting directly to single database.
Allow other HMPPS accounts (both dev and test) access to T3 database.