### PR TITLE
nomis: DSOS-2000: xtag fix

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -87,6 +87,7 @@ locals {
           oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
           oracle-db-name       = "T1CNOM"
+          ndh-ems-hostname     = "t1pml0005"
         })
       })
       t1-nomis-xtag-b = merge(local.xtag_ec2_b, {
@@ -95,6 +96,7 @@ locals {
           oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
           oracle-db-name       = "T1CNOM"
+          ndh-ems-hostname     = "t1pml0005"
         })
       })
 
@@ -124,6 +126,7 @@ locals {
           oracle-db-hostname-a = "t2nomis-a.test.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
           oracle-db-name       = "T2CNOM"
+          ndh-ems-hostname     = "t2pml0008"
         })
       })
       t2-nomis-xtag-b = merge(local.xtag_ec2_b, {
@@ -132,6 +135,7 @@ locals {
           oracle-db-hostname-a = "t2nomis-a.test.nomis.service.justice.gov.uk"
           oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
           oracle-db-name       = "T2CNOM"
+          ndh-ems-hostname     = "t2pml0008"
         })
       })
 

--- a/terraform/environments/nomis/locals_xtag.tf
+++ b/terraform/environments/nomis/locals_xtag.tf
@@ -58,7 +58,7 @@ locals {
     })
     user_data_cloud_init = merge(local.xtag_ec2_default.user_data_cloud_init, {
       args = merge(local.xtag_ec2_default.user_data_cloud_init.args, {
-        branch = "3c5a4f32dd350feb6df797e9ec19ffe4ed0c47f9" # from AMI, but no collectd
+        branch = "61f2bd80235ff8453f516d6549c9fb89bf38feec" # from AMI, no collectd, NDH taken from tag
       })
     })
     autoscaling_group = merge(local.xtag_ec2_default.autoscaling_group, {


### PR DESCRIPTION
Get NDH EMS hostname from tag instead of hardcoded in ansible defaults.