### PR TITLE
CC-1993: Added user_data, user_data_replace_on_change to the ignore_changes block.

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-ec2-clamav.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-clamav.tf
@@ -13,7 +13,12 @@ resource "aws_instance" "ec2_clamav" {
 
   # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below
   lifecycle {
-    ignore_changes = [ebs_block_device, root_block_device]
+    ignore_changes = [
+      ebs_block_device,
+      root_block_device,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
   user_data_replace_on_change = false
   user_data                   = <<EOF

--- a/terraform/environments/ccms-ebs/ccms-ec2-ftp.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-ftp.tf
@@ -12,7 +12,12 @@ resource "aws_instance" "ec2_ftp" {
 
   # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below
   lifecycle {
-    ignore_changes = [ebs_block_device, root_block_device]
+    ignore_changes = [
+      ebs_block_device,
+      root_block_device,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
   user_data_replace_on_change = false
   user_data                   = <<EOF

--- a/terraform/environments/ccms-ebs/ccms-ec2-mailrelay.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-mailrelay.tf
@@ -13,10 +13,15 @@ resource "aws_instance" "ec2_mailrelay" {
 
   # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below
   lifecycle {
-    ignore_changes = [ebs_block_device, root_block_device]
+    ignore_changes = [
+      ebs_block_device,
+      root_block_device,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
 
-  user_data_replace_on_change = true
+  user_data_replace_on_change = false
   user_data = base64encode(templatefile("./templates/ec2_user_data_mailrelay.sh", {
     hostname  = "mailrelay"
     mp_fqdn   = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_accessgate.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_accessgate.tf
@@ -14,13 +14,15 @@ resource "aws_instance" "ec2_accessgate" {
   cpu_core_count       = local.application_data.accounts[local.environment].ec2_oracle_instance_cores_accessgate
   cpu_threads_per_core = local.application_data.accounts[local.environment].ec2_oracle_instance_threads_accessgate
 
-  # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below
+  # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below.
   # Also includes ebs_optimized and cpu_core_count due to changing instance family from c5d.2xlarge to m5d.large
   lifecycle {
     ignore_changes = [
+      cpu_core_count,
       ebs_block_device,
       ebs_optimized,
-      cpu_core_count
+      user_data,
+      user_data_replace_on_change
     ]
   }
   user_data_replace_on_change = false

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs.tf
@@ -19,7 +19,13 @@ resource "aws_instance" "ec2_oracle_ebs" {
   #  ignore_changes = [ebs_block_device]
   #}
   lifecycle {
-    ignore_changes = [ebs_block_device, user_data_replace_on_change, user_data, ebs_optimized, cpu_core_count]
+    ignore_changes = [
+      cpu_core_count,
+      ebs_block_device,
+      ebs_optimized,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
   user_data_replace_on_change = false
   user_data                   = <<EOF

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps.tf
@@ -16,7 +16,11 @@ resource "aws_instance" "ec2_ebsapps" {
 
   # Due to a bug in terraform wanting to rebuild the ec2 if more than 1 ebs block is attached, we need the lifecycle clause below
   lifecycle {
-    ignore_changes = [ebs_block_device]
+    ignore_changes = [
+      ebs_block_device,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
   user_data_replace_on_change = false
   user_data                   = <<EOF

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_dr_testing.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_dr_testing.tf
@@ -20,7 +20,13 @@ resource "aws_instance" "ec2_oracle_ebs_dr" {
   #  ignore_changes = [ebs_block_device]
   #}
   lifecycle {
-    ignore_changes = [ebs_block_device, user_data_replace_on_change, user_data, ebs_optimized, cpu_core_count]
+    ignore_changes = [
+      cpu_core_count,
+      ebs_block_device,
+      ebs_optimized,
+      user_data,
+      user_data_replace_on_change
+    ]
   }
   user_data_replace_on_change = false
   user_data                   = <<EOF

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_webgate.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_webgate.tf
@@ -20,7 +20,9 @@ resource "aws_instance" "ec2_webgate" {
     ignore_changes = [
       ebs_block_device,
       ebs_optimized,
-      cpu_core_count
+      cpu_core_count,
+      user_data,
+      user_data_replace_on_change
     ]
   }
   user_data_replace_on_change = false


### PR DESCRIPTION
Added user_data, user_data_replace_on_change to the ignore_changes block – this is required before the `CC-1993/user-data-templates` branch is merged, so no instances will be recreated.