### PR TITLE
enable alarms for t2-nomis-db-1-a and t3-nomis-db-1

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -293,7 +293,6 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
-        cloudwatch_metric_alarms = {} # no alarms as -a is not currently the live environment
       })
 
       t3-nomis-db-1 = merge(local.database_ec2_a, {
@@ -311,7 +310,6 @@ locals {
           data  = { total_size = 2000 }
           flash = { total_size = 500 }
         })
-        cloudwatch_metric_alarms = {} # disable for failover test
       })
       t3-nomis-db-1-b = merge(local.database_ec2_b, {
         tags = merge(local.database_ec2_b.tags, {


### PR DESCRIPTION
now that these are both live turn on alarms for these

will follow up by running the mod-platform-config-management roles to set up collectd and the cloudwatch-agent settings on all nomis-test instances after this