### PR TITLE
add docs for the get_glue_metadata API endpoint

### DIFF
--- a/terraform/environments/data-platform/src/docs/swagger.json
+++ b/terraform/environments/data-platform/src/docs/swagger.json
@@ -20,7 +20,9 @@
   "paths": {
     "/upload_data": {
       "get": {
-        "tags": ["upload_data"],
+        "tags": [
+          "upload_data"
+        ],
         "summary": "Get a presigned url to upload some data to an existing data product.",
         "description": "Returns a presigned url to post data to.",
         "operationId": "uploadData",
@@ -83,12 +85,76 @@
           }
         ]
       }
+    },
+    "/get_glue_metadata": {
+      "get": {
+        "tags": [
+          "get_glue_metadata"
+        ],
+        "summary": "Get metadata for a specified table in a specified Glue database",
+        "description": "Returns a json object with all the metadata available for the specified database and table",
+        "operationId": "getGlueMetadata",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "database",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "table",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorizationToken",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation, response format https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/client/get_table.html",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Inputs supplied"
+          },
+          "404": {
+            "description": "Glue database and/or table not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
     }
   },
   "components": {
     "schemas": {
       "UploadDataRequest": {
-        "required": ["database", "table", "contentMD5"],
+        "required": [
+          "database",
+          "table",
+          "contentMD5"
+        ],
         "type": "object",
         "properties": {
           "database": {
@@ -107,7 +173,10 @@
       },
       "URL": {
         "type": "object",
-        "required": ["url", "fields"],
+        "required": [
+          "url",
+          "fields"
+        ],
         "properties": {
           "url": {
             "type": "string",
@@ -120,7 +189,9 @@
       },
       "UploadDataResponse": {
         "type": "object",
-        "required": ["URL"],
+        "required": [
+          "URL"
+        ],
         "properties": {
           "URL": {
             "$ref": "#/components/schemas/URL"

--- a/terraform/environments/data-platform/src/docs/swagger.json
+++ b/terraform/environments/data-platform/src/docs/swagger.json
@@ -138,12 +138,7 @@
           "404": {
             "description": "Glue database and/or table not found"
           }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
+        }
       }
     }
   },


### PR DESCRIPTION
## Please note:

The response is not yet documented as it currently returns all the available metadata, the format can be found [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/client/get_table.html)

This will need to be refined to return only that metadata which is of interest to us. 