### PR TITLE
Csr/install ssm

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -39,6 +39,7 @@ locals {
         effect = "Allow"
         actions = [
           "ec2-instance-connect:SendSerialConsoleSSHPublicKey",
+          "ssm:SendCommand",
         ]
         resources = ["*"]
       }]

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -36,7 +36,7 @@ locals {
           ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
           ami_owner                     = "374269020027"
           ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
           instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
         })
 

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -36,7 +36,7 @@ locals {
           ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
           ami_owner                     = "374269020027"
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
+          # user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
           instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
         })
 

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -33,7 +33,7 @@ locals {
 
       dev-tst = {
         config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
+          ami_name                      = "base_windows_server_2012_r2_release_2023-*"
           ami_owner                     = "374269020027"
           ebs_volumes_copy_all_from_ami = false
           user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -31,6 +31,29 @@ locals {
         }
       }
 
+      dev-tst-4 = {
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
+          ami_owner                     = "374269020027"
+          ebs_volumes_copy_all_from_ami = false
+          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
+          instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
+        })
+
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["migration-app-sg"]
+          instance_type          = "t3.medium"
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 192 } # minimum size has to be 128 due to snapshot sizes
+        }
+        tags = {
+          description = "Test AWS AMI Windows Server 2012 R2"
+          os-type     = "Windows"
+          component   = "appserver"
+          server-type = "test-server"
+        }
+      }
     }
 
     baseline_ec2_instances = {
@@ -99,29 +122,7 @@ locals {
           server-type = "csr-db"
         }
       }
-      dev-tst-3 = {
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
-          ami_owner                     = "374269020027"
-          ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/test-user-data.yaml"))
-          instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
-        })
 
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["migration-app-sg"]
-          instance_type          = "t3.medium"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 192 } # minimum size has to be 128 due to snapshot sizes
-        }
-        tags = {
-          description = "Test AWS AMI Windows Server 2012 R2"
-          os-type     = "Windows"
-          component   = "appserver"
-          server-type = "test-server"
-        }
-      }
     }
     baseline_route53_zones = {
       "hmpps-dev.modernisation-platform.service.justice.gov.uk" = {

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -31,7 +31,7 @@ locals {
         }
       }
 
-      dev-tst-4 = {
+      dev-tst = {
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name                      = "base_windows_server_2012_r2_release_2023-09-05*"
           ami_owner                     = "374269020027"
@@ -43,6 +43,9 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["migration-app-sg"]
           instance_type          = "t3.medium"
+        })
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+          desired_capacity = 0 # set to 0 while testing
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 192 } # minimum size has to be 128 due to snapshot sizes

--- a/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
@@ -2,22 +2,17 @@
 schemaVersion: "2.2"
 description: "SSM Document for creating local configs on Windows Server"
 parameters:
-  configFolder:
-    type: "String"
-    description: "The folder to create"
-    default: "C:\\temp\\Test"
   configFile:
     type: "String"
     description: "The file to create"
-    default: "C:\\temp\\Test\\test-success-ssm.txt"
+    default: "C:\\Temp\\test-success-ssm.txt"
 mainSteps:
   - name: CreateTestDocument
     action: aws:runPowerShellScript
     inputs:
       runCommand: |
-        "$secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' ).Parameters[0].Value"
-        "$secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' ).Parameters[0].Value"
-        New-Item -ItemType Directory -Force -Path $configFolder
+        $secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
+        $secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
         New-Item -ItemType File -Force -Path $configFile
         Add-Content -Path $configFile -Value $secretValue1
         Add-Content -Path $configFile -Value $secretValue2

--- a/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
@@ -15,5 +15,5 @@ mainSteps:
           $secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
           $secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
           New-Item -ItemType File -Path {{configFile}} -Force
-          Add-Content -Path $configFile -Value $secretValue1
-          Add-Content -Path $configFile -Value $secretValue2
+          Add-Content -Path {{configFile}} -Value $secretValue1
+          Add-Content -Path {{configFile}} -Value $secretValue2

--- a/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
@@ -10,9 +10,10 @@ mainSteps:
   - name: CreateTestDocument
     action: aws:runPowerShellScript
     inputs:
-      runCommand: |
-        $secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
-        $secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
-        New-Item -ItemType File -Force -Path $configFile
-        Add-Content -Path $configFile -Value $secretValue1
-        Add-Content -Path $configFile -Value $secretValue2
+      runCommand:
+        - |
+          $secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
+          $secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
+          New-Item -ItemType File -Force -Path $configFile
+          Add-Content -Path $configFile -Value $secretValue1
+          Add-Content -Path $configFile -Value $secretValue2

--- a/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/csr-server-config.yaml
@@ -14,6 +14,6 @@ mainSteps:
         - |
           $secretValue1 = (Get-SSMParameterValue -Name 'test-param-1' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
           $secretValue2 = (Get-SSMParameterValue -Name 'test-param-2' -WithDecryption $true -Region eu-west-2).Parameters[0].Value
-          New-Item -ItemType File -Force -Path $configFile
+          New-Item -ItemType File -Path {{configFile}} -Force
           Add-Content -Path $configFile -Value $secretValue1
           Add-Content -Path $configFile -Value $secretValue2

--- a/terraform/environments/corporate-staff-rostering/templates/app-server-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/app-server-user-data.yaml
@@ -1,7 +1,7 @@
 # This is an EC2Launch V2 type user-data script
 # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
 # See C:\ProgramData\Amazon\EC2Launch\log for logs
-version: 1.1
+version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
   - task: executeScript
     inputs:
@@ -19,8 +19,8 @@ tasks:
         runAs: admin # or localSystem
         # create a folder and file to test that the script ran
         content: |-
-          New-Item -ItemType Directory -Force -Path C:\temp\Test
-          New-Item -ItemType File -Force -Path C:\temp\Test\test-success.txt
+          New-Item -ItemType Directory -Force -Path C:\Temp\test
+          New-Item -ItemType File -Force -Path C:\Temp\test\app-server-test-success.txt
       - frequency: once
         type: powershell
         runAs: admin # or localSystem
@@ -28,10 +28,9 @@ tasks:
         content: |-
           # Install AWS PowerShell module if not already installed
           if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
-          Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+            Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
           }
 
-          # Function to check if SSM Agent is running
           Function Check-SSMAgent {
             $service = Get-Service -Name "AmazonSSMAgent"
             if ($service.Status -eq "Running") {
@@ -41,23 +40,24 @@ tasks:
             }
           }
 
-          # Function to execute the SSM command
           Function Execute-SSMCommand {
-            $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
+            $instanceId = Get-EC2InstanceMetadata -Category InstanceId
             $documentName = "csr-server-config"
 
-            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName
+            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
           }
 
+          $startTime = Get-Date
+
           # Main loop to wait for SSM Agent to be running
-          while ($true) {
+          do {
             if (Check-SSMAgent) {
-              Write-Host "SSM Agent is running, executing SSM command."
+              Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
               Execute-SSMCommand
               break
             } else {
-              Write-Host "SSM Agent is not running yet. Waiting..."
+              Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
               Start-Sleep -Seconds 10
             }
-          }
+          } while ((Get-Date) -lt $startTime.AddMinutes(10))

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -11,16 +11,19 @@ tasks:
         content: |-
           $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
 
+          $logFilePath = "C:\Temp\ssm_status.txt"
+          New-Item -Type File -Force -Path $logFilePath -Value $aws_ssm_status
+
           if ($aws_ssm_status -eq "Running") {
-            Write-Host "SSM Agent is running, no action required."
+            Add-Content -Path $logFilePath -Value "SSM Agent is running, no action required."
           } elseif ($aws_ssm_status -eq "Stopped") {
-            Write-Host "SSM Agent is not running, starting service."
+            Add-Content -Path $logFilePath -Value "SSM Agent is not running, starting service."
             Start-Service -Name "AmazonSSMAgent"
           } elseif ($aws_ssm_status -eq "Paused") {
-            Write-Host "SSM Agent is paused, resuming service."
+            Add-Content -Path $logFilePath -Value "SSM Agent is paused, resuming service."
             Resume-Service -Name "AmazonSSMAgent"
           } elseif ($aws_ssm_status -eq $null) {
-            Write-Host "SSM Agent is not installed... Installing"
+            Add-Content -Path $logFilePath -Value "SSM Agent is not installed... Installing"
             [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
             $progressPreference = 'silentlyContinue'
             Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
@@ -31,7 +34,7 @@ tasks:
 
             Start-Service -Name "AmazonSSMAgent"
           } else {
-            Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
+            Add-Content -Path $logFilePath -Value "SSM Agent is in an unknown state: $aws_ssm_status"
           }
       - frequency: once
         type: powershell
@@ -51,8 +54,6 @@ tasks:
           }
 
           Execute-SSMCommand
-
-
       # - frequency: always
       #   type: powershell
       #   runAs: admin # or localSystem

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -12,7 +12,8 @@ tasks:
           $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
 
           $logFilePath = "C:\Temp\ssm_status.txt"
-          New-Item -Type File -Force -Path $logFilePath -Value $aws_ssm_status
+          New-Item -Type File -Force -Path $logFilePath
+          Add-Content -Path $logFilePath -Value "SSM Agent status start: $aws_ssm_status"
 
           if ($aws_ssm_status -eq "Running") {
             Add-Content -Path $logFilePath -Value "SSM Agent is running, no action required."
@@ -40,16 +41,16 @@ tasks:
         type: powershell
         runAs: admin
         content: |-
-          Install AWS PowerShell module if not already installed
+          # Install AWS PowerShell module if not already installed
           if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
           }
 
           Function Execute-SSMCommand {
-            $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
+            $instanceId = Get-EC2InstanceMetadata -Category InstanceId
             $documentName = "csr-server-config"
 
-            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
+            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
           }
 

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -1,7 +1,7 @@
 # This is an EC2Launch V2 type user-data script
 # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
 # See C:\ProgramData\Amazon\EC2Launch\log for logs
-version: 1.1
+version: 1.0
 tasks:
   - task: executeScript
     inputs:

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -5,6 +5,19 @@ version: 1.1
 tasks:
   - task: executeScript
     inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
+          $progressPreference = 'silentlyContinue'
+          Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+
+          Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
+
+          rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+
+          Start-Service -Name "AmazonSSMAgent"
       - frequency: always
         type: powershell
         runAs: admin # or localSystem

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -33,6 +33,26 @@ tasks:
           } else {
             Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
           }
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          Install AWS PowerShell module if not already installed
+          if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
+            Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+          }
+
+          Function Execute-SSMCommand {
+            $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
+            $documentName = "csr-server-config"
+
+            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
+            Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
+          }
+
+          Execute-SSMCommand
+
+
       # - frequency: always
       #   type: powershell
       #   runAs: admin # or localSystem

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -9,15 +9,30 @@ tasks:
         type: powershell
         runAs: admin
         content: |-
-          [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
-          $progressPreference = 'silentlyContinue'
-          Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+          $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
 
-          Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
+          if ($aws_ssm_status -eq "Running") {
+            Write-Host "SSM Agent is running, no action required."
+          } elseif ($aws_ssm_status -eq "Stopped") {
+            Write-Host "SSM Agent is not running, starting service."
+            Start-Service -Name "AmazonSSMAgent"
+          } elseif ($aws_ssm_status -eq "Paused") {
+            Write-Host "SSM Agent is paused, resuming service."
+            Resume-Service -Name "AmazonSSMAgent"
+          } elseif ($aws_ssm_status -eq $null) {
+            Write-Host "SSM Agent is not installed... Installing"
+            [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
+            $progressPreference = 'silentlyContinue'
+            Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
 
-          rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+            Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
 
-          Start-Service -Name "AmazonSSMAgent"
+            # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
+
+            Start-Service -Name "AmazonSSMAgent"
+          } else {
+            Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
+          }
       - frequency: always
         type: powershell
         runAs: admin # or localSystem
@@ -65,7 +80,7 @@ tasks:
             $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
             $documentName = "csr-server-config"
 
-            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName
+            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
           }
 

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -5,93 +5,93 @@ version: 1.1
 tasks:
   - task: executeScript
     inputs:
+      - frequency: always
+        type: powershell
+        runAs: admin
+        content: |-
+          $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
+
+          if ($aws_ssm_status -eq "Running") {
+            Write-Host "SSM Agent is running, no action required."
+          } elseif ($aws_ssm_status -eq "Stopped") {
+            Write-Host "SSM Agent is not running, starting service."
+            Start-Service -Name "AmazonSSMAgent"
+          } elseif ($aws_ssm_status -eq "Paused") {
+            Write-Host "SSM Agent is paused, resuming service."
+            Resume-Service -Name "AmazonSSMAgent"
+          } elseif ($aws_ssm_status -eq $null) {
+            Write-Host "SSM Agent is not installed... Installing"
+            [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
+            $progressPreference = 'silentlyContinue'
+            Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+
+            Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
+
+            # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
+
+            Start-Service -Name "AmazonSSMAgent"
+          } else {
+            Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
+          }
       # - frequency: always
       #   type: powershell
-      #   runAs: admin
+      #   runAs: admin # or localSystem
+      #   # Set time to local and locale
       #   content: |-
-      #     $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
-
-      #     if ($aws_ssm_status -eq "Running") {
-      #       Write-Host "SSM Agent is running, no action required."
-      #     } elseif ($aws_ssm_status -eq "Stopped") {
-      #       Write-Host "SSM Agent is not running, starting service."
-      #       Start-Service -Name "AmazonSSMAgent"
-      #     } elseif ($aws_ssm_status -eq "Paused") {
-      #       Write-Host "SSM Agent is paused, resuming service."
-      #       Resume-Service -Name "AmazonSSMAgent"
-      #     } elseif ($aws_ssm_status -eq $null) {
-      #       Write-Host "SSM Agent is not installed... Installing"
-      #       [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
-      #       $progressPreference = 'silentlyContinue'
-      #       Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
-
-      #       Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
-
-      #       # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
-
-      #       Start-Service -Name "AmazonSSMAgent"
-      #     } else {
-      #       Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
-      #     }
-      - frequency: always
-        type: powershell
-        runAs: admin # or localSystem
-        # Set time to local and locale
-        content: |-
-          # $ErrorActionPreference = "Stop" # un-comment to set all errors to terminate script 
+      #     # $ErrorActionPreference = "Stop" # un-comment to set all errors to terminate script 
           
-          # Set-TimeZone "GMT Standard Time" # does not work for Server 2012 R2 version of PowerShell
-          Set-WinSystemLocale "en-GB"
-      - frequency: always
-        type: powershell
-        runAs: admin # or localSystem
-        # install AD commands
-        content: |-
-          Install-WindowsFeature -Name RSAT-AD-PowerShell
-      - frequency: always
-        type: powershell
-        runAs: admin # or localSystem
-        # create a folder and file to test that the script ran
-        content: |-
-          New-Item -ItemType Directory -Force -Path C:\temp\Test
-          New-Item -ItemType File -Force -Path C:\temp\Test\test-success.txt
-      - frequency: always
-        type: powershell
-        runAs: admin # or localSystem
-        # run a test SSM document
-        content: |-
-          # Install AWS PowerShell module if not already installed
-          if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
-          Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
-          }
+      #     # Set-TimeZone "GMT Standard Time" # does not work for Server 2012 R2 version of PowerShell
+      #     Set-WinSystemLocale "en-GB"
+      # - frequency: always
+      #   type: powershell
+      #   runAs: admin # or localSystem
+      #   # install AD commands
+      #   content: |-
+      #     Install-WindowsFeature -Name RSAT-AD-PowerShell
+      # - frequency: always
+      #   type: powershell
+      #   runAs: admin # or localSystem
+      #   # create a folder and file to test that the script ran
+      #   content: |-
+      #     New-Item -ItemType Directory -Force -Path C:\temp\Test
+      #     New-Item -ItemType File -Force -Path C:\temp\Test\test-success.txt
+      # - frequency: always
+      #   type: powershell
+      #   runAs: admin # or localSystem
+      #   # run a test SSM document
+      #   content: |-
+      #     # Install AWS PowerShell module if not already installed
+      #     if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
+      #     Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+      #     }
 
-          # Function to check if SSM Agent is running
-          Function Check-SSMAgent {
-            $service = Get-Service -Name "AmazonSSMAgent"
-            if ($service.Status -eq "Running") {
-                return $true
-            } else {
-                Start-Service -Name "AmazonSSMAgent" -Force
-            }
-          }
+      #     # Function to check if SSM Agent is running
+      #     Function Check-SSMAgent {
+      #       $service = Get-Service -Name "AmazonSSMAgent"
+      #       if ($service.Status -eq "Running") {
+      #           return $true
+      #       } else {
+      #           Start-Service -Name "AmazonSSMAgent" -Force
+      #       }
+      #     }
 
-          # Function to execute the SSM command
-          Function Execute-SSMCommand {
-            $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
-            $documentName = "csr-server-config"
+      #     # Function to execute the SSM command
+      #     Function Execute-SSMCommand {
+      #       $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
+      #       $documentName = "csr-server-config"
 
-            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
-            Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
-          }
+      #       $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
+      #       Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
+      #     }
 
-          # Main loop to wait for SSM Agent to be running
-          while ($true) {
-            if (Check-SSMAgent) {
-              Write-Host "SSM Agent is running, executing SSM command."
-              Execute-SSMCommand
-              break
-            } else {
-              Write-Host "SSM Agent is not running yet. Waiting..."
-              Start-Sleep -Seconds 10
-            }
-          }
+      #     # Main loop to wait for SSM Agent to be running
+      #     while ($true) {
+      #       if (Check-SSMAgent) {
+      #         Write-Host "SSM Agent is running, executing SSM command."
+      #         Execute-SSMCommand
+      #         break
+      #       } else {
+      #         Write-Host "SSM Agent is not running yet. Waiting..."
+      #         Start-Sleep -Seconds 10
+      #       }
+      #     }

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -5,7 +5,7 @@ version: 1.1
 tasks:
   - task: executeScript
     inputs:
-      - frequency: once
+      - frequency: always
         type: powershell
         runAs: admin
         content: |-

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -1,7 +1,7 @@
 # This is an EC2Launch V2 type user-data script
 # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
 # See C:\ProgramData\Amazon\EC2Launch\log for logs
-version: 1.0
+version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
   - task: executeScript
     inputs:
@@ -31,7 +31,7 @@ tasks:
 
             Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
 
-            # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
+            Remove-Item $env:USERPROFILE\Desktop\SSMAgent_latest.exe -Force
 
             Start-Service -Name "AmazonSSMAgent"
           } else {
@@ -90,51 +90,4 @@ tasks:
       #   runAs: admin # or localSystem
       #   # install AD commands
       #   content: |-
-      #     Install-WindowsFeature -Name RSAT-AD-PowerShell
-      # - frequency: always
-      #   type: powershell
-      #   runAs: admin # or localSystem
-      #   # create a folder and file to test that the script ran
-      #   content: |-
-      #     New-Item -ItemType Directory -Force -Path C:\temp\Test
-      #     New-Item -ItemType File -Force -Path C:\temp\Test\test-success.txt
-      # - frequency: always
-      #   type: powershell
-      #   runAs: admin # or localSystem
-      #   # run a test SSM document
-      #   content: |-
-      #     # Install AWS PowerShell module if not already installed
-      #     if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
-      #     Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
-      #     }
-
-      #     # Function to check if SSM Agent is running
-      #     Function Check-SSMAgent {
-      #       $service = Get-Service -Name "AmazonSSMAgent"
-      #       if ($service.Status -eq "Running") {
-      #           return $true
-      #       } else {
-      #           Start-Service -Name "AmazonSSMAgent" -Force
-      #       }
-      #     }
-
-      #     # Function to execute the SSM command
-      #     Function Execute-SSMCommand {
-      #       $instanceId = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-id"
-      #       $documentName = "csr-server-config"
-
-      #       $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force -TimeoutSecond 300
-      #       Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
-      #     }
-
-      #     # Main loop to wait for SSM Agent to be running
-      #     while ($true) {
-      #       if (Check-SSMAgent) {
-      #         Write-Host "SSM Agent is running, executing SSM command."
-      #         Execute-SSMCommand
-      #         break
-      #       } else {
-      #         Write-Host "SSM Agent is not running yet. Waiting..."
-      #         Start-Sleep -Seconds 10
-      #       }
-      #     }
+      #     Install-WindowsFeature -Name RSAT-AD-PowerShell -IncludeAllSubFeature -IncludeManagementTools

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -63,8 +63,10 @@ tasks:
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
           }
 
+          $startTime = Get-Date
+
           # Main loop to wait for SSM Agent to be running
-          while ($true) {
+          do {
             if (Check-SSMAgent) {
               Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
               Execute-SSMCommand
@@ -73,9 +75,7 @@ tasks:
               Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
               Start-Sleep -Seconds 10
             }
-          }
-
-          Execute-SSMCommand
+          } while ((Get-Date) -lt $startTime.AddMinutes(10))
       # - frequency: always
       #   type: powershell
       #   runAs: admin # or localSystem

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -5,34 +5,34 @@ version: 1.1
 tasks:
   - task: executeScript
     inputs:
-      - frequency: always
-        type: powershell
-        runAs: admin
-        content: |-
-          $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
+      # - frequency: always
+      #   type: powershell
+      #   runAs: admin
+      #   content: |-
+      #     $aws_ssm_status = (Get-Service -Name "AmazonSSMAgent").Status
 
-          if ($aws_ssm_status -eq "Running") {
-            Write-Host "SSM Agent is running, no action required."
-          } elseif ($aws_ssm_status -eq "Stopped") {
-            Write-Host "SSM Agent is not running, starting service."
-            Start-Service -Name "AmazonSSMAgent"
-          } elseif ($aws_ssm_status -eq "Paused") {
-            Write-Host "SSM Agent is paused, resuming service."
-            Resume-Service -Name "AmazonSSMAgent"
-          } elseif ($aws_ssm_status -eq $null) {
-            Write-Host "SSM Agent is not installed... Installing"
-            [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
-            $progressPreference = 'silentlyContinue'
-            Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
+      #     if ($aws_ssm_status -eq "Running") {
+      #       Write-Host "SSM Agent is running, no action required."
+      #     } elseif ($aws_ssm_status -eq "Stopped") {
+      #       Write-Host "SSM Agent is not running, starting service."
+      #       Start-Service -Name "AmazonSSMAgent"
+      #     } elseif ($aws_ssm_status -eq "Paused") {
+      #       Write-Host "SSM Agent is paused, resuming service."
+      #       Resume-Service -Name "AmazonSSMAgent"
+      #     } elseif ($aws_ssm_status -eq $null) {
+      #       Write-Host "SSM Agent is not installed... Installing"
+      #       [System.Net.ServicePointManager]::SecurityProtocol = 'TLS12'
+      #       $progressPreference = 'silentlyContinue'
+      #       Invoke-WebRequest https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -OutFile $env:USERPROFILE\Desktop\SSMAgent_latest.exe
 
-            Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
+      #       Start-Process -FilePath $env:USERPROFILE\Desktop\SSMAgent_latest.exe -ArgumentList "/S"
 
-            # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
+      #       # rm -Force $env:USERPROFILE\Desktop\SSMAgent_latest.exe FIXME: why does this cause an error?
 
-            Start-Service -Name "AmazonSSMAgent"
-          } else {
-            Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
-          }
+      #       Start-Service -Name "AmazonSSMAgent"
+      #     } else {
+      #       Write-Host "SSM Agent is in an unknown state: $aws_ssm_status"
+      #     }
       - frequency: always
         type: powershell
         runAs: admin # or localSystem

--- a/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/test-user-data.yaml
@@ -16,12 +16,12 @@ tasks:
           Add-Content -Path $logFilePath -Value "SSM Agent status start: $aws_ssm_status"
 
           if ($aws_ssm_status -eq "Running") {
-            Add-Content -Path $logFilePath -Value "SSM Agent is running, no action required."
+            Add-Content -Path $logFilePath -Value "SSM Agent is running, no action required. $(Get-Date)"
           } elseif ($aws_ssm_status -eq "Stopped") {
-            Add-Content -Path $logFilePath -Value "SSM Agent is not running, starting service."
+            Add-Content -Path $logFilePath -Value "SSM Agent is not running, starting service. $(Get-Date)"
             Start-Service -Name "AmazonSSMAgent"
           } elseif ($aws_ssm_status -eq "Paused") {
-            Add-Content -Path $logFilePath -Value "SSM Agent is paused, resuming service."
+            Add-Content -Path $logFilePath -Value "SSM Agent is paused, resuming service. $(Get-Date)"
             Resume-Service -Name "AmazonSSMAgent"
           } elseif ($aws_ssm_status -eq $null) {
             Add-Content -Path $logFilePath -Value "SSM Agent is not installed... Installing"
@@ -35,7 +35,7 @@ tasks:
 
             Start-Service -Name "AmazonSSMAgent"
           } else {
-            Add-Content -Path $logFilePath -Value "SSM Agent is in an unknown state: $aws_ssm_status"
+            Add-Content -Path $logFilePath -Value "SSM Agent is in an unknown state: $aws_ssm_status $(Get-Date)"
           }
       - frequency: once
         type: powershell
@@ -46,12 +46,33 @@ tasks:
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
           }
 
+          Function Check-SSMAgent {
+            $service = Get-Service -Name "AmazonSSMAgent"
+            if ($service.Status -eq "Running") {
+                return $true
+            } else {
+                Start-Service -Name "AmazonSSMAgent" -Force
+            }
+          }
+
           Function Execute-SSMCommand {
             $instanceId = Get-EC2InstanceMetadata -Category InstanceId
             $documentName = "csr-server-config"
 
             $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Force
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
+          }
+
+          # Main loop to wait for SSM Agent to be running
+          while ($true) {
+            if (Check-SSMAgent) {
+              Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
+              Execute-SSMCommand
+              break
+            } else {
+              Add-Content -Path "C:\Temp\ssm_status.txt" -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
+              Start-Sleep -Seconds 10
+            }
           }
 
           Execute-SSMCommand

--- a/terraform/environments/corporate-staff-rostering/templates/web-server-user-data.yaml
+++ b/terraform/environments/corporate-staff-rostering/templates/web-server-user-data.yaml
@@ -2,7 +2,7 @@
 # This is an EC2Launch V2 type user-data script
 # https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
 # See C:\ProgramData\Amazon\EC2Launch\log for logs
-version: 1.1
+version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
   - task: executeScript
     inputs:


### PR DESCRIPTION
POC for using ssm agent / ssm documents to automatically configure windows instances

- user-data schema 1.0 allows calling SSM documents as part of bringing up a Server 2012 R2 instance
- test-user-data script calls csr-server-config ssm document and populates a file in the server
- advantage of using ssm documents is that they are fully traceable/versioned as well as showing execution output
- added ssm:SendCommand permissions to instances to allow these to call ssm documents in their user-data scripts