### PR TITLE
move test server to ec2 instance to debug ssm launch issues

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -30,32 +30,7 @@ locals {
           server-type = "base-ol-8-5"
         }
       }
-      dev-tst-1 = {
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "base_windows_server_2012_r2_release_2023-*"
-          ami_owner                     = "374269020027"
-          ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
-          instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
-        })
-
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["migration-app-sg"]
-          instance_type          = "t3.xlarge"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 256 }
-        }
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 0 # set to 0 while testing
-        })
-        tags = {
-          description = "Test AWS AMI Windows Server 2012 R2"
-          os-type     = "Windows"
-          component   = "appserver"
-          server-type = "test-server"
-        }
-      }
+      
     }
 
     baseline_ec2_instances = {
@@ -122,6 +97,29 @@ locals {
           os-type     = "Linux"
           component   = "test"
           server-type = "csr-db"
+        }
+      }
+      dev-tst-1 = {
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "base_windows_server_2012_r2_release_2023-*"
+          ami_owner                     = "374269020027"
+          ebs_volumes_copy_all_from_ami = false
+          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
+          instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
+        })
+
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["migration-app-sg"]
+          instance_type          = "t3.xlarge"
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 256 }
+        }
+        tags = {
+          description = "Test AWS AMI Windows Server 2012 R2"
+          os-type     = "Windows"
+          component   = "appserver"
+          server-type = "test-server"
         }
       }
     }


### PR DESCRIPTION
server 2012 r2 ami seems to have issues with ssm launching properly
if it's an asg you can't actually reboot it without it failing
turn it into an ec2 instance so that it's easier to reboot