### PR TITLE
DPR-356 ensure ssm-user can write to their home directory and introduce domain builder launch script

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -20,36 +20,12 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 ./aws/install
 
-# Create home directory with dir structure for domain builder jars
-sudo mkdir -p /home/ssm-user/domain-builder/jars
-sudo chown -R ssm-user /home/ssm-user
-chmod -R 0777 /home/ssm-user/domain-builder
+# Set Env Configuration
+sudo mkdir -p /home/ssm-user/domain-builder/jars; chmod -R 0777 /home/ssm-user/domain-builder
 cd /home/ssm-user
+sudo chown -R ssm-user domain-builder
 
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars
-
-# Location of script that will be used to launch the domain builder jar.
-launcher_script_location=/usr/bin/domain-builder
-
-# TODO - disabled until we have an endpoint configured for the function.
-# Get the configured function url...
-# function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
-# ...and remove the trailing slash using vanilla bash parameter expansion.
-# domain_builder_url=${function_url%?}
-domain_builder_url="http://localhost:8080"
-
-# Generate a launcher script for the jar that starts domain-builder in interactive mode
-# and configured to use the function URL via the DOMAIN_API_URL environment variable.
-#cat <<EOF > $launcher_script_location
-##!/bin/bash
-#
-#cd /home/ssm-user
-#
-#DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
-#
-#EOF
-#
-#chmod 0755 $launcher_script_location
 
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -9,7 +9,7 @@ echo "assumeyes=1" >> /etc/yum.conf
 sudo yum -y update
 
 # Setup YUM install Utils
-sudo yum -y install curl wget unzip
+sudo yum -y install curl wget unzip jq
 
 # Install Java 11
 sudo amazon-linux-extras install java-openjdk11

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -20,10 +20,11 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 ./aws/install
 
-# Set Env Configuration
-sudo mkdir -p /home/ssm-user/domain-builder/jars; chmod -R 0777 /home/ssm-user/domain-builder
+# Create home directory with dir structure for domain builder jars
+sudo mkdir -p /home/ssm-user/domain-builder/jars
+sudo chown -R ssm-user /home/ssm-user
+chmod -R 0777 /home/ssm-user/domain-builder
 cd /home/ssm-user
-sudo chown -R ssm-user domain-builder
 
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -29,4 +29,10 @@ cd /home/ssm-user
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars
 
+# Location of script that will be used to launch the domain builder jar.
+launcher_script_location=/usr/bin/domain-builder
+
+# Get the configured API gateway for the domain builder backend API lambda
+domain_builder_url=$(aws apigatewayv2 get-apis --output json | jq -r  '.Items[] | select(.Name == "domain-builder-backend-api") | .ApiEndpoint')
+
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -20,12 +20,36 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip awscliv2.zip
 ./aws/install
 
-# Set Env Configuration
-sudo mkdir -p /home/ssm-user/domain-builder/jars; chmod -R 0777 /home/ssm-user/domain-builder
+# Create home directory with dir structure for domain builder jars
+sudo mkdir -p /home/ssm-user/domain-builder/jars
+sudo chown -R ssm-user /home/ssm-user
+chmod -R 0777 /home/ssm-user/domain-builder
 cd /home/ssm-user
-sudo chown -R ssm-user domain-builder
 
 # Sync S3 Domain Builder Artifacts
 aws s3 cp s3://dpr-artifact-store-development/build-artifacts/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar /home/ssm-user/domain-builder/jars
+
+# Location of script that will be used to launch the domain builder jar.
+launcher_script_location=/usr/bin/domain-builder
+
+# TODO - disabled until we have an endpoint configured for the function.
+# Get the configured function url...
+# function_url=$(aws lambda get-function-url-config --function-name dpr-domain-builder-backend-api-function --output table | tr -d ' ' | grep '|FunctionUrl|' | cut -d '|' -f3 )
+# ...and remove the trailing slash using vanilla bash parameter expansion.
+# domain_builder_url=${function_url%?}
+domain_builder_url="http://localhost:8080"
+
+# Generate a launcher script for the jar that starts domain-builder in interactive mode
+# and configured to use the function URL via the DOMAIN_API_URL environment variable.
+cat <<EOF > $launcher_script_location
+#!/bin/bash
+
+cd /home/ssm-user
+
+DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
+
+EOF
+
+chmod 0755 $launcher_script_location
 
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -41,15 +41,15 @@ domain_builder_url="http://localhost:8080"
 
 # Generate a launcher script for the jar that starts domain-builder in interactive mode
 # and configured to use the function URL via the DOMAIN_API_URL environment variable.
-cat <<EOF > $launcher_script_location
-#!/bin/bash
-
-cd /home/ssm-user
-
-DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
-
-EOF
-
-chmod 0755 $launcher_script_location
+#cat <<EOF > $launcher_script_location
+##!/bin/bash
+#
+#cd /home/ssm-user
+#
+#DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
+#
+#EOF
+#
+#chmod 0755 $launcher_script_location
 
 echo "Bootstrap Complete"

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -40,9 +40,7 @@ domain_builder_url=$(aws apigatewayv2 get-apis --output json | jq -r  '.Items[] 
 sudo cat <<EOF > $launcher_script_location
 #!/bin/bash
 
-cd /home/ssm-user
-
-DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
+DOMAIN_API_URL="$domain_builder_url" java -jar /home/ssm-user/domain-builder/jars/domain-builder-cli-frontend-vLatest-all.jar -i --enable-ansi
 
 EOF
 

--- a/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
+++ b/terraform/environments/digital-prison-reporting/modules/compute_node/scripts/domain-builder.sh
@@ -35,4 +35,17 @@ launcher_script_location=/usr/bin/domain-builder
 # Get the configured API gateway for the domain builder backend API lambda
 domain_builder_url=$(aws apigatewayv2 get-apis --output json | jq -r  '.Items[] | select(.Name == "domain-builder-backend-api") | .ApiEndpoint')
 
+# Generate a launcher script for the jar that starts domain-builder in interactive mode
+# and configured to use the function URL via the DOMAIN_API_URL environment variable.
+sudo cat <<EOF > $launcher_script_location
+#!/bin/bash
+
+cd /home/ssm-user
+
+DOMAIN_API_URL="$domain_builder_url" java -jar domain-builder/jars/domain-builder-cli-vLatest-all.jar -i --enable-ansi
+
+EOF
+
+sudo chmod 0755 $launcher_script_location
+
 echo "Bootstrap Complete"


### PR DESCRIPTION
Summary of changes
* revised bootstrap to
  * ensure ssm-user is able to write anywhere in their home directory
  * write a domain-builder wrapper script into /usr/bin that also sets the api URL using the aws client to fetch the URL from the apigatewayv2 configuration