### PR TITLE
nomis: prod DNS records attempt 2

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -237,6 +237,7 @@ locals {
         lb_alias_records = [
           { name = "prod-nomis-web-a", type = "A", lbs_map_key = "private" },
           { name = "prod-nomis-web-b", type = "A", lbs_map_key = "private" },
+          { name = "c", type = "A", lbs_map_key = "private" },
         ]
       }
     }


### PR DESCRIPTION
Shouldn't have deleted this in last PR.  It's temporarily needed for the CNAME from Azure.