### PR TITLE
Add 'oracle-sids' tag to hmpps-oem-test auto-scaling group

### DIFF
--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -23,6 +23,9 @@ locals {
             branch = "main"
           })
         })
+        tags = merge(local.oem_ec2_default.tags, {
+            oracle-sids = "EMREP TRCVCAT"
+        })
       })
     }
 


### PR DESCRIPTION
This tag is required for an Ansible condition.