### PR TITLE
noms: DSOS-2001: reduce number of SG rules

### DIFF
--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -19,16 +19,11 @@ locals {
     ])
     ssh = module.ip_addresses.azure_fixngo_cidrs.devtest
     https = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.devtest,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
+      "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
-      module.ip_addresses.moj_cidrs.trusted_moj_enduser_internal,
-      module.ip_addresses.azure_studio_hosting_cidrs.devtest,
-      module.ip_addresses.azure_nomisapi_cidrs.devtest,
     ])
     http7xxx = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
     ])
     oracle_db = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,
@@ -49,16 +44,11 @@ locals {
     ])
     ssh = module.ip_addresses.azure_fixngo_cidrs.prod
     https = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
+      "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
-      module.ip_addresses.moj_cidrs.trusted_moj_enduser_internal,
-      module.ip_addresses.azure_studio_hosting_cidrs.prod,
-      module.ip_addresses.azure_nomisapi_cidrs.prod,
     ])
     http7xxx = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
     ])
     oracle_db = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,


### PR DESCRIPTION
Move to a 10/8 for https traffic to reduce number of SG rules.  This is what we allow on Azure and there's a whole bunch of IPs that we haven't included in the current rule set.