### PR TITLE
random passwords for these cannot begin with numbers or they fail

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -313,6 +313,7 @@ locals {
         random = {
           length  = 30
           special = false
+          numeric = false
         }
         description = "ASMSYS password"
       }
@@ -320,6 +321,7 @@ locals {
         random = {
           length  = 30
           special = false
+          numeric = false
         }
         description = "ASMSNMP password"
       }

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -307,13 +307,12 @@ locals {
       create_external_record = true
     }
 
-    # See DSOS-1975: these random passwords cannot start with a digit
     ssm_parameters = {
       ASMSYS = {
         random = {
           length  = 30
           special = false
-          numeric = false
+          numeric = false # these db random passwords cannot start with a number
         }
         description = "ASMSYS password"
       }
@@ -321,7 +320,7 @@ locals {
         random = {
           length  = 30
           special = false
-          numeric = false
+          numeric = false # these db random passwords cannot start with a number
         }
         description = "ASMSNMP password"
       }

--- a/terraform/modules/baseline/ssm.tf
+++ b/terraform/modules/baseline/ssm.tf
@@ -46,6 +46,7 @@ resource "random_password" "this" {
 
   length  = each.value.length
   special = each.value.special
+  numeric = each.value.numeric
 }
 
 resource "aws_ssm_parameter" "fixed" {

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -884,6 +884,7 @@ variable "ssm_parameters" {
       random = optional(object({
         length  = number
         special = optional(bool)
+        numeric = optional(bool)
       }))
       value = optional(string)
     }))


### PR DESCRIPTION
- set these long passwords to numeric = false (i.e. won't contain numbers)
- they're still 30 characters long so this is more than adequate
- password resources are only creaated on first run, shouldn't be over-written on merge
  - we aren't using 'keepers' to trigger a re-run and this change doesn't appear in the terraform plan