### PR TITLE
Create S3 bucket for remote supervision storage

### DIFF
--- a/terraform/environments/long-term-storage/platform_versions.tf
+++ b/terraform/environments/long-term-storage/platform_versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/long-term-storage/remote-supervision.tf
+++ b/terraform/environments/long-term-storage/remote-supervision.tf
@@ -1,0 +1,68 @@
+# Remote Supervision
+# owner : Remote Supervision: remote.supervision+hosting@digital.justice.gov.uk
+
+module "remote_supervision_s3" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
+
+  bucket_prefix                            = "s3-bucket"
+  versioning_enabled                       = true
+
+  # to disable ACLs in preference of BucketOwnership controls as per https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ set:
+  ownership_controls = "BucketOwnerEnforced"
+
+  # Refer to the below section "Replication" before enabling replication
+  replication_enabled                      = false
+  # Below two variables and providers configuration are only relevant if 'replication_enabled' is set to true
+  # replication_region                       = "eu-west-2"
+  # replication_role_arn                     = module.s3-bucket-replication-role.role.arn
+  providers = {
+    # Here we use the default provider Region for replication. Destination buckets can be within the same Region as the
+    # source bucket. On the other hand, if you need to enable cross-region replication, please contact the Modernisation
+    # Platform team to add a new provider for the additional Region.
+    # Leave this provider block in even if you are not using replication
+    aws.bucket-replication = aws
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      transition = [
+        {
+          days          = 30
+          storage_class = "GLACIER"
+        }
+      ]
+
+      expiration = {
+        days = 36135 # 99 years
+      }
+
+      noncurrent_version_transition = [
+        {
+          days          = 30
+          storage_class = "GLACIER"
+        }
+      ]
+
+      noncurrent_version_expiration = {
+        days = 36135 # 99 years      
+      }
+    }
+  ]
+
+  tags = merge(
+    local.tags,
+    {
+      Name  = "Remote Supervision",
+      owner = "remote.supervision+hosting@digital.justice.gov.uk"
+    }
+  )
+}


### PR DESCRIPTION
The will hold the remaining remote supervision data and enable the closure of the remote supervision AWS account.