### PR TITLE
add IE Enhanced Security exceptions list to Jumpserver

### DIFF
--- a/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
+++ b/terraform/environments/nomis/templates/new-jumpserver-user-data.yaml
@@ -58,11 +58,9 @@ tasks:
           Read-S3Object -BucketName $S3_BUCKET -Key jumpserver-software/trusted.certs -File $deployment_folder\trusted.certs
 
           # Prevent Java update check
-          # Remove-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run" -Name SunJavaUpdateSched -Force 
+          Remove-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Run" -Name SunJavaUpdateSched -Force 
 
-          # TODO: Add new section with check java -version and fail if not on path
-
-          ######## EDGE CHANGES GO HERE ########
+          ######## EDGE GLOBAL CHANGES ########
           
           $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge"
           
@@ -77,6 +75,135 @@ tasks:
           $reg_path = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\PopupsAllowedForUrls"
           New-Item -Path $reg_path -Force
           New-ItemProperty -Path $reg_path -Name 1 -Value "[*.]justice.gov.uk" -PropertyType String -Force
+
+          ######## IE COMPATIBILITY MODE SITE LIST ########
+
+          $ie_compatibility_mode_site_list = @(
+              "t1-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t1-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t1-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t1-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t1-cn.hmpp-azdt.justice.gov.uk:7777/forms/frmservlet?config=tag"
+              "t1-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t1.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t1.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t2-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t2-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t2-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t2-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t2-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t2.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t2.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-nomis-web-a.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-nomis-web-a.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-nomis-web-b.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-nomis-web-b.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-cn.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+              "t3-cn-ha.hmpp-azdt.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t3.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c-t3.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "preprod-nomis-web-a.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "preprod-nomis-web-b.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.pp-nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.preproduction.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.preproduction.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "prod-nomis-web-a.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "prod-nomis-web-a.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "prod-nomis-web-b.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "prod-nomis-web-b.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.production.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.production.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+              "c.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
+          )
+
+          $compatibility_site_list_path = "C:\\compatibility_site_list.xml"
+
+          $xmlDoc = New-Object System.Xml.XmlDocument
+          $root = $xmlDoc.CreateElement("site-list")
+          $root.SetAttribute('version', 1)
+          $xmlDoc.AppendChild($root)
+
+          $created_byElement = $xmlDoc.CreateElement("created-by")
+
+          $toolElement = $xmlDoc.CreateElement("tool")
+          $versionElement = $xmlDoc.CreateElement("version")
+          $date_createdElement = $xmlDoc.CreateElement("date_created")
+          $toolElement.InnerText = "EMIESiteListManager"
+          $versionElement.InnerText = "10.0.0.0"
+          $date_createdElement.InnerText = $(Get-Date -Format "MM/dd/yyyy hh:mm:ss")
+          $created_byElement.AppendChild($toolElement)
+          $created_byElement.AppendChild($versionElement)
+          $created_byElement.AppendChild($date_createdElement)
+          $root.AppendChild($created_byElement)
+
+          foreach ($site in $ie_compatibility_mode_site_list) {
+            $siteElement = $xmlDoc.CreateElement("site")
+            $siteElement.SetAttribute('url', $site)
+            $compatModeElement = $xmlDoc.CreateElement("compat-mode")
+            $openInElement = $xmlDoc.CreateElement("open-in")
+            $openInElement.SetAttribute('allow-redirect', 'true')
+            $compatModeElement.InnerText = "Default"
+            $openInElement.InnerText = "IE11"
+            $siteElement.AppendChild($compatModeElement)
+            $siteElement.AppendChild($openInElement)
+            $root.AppendChild($siteElement)
+          }
+
+          $xmlDoc.Save($compatibility_site_list_path)
+
+          # Add compatibility list to registry
+          New-ItemProperty -Path $reg_path -Name InternetExplorerIntegrationSiteList -Value $compatibility_site_list_path -PropertyType String -Force
+
+          ######## CREATE DOMAIN ALLOW LIST FOR EDGE ########
+
+          # The jumpserver is using IE Enhanced Security so each domain needs to be explicitly added to the following
+          # - Registry to allow certain domains to Bypass Enhanced Security (see below)  
+          # - Trusted Sites - HKCU, HKLM does not apply since the machine is not on the domain 
+          # NOTE: https:// traffic ONLY is allowed, these settings are external to this environment and are not managed by this script
+
+          $domains = @(
+            "*.nomis.hmpps-development.modernisation-platform.justice.gov.uk"
+            "*.nomis.hmpps-test.modernisation-platform.justice.gov.uk"
+            "*.nomis.hmpps-preproduction.modernisation-platform.justice.gov.uk"
+            "*.nomis.hmpps-production.modernisation-platform.justice.gov.uk"
+            "*.nomis.service.justice.gov.uk"
+            "*.nomis.az.justice.gov.uk"
+            "*.hmpp-azdt.justice.gov.uk"
+          )
+
+          $registryPath = "SOFTWARE\Policies\Microsoft\Edge\EnhanceSecurityModeBypassListDomains"
+
+          # Ensure the registry path exists
+          if (!(Test-Path $registryPath)) {
+            New-Item -Path $registryPath -Force
+          }
+
+          # Add each domain to the exclusion list for IE Enhanced Security
+          # NOTE: subdomains are automatically included
+          for ($i = 0; $i -lt $domains.Length; $i++) {
+            $index = $i + 1
+            $value = $domains[$i] -replace '^\*\.', '' 
+
+            New-Item -Path "$registryPath\$index" -Force    
+
+            New-ItemProperty -Path "$registryPath\$index" -Name "(Default)" -Value $value -PropertyType String -Force
+          
+          }
+
+          # Add each domain to the trusted sites list
+          $paths = @(
+              "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\EscDomains"
+          )
+
+          foreach($path in $paths){
+            $domains | ForEach-Object {
+                New-Item -Path $path\$_ -Force
+                New-ItemProperty -Path $path\$_ -Name https -Value 2 -PropertyType DWORD -Force
+            }
+          }
 
           ######## INSTALL SQL DEVELOPER ########
 
@@ -95,3 +222,22 @@ tasks:
           ######## INSTALL LIBREOFFICE ########
 
           choco install -y libreoffice-still
+
+          ######## ADD DESKTOP SHORTCUTS FOR T1-3 ########
+
+          for ($i = 1; $i -le 3; $i++) {
+
+            $url = "https://c-t$i.test.nomis.az.justice.gov.uk/forms/frmservlet?config=tag"
+
+            $shortcut = New-Object -ComObject WScript.Shell
+            $destination = $shortcut.SpecialFolders.Item("AllUsersDesktop")
+            $source_path = Join-Path -Path $destination -ChildPath "\\C-T$i-Nomis.url"
+            $sourc = $shortcut.CreateShortcut($source_path)
+            $sourc.TargetPath = $url
+
+            $sourc.Save()       
+          
+          }
+          
+          ######## ADD DESKTOP SHORTCUTS FOR PRODUCTION AND PREPRODUCTION ########
+          # NOTE: Not yet implemented, hoping to add these later based on the environment the jumpserver is deployed to


### PR DESCRIPTION
- Set user-data script to fail on error
- Comment out Cloudwatch-Agent Config/Setup temporarily (let's fix one thing at a time!)
- Set IE Compatibility mode for sites
- Allow only certain domains under IE Enhanced Security Mode 
- Add desktop shortcuts for user to T1-T3
  - If we can move this user-data/setup from ssm documents we might be able to add the shortcuts for the environment the jumpserver is deployed in  