### PR TITLE
LAWS-3328: enable multi-az in mojfin during next maintenance window

### DIFF
--- a/terraform/environments/mojfin/rds.tf
+++ b/terraform/environments/mojfin/rds.tf
@@ -173,7 +173,7 @@ resource "aws_db_instance" "appdb1" {
   apply_immediately               = false
   # snapshot_identifier             = format("arn:aws:rds:eu-west-2:%s:snapshot:%s", data.aws_caller_identity.current.account_id,local.application_data.accounts[local.environment].mojfinrdssnapshotid)
   kms_key_id = data.aws_kms_key.rds_shared.arn
-  # multi_az                        = true
+  multi_az                        = true
 
   # restore_to_point_in_time {
   #   restore_time = "2023-07-04T14:54:00Z"


### PR DESCRIPTION
Added the multi_az attribute to mojfin RDS instance, now that the apply_immediately setting has been set to 'false' (in previous change); so that this change is implemented during the next maintenance window (July 24, 2023 02:15 - 07:00 UTC+1 (next Monday morning)
