### PR TITLE
Nomis: DSOS-1987: custom backup policies

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -11,6 +11,10 @@ locals {
   baseline_environment_config = local.environment_configs[local.environment]
 
   baseline_presets_options = {
+    backup_plans = [
+      "daily_except_sunday",
+      "weekly_on_sunday"
+    ]
     enable_application_environment_wildcard_cert = false
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
@@ -47,6 +51,8 @@ locals {
   }
 
   baseline_acm_certificates = {}
+
+  baseline_backup_plans = {}
 
   baseline_bastion_linux = {
     public_key_data = merge(

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -11,11 +11,8 @@ locals {
   baseline_environment_config = local.environment_configs[local.environment]
 
   baseline_presets_options = {
-    backup_plans = [
-      "daily_except_sunday",
-      "weekly_on_sunday"
-    ]
     enable_application_environment_wildcard_cert = false
+    enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -197,6 +197,9 @@ locals {
       metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
       monitoring                   = true
       vpc_security_group_ids       = ["data-db"]
+      tags = {
+        backup-plan = "daily-and-weekly"
+      }
     })
 
     user_data_cloud_init = {
@@ -267,7 +270,6 @@ locals {
       os-version           = "RHEL 7.9"
       licence-requirements = "Oracle Database"
       "Patch Group"        = "RHEL"
-      backup               = "true"
     }
   }
 

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -238,8 +238,6 @@ locals {
       }
     }
 
-    ebs_volume_tags = { foo: "ebs-bar" }
-
     route53_records = {
       create_internal_record = true
       create_external_record = true

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -238,6 +238,8 @@ locals {
       }
     }
 
+    ebs_volume_tags = { foo: "ebs-bar" }
+
     route53_records = {
       create_internal_record = true
       create_external_record = true

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -58,6 +58,7 @@ locals {
           oracle-db-hostname-a = "pnomis-a.production.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "pnomis-b.production.nomis.service.justice.gov.uk"
           oracle-db-name       = "PCNOM"
+          is-production        = "true-no-default-backup-workaround"
         })
       })
 
@@ -68,6 +69,7 @@ locals {
           oracle-db-hostname-a = "pnomis-a.production.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "pnomis-b.production.nomis.service.justice.gov.uk"
           oracle-db-name       = "PCNOM"
+          is-production        = "true-no-default-backup-workaround"
         })
       })
     }
@@ -78,6 +80,7 @@ locals {
           nomis-environment = "preprod"
           description       = "PreProduction NOMIS MIS and Audit database to replace Azure PPPDL00017"
           oracle-sids       = "PPCNMAUD"
+          is-production     = "true-no-default-backup-workaround"
         })
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
@@ -102,6 +105,7 @@ locals {
           description               = "Production NOMIS MIS and Audit database to replace Azure PDPDL00036 and PDPDL00038"
           oracle-sids               = "CNMAUD"
           fixngo-connection-targets = "10.40.0.136 4903 10.40.129.79 22" # fixngo connection alarm
+          is-production             = "true-no-default-backup-workaround"
         })
         instance = merge(local.database_ec2_a.instance, {
           instance_type = "r6i.2xlarge"
@@ -124,6 +128,7 @@ locals {
           nomis-environment = "prod"
           description       = "Production NOMIS HA database to replace Azure PDPDL00062"
           oracle-sids       = "PCNOMHA"
+          is-production     = "true-no-default-backup-workaround"
         })
         instance = merge(local.database_ec2_a.instance, {
           instance_type = "r6i.4xlarge"

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -151,10 +151,8 @@ locals {
     instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {
       instance_type          = "t2.large"
       vpc_security_group_ids = ["private-web"]
-      tags = { foo: "ec2-bar" }
     })
 
-    ebs_volume_tags = { foo: "ebs-bar" }
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
     autoscaling_group    = module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool
 

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -151,8 +151,10 @@ locals {
     instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {
       instance_type          = "t2.large"
       vpc_security_group_ids = ["private-web"]
+      tags = { foo: "ec2-bar" }
     })
 
+    ebs_volume_tags = { foo: "ebs-bar" }
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
     autoscaling_group    = module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool
 

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -48,6 +48,16 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_acm_certificates", {})
   )
 
+  backups = {
+    "everything" = {
+      plans = merge(
+        module.baseline_presets.backup_plans,
+        local.baseline_backup_plans,
+        lookup(local.baseline_environment_config, "baseline_backup_plans", {})
+      )
+    }
+  }
+
   bastion_linux = merge(
     local.baseline_bastion_linux,
     lookup(local.baseline_environment_config, "baseline_bastion_linux", {})

--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -67,7 +67,7 @@ resource "aws_backup_plan" "this" {
   dynamic "advanced_backup_setting" {
     for_each = each.value.advanced_backup_setting != null ? [each.value.advanced_backup_setting] : []
     content {
-      backup_options = advanced_backup_settings.backup_options
+      backup_options = advanced_backup_setting.backup_options
       resource_type  = advanced_backup_setting.resource_type
     }
   }

--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -55,20 +55,17 @@ resource "aws_backup_plan" "this" {
     start_window             = each.value.start_window
     completion_window        = each.value.completion_window
 
-    dynamic "lifecycle" {
-      for_each = each.value.lifecycle != null ? [each.value.lifecycle] : []
-      content {
-        cold_storage_after = lifecycle.cold_storage_after
-        delete_after       = lifecycle.delete_after
-      }
+    lifecycle {
+      cold_storage_after = each.value.cold_storage_after
+      delete_after       = each.value.delete_after
     }
   }
 
   dynamic "advanced_backup_setting" {
     for_each = each.value.advanced_backup_setting != null ? [each.value.advanced_backup_setting] : []
     content {
-      backup_options = advanced_backup_setting.backup_options
-      resource_type  = advanced_backup_setting.resource_type
+      backup_options = advanced_backup_setting.value.backup_options
+      resource_type  = advanced_backup_setting.value.resource_type
     }
   }
 

--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -49,7 +49,7 @@ resource "aws_backup_plan" "this" {
 
   rule {
     rule_name                = each.key
-    target_vault_name        = each.value.rule.target_vault_name
+    target_vault_name        = each.value.target_vault_name
     schedule                 = each.value.rule.schedule
     enable_continuous_backup = each.value.rule.enable_continuous_backup
     start_window             = each.value.rule.start_window

--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -49,15 +49,15 @@ resource "aws_backup_plan" "this" {
 
   rule {
     rule_name                = each.key
-    target_vault_name        = each.value.target_vault_name
-    schedule                 = each.value.schedule
-    enable_continuous_backup = each.value.enable_continuous_backup
-    start_window             = each.value.start_window
-    completion_window        = each.value.completion_window
+    target_vault_name        = each.value.rule.target_vault_name
+    schedule                 = each.value.rule.schedule
+    enable_continuous_backup = each.value.rule.enable_continuous_backup
+    start_window             = each.value.rule.start_window
+    completion_window        = each.value.rule.completion_window
 
     lifecycle {
-      cold_storage_after = each.value.cold_storage_after
-      delete_after       = each.value.delete_after
+      cold_storage_after = each.value.rule.cold_storage_after
+      delete_after       = each.value.rule.delete_after
     }
   }
 

--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -1,0 +1,97 @@
+locals {
+
+  # everything vault is created by mod platform
+  backup_vaults = {
+    for key, value in var.backups : key => value if key != "everything"
+  }
+
+  backup_plans_list = flatten([
+    for vault_key, vault_value in var.backups : [
+      for plan_key, plan_value in vault_value.plans : [{
+        key = "${vault_key}-${plan_key}"
+        value = merge(plan_value, {
+          target_vault_name = vault_key
+        })
+      }]
+    ]
+  ])
+
+  backup_plans = {
+    for item in local.backup_plans_list : item.key => item.value
+  }
+
+}
+
+# created elsewhere (modernisation-platform-terraform-baselines)
+data "aws_backup_vault" "everything" {
+  name = "everything"
+}
+
+# created elsewhere (modernisation-platform-terraform-baselines)
+data "aws_iam_role" "backup" {
+  name = "AWSBackup"
+}
+
+resource "aws_backup_vault" "this" {
+  for_each = local.backup_vaults
+
+  name = each.key
+
+  tags = merge(local.tags, each.value.tags, {
+    Name = each.key
+  })
+}
+
+resource "aws_backup_plan" "this" {
+  for_each = local.backup_plans
+
+  name = each.key
+
+  rule {
+    rule_name                = each.key
+    target_vault_name        = each.value.target_vault_name
+    schedule                 = each.value.schedule
+    enable_continuous_backup = each.value.enable_continuous_backup
+    start_window             = each.value.start_window
+    completion_window        = each.value.completion_window
+
+    dynamic "lifecycle" {
+      for_each = each.value.lifecycle != null ? [each.value.lifecycle] : []
+      content {
+        cold_storage_after = lifecycle.cold_storage_after
+        delete_after       = lifecycle.delete_after
+      }
+    }
+  }
+
+  dynamic "advanced_backup_setting" {
+    for_each = each.value.advanced_backup_setting != null ? [each.value.advanced_backup_setting] : []
+    content {
+      backup_options = advanced_backup_settings.backup_options
+      resource_type  = advanced_backup_setting.resource_type
+    }
+  }
+
+  tags = merge(local.tags, each.value.tags, {
+    Name = each.key
+  })
+}
+
+resource "aws_backup_selection" "this" {
+  for_each = local.backup_plans
+
+  name          = each.key
+  iam_role_arn  = data.aws_iam_role.backup.arn
+  plan_id       = aws_backup_plan.this[each.key].id
+  resources     = each.value.selection.resources
+  not_resources = each.value.selection.not_resources
+
+  dynamic "selection_tag" {
+    for_each = each.value.selection.selection_tags
+    content {
+      type  = selection_tag.value.type
+      key   = selection_tag.value.key
+      value = selection_tag.value.value
+    }
+  }
+}

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -13,8 +13,7 @@ locals {
 module "ec2_autoscaling_group" {
   for_each = var.ec2_autoscaling_groups
 
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.0"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=DSOS-1987-more-control-over-tagging"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.1"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -13,7 +13,8 @@ locals {
 module "ec2_autoscaling_group" {
   for_each = var.ec2_autoscaling_groups
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.0"
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=DSOS-1987-more-control-over-tagging"
 
   providers = {
     aws.core-vpc = aws.core-vpc
@@ -40,6 +41,7 @@ module "ec2_autoscaling_group" {
   ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
   ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
   ebs_volume_config             = each.value.ebs_volume_config
+  ebs_volume_tags               = each.value.ebs_volume_tags
   ebs_volumes                   = each.value.ebs_volumes
   user_data_raw                 = each.value.config.user_data_raw
   user_data_cloud_init          = each.value.user_data_cloud_init

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -13,7 +13,7 @@ locals {
 module "ec2_autoscaling_group" {
   for_each = var.ec2_autoscaling_groups
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.0.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.1.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,7 +1,7 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.2"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.1.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,7 +1,8 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.1"
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=DSOS-1987-more-control-over-tagging"
 
   providers = {
     aws.core-vpc = aws.core-vpc
@@ -29,6 +30,7 @@ module "ec2_instance" {
   ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
   ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
   ebs_volume_config             = each.value.ebs_volume_config
+  ebs_volume_tags               = each.value.ebs_volume_tags
   ebs_volumes                   = each.value.ebs_volumes
   user_data_raw                 = each.value.config.user_data_raw
   user_data_cloud_init          = each.value.user_data_cloud_init

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,8 +1,7 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.1"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=DSOS-1987-more-control-over-tagging"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.0.2"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -3,6 +3,21 @@ output "acm_certificates" {
   value       = module.acm_certificate
 }
 
+output "backups" {
+  description = "map of backups corresponding to var.backups"
+  value = {
+    for vault_key, vault_value in var.backups : vault_key => {
+      vault = vault_key == "everything" ? data.aws_backup_vault.everything : aws_backup_vault.this[vault_key]
+      plans = {
+        for plan_key, plan_value in vault_value.plans : plan_key => {
+          plan      = aws_backup_plan.this["${vault_key}-${plan_key}"]
+          selection = aws_backup_selection.this["${vault_key}-${plan_key}"]
+        }
+      }
+    }
+  }
+}
+
 output "bastion_linux" {
   description = "See bastion_linux module github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux for more detail"
   value       = length(module.bastion_linux) == 1 ? module.bastion_linux[0] : null

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -32,14 +32,14 @@ variable "backups" {
   description = "map of backup_vaults with associated backup plans to create, where the plan name is the backup_vault name and plan key combined.  Use  'everything' as the map key to use the modernisation platform managed vault"
   type = map(object({
     plans = map(object({
-      schedule                 = optional(string)
-      enable_continuous_backup = optional(bool)
-      start_window             = optional(number)
-      completion_window        = optional(number)
-      lifecycle = optional(object({
-        cold_storage_after = optional(number)
-        delete_after       = optional(number)
-      }))
+      rule = object({
+        schedule                 = optional(string)
+        enable_continuous_backup = optional(bool)
+        start_window             = optional(number)
+        completion_window        = optional(number)
+        cold_storage_after       = optional(number)
+        delete_after             = number
+      })
       advanced_backup_setting = optional(object({
         backup_options = object({
           WindowsVSS = string

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -119,6 +119,7 @@ variable "ec2_autoscaling_groups" {
         enable_resource_name_dns_a_record    = optional(bool)
         hostname_type                        = string
       }))
+      tags = optional(map(string), {})
     })
     user_data_cloud_init = optional(object({
       args    = optional(map(string))
@@ -136,6 +137,7 @@ variable "ec2_autoscaling_groups" {
       type       = optional(string)
       kms_key_id = optional(string)
     })), {})
+    ebs_volume_tags = optional(map(string), {})
     ebs_volumes = optional(map(object({
       label       = optional(string)
       snapshot_id = optional(string)
@@ -260,6 +262,7 @@ variable "ec2_instances" {
         enable_resource_name_dns_a_record    = optional(bool)
         hostname_type                        = string
       }))
+      tags = optional(map(string), {})
     })
     user_data_cloud_init = optional(object({
       args    = optional(map(string))
@@ -277,6 +280,7 @@ variable "ec2_instances" {
       type       = optional(string)
       kms_key_id = optional(string)
     })), {})
+    ebs_volume_tags = optional(map(string), {})
     ebs_volumes = optional(map(object({
       label       = optional(string)
       snapshot_id = optional(string)

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -28,6 +28,40 @@ variable "acm_certificates" {
   default = {}
 }
 
+variable "backups" {
+  description = "map of backup_vaults with associated backup plans to create, where the plan name is the backup_vault name and plan key combined.  Use  'everything' as the map key to use the modernisation platform managed vault"
+  type = map(object({
+    plans = map(object({
+      schedule                 = optional(string)
+      enable_continuous_backup = optional(bool)
+      start_window             = optional(number)
+      completion_window        = optional(number)
+      lifecycle = optional(object({
+        cold_storage_after = optional(number)
+        delete_after       = optional(number)
+      }))
+      advanced_backup_setting = optional(object({
+        backup_options = object({
+          WindowsVSS = string
+        })
+        resource_type = string
+      }))
+      selection = object({
+        resources     = optional(list(string))
+        not_resources = optional(list(string))
+        selection_tags = list(object({
+          type  = string
+          key   = string
+          value = string
+        }))
+      })
+      tags = optional(map(string), {})
+    }))
+    tags = optional(map(string), {})
+  }))
+  default = {}
+}
+
 variable "bastion_linux" {
   description = "set this if you want a bastion linux created"
   type = object({

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -13,12 +13,12 @@ locals {
         lifecycle = {
           delete_after = lookup(var.options, "backup_plan_daily_delete_after", 7)
         }
-        advanced_backup_setting = {
-          backup_options = {
-            WindowsVSS = "enabled"
-          }
-          resource_type = "EC2"
+      }
+      advanced_backup_setting = {
+        backup_options = {
+          WindowsVSS = "enabled"
         }
+        resource_type = "EC2"
       }
       selection = {
         selection_tags = [{
@@ -36,12 +36,12 @@ locals {
         lifecycle = {
           delete_after = lookup(var.options, "backup_plan_weekly_delete_after", 28)
         }
-        advanced_backup_setting = {
-          backup_options = {
-            WindowsVSS = "enabled"
-          }
-          resource_type = "EC2"
+      }
+      advanced_backup_setting = {
+        backup_options = {
+          WindowsVSS = "enabled"
         }
+        resource_type = "EC2"
       }
       selection = {
         selection_tags = [{

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -1,5 +1,9 @@
 locals {
 
+  backup_plans_filter = flatten([
+    var.options.enable_backup_plan_daily_and_weekly ? ["daily_except_sunday", "weekly_on_sunday"] : []
+  ])
+
   backup_plans = {
     daily_except_sunday = {
       rule = {
@@ -7,7 +11,7 @@ locals {
         start_window      = 60
         completion_window = 3600
         lifecycle = {
-          delete_after = "7"
+          delete_after = lookup(var.options, "backup_plan_daily_delete_after", 7)
         }
         advanced_backup_setting = {
           backup_options = {
@@ -20,7 +24,7 @@ locals {
         selection_tags = [{
           type  = "STRINGEQUALS"
           key   = "backup-plan"
-          value = "daily-weekly"
+          value = "daily-and-weekly"
         }]
       }
     }
@@ -30,7 +34,7 @@ locals {
         start_window      = 60
         completion_window = 3600
         lifecycle = {
-          delete_after = "28"
+          delete_after = lookup(var.options, "backup_plan_weekly_delete_after", 28)
         }
         advanced_backup_setting = {
           backup_options = {
@@ -43,7 +47,7 @@ locals {
         selection_tags = [{
           type  = "STRINGEQUALS"
           key   = "backup-plan"
-          value = "daily-weekly"
+          value = "daily-and-weekly"
         }]
       }
     }

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -1,0 +1,53 @@
+locals {
+
+  backup_plans = {
+    daily_except_sunday = {
+      rule = {
+        schedule          = "cron(30 23 * * MON-SAT *)"
+        start_window      = 60
+        completion_window = 3600
+        lifecycle = {
+          delete_after = "7"
+        }
+        advanced_backup_setting = {
+          backup_options = {
+            WindowsVSS = "enabled"
+          }
+          resource_type = "EC2"
+        }
+      }
+      selection = {
+        not_resources = ["*vol-*"]
+        selection_tags = [{
+          type  = "STRINGEQUALS"
+          key   = "backup-plan"
+          value = "daily-weekly"
+        }]
+      }
+    }
+    weekly_on_sunday = {
+      rule = {
+        schedule          = "cron(30 23 * * SUN *)"
+        start_window      = 60
+        completion_window = 3600
+        lifecycle = {
+          delete_after = "28"
+        }
+        advanced_backup_setting = {
+          backup_options = {
+            WindowsVSS = "enabled"
+          }
+          resource_type = "EC2"
+        }
+      }
+      selection = {
+        not_resources = ["*vol-*"]
+        selection_tags = [{
+          type  = "STRINGEQUALS"
+          key   = "backup-plan"
+          value = "daily-weekly"
+        }]
+      }
+    }
+  }
+}

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -10,9 +10,7 @@ locals {
         schedule          = "cron(30 23 * * MON-SAT *)"
         start_window      = 60
         completion_window = 3600
-        lifecycle = {
-          delete_after = lookup(var.options, "backup_plan_daily_delete_after", 7)
-        }
+        delete_after      = lookup(var.options, "backup_plan_daily_delete_after", 7)
       }
       advanced_backup_setting = {
         backup_options = {
@@ -33,9 +31,7 @@ locals {
         schedule          = "cron(30 23 * * SUN *)"
         start_window      = 60
         completion_window = 3600
-        lifecycle = {
-          delete_after = lookup(var.options, "backup_plan_weekly_delete_after", 28)
-        }
+        delete_after      = lookup(var.options, "backup_plan_weekly_delete_after", 28)
       }
       advanced_backup_setting = {
         backup_options = {

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -17,7 +17,6 @@ locals {
         }
       }
       selection = {
-        not_resources = ["*vol-*"]
         selection_tags = [{
           type  = "STRINGEQUALS"
           key   = "backup-plan"
@@ -41,7 +40,6 @@ locals {
         }
       }
       selection = {
-        not_resources = ["*vol-*"]
         selection_tags = [{
           type  = "STRINGEQUALS"
           key   = "backup-plan"

--- a/terraform/modules/baseline_presets/backups.tf
+++ b/terraform/modules/baseline_presets/backups.tf
@@ -5,9 +5,13 @@ locals {
   ])
 
   backup_plans = {
+
+    # Cron Format: Minutes Hours Day-of-month Month Day-of-week Year
+    # Note: You cannot use * in both the Day-of-month and Day-of-week fields. If you use it in one, you must use ? in the other.
+
     daily_except_sunday = {
       rule = {
-        schedule          = "cron(30 23 * * MON-SAT *)"
+        schedule          = "cron(30 23 ? * MON-SAT *)"
         start_window      = 60
         completion_window = 3600
         delete_after      = lookup(var.options, "backup_plan_daily_delete_after", 7)
@@ -28,7 +32,7 @@ locals {
     }
     weekly_on_sunday = {
       rule = {
-        schedule          = "cron(30 23 * * SUN *)"
+        schedule          = "cron(30 23 ? * SUN *)"
         start_window      = 60
         completion_window = 3600
         delete_after      = lookup(var.options, "backup_plan_weekly_delete_after", 28)

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -10,7 +10,7 @@ output "backup_plans" {
   description = "Map of backup_plans to create depending on options provided"
 
   value = {
-    for key, value in local.backup_plans : key => value if contains(var.options.backup_plans, key)
+    for key, value in local.backup_plans : key => value if contains(local.backup_plans_filter, key)
   }
 }
 

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -6,6 +6,14 @@ output "acm_certificates" {
   }
 }
 
+output "backup_plans" {
+  description = "Map of backup_plans to create depending on options provided"
+
+  value = {
+    for key, value in local.backup_plans : key => value if contains(var.options.backup_plans, key)
+  }
+}
+
 output "cloudwatch_log_groups" {
   description = "Map of log groups"
 

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -9,6 +9,7 @@ variable "ip_addresses" {
 variable "options" {
   description = "Map of options controlling what resources to return"
   type = object({
+    backup_plans          = optional(list(string), [])
     cloudwatch_log_groups = optional(list(string))
     cloudwatch_metric_alarms = optional(map(map(object({
       comparison_operator = string

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -9,8 +9,9 @@ variable "ip_addresses" {
 variable "options" {
   description = "Map of options controlling what resources to return"
   type = object({
-    backup_plans          = optional(list(string), [])
-    cloudwatch_log_groups = optional(list(string))
+    backup_plan_daily_delete_after  = optional(number, 7)
+    backup_plan_weekly_delete_after = optional(number, 28)
+    cloudwatch_log_groups           = optional(list(string))
     cloudwatch_metric_alarms = optional(map(map(object({
       comparison_operator = string
       evaluation_periods  = number
@@ -38,6 +39,7 @@ variable "options" {
       actions_key     = string
     }))
     enable_application_environment_wildcard_cert = optional(bool, false)
+    enable_backup_plan_daily_and_weekly          = optional(bool, false)
     enable_business_unit_kms_cmks                = optional(bool, false)
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)


### PR DESCRIPTION
Add a custom backup policy as the default one is way more than we need.
- create new daily/weekly policy (daily backups kept for 7 days, weekly backups for 4 weeks) in line with Azure config via baseline
- remove existing mod platform backups (remove backup tag, rename is-production: true).  NB, there is a ticket raised with mod-platform to improve this.
- use new EC2/ASG modules which allows separate tagging on ec2 instance and ebs resources
- add new backup-plan tag to the databases EC2 instances only.  No need for separate backup of EBS resources, nor backup of anything that we have fully in code, i.e. ASGs.