### PR TITLE
DPR-620: Fix log group name for glue jobs

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -180,7 +180,7 @@ resource "aws_iam_role_policy_attachment" "glue_policies" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  name              = "/aws-glue/jobs/${var.name}-sec-config"
+  name              = "/aws-glue/jobs/${var.name}"
   retention_in_days = var.log_group_retention_in_days
   tags              = var.tags
 }


### PR DESCRIPTION
This fixes the name mis-match in the Glue job Cloudwatch log groups.
The name mis-match meant that the expiry period of 7 days was not applied to the log groups.