### PR TITLE
add dev jumpservers to rdp port allow range, fix ldap and netbios rules

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -12,7 +12,7 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
     ])
     rdp = {
-      inbound = ["10.40.165.0/26", "10.112.3.0/26", "10.102.3.0/26", "10.102.1.64/26"]
+      inbound = ["10.40.165.0/26", "10.112.3.0/26", "10.102.3.0/26", "10.102.1.64/26", "10.102.0.128/26"]
     }
     oracle_db = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -141,7 +141,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        /* netbios = {
+        netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
           to_port         = 139
@@ -156,7 +156,7 @@ locals {
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        } */
+        }
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443
@@ -320,7 +320,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        /* netbios = {
+        netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
           to_port         = 139
@@ -335,7 +335,7 @@ locals {
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        } */
+        }
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -149,8 +149,8 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap_new = {
-          description     = "Allow ingress Azure domain controllers"
+        ldap = {
+          description     = "Allow ingress Azure domain controllers for LDAP"
           from_port       = 389
           to_port         = 389
           protocol        = -1
@@ -328,8 +328,8 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap_new = {
-          description     = "Allow ingress Azure domain controllers"
+        ldap = {
+          description     = "Allow ingress Azure domain controllers for LDAP"
           from_port       = 389
           to_port         = 389
           protocol        = -1

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -149,7 +149,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap = {
+        ldap_new = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 389
           to_port         = 389

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -12,7 +12,7 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
     ])
     rdp = {
-      inbound = ["10.40.165.0/26", "10.112.3.0/26", "10.102.3.0/26"]
+      inbound = ["10.40.165.0/26", "10.112.3.0/26", "10.102.3.0/26", "10.102.1.64/26"]
     }
     oracle_db = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,
@@ -141,30 +141,22 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        /* netbios = {   FIXME: add this back in
+        netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
           to_port         = 139
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        } */
-        /* ldap = { FIXME: add this back in
+        }
+        ldap = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 389
           to_port         = 389
-          protocol        = "TCP"
+          protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap_udp = {
-          description     = "Allow ingress Azure domain controllers"
-          from_port       = 389
-          to_port         = 389
-          protocol        = "UDP"
-          cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
-          security_groups = []
-        } */
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443
@@ -328,7 +320,6 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        /* } FIXME: add this back in 
         netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
@@ -336,23 +327,15 @@ locals {
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        } */
-        /* ldap = {  FIXME: add this back in 
+        }
+        ldap = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 389
           to_port         = 389
-          protocol        = "TCP"
+          protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap_udp = {
-          description     = "Allow ingress Azure domain controllers"
-          from_port       = 389
-          to_port         = 389
-          protocol        = "UDP"
-          cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
-          security_groups = []
-        } */
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -150,7 +150,7 @@ locals {
           security_groups = []
         }
         ldap = {
-          description     = "Allow ingress Azure domain controllers for LDAP"
+          description     = "Allow LDAP ingress from Azure domain controllers"
           from_port       = 389
           to_port         = 389
           protocol        = -1
@@ -329,7 +329,7 @@ locals {
           security_groups = []
         }
         ldap = {
-          description     = "Allow ingress Azure domain controllers for LDAP"
+          description     = "Allow LDAP ingress from Azure domain controllers"
           from_port       = 389
           to_port         = 389
           protocol        = -1

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -141,7 +141,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        netbios = {
+        /* netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
           to_port         = 139
@@ -156,7 +156,7 @@ locals {
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        }
+        } */
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443
@@ -320,7 +320,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        netbios = {
+        /* netbios = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 137
           to_port         = 139
@@ -335,7 +335,7 @@ locals {
           protocol        = -1
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
-        }
+        } */
         https = {
           description     = "Allow ingress from port 443"
           from_port       = 443

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -328,7 +328,7 @@ locals {
           cidr_blocks     = [for ip in module.ip_addresses.azure_fixngo_ips.devtest.domain_controllers : "${ip}/32"]
           security_groups = []
         }
-        ldap = {
+        ldap_new = {
           description     = "Allow ingress Azure domain controllers"
           from_port       = 389
           to_port         = 389


### PR DESCRIPTION
applied to test and development already
- extended rdp rules to include fixngo jumpserver and rd gateway
- need to comment out ldap and netbios rules for now and apply to prod/pre-prod