### PR TITLE
swap monitoring to the correct db-b version

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -243,6 +243,7 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
+        cloudwatch_metric_alarms = {} # no alarms as -a is not currently the live environment
       })
 
       t1-nomis-db-1-b = merge(local.database_ec2_b, {
@@ -263,7 +264,6 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
-        cloudwatch_metric_alarms = {} # disabled until commissioned
       })
 
       t1-nomis-db-2 = merge(local.database_ec2_a, {


### PR DESCRIPTION
forgot that -b was the live nomis-db version so putting the alarms on the correct host