### PR TITLE
alarm metric changes

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -97,11 +97,10 @@ locals {
   }
 
   # Alarms created directly by ec2-instance module
-  # TODO - change alarm actions to dba_pagerduty once alarms proven out
+  # TODO: - change alarm actions to dba_pagerduty once alarms proven out
   database_ec2_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
     {
       # oracle-db-disconnected = {
       #   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -150,34 +149,28 @@ locals {
       #     instance = "nomis_long_running_batch"
       #   }
       # }
-      # oracleasm-service = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "3"
-      #   namespace      #      = "CWAgent"
-      #   metric_name      #    = "collectd_exec_value"
-      #   period      #       #   = "60"
-      #   statistic      #      = "Average"
-      #   threshold      #      = "1"
-      #   alarm_description   = "oracleasm service has stopped"
-      #   alarm_actions      #  = ["dba_pagerduty"]
-      #   dimensions = {
-      #     instance = "oracleasm"
-      #   }
-      # }
-      # oracle-ohasd-service = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "3"
-      #   namespace      #      = "CWAgent"
-      #   metric_name      #    = "collectd_exec_value"
-      #   period      #       #   = "60"
-      #   statistic      #      = "Average"
-      #   threshold      #      = "1"
-      #   alarm_description   = "oracle ohasd service has stopped"
-      #   alarm_actions      #  = ["dba_pagerduty"]
-      #   dimensions = {
-      #     instance = "oracle_ohasd"
-      #   }
-      # }
+      oracleasm-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_oracleasm_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "oracleasm service has stopped"
+        alarm_actions       = ["dba_pagerduty"]
+      }
+      oracle-ohasd-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_oracleohasd_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "oracle ohasd service has stopped"
+        alarm_actions       = ["dba_pagerduty"]
+      }
       cpu-utilization-high = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "120"

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -103,53 +103,56 @@ locals {
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
     {
-      # oracle-db-disconnected = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "5"
-      #   datapoints_to_alarm = "5"
-      #   metric_name      #    = "collectd_exec_value"
-      #   namespace      #      = "CWAgent"
-      #   period      #       #   = "60"
-      #   statistic      #      = "Average"
-      #   threshold      #      = "1"
-      #   alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
-      #   alarm_actions      #  = ["dba_pagerduty"]
-      #   dimensions = {
-      #     instance = "db_connected"
-      #   }
-      # }
-      # oracle-batch-failure = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "5"
-      #   datapoints_to_alarm = "5"
-      #   metric_name      #    = "collectd_exec_value"
-      #   namespace      #      = "CWAgent"
-      #   period      #       #   = "60"
-      #   statistic      #      = "Average"
-      #   threshold      #      = "1"
-      #   treat_missing_data  = "notBreaching"
-      #   alarm_description   = "Oracle db has recorded a failed batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4295000327/Batch+Failure for remediation steps."
-      #   alarm_actions      #  = ["dba_pagerduty"]
-      #   dimensions = {
-      #     instance = "nomis_batch_failure_status"
-      #   }
-      # }
-      # oracle-long-running-batch = {
-      #   comparison_operator = "GreaterThanOrEqualToThreshold"
-      #   evaluation_periods  = "5"
-      #   datapoints_to_alarm = "5"
-      #   metric_name      #    = "collectd_exec_value"
-      #   namespace      #      = "CWAgent"
-      #   period      #       #   = "60"
-      #   statistic      #      = "Average"
-      #   threshold      #      = "1"
-      #   treat_missing_data  = "notBreaching"
-      #   alarm_description   = "Oracle db has recorded a long-running batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325966186/Long+Running+Batch for remediation steps."
-      #   alarm_actions      #  = ["dba_pagerduty"]
-      #   dimensions = {
-      #     instance = "nomis_long_running_batch"
-      #   }
-      # }
+      # FIXME: metric name needs changing to collectd_dbconnected_value as part of DSOS-2092, remove dimensions
+      oracle-db-disconnected = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "collectd_exec_value"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
+        alarm_actions       = ["dba_pagerduty"]
+        dimensions = {
+          instance = "db_connected"
+        }
+      }
+      # FIXME: metric name needs changing to collectd_nomisbatchfailure_value as part of DSOS-2092, remove dimensions
+      oracle-batch-failure = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "collectd_exec_value"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        treat_missing_data  = "notBreaching"
+        alarm_description   = "Oracle db has recorded a failed batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4295000327/Batch+Failure for remediation steps."
+        alarm_actions       = ["dba_pagerduty"]
+        dimensions = {
+          instance = "nomis_batch_failure_status"
+        }
+      }
+      # FIXME: metric name needs changing to collectd_nomislongrunningbatch_value as part of DSOS-2092, remove dimensions
+      oracle-long-running-batch = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "collectd_exec_value"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        treat_missing_data  = "notBreaching"
+        alarm_description   = "Oracle db has recorded a long-running batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325966186/Long+Running+Batch for remediation steps."
+        alarm_actions       = ["dba_pagerduty"]
+        dimensions = {
+          instance = "nomis_long_running_batch"
+        }
+      }
       oracleasm-service = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
@@ -186,37 +189,39 @@ locals {
       }
   })
   database_ec2_cloudwatch_metric_alarms_high_priority = {
-    # oracle-db-disconnected = {
-    #   comparison_operator = "GreaterThanOrEqualToThreshold"
-    #   evaluation_periods  = "5"
-    #   datapoints_to_alarm = "5"
-    #   metric_name         = "collectd_exec_value"
-    #   namespace           = "CWAgent"
-    #   period              = "60"
-    #   statistic           = "Average"
-    #   threshold           = "1"
-    #   alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
-    #   alarm_actions       = ["dba_high_priority_pagerduty"]
-    #   dimensions = {
-    #     instance = "db_connected"
-    #   }
-    # }
+    # FIXME: metric name needs changing to collectd_dbconnected_value as part of DSOS-2092, remove dimensions
+    oracle-db-disconnected = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "5"
+      datapoints_to_alarm = "5"
+      metric_name         = "collectd_exec_value"
+      namespace           = "CWAgent"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
+      alarm_actions       = ["dba_high_priority_pagerduty"]
+      dimensions = {
+        instance = "db_connected"
+      }
+    }
   }
+  # FIXME: metric name needs changing to collectd_fixngoconnected_value as part of DSOS-2093, remove dimensions
   fixngo_connection_cloudwatch_metric_alarms = {
-    # fixngo-connection = {
-    #   comparison_operator = "GreaterThanOrEqualToThreshold"
-    #   evaluation_periods  = "3"
-    #   namespace           = "CWAgent"
-    #   metric_name         = "collectd_exec_value"
-    #   period              = "60"
-    #   statistic           = "Average"
-    #   threshold           = "1"
-    #   alarm_description   = "this EC2 instance no longer has a connection to the Oracle Enterprise Manager in FixNGo of the connection-target machine"
-    #   alarm_actions       = ["dso_pagerduty"]
-    #   dimensions = {
-    #     instance = "fixngo_connected" # required dimension value for this metric
-    #   }
-    # }
+    fixngo-connection = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_exec_value"
+      period              = "60"
+      statistic           = "Average"
+      threshold           = "1"
+      alarm_description   = "this EC2 instance no longer has a connection to the Oracle Enterprise Manager in FixNGo of the connection-target machine"
+      alarm_actions       = ["dso_pagerduty"]
+      dimensions = {
+        instance = "fixngo_connected" # required dimension value for this metric
+      }
+    }
   }
 
   database_cloudwatch_log_groups = {

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -101,6 +101,7 @@ locals {
   database_ec2_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
     {
       # oracle-db-disconnected = {
       #   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -109,6 +109,7 @@ locals {
   weblogic_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
     {
       weblogic-healthcheck = {
         comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -109,7 +109,19 @@ locals {
   weblogic_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    # module.baseline_presets.cloudwatch_metric_alarms.ec2_asg_cwagent_collectd,
+    {
+      weblogic-healthcheck = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_weblogichealthcheck_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "weblogic-healthcheck has found an unhealthy service"
+        alarm_actions       = ["dso_pagerduty"]
+      }
+    }
   )
 
   weblogic_cloudwatch_log_groups = {

--- a/terraform/environments/nomis/locals_xtag.tf
+++ b/terraform/environments/nomis/locals_xtag.tf
@@ -14,42 +14,41 @@ locals {
   xtag_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    # module.baseline_presets.cloudwatch_metric_alarms.ec2_asg_cwagent_collectd,
-    # {
-    #   xtag-wls-nodemanager-service = {
-    #     comparison_operator = "GreaterThanOrEqualToThreshold"
-    #     evaluation_periods  = "3"
-    #     namespace           = "CWAgent"
-    #     metric_name         = "collectd_wlsnodemanager_value"
-    #     period              = "60"
-    #     statistic           = "Average"
-    #     threshold           = "1"
-    #     alarm_description   = "wls_nodemanager.service has stopped"
-    #     alarm_actions       = ["dso_pagerduty"]
-    #   }
-    #  xtag-wls-adminserver-service = {
-    #    comparison_operator = "GreaterThanOrEqualToThreshold"
-    #    evaluation_periods  = "3"
-    #    namespace           = "CWAgent"
-    #    metric_name         = "collectd_wlsadminserver_value"
-    #    period              = "60"
-    #    statistic           = "Average"
-    #    threshold           = "1"
-    #    alarm_description   = "wls_adminserver.service has stopped"
-    #    alarm_actions       = ["dso_pagerduty"]
-    #  }
-    #  xtag-wls-managedserver-service = {
-    #    comparison_operator = "GreaterThanOrEqualToThreshold"
-    #    evaluation_periods  = "3"
-    #    namespace           = "CWAgent"
-    #    metric_name         = "collectd_wlsmanagedserver_value"
-    #    period              = "60"
-    #    statistic           = "Average"
-    #    threshold           = "1"
-    #    alarm_description   = "wls_managedserver.service has stopped"
-    #    alarm_actions       = ["dso_pagerduty"]
-    #  }
-    # }
+    {
+      xtag-wls-nodemanager-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_wlsnodemanager_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "wls_nodemanager.service has stopped"
+        alarm_actions       = ["dso_pagerduty"]
+      }
+      xtag-wls-adminserver-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_wlsadminserver_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "wls_adminserver.service has stopped"
+        alarm_actions       = ["dso_pagerduty"]
+      }
+      xtag-wls-managedserver-service = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_wlsmanagedserver_value"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "wls_managedserver.service has stopped"
+        alarm_actions       = ["dso_pagerduty"]
+      }
+    }
   )
 
   xtag_ec2_default = {

--- a/terraform/environments/nomis/locals_xtag.tf
+++ b/terraform/environments/nomis/locals_xtag.tf
@@ -14,6 +14,7 @@ locals {
   xtag_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
     {
       xtag-wls-nodemanager-service = {
         comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -147,72 +147,35 @@ locals {
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_exec_value"
+        metric_name         = "collectd_chronyd_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
         alarm_description   = "Triggers if the chronyd service has stopped"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-        dimensions = {
-          instance = "chronyd"
-        }
-      }
-      sshd-stopped = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        datapoints_to_alarm = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_exec_value"
-        period              = "60"
-        statistic           = "Maximum"
-        threshold           = "1"
-        alarm_description   = "Triggers if the sshd service has stopped"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-        dimensions = {
-          instance = "sshd"
-        }
       }
       cloudwatch-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_exec_value"
+        metric_name         = "collectd_amazoncloudwatchagent_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
         alarm_description   = "Triggers if the cloudwatch agent service has stopped"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-        dimensions = {
-          instance = "cloudwatch_agent_status"
-        }
       }
       ssm-agent-stopped = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_exec_value"
+        metric_name         = "collectd_amazonssmagent_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
         alarm_description   = "Triggers if the ssm agent service has stopped"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-        dimensions = {
-          instance = "ssm_agent_status"
-        }
-      }
-    }
-    ec2_asg_cwagent_collectd = {
-      stopped-linux-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_exec_value"
-        period              = "60"
-        statistic           = "Maximum"
-        threshold           = "1"
-        alarm_description   = "A service or metric that's being monitored by collectd has stopped"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }


### PR DESCRIPTION
- collectd metrics which were previously common, split by dimension, now have named metrics making things way easier
- weblogic-healthcheck alarm will appear per asg, not some vague collectd-exec-value alarm saying 'something broke'
- alarms will appear with their metric names in slack so they're way easier to react to
- nomis-db alarms are as previous but pending re-write of how the metrics are collected in DSOS-2092
- fixngo connection alarm also pending re-write of how this status is collected in DSOS-2093