### PR TITLE
add s3 log get and put access to lambda role policies

### DIFF
--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -116,6 +116,7 @@ data "aws_iam_policy_document" "iam_policy_document_for_authorizer_lambda" {
     resources = [
       "${module.s3-bucket.bucket.arn}/logs/*"
     ]
+  }
 }
 
 data "aws_iam_policy_document" "iam_policy_document_for_get_glue_metadata_lambda" {
@@ -145,6 +146,7 @@ data "aws_iam_policy_document" "iam_policy_document_for_get_glue_metadata_lambda
     resources = [
       "${module.s3-bucket.bucket.arn}/logs/*"
     ]
+  }
 }
 
 data "aws_iam_policy_document" "iam_policy_document_for_presigned_url_lambda" {


### PR DESCRIPTION
each lambda needs access to the logs s3 path to read and write log files