### PR TITLE
Tidy up Example certificate code

### DIFF
--- a/terraform/environments/example/certificates.tf
+++ b/terraform/environments/example/certificates.tf
@@ -3,11 +3,11 @@
 ###########################################################################################
 
 resource "aws_acm_certificate" "example_cert" {
-  domain_name       = "modernisation-platform.service.justice.gov.uk"
+  domain_name       = data.aws_route53_zone.external.name
   validation_method = "DNS"
 
   subject_alternative_names = [
-    format("%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment),
+    format("%s.%s", local.application_name, data.aws_route53_zone.external.name),
   ]
 
   tags = merge(local.tags,

--- a/terraform/environments/example/certificates.tf
+++ b/terraform/environments/example/certificates.tf
@@ -28,7 +28,7 @@ resource "aws_acm_certificate_validation" "example_cert" {
 }
 
 resource "aws_route53_record" "example_cert_validation" {
-  provider = aws.core-network-services
+  provider = aws.core-vpc
   for_each = {
     for dvo in aws_acm_certificate.example_cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -42,7 +42,7 @@ resource "aws_route53_record" "example_cert_validation" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = data.aws_route53_zone.network-services.zone_id
+  zone_id         = data.aws_route53_zone.external.zone_id
 }
 
 

--- a/terraform/environments/example/certificates.tf
+++ b/terraform/environments/example/certificates.tf
@@ -3,7 +3,7 @@
 ###########################################################################################
 
 resource "aws_acm_certificate" "example_cert" {
-  domain_name       = data.aws_route53_zone.external.name
+  domain_name       = "modernisation-platform.service.justice.gov.uk"
   validation_method = "DNS"
 
   subject_alternative_names = [


### PR DESCRIPTION
After reviewing the Modernisation Platform DNS configuration, this should bring the certificate code in the example environment more into line with our intended uses.