### PR TITLE
Raise default terraform version used by workflows

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -40,8 +40,8 @@ on:
       terraform_version:
         type: string
         required: false
-        description: "The terraform version to use, default is temporarily set to 1.3.9 due to bugs in 1.4.0"
-        default: "1.3.9"
+        description: "The terraform version to use"
+        default: "~1.5"
       init_plan_apply_tfargs:
         type: string
         required: false


### PR DESCRIPTION
In line with the syntax [here](https://github.com/hashicorp/setup-terraform#:~:text=CLI%20configuration%20file.-,terraform_version,-%2D%20(optional)%20The%20version), this PR bumps the minimum version of Terraform used to `1.5.0`.

Teams can still override this in their workflows by supplying `"${{ inputs.terraform_version }}"`.