### PR TITLE
DSOS-2189: Add ec2-user and cloud-watch-agent-windows ssm params

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -18,6 +18,7 @@ locals {
     enable_ec2_self_provision                    = true
     enable_oracle_secure_web                     = true
     enable_ec2_put_parameter                     = false
+    enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms                     = {}
     route53_resolver_rules = {
       # outbound-data-and-private-subnets = ["azure-fixngo-domain"]  # already set by nomis account
@@ -72,18 +73,6 @@ locals {
     domain-controller = local.security_groups.domain-controller-access
   }
 
-  baseline_sns_topics = {}
-
-  baseline_ssm_parameters = {
-    # ssm params at root level
-    "" = {
-      prefix  = ""
-      postfix = ""
-      parameters = {
-        ec2-user_pem = {}
-        test-param-1 = { description = "for SSM docs test" }
-        test-param-2 = { description = "for SSM docs test" }
-      }
-    }
-  }
+  baseline_sns_topics     = {}
+  baseline_ssm_parameters = {}
 }

--- a/terraform/environments/corporate-staff-rostering/main.tf
+++ b/terraform/environments/corporate-staff-rostering/main.tf
@@ -128,6 +128,7 @@ module "baseline" {
   )
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -19,6 +19,7 @@ locals {
     enable_ec2_self_provision                    = true
     enable_oracle_secure_web                     = false
     enable_ec2_put_parameter                     = false
+    enable_ec2_user_keypair                      = true
     enable_shared_s3                             = false # adds permissions to ec2s to interact with devtest or prodpreprod buckets
     db_backup_s3                                 = false # adds db backup buckets
     enable_oracle_secure_web                     = false # allows db to list all buckets
@@ -60,16 +61,6 @@ locals {
     private-dc = local.security_groups.private_dc
   }
 
-  baseline_sns_topics = {}
-
-  baseline_ssm_parameters = {
-    # ssm params at root level
-    "" = {
-      prefix  = ""
-      postfix = ""
-      parameters = {
-        ec2-user_pem = {}
-      }
-    }
-  }
+  baseline_sns_topics     = {}
+  baseline_ssm_parameters = {}
 }

--- a/terraform/environments/hmpps-domain-services/main.tf
+++ b/terraform/environments/hmpps-domain-services/main.tf
@@ -153,6 +153,7 @@ module "baseline" {
   )
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -20,6 +20,7 @@ locals {
     enable_oracle_secure_web                     = true
     enable_ec2_put_parameter                     = true
     enable_ec2_put_secret                        = true
+    enable_ec2_user_keypair                      = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
     db_backup_s3                                 = true # adds db backup buckets
     enable_oracle_secure_web                     = true # allows db to list all buckets
@@ -64,16 +65,6 @@ locals {
     data-oem = local.security_groups.data_oem
   }
 
-  baseline_sns_topics = {}
-
-  baseline_ssm_parameters = {
-    # ssm params at root level
-    "" = {
-      prefix  = ""
-      postfix = ""
-      parameters = {
-        ec2-user_pem = {}
-      }
-    }
-  }
+  baseline_sns_topics     = {}
+  baseline_ssm_parameters = {}
 }

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -153,6 +153,7 @@ module "baseline" {
   )
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -14,6 +14,7 @@ locals {
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
     enable_oracle_secure_web                     = true
+    enable_ec2_user_keypair                      = true
     iam_policies_filter                          = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/nomis-combined-reporting/main.tf
+++ b/terraform/environments/nomis-combined-reporting/main.tf
@@ -77,6 +77,7 @@ module "baseline" {
     lookup(local.environment_config, "baseline_rds_instances", {}),
   )
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -26,18 +26,7 @@ locals {
     "ndh_harkemsadmin_ssl_pass",
   ]
 
-  baseline_ssm_parameters = {
-    "" = {
-      postfix = ""
-      parameters = {
-        cloud-watch-config-windows = {
-          description = "cloud watch agent config for windows"
-          file        = "./templates/cloud_watch_windows.json"
-          type        = "String"
-        }
-      }
-    }
-  }
+  baseline_ssm_parameters = {}
 
   baseline_s3_buckets = {
     s3-bucket = {

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -30,6 +30,7 @@ module "baseline_presets" {
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
+    enable_ec2_user_keypair                      = true
     iam_policies_filter                          = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
@@ -71,6 +72,7 @@ module "baseline" {
   lbs                    = lookup(local.environment_config, "baseline_lbs", {})
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/nomis/ec2_common.tf
+++ b/terraform/environments/nomis/ec2_common.tf
@@ -74,21 +74,22 @@ resource "aws_ssm_document" "cloud_watch_agent" {
 # Patch Management - Run Ansible Roles manually from SSM document
 #------------------------------------------------------------------------------
 
-resource "aws_ssm_document" "run_ansible_patches" {
-  name            = "RunAnsiblePatches"
-  document_type   = "Command"
-  document_format = "YAML"
-  content         = file("./ssm-documents/run-ansible-patches.yaml")
-  target_type     = "/AWS::EC2::Instance"
-
-  tags = merge(
-    local.tags,
-    {
-      Name = "run-ansible-patches"
-    },
-  )
-}
-
+# Disabling - we need to migrate to new solution for CI/CD user and this isn't
+# being used in practice.
+#resource "aws_ssm_document" "run_ansible_patches" {
+#  name            = "RunAnsiblePatches"
+#  document_type   = "Command"
+#  document_format = "YAML"
+#  content         = file("./ssm-documents/run-ansible-patches.yaml")
+#  target_type     = "/AWS::EC2::Instance"
+#
+#  tags = merge(
+#    local.tags,
+#    {
+#      Name = "run-ansible-patches"
+#    },
+#  )
+#}
 
 #------------------------------------------------------------------------------
 # Patch Manager

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -20,6 +20,7 @@ locals {
     enable_oracle_secure_web                     = true
     enable_ec2_get_parameter                     = false
     enable_ec2_get_secret                        = false
+    enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
@@ -107,22 +108,6 @@ locals {
     data-db            = local.security_groups.data_db
   }
 
-  baseline_sns_topics = {}
-
-  baseline_ssm_parameters = {
-    "" = {
-      postfix = ""
-      parameters = {
-        cloud-watch-config-windows = {
-          description = "cloud watch agent config for windows"
-          file        = "./templates/cloud_watch_windows.json"
-          type        = "String"
-        }
-
-        # Placeholders - set values outside of terraform
-        ec2-user_pem       = { description = "ec2-user ssh private key" }
-        github-ci-user-pat = { description = "for SSM docs, see ssm-documents/README.md" }
-      }
-    }
-  }
+  baseline_sns_topics     = {}
+  baseline_ssm_parameters = {}
 }

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -158,6 +158,7 @@ module "baseline" {
   )
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -31,6 +31,7 @@ module "baseline_presets" {
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
+    enable_ec2_user_keypair                      = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
     db_backup_s3                                 = true # adds db backup buckets
     enable_oracle_secure_web                     = true # allows db to list all buckets

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -18,6 +18,7 @@ locals {
     enable_ec2_self_provision                    = true
     enable_oracle_secure_web                     = true
     enable_ec2_put_parameter                     = false
+    enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms                     = {}
     route53_resolver_rules = {
       # outbound-data-and-private-subnets = ["azure-fixngo-domain"]  # already set by nomis account
@@ -51,16 +52,6 @@ locals {
     data-db = local.security_groups.data_db
   }
 
-  baseline_sns_topics = {}
-
-  baseline_ssm_parameters = {
-    # ssm params at root level
-    "" = {
-      prefix  = ""
-      postfix = ""
-      parameters = {
-        ec2-user_pem = {}
-      }
-    }
-  }
+  baseline_sns_topics     = {}
+  baseline_ssm_parameters = {}
 }

--- a/terraform/environments/planetfm/main.tf
+++ b/terraform/environments/planetfm/main.tf
@@ -128,6 +128,7 @@ module "baseline" {
   )
 
   ssm_parameters = merge(
+    module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )

--- a/terraform/modules/baseline_presets/README.md
+++ b/terraform/modules/baseline_presets/README.md
@@ -1,6 +1,33 @@
+# Introduction
+
 Preset configuration that can be plugged into the baseline module.
 
 For example:
 - standard wildcard cert
 - resources required for using image builder
 - an example security group setup
+
+## ec2-user key pairs
+
+If using baseline to create EC2 instances, follow these steps to create an
+`ec2-user` admin user.
+
+Step 1: Run terraform with `enable_ec2_user_keypair` set to true
+
+This will create a placeholder SSM parameter `ec2-user_pem` for storing the
+private key.
+
+Step 2: Generate key pairs
+
+Use `ssh-keygen` to generate key pairs.  See example scripts in nomis
+terraform under the `.ssh` directory.
+
+Step 3: Generate key pairs
+
+Upload the private key to the `ec2-user_pem` ssm parameter.
+Commit the public key to this repo under the relevant application
+directory, e.g. for nomis, under `.ssh/nomis-test/ec2-user.pub`
+
+Step 4: Re-run terrafrom
+
+This will create the keypair resource.

--- a/terraform/modules/baseline_presets/key_pairs.tf
+++ b/terraform/modules/baseline_presets/key_pairs.tf
@@ -1,11 +1,16 @@
+# See README.md for how to use
+
 locals {
 
-  key_pairs = {
+  ec2_user_public_key_filename = ".ssh/${var.environment.account_name}/ec2-user.pub"
 
-    # default admin user for EC2s
+  key_pairs_filter = flatten([
+    var.options.enable_ec2_user_keypair && fileexists(local.ec2_user_public_key_filename) ? ["ec2-user"] : [],
+  ])
+
+  key_pairs = {
     ec2-user = {
-      # commit the public key into environments repo, keep the private key somewhere safe
-      public_key_filename = ".ssh/${var.environment.account_name}/ec2-user.pub"
+      public_key_filename = local.ec2_user_public_key_filename
     }
   }
 

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -70,7 +70,9 @@ output "iam_policies" {
 output "key_pairs" {
   description = "Common key pairs to create"
 
-  value = local.key_pairs
+  value = {
+    for key, value in local.key_pairs : key => value if contains(local.key_pairs_filter, key)
+  }
 }
 
 output "kms_grants" {
@@ -108,6 +110,13 @@ output "s3_iam_policies" {
 output "s3_buckets" {
   description = "Map of s3_buckets"
   value       = local.s3_buckets
+}
+
+output "ssm_parameters" {
+  description = "Map of common ssm parameters to create"
+  value = {
+    for key, value in local.ssm_parameters : key => value if contains(local.ssm_parameters_filter, key)
+  }
 }
 
 output "sns_topics" {

--- a/terraform/modules/baseline_presets/ssm.tf
+++ b/terraform/modules/baseline_presets/ssm.tf
@@ -1,0 +1,35 @@
+locals {
+
+  # add a cloud watch windows SSM param if the file is present
+  cloud_watch_windows_filename = "./templates/cloud_watch_windows.json"
+
+  ssm_parameters_filter = flatten([
+    var.options.enable_ec2_user_keypair ? ["ec2-user"] : [],
+    var.options.enable_ec2_cloud_watch_agent && fileexists(local.cloud_watch_windows_filename) ? ["cloud-watch-config"] : [],
+  ])
+
+  ssm_parameters = {
+
+    cloud-watch-config = {
+      postfix = "-"
+      parameters = {
+        windows = {
+          description = "cloud watch agent config for windows"
+          file        = local.cloud_watch_windows_filename
+          type        = "String"
+        }
+      }
+    }
+
+    ec2-user = {
+      postfix = "_"
+      parameters = {
+        pem = {
+          description = "Private key for ec2-user key pair"
+        }
+      }
+    }
+
+  }
+}
+

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -23,6 +23,7 @@ variable "options" {
     enable_ec2_get_secret                        = optional(bool, false)
     enable_ec2_put_parameter                     = optional(bool, false)
     enable_ec2_put_secret                        = optional(bool, false)
+    enable_ec2_user_keypair                      = optional(bool, false)
     enable_shared_s3                             = optional(bool, false)
     enable_oracle_secure_web                     = optional(bool, false)
     db_backup_s3                                 = optional(bool, false)


### PR DESCRIPTION
First of several PRs improving secret management.
This ensures ec2-user_pem and cloud watch agent windows SSM parameters are in code.  The former is just a placeholder which is updated outside of terraform.
For nomis, I'm removing the CI/CD secret and associated SSM doc since there is a new solution from mod platform that we need to migrate to