### PR TITLE
re-add initial config for pre-pd web server 7

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -3,6 +3,26 @@ locals {
 
   # baseline config
   preproduction_config = {
+    baseline_ec2_instances = {
+      pp-csr-w-7-b = {
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "pp-csr-w-7-b"
+          ami_owner                     = "self"
+          availability_zone             = "${local.region}b"
+          ebs_volumes_copy_all_from_ami = false
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          instance_type           = "m5.2xlarge"
+          disable_api_termination = true
+          monitoring              = true
+          vpc_security_group_ids  = ["migration-web-sg", "domain-controller"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 128 }
+          "/dev/sdb"  = { type = "gp3", size = 56 }
+        }
+      }
+    }
 
     baseline_ec2_autoscaling_groups = {
       prepprod-tst-1 = {
@@ -44,4 +64,4 @@ locals {
 }
 
 
-      
+


### PR DESCRIPTION
This re-adds the config that was removed in #3427.