### PR TITLE
DSOS-2190: Add option to use reduced scope for SSM params

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -18,6 +18,7 @@ locals {
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true
     enable_ec2_oracle_enterprise_manager         = true
+    enable_ec2_reduced_ssm_policy                = true
     enable_ec2_user_keypair                      = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
     db_backup_s3                                 = true # adds db backup buckets

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -20,7 +20,7 @@ locals {
         subnet_name                   = "data"
         ebs_volumes_copy_all_from_ami = true
         user_data_raw                 = null
-        ssm_parameters_prefix         = "ec2/"
+        ssm_parameters_prefix         = "database/"
         iam_resource_names_prefix     = "ec2-database"
         instance_profile_policies     = local.iam_policies_ec2_default
       }

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -12,10 +12,7 @@ locals {
         user_data_raw                 = null
         ssm_parameters_prefix         = "ec2/"
         iam_resource_names_prefix     = "ec2-instance"
-        instance_profile_policies = flatten([
-          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-          local.iam_policies_ec2_default,
-        ])
+        instance_profile_policies     = local.iam_policies_ec2_default
       }
 
       db = {
@@ -23,12 +20,9 @@ locals {
         subnet_name                   = "data"
         ebs_volumes_copy_all_from_ami = true
         user_data_raw                 = null
-        ssm_parameters_prefix         = "database/"
+        ssm_parameters_prefix         = "ec2/"
         iam_resource_names_prefix     = "ec2-database"
-        instance_profile_policies = flatten([
-          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-          local.iam_policies_ec2_default,
-        ])
+        instance_profile_policies     = local.iam_policies_ec2_default
       }
     }
 

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -6,6 +6,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
     var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
+    var.options.enable_ec2_reduced_ssm_policy ? ["SSMManagedInstanceCoreReducedPolicy"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["OracleEnterpriseManagementSecretsPolicy"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["Ec2OracleEnterpriseManagedServerPolicy"] : [],
     var.options.enable_ec2_oracle_enterprise_manager ? ["Ec2OracleEnterpriseManagerPolicy"] : [],
@@ -17,6 +18,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
     var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
+    var.options.enable_ec2_reduced_ssm_policy ? ["SSMManagedInstanceCoreReducedPolicy"] : ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["Ec2OracleEnterpriseManagedServerPolicy"] : [],
     var.options.enable_ec2_oracle_enterprise_manager ? ["Ec2OracleEnterpriseManagerPolicy"] : [],
     var.options.iam_policies_ec2_default,
@@ -312,5 +314,51 @@ locals {
       ]
     }
 
+    SSMManagedInstanceCoreReducedPolicy = {
+      description = "AmazonSSMManagedInstanceCore minus GetParameters"
+      statements = [
+        {
+          effect = "Allow"
+          actions = [
+            "ssm:DescribeAssociation",
+            "ssm:GetDeployablePatchSnapshotForInstance",
+            "ssm:GetDocument",
+            "ssm:DescribeDocument",
+            "ssm:GetManifest",
+            "ssm:ListAssociations",
+            "ssm:ListInstanceAssociations",
+            "ssm:PutInventory",
+            "ssm:PutComplianceItems",
+            "ssm:PutConfigurePackageResult",
+            "ssm:UpdateAssociationStatus",
+            "ssm:UpdateInstanceAssociationStatus",
+            "ssm:UpdateInstanceInformation",
+          ]
+          resources = ["*"]
+        },
+        {
+          effect = "Allow"
+          actions = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel",
+          ]
+          resources = ["*"]
+        },
+        {
+          effect = "Allow"
+          actions = [
+            "ec2messages:AcknowledgeMessage",
+            "ec2messages:DeleteMessage",
+            "ec2messages:FailMessage",
+            "ec2messages:GetEndpoint",
+            "ec2messages:GetMessages",
+            "ec2messages:SendReply"
+          ]
+          resources = ["*"]
+        },
+      ]
+    }
   }
 }

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -19,6 +19,7 @@ variable "options" {
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)
     enable_ec2_self_provision                    = optional(bool, false)
+    enable_ec2_reduced_ssm_policy                = optional(bool, false)
     enable_ec2_oracle_enterprise_managed_server  = optional(bool, false)
     enable_ec2_oracle_enterprise_manager         = optional(bool, false)
     enable_ec2_user_keypair                      = optional(bool, false)


### PR DESCRIPTION
The default policy allows any EC2 to access any SSM param.  Given that we are storing passwords in SSM params this is a bit excessive.  Create a reduced policy for testing in hmpps-oem account