### PR TITLE
IAPS: CPU alarm treat missing data as in alarm.

### DIFF
--- a/terraform/environments/delius-iaps/cloudwatch-alarms.tf
+++ b/terraform/environments/delius-iaps/cloudwatch-alarms.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "interface_low_level_error" {
 
 // RDS Alarms
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_over_threshold" {
-  alarm_name          = "${local.application_name}-rds-cpu-utilization-over-threshold-or-missing"
+  alarm_name          = "${local.application_name}-rds-cpu-utilization-over-threshold"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "CPUUtilization"

--- a/terraform/environments/delius-iaps/cloudwatch-alarms.tf
+++ b/terraform/environments/delius-iaps/cloudwatch-alarms.tf
@@ -131,7 +131,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_over_threshold" {
   statistic           = "Average"
   threshold           = "90"
   alarm_description   = "This metric monitors CPU utilization for the RDS instance"
-  treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.iaps_alerting.arn]
   ok_actions          = [aws_sns_topic.iaps_alerting.arn]
   dimensions = {
@@ -149,6 +148,24 @@ resource "aws_cloudwatch_metric_alarm" "rds_free_storage_space" {
   statistic           = "Minimum"
   threshold           = "104857600" # 100 GB
   alarm_description   = "This metric monitors free storage space for the RDS instance"
+  alarm_actions       = [aws_sns_topic.iaps_alerting.arn]
+  ok_actions          = [aws_sns_topic.iaps_alerting.arn]
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.iaps.identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_metrics_missing" {
+  alarm_name          = "${local.application_name}-rds-missing-metrics"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Average"
+  treat_missing_data  = "breaching"
+  threshold           = "0" # CPU will never go to 0 in normal operation, so only missing metrics will trigger this alarm
+  alarm_description   = "This metric monitors missing RDS metrics to prompt for an investigation for why metrics are missing"
   alarm_actions       = [aws_sns_topic.iaps_alerting.arn]
   ok_actions          = [aws_sns_topic.iaps_alerting.arn]
   dimensions = {

--- a/terraform/environments/delius-iaps/cloudwatch-alarms.tf
+++ b/terraform/environments/delius-iaps/cloudwatch-alarms.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "interface_low_level_error" {
 
 // RDS Alarms
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_over_threshold" {
-  alarm_name          = "${local.application_name}-rds-cpu-utilization-over-threshold"
+  alarm_name          = "${local.application_name}-rds-cpu-utilization-over-threshold-or-missing"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "CPUUtilization"
@@ -131,6 +131,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_over_threshold" {
   statistic           = "Average"
   threshold           = "90"
   alarm_description   = "This metric monitors CPU utilization for the RDS instance"
+  treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.iaps_alerting.arn]
   ok_actions          = [aws_sns_topic.iaps_alerting.arn]
   dimensions = {


### PR DESCRIPTION
When in alarm due to missing data, this could be an indication of the instance being down.