### PR TITLE
create per-environment alarm for rman backup failures

### DIFF
--- a/terraform/environments/nomis/ec2_common.tf
+++ b/terraform/environments/nomis/ec2_common.tf
@@ -458,15 +458,15 @@ resource "aws_cloudwatch_metric_alarm" "rman_backup_success_failure_alarm" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "rman_backup_missing_24h" {
+resource "aws_cloudwatch_metric_alarm" "rman_backup_missing_36h" {
   for_each = try(toset(local.environment_configs[local.environment].rman_database_backups), {})
 
-  alarm_name          = "rman-backup-missing-24h-${each.value}"
+  alarm_name          = "rman-backup-missing-36h-${each.value}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   threshold           = "1"
   treat_missing_data  = "breaching"
-  alarm_description   = "Rman reported missing backup, no backup in the last 24 hours"
+  alarm_description   = "Rman reported missing backup, no backup in the last 36 hours"
   # alarm_actions       = [""] # SNS Topic required
 
   metric_query {
@@ -483,7 +483,7 @@ resource "aws_cloudwatch_metric_alarm" "rman_backup_missing_24h" {
     metric {
       metric_name = "RmanBackupSuccess${each.value}"
       namespace   = "RmanBackupMetrics" # custom namespace
-      period      = "86400"             # 24 hours in seconds
+      period      = "129600"             # 36 hours in seconds
       stat        = "SampleCount"
     }
   }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -11,6 +11,8 @@ locals {
   # baseline config
   development_config = {
 
+    # monitored_database_backups = ["ALPHA", "BETA"]
+
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -11,7 +11,7 @@ locals {
   # baseline config
   development_config = {
 
-    # monitored_database_backups = ["ALPHA", "BETA"]
+    # rman_database_backups = ["ALPHA", "BETA"] <== for testing only, list of "fake" database
 
     baseline_acm_certificates = {
       nomis_wildcard_cert = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -4,7 +4,7 @@ locals {
   # baseline config
   test_config = {
 
-    # rman_database_backups = ["T1CNOM", "T1NDH", "T1TRDAT", "T1ORSYS", "T1MIS", "T1CNMAUD", "T2CNOM", "T2NDH", "T2TRDAT", "T3CNOM"]
+    rman_database_backups = ["T1CNOM", "T1NDH", "T1TRDAT", "T1ORSYS", "T1MIS", "T1CNMAUD", "T2CNOM", "T2NDH", "T2TRDAT", "T3CNOM"]
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -4,7 +4,7 @@ locals {
   # baseline config
   test_config = {
 
-    # monitored_database_backups = ["T1CNOM", "T1NDH", "T1TRDAT", "T1ORSYS", "T1MIS", "T1CNMAUD", "T2CNOM", "T2NDH", "T2TRDAT", "T3CNOM"]
+    # rman_database_backups = ["T1CNOM", "T1NDH", "T1TRDAT", "T1ORSYS", "T1MIS", "T1CNMAUD", "T2CNOM", "T2NDH", "T2TRDAT", "T3CNOM"]
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -4,7 +4,7 @@ locals {
   # baseline config
   test_config = {
 
-
+    # monitored_database_backups = ["T1CNOM", "T1NDH", "T1TRDAT", "T1ORSYS", "T1MIS", "T1CNMAUD", "T2CNOM", "T2NDH", "T2TRDAT", "T3CNOM"]
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this


### PR DESCRIPTION
- creates rman backup failure and success metric filters on cwagent-var-log-messages log stream 
- alarm for failure
- alarm for success not within last 36 hours (backup is missing basically)
- runs off of logs in cloudwatch log stream to /var/log/messages in the each environment if rman_database_backups is defined in locals
- sns topics are not yet enabled for this but alarms will appear in the cloudwatch alarms list for each db in nomis-test 