### PR TITLE
Create ACM certificate for DIH

### DIFF
--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "redshift_cert" {
-  domain_name       = format("%s-%s.modernisation-platform.service.justice.gov.uk", var.networking[0].business-unit, local.environment)
+  domain_name       = "modernisation-platform.service.justice.gov.uk"
   validation_method = "DNS"
 
   subject_alternative_names = [
@@ -7,7 +7,7 @@ resource "aws_acm_certificate" "redshift_cert" {
   ]
 
   tags = merge(local.tags,
-    { Name = lower(format("redshift.%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment)) }
+    { Name = lower(format("redshift.%s-%s-certificate", local.application_name, local.environment)) }
   )
 
   lifecycle {
@@ -15,16 +15,16 @@ resource "aws_acm_certificate" "redshift_cert" {
   }
 }
 
-resource "aws_acm_certificate_validation" "redshift_cert" {
+resource "aws_acm_certificate_validation" "example_cert" {
   certificate_arn         = aws_acm_certificate.redshift_cert.arn
   validation_record_fqdns = [for record in aws_route53_record.redshift_cert_validation : record.fqdn]
   timeouts {
-    create = "15m"
+    create = "10m"
   }
 }
 
 resource "aws_route53_record" "redshift_cert_validation" {
-  provider = aws.core-vpc
+  provider = aws.core-network-services
   for_each = {
     for dvo in aws_acm_certificate.redshift_cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "redshift_cert" {
-  domain_name       = "modernisation-platform.service.justice.gov.uk"
+  domain_name       = format("%s-%s.modernisation-platform.service.justice.gov.uk", var.networking[0].business-unit, local.environment)
   validation_method = "DNS"
 
   subject_alternative_names = [
@@ -24,7 +24,7 @@ resource "aws_acm_certificate_validation" "redshift_cert" {
 }
 
 resource "aws_route53_record" "redshift_cert_validation" {
-  provider = aws.core-network-services
+  provider = aws.core-vpc
   for_each = {
     for dvo in aws_acm_certificate.redshift_cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -4,6 +4,7 @@ resource "aws_acm_certificate" "redshift_cert" {
 
   subject_alternative_names = [
     format("redshift.%s.%s", local.application_name, data.aws_route53_zone.inner.name),
+    aws_redshift_cluster.wepi_redshift_cluster.dns_name
   ]
 
   tags = merge(local.tags,

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -4,7 +4,6 @@ resource "aws_acm_certificate" "redshift_cert" {
 
   subject_alternative_names = [
     format("redshift.%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment),
-    aws_redshift_cluster.wepi_redshift_cluster.dns_name
   ]
 
   tags = merge(local.tags,

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -16,6 +16,7 @@ resource "aws_acm_certificate" "redshift_cert" {
 }
 
 resource "aws_acm_certificate_validation" "redshift_cert" {
+  depends_on = [aws_route53_record.redshift_cert_validation_core, aws_route53_record.redshift_cert_validation_vpc]
   certificate_arn = aws_acm_certificate.redshift_cert.arn
   validation_record_fqdns = concat(
     [for record_core in aws_route53_record.redshift_cert_validation_core : record_core.fqdn],

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -1,0 +1,42 @@
+resource "aws_acm_certificate" "redshift_cert" {
+  domain_name       = data.aws_route53_zone.inner.name
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    format("redshift.%s.%s", local.application_name, data.aws_route53_zone.inner.name),
+  ]
+
+  tags = merge(local.tags,
+    { Name = lower(format("redshift.%s.%s", local.application_name, data.aws_route53_zone.inner.name)) }
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "redshift_cert" {
+  certificate_arn         = aws_acm_certificate.redshift_cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.redshift_cert_validation : record.fqdn]
+  timeouts {
+    create = "15m"
+  }
+}
+
+resource "aws_route53_record" "redshift_cert_validation" {
+  provider = aws.core-network-services
+  for_each = {
+    for dvo in aws_acm_certificate.redshift_cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.network-services.zone_id
+}

--- a/terraform/environments/data-and-insights-wepi/certificates.tf
+++ b/terraform/environments/data-and-insights-wepi/certificates.tf
@@ -1,14 +1,14 @@
 resource "aws_acm_certificate" "redshift_cert" {
-  domain_name       = data.aws_route53_zone.inner.name
+  domain_name       = "modernisation-platform.service.justice.gov.uk"
   validation_method = "DNS"
 
   subject_alternative_names = [
-    format("redshift.%s.%s", local.application_name, data.aws_route53_zone.inner.name),
+    format("redshift.%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment),
     aws_redshift_cluster.wepi_redshift_cluster.dns_name
   ]
 
   tags = merge(local.tags,
-    { Name = lower(format("redshift.%s.%s", local.application_name, data.aws_route53_zone.inner.name)) }
+    { Name = lower(format("redshift.%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment)) }
   )
 
   lifecycle {


### PR DESCRIPTION
This PR creates an ACM certificate and necessary validation records that corresponds to the name of the DNS record used for the current DIH network LB.

This will allow the use of a custom domain name for the redshift cluster.