### PR TITLE
DSOS-2011: use business unit kms keys for ssm params

### DIFF
--- a/terraform/modules/baseline/backups.tf
+++ b/terraform/modules/baseline/backups.tf
@@ -35,7 +35,8 @@ data "aws_iam_role" "backup" {
 resource "aws_backup_vault" "this" {
   for_each = local.backup_vaults
 
-  name = each.key
+  name        = each.key
+  kms_key_arn = try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id)
 
   tags = merge(local.tags, each.value.tags, {
     Name = each.key

--- a/terraform/modules/baseline/bastion_linux.tf
+++ b/terraform/modules/baseline/bastion_linux.tf
@@ -1,4 +1,6 @@
 module "bastion_linux" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
   count = var.bastion_linux != null ? 1 : 0
 
   source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.0.0"

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -11,6 +11,8 @@ locals {
 }
 
 module "ec2_autoscaling_group" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
   for_each = var.ec2_autoscaling_groups
 
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.1.1"

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -50,7 +50,8 @@ module "ec2_autoscaling_group" {
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {
     for key, value in each.value.ssm_parameters : key => merge(value,
-      value.kms_key_id == null ? {} : {
+      value.kms_key_id == null || value.type != "SecureString" ? {
+        kms_key_id = null } : {
         kms_key_id = try(var.environment.kms_keys[value.kms_key_id].arn, value.kms_key_id)
       }
     )

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -1,4 +1,6 @@
 module "ec2_instance" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
   for_each = var.ec2_instances
 
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.1.1"

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -40,7 +40,8 @@ module "ec2_instance" {
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {
     for key, value in each.value.ssm_parameters : key => merge(value,
-      value.kms_key_id == null ? {} : {
+      value.kms_key_id == null || value.type != "SecureString" ? {
+        kms_key_id = null } : {
         kms_key_id = try(var.environment.kms_keys[value.kms_key_id].arn, value.kms_key_id)
       }
     )

--- a/terraform/modules/baseline/lb.tf
+++ b/terraform/modules/baseline/lb.tf
@@ -15,6 +15,8 @@ locals {
 
 # following AWS terraform naming convention here aws_lb, aws_lb_listener, so lbs.tf and lb_listeners.tf.
 module "lb" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
   for_each = var.lbs
 
   source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer.git?ref=v3.0.0"

--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -264,6 +264,8 @@ resource "aws_route53_record" "core_network_services" {
 # Create single security group to cover all resolvers
 # Prefix the name with application since this is created in VPC account
 resource "aws_security_group" "route53_resolver" {
+  #checkov:skip=CKV2_AWS_5:Ensure that Security Groups are attached to another resource; this is attached to the resolver endpoint
+
   count = length(var.route53_resolvers) != 0 ? 1 : 0
 
   provider = aws.core-vpc

--- a/terraform/modules/baseline/s3_bucket.tf
+++ b/terraform/modules/baseline/s3_bucket.tf
@@ -27,6 +27,8 @@ locals {
 }
 
 module "s3_bucket" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
   for_each = var.s3_buckets
 
   source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"

--- a/terraform/modules/baseline/secretsmanager.tf
+++ b/terraform/modules/baseline/secretsmanager.tf
@@ -91,6 +91,8 @@ data "aws_iam_policy_document" "secretsmanager_secret_policy" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
+  #checkov:skip=CKV2_AWS_57:Ensure Secrets Manager secrets should have automatic rotation enabled; needs to be manual as these are intended to store things like DB passwords
+
   for_each = merge(
     local.secretsmanager_secrets_value,
     local.secretsmanager_secrets_random,

--- a/terraform/modules/baseline/ssm.tf
+++ b/terraform/modules/baseline/ssm.tf
@@ -54,6 +54,9 @@ resource "random_password" "this" {
 }
 
 resource "aws_ssm_parameter" "fixed" {
+  #checkov:skip=CKV_AWS_337:Ensure SSM parameters are using KMS CMK; default is now to use general business unit key
+  #checkov:skip=CKV2_AWS_34:AWS SSM Parameter should be Encrypted; default is SecureString but some resources don't support this, e.g. cloud watch agent
+
   for_each = merge(
     local.ssm_parameters_value,
     local.ssm_parameters_random,
@@ -72,6 +75,9 @@ resource "aws_ssm_parameter" "fixed" {
 }
 
 resource "aws_ssm_parameter" "placeholder" {
+  #checkov:skip=CKV_AWS_337:Ensure SSM parameters are using KMS CMK; default is now to use general business unit key
+  #checkov:skip=CKV2_AWS_34:AWS SSM Parameter should be Encrypted; default is SecureString but some resources don't support this, e.g. cloud watch agent
+
   for_each = local.ssm_parameters_default
 
   name        = each.key

--- a/terraform/modules/baseline/ssm.tf
+++ b/terraform/modules/baseline/ssm.tf
@@ -63,7 +63,7 @@ resource "aws_ssm_parameter" "fixed" {
   name        = each.key
   description = each.value.description
   type        = each.value.type
-  key_id      = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  key_id      = each.value.type == "SecureString" && each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
   value       = each.value.value
 
   tags = merge(local.tags, {
@@ -77,7 +77,7 @@ resource "aws_ssm_parameter" "placeholder" {
   name        = each.key
   description = each.value.description
   type        = each.value.type
-  key_id      = each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
+  key_id      = each.value.type == "SecureString" && each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
   value       = each.value.value
 
   tags = merge(local.tags, {

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -31,6 +31,7 @@ variable "acm_certificates" {
 variable "backups" {
   description = "map of backup_vaults with associated backup plans to create, where the plan name is the backup_vault name and plan key combined.  Use  'everything' as the map key to use the modernisation platform managed vault"
   type = map(object({
+    kms_key_id = optional(string, "general")
     plans = map(object({
       rule = object({
         schedule                 = optional(string)

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -474,6 +474,8 @@ variable "rds_instances" {
 }
 
 variable "environment" {
+  # tflint-ignore: terraform_typed_variables
+  # Not defining 'type' as it is defined in the output of the environment module
   description = "Standard environmental data resources from the environment module"
 }
 

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -224,7 +224,7 @@ variable "ec2_autoscaling_groups" {
     ssm_parameters = optional(map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      kms_key_id  = optional(string) # FIXME set default to "general" for DSOS-2011
+      kms_key_id  = optional(string, "general")
       file        = optional(string)
       random = optional(object({
         length  = number
@@ -338,7 +338,7 @@ variable "ec2_instances" {
     ssm_parameters = optional(map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      kms_key_id  = optional(string) # FIXME set default to "general" for DSOS-2011
+      kms_key_id  = optional(string, "general")
       file        = optional(string)
       random = optional(object({
         length  = number
@@ -914,7 +914,7 @@ variable "ssm_parameters" {
   type = map(object({
     prefix     = optional(string, "")
     postfix    = optional(string, "/")
-    kms_key_id = optional(string) # FIXME set default to "general" for DSOS-2011
+    kms_key_id = optional(string, "general")
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")

--- a/terraform/modules/baseline/versions.tf
+++ b/terraform/modules/baseline/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source                = "hashicorp/aws"
       configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.us-east-1]
     }
+    random = {
+      version = "~> 3.4.1"
+      source  = "hashicorp/random"
+    }
   }
-  required_version = ">= 1.1.7"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
Best practice - use customer managed KMS Key for encrypted SSM params.
Setting default key to the "general" business unit key.  This won't touch the value of existing parameters (I have double-checked this)
Plus fixed some checkov/lint warnings