### PR TITLE
add acl_configuration to workgroup

### DIFF
--- a/terraform/environments/data-platform/lambda_for_athena_load.tf
+++ b/terraform/environments/data-platform/lambda_for_athena_load.tf
@@ -13,6 +13,9 @@ resource "aws_athena_workgroup" "data_product_athena_workgroup" {
       encryption_configuration {
         encryption_option = "SSE_S3"
       }
+      acl_configuration {
+        s3_acl_option = "BUCKET_OWNER_FULL_CONTROL"
+      }
     }
   }
 }


### PR DESCRIPTION
Assign bucket owner full control over query results by setting `acl_configuration` in athena `data_product_workgroup`

In accordance with policy set on the data bucket