### PR TITLE
address cpu alarm triggering on nomis-db instances and re-add mem alarm

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -104,6 +104,17 @@ locals {
         instance = "fixngo_connected" # required dimension value for this metric
       }
     }
+    cpu-utilization-high-db-2hrs = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "120"
+      datapoints_to_alarm = "120"
+      metric_name         = "CPUUtilization"
+      namespace           = "AWS/EC2"
+      period              = "60"
+      statistic           = "Maximum"
+      threshold           = "95"
+      alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 2 hours on a nomis-db instance"
+    }
   }
 
   database_cloudwatch_metric_alarms_lists = {
@@ -122,17 +133,17 @@ locals {
     database_dba = {
       parent_keys = []
       alarms_list = [
-        { key = "ec2", name = "cpu-utilization-high-15mins" },
         { key = "ec2", name = "instance-status-check-failed-in-last-hour" },
         { key = "ec2", name = "system-status-check-failed-in-last-hour" },
         { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
-        # { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
+        { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
         { key = "ec2_cwagent_linux", name = "cpu-iowait-high-3hour" },
         { key = "database", name = "oracle-db-disconnected" },
         { key = "database", name = "oracle-batch-failure" },
         { key = "database", name = "oracle-long-running-batch" },
         { key = "database", name = "oracleasm-service" },
         { key = "database", name = "oracle-ohasd-service" },
+        { key = "database", name = "cpu-utilization-high-db-2hrs" },
       ]
     }
     database_dba_high_priority = {

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,7 +1,7 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,7 +1,7 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.1"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -130,18 +130,17 @@ locals {
         threshold           = "85"
         alarm_description   = "Triggers if free disk space falls below the threshold for an hour. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4289822860/Disk+Free+alarm+-+Linux"
       }
-      # NOTE: see DSOS-1956 for why this is commented out temporarily
-      # high-memory-usage-15mins = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "15"
-      #   datapoints_to_alarm = "15"
-      #   metric_name         = "mem_used_percent"
-      #   namespace           = "CWAgent"
-      #   period              = "60"
-      #   statistic           = "Average"
-      #   threshold           = "90"
-      #   alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
-      # }
+      high-memory-usage-15mins = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
+        metric_name         = "mem_used_percent"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "90"
+        alarm_description   = "Triggers if memory usage is continually high for 15 minutes."
+      }
       cpu-iowait-high-3hour = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "180"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms_lists.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms_lists.tf
@@ -65,7 +65,7 @@ locals {
       parent_keys = ["ec2_default"]
       alarms_list = [
         { key = "ec2_cwagent_linux", name = "free-disk-space-low-1hour" },
-        # { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
+        { key = "ec2_cwagent_linux", name = "high-memory-usage-15mins" },
         { key = "ec2_cwagent_linux", name = "cpu-iowait-high-3hour" },
       ]
     }


### PR DESCRIPTION
- set cpu alarm params to not trigger on db instances under normal load
- re-add memory alarm now that root cause is understood
  - basically a miss-configuring the cloudwatch-agent log collector by using a wildcard for the log files is a bad idea!
