### PR TITLE
Add GitHub Actions role for Data Platform

### DIFF
--- a/terraform/environments/data-platform/iam-policies.tf
+++ b/terraform/environments/data-platform/iam-policies.tf
@@ -1,0 +1,29 @@
+data "aws_iam_policy_document" "github_actions" {
+  statement {
+    sid    = "AllowECR"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:UploadLayerPart",
+    ]
+    resources = ["*"]
+  }
+}
+
+module "github_actions_iam_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.22.0"
+
+  name = "${local.application_name}-github-actions"
+
+  policy = data.aws_iam_policy_document.github_actions.json
+
+  tags = local.tags
+}

--- a/terraform/environments/data-platform/iam-roles.tf
+++ b/terraform/environments/data-platform/iam-roles.tf
@@ -1,0 +1,14 @@
+module "github_actions_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.22.0"
+
+  name = "${local.application_name}-github-actions"
+
+  subjects = ["ministryofjustice/data-platform:*"]
+
+  policies = {
+    "github-actions" = module.github_actions_iam_policy.arn
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
Allows us to use and OIDC role for pushing to shared services ECR

Related: https://github.com/ministryofjustice/modernisation-platform-environments/pull/2691