### PR TITLE
DPR-356 revise ssm-user home setup and create domain-builder launcher script

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -20,12 +20,34 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 ./aws/install
 
-# Set Env Configuration
-sudo mkdir -p /home/ssm-user/domain-builder/jars; chmod -R 0777 /home/ssm-user/domain-builder
+# Create home directory with dir structure for domain builder jars
+sudo mkdir -p /home/ssm-user/domain-builder/jars
+sudo chown -R ssm-user /home/ssm-user
+chmod -R 0777 /home/ssm-user/domain-builder
 cd /home/ssm-user
-sudo chown -R ssm-user domain-builder
 
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars
+
+# Location of script that will be used to launch the domain builder jar.
+launcher_script_location=/usr/bin/domain-builder
+
+# Get the configured function url...
+function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-migrations-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
+# ...and remove the trailing slash using vanilla bash parameter expansion.
+domain_builder_url=${function_url%?}
+
+# Generate a launcher script for the jar that starts domain-builder in interactive mode
+# and configured to use the function URL via the DOMAIN_API_URL environment variable.
+cat <<EOF > $launcher_script_location
+#!/bin/bash
+
+cd /home/ssm-user
+
+DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
+
+EOF
+
+chmod 0755 $launcher_script_location
 
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -32,10 +32,12 @@ aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jar
 # Location of script that will be used to launch the domain builder jar.
 launcher_script_location=/usr/bin/domain-builder
 
+# TODO - disabled until we have an endpoint configured for the function.
 # Get the configured function url...
-function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
+# function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
 # ...and remove the trailing slash using vanilla bash parameter expansion.
-domain_builder_url=${function_url%?}
+# domain_builder_url=${function_url%?}
+domain_builder_url="http://localhost:8080"
 
 # Generate a launcher script for the jar that starts domain-builder in interactive mode
 # and configured to use the function URL via the DOMAIN_API_URL environment variable.

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -20,36 +20,12 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 ./aws/install
 
-# Create home directory with dir structure for domain builder jars
-sudo mkdir -p /home/ssm-user/domain-builder/jars
-sudo chown -R ssm-user /home/ssm-user
-chmod -R 0777 /home/ssm-user/domain-builder
+# Set Env Configuration
+sudo mkdir -p /home/ssm-user/domain-builder/jars; chmod -R 0777 /home/ssm-user/domain-builder
 cd /home/ssm-user
+sudo chown -R ssm-user domain-builder
 
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars
-
-# Location of script that will be used to launch the domain builder jar.
-launcher_script_location=/usr/bin/domain-builder
-
-# TODO - disabled until we have an endpoint configured for the function.
-# Get the configured function url...
-# function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
-# ...and remove the trailing slash using vanilla bash parameter expansion.
-# domain_builder_url=${function_url%?}
-domain_builder_url="http://localhost:8080"
-
-# Generate a launcher script for the jar that starts domain-builder in interactive mode
-# and configured to use the function URL via the DOMAIN_API_URL environment variable.
-cat <<EOF > $launcher_script_location
-#!/bin/bash
-
-cd /home/ssm-user
-
-DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
-
-EOF
-
-chmod 0755 $launcher_script_location
 
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -33,7 +33,7 @@ aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jar
 launcher_script_location=/usr/bin/domain-builder
 
 # Get the configured function url...
-function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-migrations-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
+function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
 # ...and remove the trailing slash using vanilla bash parameter expansion.
 domain_builder_url=${function_url%?}
 


### PR DESCRIPTION
Summary of changes
* ensure the ssm user home directory is writeable by the ssm user so that the command history and potentially any other local files can be written there
* a launcher script is now generated and written to `/usr/bin/domain-builder` which fetches the function URL via the aws cli

Note - we will need to update the TF to also ensure this URL is set