### PR TITLE
change the asg in nomis-development to test new jumpserver setup fixes

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -121,7 +121,7 @@ locals {
           ami_name                      = "nomis_windows_server_2022_jumpserver_release_*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/new-jumpserver-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/jumpserver-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-jumpserver"]

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -118,7 +118,7 @@ locals {
       dev-jumpserver-2022 = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "mp_WindowsServer2022_*"
+          ami_name                      = "nomis_windows_server_2022_jumpserver_release_*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
           user_data_raw                 = base64encode(file("./templates/new-jumpserver-user-data.yaml"))

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -118,10 +118,10 @@ locals {
       dev-jumpserver-2022 = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "nomis_windows_server_2022_jumpserver_release_*"
+          ami_name                      = "mp_WindowsServer2022_*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/jumpserver-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/new-jumpserver-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-jumpserver"]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -198,7 +198,7 @@ locals {
           ami_name                      = "nomis_windows_server_2022_jumpserver_release_*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/jumpserver-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/new-jumpserver-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-jumpserver"]

--- a/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
@@ -1,0 +1,34 @@
+# This is an EC2Launch V2 type user-data script
+# https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
+# See C:\ProgramData\Amazon\EC2Launch\log for logs
+version: 1.0
+tasks:
+  - task: executeScript
+    inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        #not actually a secret
+        #checkov:skip=CKV_SECRET_6: "Base64 High Entropy String"
+        content: |
+          $ErrorActionPreference = "Stop" # set all errors to terminate script
+
+          Set-TimeZone "GMT Standard Time"
+          Set-WinSystemLocale "en-GB"
+
+          # Check CWAgent is installed, if it isn't then install it
+          $timeout = New-TimeSpan -Seconds 600
+          $endTime = (Get-Date).Add($timeout)
+          $cwagent = Get-Service -Name "AmazonCloudWatchAgent" -ErrorAction SilentlyContinue
+          if ($cwagent) {
+            Do {
+            & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
+            } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
+          } else {
+            Invoke-WebRequest -Uri "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi" -OutFile "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+            $cwagent_installer = "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+            Start-Process -FilePath msiexec.exe -ArgumentList "/i $cwagent_installer /qn" -Wait
+            Do {
+            & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
+            } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
+          }

--- a/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
@@ -11,27 +11,30 @@ tasks:
         #not actually a secret
         #checkov:skip=CKV_SECRET_6: "Base64 High Entropy String"
         content: |
+          # FIXME: This step currently doesn't work as the ssm:cloud-watch-config-windows document doesn't exist
+          # It's probably been removed ages ago but since this step was set to 'silently continue' no-one has noticed...
+      
           $ErrorActionPreference = "Stop" # set all errors to terminate script
 
           Set-TimeZone "GMT Standard Time"
           Set-WinSystemLocale "en-GB"
 
           # Check CWAgent is installed, if it isn't then install it
-          $timeout = New-TimeSpan -Seconds 600
-          $endTime = (Get-Date).Add($timeout)
-          $cwagent = Get-Service -Name "AmazonCloudWatchAgent"
-          if ($cwagent) {
-            Do {
-            & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
-            } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
-          } else {
-            Invoke-WebRequest -Uri "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi" -OutFile "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
-            $cwagent_installer = "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
-            Start-Process -FilePath msiexec.exe -ArgumentList "/i $cwagent_installer /qn" -Wait
-            Do {
-            & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
-            } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
-          }
+          # $timeout = New-TimeSpan -Seconds 600
+          # $endTime = (Get-Date).Add($timeout)
+          # $cwagent = Get-Service -Name "AmazonCloudWatchAgent"
+          # if ($cwagent) {
+          #   Do {
+          #   & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
+          #   } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
+          # } else {
+          #   Invoke-WebRequest -Uri "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi" -OutFile "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+          #   $cwagent_installer = "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi"
+          #   Start-Process -FilePath msiexec.exe -ArgumentList "/i $cwagent_installer /qn" -Wait
+          #   Do {
+          #   & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
+          #   } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
+          # }
   - task: executeScript
     inputs:
       - frequency: once
@@ -49,10 +52,10 @@ tasks:
           Start-Process -Wait -Verbose -FilePath "C:\jumpserver-software\jre-6u33-windows-i586.exe" -ArgumentList "/s", "/L C:\jumpserver-software\jre-install.log"
 
           # Set JAVA_HOME environment variable
-          # New-Item -Path Env:\JAVA_HOME -Value "C:\Program Files (x86)\Java\jre6"
+          [System.Environment]::SetEnvironmentVariable("JAVA_HOME", "C:\Program Files (x86)\Java\jre6", [System.EnvironmentVariableTarget]::Machine)
 
           # Add Java to PATH environment variable
-          # [Environment]::SetEnvironmentVariable("Path", $env:Path + ";%JAVA_HOME%\bin", [EnvironmentVariableTarget]::Machine)
+          [System.Environment]::SetEnvironmentVariable("Path", $env:Path + ";%JAVA_HOME%\bin", [System.EnvironmentVariableTarget]::Machine)
 
           # Copy deployment config files
           $deployment_folder = "C:\Windows\Sun\Java\Deployment"
@@ -63,3 +66,5 @@ tasks:
 
           # Prevent Java update check
           # Remove-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run" -Name SunJavaUpdateSched -Force 
+
+          # TODO: Add new section with check java -version and fail if not on path

--- a/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
@@ -19,7 +19,7 @@ tasks:
           # Check CWAgent is installed, if it isn't then install it
           $timeout = New-TimeSpan -Seconds 600
           $endTime = (Get-Date).Add($timeout)
-          $cwagent = Get-Service -Name "AmazonCloudWatchAgent" -ErrorAction SilentlyContinue
+          $cwagent = Get-Service -Name "AmazonCloudWatchAgent"
           if ($cwagent) {
             Do {
             & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
@@ -32,3 +32,34 @@ tasks:
             & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c ssm:cloud-watch-config-windows
             } Until ((Get-Service -Name "AmazonCloudWatchAgent" | Where-Object {$_.Status -eq "Running"}) -or ((Get-Date) -gt $endTime))
           }
+  - task: executeScript
+    inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |
+          $ErrorActionPreference = "Stop" # set all errors to terminate script
+
+          $S3_BUCKET = "ec2-image-builder-nomis20220314103938567000000001"
+
+          # Download Java exe from S3 Bucket
+          Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/jre-6u33-windows-i586.exe -File C:\jumpserver-software\jre-6u33-windows-i586.exe
+
+          # Install Java
+          Start-Process -Wait -Verbose -FilePath "C:\jumpserver-software\jre-6u33-windows-i586.exe" -ArgumentList "/s", "/L C:\jumpserver-software\jre-install.log"
+
+          # Set JAVA_HOME environment variable
+          # New-Item -Path Env:\JAVA_HOME -Value "C:\Program Files (x86)\Java\jre6"
+
+          # Add Java to PATH environment variable
+          # [Environment]::SetEnvironmentVariable("Path", $env:Path + ";%JAVA_HOME%\bin", [EnvironmentVariableTarget]::Machine)
+
+          # Copy deployment config files
+          $deployment_folder = "C:\Windows\Sun\Java\Deployment"
+          New-Item -Path $deployment_folder -ItemType Directory -Force
+          Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/deployment.config -File $deployment_folder\deployment.config
+          Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/deployment.properties -File $deployment_folder\deployment.properties
+          Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/trusted.certs -File $deployment_folder\trusted.certs
+
+          # Prevent Java update check
+          # Remove-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run" -Name SunJavaUpdateSched -Force 


### PR DESCRIPTION
start building the jumpserver config on top of a blank windows server
- contains the java installer only so we can at least start testing the connectivity to t1/2/3 environments without having to guess what's broken