### PR TITLE
Deploy infra with policies not dependent on other resources

### DIFF
--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -94,7 +94,8 @@ module "data_product_presigned_url_lambda" {
   tags                           = local.tags
   description                    = "Lambda to generate a presigned url for uploading data"
   role_name                      = "presigned_url_lambda_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_presigned_url_lambda.json
+  # policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_presigned_url_lambda.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_get_glue_metadata_lambda.json
   function_name                  = "data_product_presigned_url_${local.environment}"
   create_role                    = true
   reserved_concurrent_executions = 1
@@ -126,7 +127,8 @@ module "data_product_athena_load_lambda" {
   tags                           = local.tags
   description                    = "Lambda to load and transform raw data products landing in s3. Creates partitioned parquet tables"
   role_name                      = "athena_load_lambda_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.athena_load_lambda_function_policy.json
+  # policy_json                    = data.aws_iam_policy_document.athena_load_lambda_function_policy.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_get_glue_metadata_lambda.json
   function_name                  = "data_product_athena_load_${local.environment}"
   create_role                    = true
   reserved_concurrent_executions = 1


### PR DESCRIPTION
PR coming after this to reinstate the correct lambda policies, once the resources they depend on to form are created. The problem as far as I can tell was that the policies weren't passing their dependencies (eg the athena workgroup arn) to the lambda module (as the lambda module takes in raw json rather than terraform resource names in HCL where dependencies can be mapped), so the lambda module was trying to resolve a policy with an uncreated arn and failing