### PR TITLE
Jitbit: Store app url environment variable in SSM parameter 

### DIFF
--- a/terraform/environments/delius-jitbit/ssm.tf
+++ b/terraform/environments/delius-jitbit/ssm.tf
@@ -1,0 +1,6 @@
+// SSM parameter to store local.domain as AppUrl
+resource "aws_ssm_parameter" "app_url" {
+  name  = "/${var.networking[0].application}/environment/app-url"
+  type  = "String"
+  value = local.app_url
+}

--- a/terraform/environments/delius-jitbit/ssm.tf
+++ b/terraform/environments/delius-jitbit/ssm.tf
@@ -2,5 +2,5 @@
 resource "aws_ssm_parameter" "app_url" {
   name  = "/${var.networking[0].application}/environment/app-url"
   type  = "String"
-  value = local.app_url
+  value = "https://${local.app_url}/"
 }


### PR DESCRIPTION
to be pulled down by the jitbit app terraform and passed as an environment parameter to the ECS task