### PR TITLE
nomis: DSOS-1936: oem networking

### DIFF
--- a/terraform/environments/hmpps-oem/locals_security_groups.tf
+++ b/terraform/environments/hmpps-oem/locals_security_groups.tf
@@ -11,6 +11,15 @@ locals {
           protocol    = -1
           self        = true
         }
+        oracle1521 = {
+          description = "Allow oracle database 1521 ingress"
+          from_port   = "1521"
+          to_port     = "1521"
+          protocol    = "TCP"
+          cidr_blocks = [
+            "${module.ip_addresses.mp_cidr[module.environment.vpc_name]}"
+          ]
+        }
       }
       egress = {
         all = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -535,6 +535,9 @@ locals {
       # These are used in Azure DB TNS entries
       "test.nomis.service.justice.gov.uk" = {
         records = [
+          # OEM (IP hardcoded while we are testing under an ASG)
+          { name = "oem", type = "A", ttl = "300", records = ["10.26.12.202"] },
+
           # T1 [1-b: T1CNOMS1, T1NDHS1, T1TRDS1]
           { name = "t1nomis", type = "CNAME", ttl = "300", records = ["t1nomis-b.test.nomis.service.justice.gov.uk"] },
           { name = "t1nomis-a", type = "CNAME", ttl = "3600", records = ["t1-nomis-db-1-a.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk"] },


### PR DESCRIPTION
Allow nomis DB to connect to OEM server.  Hardcoding IP for now as it's just a temporary test server sitting in an ASG