### PR TITLE
[DPR2-71] Resume Aurora cluster slightly earlier

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -648,7 +648,7 @@ module "datamart" {
     resume = {
       name           = "${local.redshift_cluster_name}-resume"
       description    = "Resume cluster every morning"
-      schedule       = "cron(30 07 * * ? *)"
+      schedule       = "cron(00 07 * * ? *)"
       resume_cluster = true
     }
   }


### PR DESCRIPTION
Resume Aurora cluster at 07:00 UTC (08:00 BST), to support those with earlier working hours.