### PR TITLE
DSOS-2124: allow placeholder ssm params

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -184,6 +184,29 @@ locals {
       })
     }
 
+    baseline_ec2_instances = {
+      dev-tmp-rhel79 = {
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name          = "base_rhel_7_9_*"
+          availability_zone = null
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["private-web"]
+        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+        ssm_parameters = {
+          test = {}
+        }
+        tags = {
+          description = "For testing our base RHEL7.9 base image"
+          ami         = "base_rhel_7_9"
+          os-type     = "Linux"
+          component   = "test"
+          server-type = "base-rhel79"
+        }
+      }
+    }
+
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -95,7 +95,9 @@ locals {
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         ssm_parameters = {
-          test = {}
+          test = {
+            kms_key_id = "general"
+          }
         }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 1

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -94,6 +94,9 @@ locals {
           vpc_security_group_ids = ["private-web"]
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+        ssm_parameters = {
+          test = {}
+        }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -188,7 +188,6 @@ locals {
       dev-tmp-rhel79 = {
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name          = "base_rhel_7_9_*"
-          availability_zone = null
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-web"]

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -98,7 +98,7 @@ locals {
           test = {}
         }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 0
+          desired_capacity = 1
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
@@ -194,7 +194,9 @@ locals {
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         ssm_parameters = {
-          test = {}
+          test = {
+            kms_key_id = "general"
+          }
         }
         tags = {
           description = "For testing our base RHEL7.9 base image"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -94,11 +94,6 @@ locals {
           vpc_security_group_ids = ["private-web"]
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        ssm_parameters = {
-          test = {
-            kms_key_id = "general"
-          }
-        }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 1
         })
@@ -184,30 +179,6 @@ locals {
           desired_capacity = 1
         })
       })
-    }
-
-    baseline_ec2_instances = {
-      dev-tmp-rhel79 = {
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name          = "base_rhel_7_9_*"
-        })
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["private-web"]
-        })
-        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        ssm_parameters = {
-          test = {
-            kms_key_id = "general"
-          }
-        }
-        tags = {
-          description = "For testing our base RHEL7.9 base image"
-          ami         = "base_rhel_7_9"
-          os-type     = "Linux"
-          component   = "test"
-          server-type = "base-rhel79"
-        }
-      }
     }
 
     baseline_lbs = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -95,7 +95,7 @@ locals {
         })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 1
+          desired_capacity = 0
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -13,8 +13,7 @@ locals {
 module "ec2_autoscaling_group" {
   for_each = var.ec2_autoscaling_groups
 
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.1.0"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=DSOS-2124-allow-placeholder-ssm-params"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.1.1"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,8 +1,7 @@
 module "ec2_instance" {
   for_each = var.ec2_instances
 
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.1.0"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=DSOS-2124-allow-placeholder-ssm-params"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.1.1"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -100,6 +100,25 @@ output "s3_buckets" {
   value       = module.s3_bucket
 }
 
+output "secretsmanager" {
+  description = "map of secretsmanager secrets and secret versions"
+  value = {
+    secrets = aws_secretsmanager_secret.this
+    secret_versions = {
+      for key, value in merge(
+        aws_secretsmanager_secret_version.fixed,
+        aws_secretsmanager_secret_version.placeholder
+        ) : key => {
+        arn            = value.arn
+        id             = value.id
+        secret_id      = value.secret_id
+        version_id     = value.version_id
+        version_stages = value.version_stages
+      }
+    }
+  }
+}
+
 output "security_groups" {
   description = "map of security groups corresponding to var.security_groups"
   value       = aws_security_group.this

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -222,11 +222,15 @@ variable "ec2_autoscaling_groups" {
       recurrence       = string
     })), {})
     ssm_parameters = optional(map(object({
-      random = object({
+      description = optional(string)
+      type        = optional(string, "SecureString")
+      kms_key_id  = optional(string, "general")
+      file        = optional(string)
+      random = optional(object({
         length  = number
-        special = bool
-      })
-      description = string
+        special = optional(bool)
+      }))
+      value = optional(string)
     })))
     lb_target_groups = optional(map(object({
       port                 = optional(number)
@@ -332,11 +336,15 @@ variable "ec2_instances" {
       kms_key_id  = optional(string)
     })), {})
     ssm_parameters = optional(map(object({
-      random = object({
+      description = optional(string)
+      type        = optional(string, "SecureString")
+      kms_key_id  = optional(string, "general")
+      file        = optional(string)
+      random = optional(object({
         length  = number
-        special = bool
-      })
-      description = string
+        special = optional(bool)
+      }))
+      value = optional(string)
     })))
     route53_records = optional(object({
       create_internal_record = bool
@@ -906,7 +914,7 @@ variable "ssm_parameters" {
   type = map(object({
     prefix     = optional(string, "")
     postfix    = optional(string, "/")
-    kms_key_id = optional(string)
+    kms_key_id = optional(string, "general")
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -224,7 +224,7 @@ variable "ec2_autoscaling_groups" {
     ssm_parameters = optional(map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      kms_key_id  = optional(string, "general")
+      kms_key_id  = optional(string) # FIXME set default to "general" for DSOS-2011
       file        = optional(string)
       random = optional(object({
         length  = number
@@ -338,7 +338,7 @@ variable "ec2_instances" {
     ssm_parameters = optional(map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      kms_key_id  = optional(string, "general")
+      kms_key_id  = optional(string) # FIXME set default to "general" for DSOS-2011
       file        = optional(string)
       random = optional(object({
         length  = number

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -914,7 +914,7 @@ variable "ssm_parameters" {
   type = map(object({
     prefix     = optional(string, "")
     postfix    = optional(string, "/")
-    kms_key_id = optional(string, "general")
+    kms_key_id = optional(string) # FIXME set default to "general" for DSOS-2011
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")


### PR DESCRIPTION
Updated baseline module to allow placeholder SSM parameters in EC2/ASG module.  Part of the SSM param simplification requested by DBAs.  Also prep for applying KMS Key ID for all params but will do this in subsequent PR.  Also added missing output for SecretsManager.

This will trigger a plan change in all EC2/ASG policies as I rename a policy from  "ASM" to "SSM".  But is not impacting anything

