### PR TITLE
Csr/dsos 2110/s3 bucket for t3 csr

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -45,7 +45,7 @@ locals {
     s3-bucket = {
       iam_policies = module.baseline_presets.s3_iam_policies
     }
-    db-backup = {
+    csr-db-backup-bucket = {
       custom_kms_key = module.environment.kms_keys["general"].arn
       iam_policies   = module.baseline_presets.s3_iam_policies
     }

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -90,23 +90,6 @@ locals {
           create_external_record = true
         }
 
-        ssm_parameters = {
-          ASMSYS = {
-            random = {
-              length  = 30
-              special = false
-            }
-            description = "ASMSYS password"
-          }
-          ASMSNMP = {
-            random = {
-              length  = 30
-              special = false
-            }
-            description = "ASMSNMP password"
-          }
-        }
-
         tags = {
           description = "Test CSR DB server"
           ami         = "base_ol_8_5"

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -91,7 +91,6 @@ locals {
     baseline_route53_zones = {
       "hmpps-test.modernisation-platform.service.justice.gov.uk" = {
         records = [
-          { name = "t3-csr-db-a", type = "CNAME", ttl = "300", records = ["t3-csr-db-a.corporate-staff-rostering.hmpps-test.modernisation-platform.service.justice.gov.uk"] }
         ]
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -62,23 +62,6 @@ locals {
           create_external_record = true
         }
 
-        ssm_parameters = {
-          ASMSYS = {
-            random = {
-              length  = 30
-              special = false
-            }
-            description = "ASMSYS password"
-          }
-          ASMSNMP = {
-            random = {
-              length  = 30
-              special = false
-            }
-            description = "ASMSNMP password"
-          }
-        }
-
         tags = {
           description = "Test CSR DB server"
           ami         = "base_ol_8_5"


### PR DESCRIPTION
- rename bucket as per dba's request
- remove un-used /ec2/<instance-name>/ASMSNMP and /ASMSYS/ ssm params
  - the /database/<instance-name>/values have been created manually elsewhere so conflict with what's in code
  - there's a pending piece of work to address this
- remove un-necessary reference to cname record