### PR TITLE
DPR-637 revise domain builder lambda config to support domain previews

### DIFF
--- a/terraform/environments/digital-prison-reporting/domain_builder.tf
+++ b/terraform/environments/digital-prison-reporting/domain_builder.tf
@@ -39,13 +39,16 @@ module "domain_builder_backend_Lambda" {
   tracing       = local.lambda_dbuilder_tracing
   timeout       = 60
   env_vars = {
-    "JAVA_TOOL_OPTIONS" = "-XX:MetaspaceSize=32m"
-    "POSTGRES_HOST"     = module.domain_builder_backend_db.rds_host
-    "POSTGRES_DB_NAME"  = local.rds_dbuilder_db_identifier
-    "POSTGRES_USERNAME" = local.rds_dbuilder_user
-    "POSTGRES_PASSWORD" = module.domain_builder_backend_db.master_password
-    "POSTGRES_PORT"     = local.rds_dbuilder_port
-    "DOMAIN_API_KEY"    = module.domain_builder_api_key[0].secret
+    "DOMAIN_API_KEY"      = module.domain_builder_api_key[0].secret
+    "JAVA_TOOL_OPTIONS"   = "-XX:MetaspaceSize=32m"
+    "POSTGRES_DB_NAME"    = local.rds_dbuilder_db_identifier
+    "POSTGRES_HOST"       = module.domain_builder_backend_db.rds_host
+    "POSTGRES_PASSWORD"   = module.domain_builder_backend_db.master_password
+    "POSTGRES_PORT"       = local.rds_dbuilder_port
+    "POSTGRES_USERNAME"   = local.rds_dbuilder_user
+    "PREVIEW_DB_NAME"     = local.domain_preview_name
+    "PREVIEW_S3_LOCATION" = local.domain_preview_s3_bucket
+    "PREVIEW_WORKGROUP"   = local.domain_preview_workgroup
   }
 
   vpc_settings = {

--- a/terraform/environments/digital-prison-reporting/domain_builder.tf
+++ b/terraform/environments/digital-prison-reporting/domain_builder.tf
@@ -206,7 +206,6 @@ module "domain_builder_gw_vpclink" {
   )
 }
 
-
 # Domain Builder API Gateway
 module "domain_builder_api_gateway" {
   count               = local.enable_dbuilder_serverless_gw == true ? 1 : 0

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -75,6 +75,9 @@ locals {
   enable_dbuilder_serverless_gw  = local.application_data.accounts[local.environment].enable_dbuilder_serverless_gw
   include_dbuilder_gw_vpclink    = local.application_data.accounts[local.environment].include_dbuilder_gw_vpclink        
   serverless_gw_dbuilder_name    = "${local.project}-serverless-lambda"
+  domain_preview_database        = "curated"
+  domain_preview_s3_bucket       = module.s3_domain_preview_bucket.bucket_id
+  domain_preview_workgroup       = "primary"
 
   nomis_secrets_placeholder = {
     db_name  = "nomis"

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -62,7 +62,11 @@ locals {
   lambda_dbuilder_handler        = "io.micronaut.function.aws.proxy.MicronautLambdaHandler"
   lambda_dbuilder_code_s3_bucket = module.s3_artifacts_store.bucket_id
   lambda_dbuilder_code_s3_key    = "build-artifacts/domain-builder/jars/domain-builder-backend-api-vLatest-all.jar"
-  lambda_dbuilder_policies       = ["arn:aws:iam::${local.account_id}:policy/${local.s3_read_access_policy}", ]
+  lambda_dbuilder_policies       = [
+    "arn:aws:iam::${local.account_id}:policy/${local.s3_read_access_policy}",
+    "arn:aws:iam::${local.account_id}:policy/${local.kms_read_access_policy}",
+    "arn:aws:iam::${local.account_id}:policy/${local.project}_domain_builder_preview_policy"
+  ]
   enable_domain_builder_agent    = local.application_data.accounts[local.environment].enable_domain_builder_agent
   enable_dbuilder_flyway_lambda  = local.application_data.accounts[local.environment].enable_dbuilder_flyway_lambda
   flyway_dbuilder_name           = "${local.project}-domain-builder-flyway"

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -331,3 +331,23 @@ resource "aws_iam_role_policy_attachment" "redshift_spectrum" {
   role       = aws_iam_role.redshift-spectrum-role.name
   policy_arn = each.value
 }
+
+# Additional policy to allow execution of preview queries.
+resource "aws_iam_policy_document" "domain_builder_preview" {
+  statement {
+    actions = [
+      "athena:GetQueryExecution",
+      "athena:StartQueryExecution",
+      "glue:GetDatabase",
+      "glue:GetTable",
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "domain_builder_preview_policy" {
+  name        = "${local.project}-domain-builder-preview-policy"
+  description = "Additional policy to allow execution of query previews in Athena"
+  policy      = data.aws_iam_policy_document.domain_builder_preview.json
+}

--- a/terraform/environments/digital-prison-reporting/s3.tf
+++ b/terraform/environments/digital-prison-reporting/s3.tf
@@ -37,3 +37,23 @@ module "s3_transfer_artifacts_bucket" {
     }
   )
 }
+
+# S3 Domain Preview Bucket, DPR-637
+module "s3_domain_preview_bucket" {
+  source                    = "./modules/s3_bucket"
+  create_s3                 = local.setup_buckets
+  name                      = "${local.project}-domain-preview-${local.environment}"
+  custom_kms_key            = local.s3_kms_arn
+  create_notification_queue = false # For SQS Queue
+  enable_lifecycle          = true
+  cloudtrail_access_policy  = true
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-domain-preview-${local.environment}"
+      Resource_Type = "S3 Bucket"
+      Jira          = "DPR-637"
+    }
+  )
+}


### PR DESCRIPTION
Summary of changes
* introduce new s3 bucket for preview query output (required by athena)
* added new policy providing additional permissions to allow execution of preview queries
* added preview environment variables to configure the athena JDBC driver