### PR TITLE
Csr/dsos 2076/ingress rules

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -237,10 +237,19 @@ locals {
           protocol    = -1
           self        = true
         }
+        # NOTE: this is a bit redundant as mod-platform does not allow http connections
         http = {
           description     = "Allow ingress from port 80"
           from_port       = 80
           to_port         = 80
+          protocol        = "TCP"
+          cidr_blocks     = ["10.0.0.0/8"]
+          security_groups = []
+        }
+        https = {
+          description     = "Allow ingress from port 443"
+          from_port       = 443
+          to_port         = 443
           protocol        = "TCP"
           cidr_blocks     = ["10.0.0.0/8"]
           security_groups = []
@@ -295,17 +304,9 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        global_catalog_3268 = {
+        global_catalog_3268_3269 = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 3268
-          to_port         = 3268
-          protocol        = "TCP"
-          cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
-          security_groups = []
-        }
-        global_catalog_3269 = {
-          description     = "Allow ingress Azure domain controllers"
-          from_port       = 3269
           to_port         = 3269
           protocol        = "TCP"
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -138,7 +138,7 @@ locals {
           "/dev/sda1" = { type = "gp3", size = 256 }
         }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 1 # set to 0 while testing
+          desired_capacity = 0 # set to 0 while testing
         })
         tags = {
           description = "Test Restore Windows Server 2012 R2 includes Ec2LaunchV2 NVMe PV drivers without run-once file"

--- a/terraform/environments/corporate-staff-rostering/templates/app-server-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/app-server-user-data.yaml
@@ -11,8 +11,8 @@ tasks:
         # Set time to local and locale
         content: |
           # $ErrorActionPreference = "Stop" # un-comment to set all errors to terminate script 
-
-          Set-TimeZone "GMT Standard Time"
+          
+          # Set-TimeZone "GMT Standard Time" # does not work for Server 2012 R2 version of PowerShell
           Set-WinSystemLocale "en-GB"
       - frequency: once
         type: powershell


### PR DESCRIPTION
- all AD related rules are in the `migration-app-sg` security group
- took a step out of the user-data script as this fails on Windows Server 2012 R2