### PR TITLE
DSOS-2151: asm password new code

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -118,6 +118,10 @@ locals {
           create_external_record = true
         }
 
+        ssm_parameters = {
+          asm-passwords = {}
+        }
+
         tags = {
           description = "Test CSR DB server"
           ami         = "base_ol_8_5"

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -62,6 +62,10 @@ locals {
           create_external_record = true
         }
 
+        ssm_parameters = {
+          asm-passwords = {}
+        }
+
         tags = {
           description = "Test CSR DB server"
           ami         = "base_ol_8_5"

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -63,6 +63,11 @@ locals {
     data-oem = local.security_groups.data_oem
   }
 
-  baseline_sns_topics     = {}
-  baseline_ssm_parameters = {}
+  baseline_sns_topics = {}
+
+  baseline_ssm_parameters = {
+    "/oracle/oem"              = local.oem_ssm_parameters_passwords
+    "/oracle/database/EMREP"   = local.oem_ssm_parameters_passwords
+    "/oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
+  }
 }

--- a/terraform/environments/hmpps-oem/locals_oem.tf
+++ b/terraform/environments/hmpps-oem/locals_oem.tf
@@ -114,20 +114,7 @@ locals {
     }
 
     ssm_parameters = {
-      ASMSYS = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSYS password"
-      }
-      ASMSNMP = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSNMP password"
-      }
+      asm-passwords = {}
     }
 
     tags = {

--- a/terraform/environments/hmpps-oem/locals_oem.tf
+++ b/terraform/environments/hmpps-oem/locals_oem.tf
@@ -4,10 +4,10 @@ locals {
   # enabled and run, or the equivalent terraform to create the 
   # EC2OracleEnterpriseManagementSecretsRole IAM role, add it to this list
   oem_managed_applications = [
-    # "corporate-staff-rostering",
-    "nomis",
-    # "nomis-combined-reporting",
-    # "oasys",
+    # "corporate-staff-rostering-${local.environment}",
+    "nomis-${local.environment}",
+    # "nomis-combined-reporting-${local.environment}",
+    # "oasys-${local.environment}",
   ]
 
   oem_database_instance_ssm_parameters = {
@@ -37,7 +37,7 @@ locals {
 
   oem_share_secret_principal_ids = [
     for key, value in module.environment.account_ids :
-    "arn:aws:iam::${value}:role/EC2OracleEnterpriseManagementSecretsRole" if contains(local.oem_managed_applications, "${key}-${local.environment}")
+    "arn:aws:iam::${value}:role/EC2OracleEnterpriseManagementSecretsRole" if contains(local.oem_managed_applications, key)
   ]
 
   oem_secret_policy_write = {

--- a/terraform/environments/hmpps-oem/locals_oem.tf
+++ b/terraform/environments/hmpps-oem/locals_oem.tf
@@ -10,31 +10,6 @@ locals {
     # "oasys-${local.environment}",
   ]
 
-  oem_database_instance_ssm_parameters = {
-    prefix = "/database/"
-    parameters = {
-      rcvcatownerpassword = {}
-      syspassword         = {}
-      systempassword      = {}
-    }
-  }
-  oem_emrep_ssm_parameters = {
-    prefix = "/oem/"
-    parameters = {
-      sysmanpassword = {}
-      syspassword    = {}
-      systempassword = {}
-    }
-  }
-  oem_ssm_parameters = {
-    prefix = "/oem/"
-    parameters = {
-      agentregpassword    = {}
-      nodemanagerpassword = {}
-      weblogicpassword    = {}
-    }
-  }
-
   oem_share_secret_principal_ids = [
     for key, value in module.environment.account_ids :
     "arn:aws:iam::${value}:role/EC2OracleEnterpriseManagementSecretsRole" if contains(local.oem_managed_applications, key)
@@ -68,6 +43,12 @@ locals {
       local.oem_secret_policy_write,
     ]
     secrets = {
+      passwords = {}
+    }
+  }
+
+  oem_ssm_parameters_passwords = {
+    parameters = {
       passwords = {}
     }
   }

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -5,15 +5,9 @@ locals {
   test_config = {
 
     baseline_ssm_parameters = {
-      "test-oem/TRCVCAT"   = local.oem_database_instance_ssm_parameters
-      "test-oem/EMREP"     = local.oem_emrep_ssm_parameters
-      "test-oem/OEM"       = local.oem_ssm_parameters
-      "test-oem-a/TRCVCAT" = local.oem_database_instance_ssm_parameters
-      "test-oem-a/EMREP"   = local.oem_emrep_ssm_parameters
-      "test-oem-a/OEM"     = local.oem_ssm_parameters
-      "test-oem-b/TRCVCAT" = local.oem_database_instance_ssm_parameters
-      "test-oem-b/EMREP"   = local.oem_emrep_ssm_parameters
-      "test-oem-b/OEM"     = local.oem_ssm_parameters
+      "oracle/database/EMREP"   = local.ssm_parameters_passwords
+      "oracle/database/TRCVCAT" = local.ssm_parameters_passwords
+      "oracle/database/TRCVCAT" = local.ssm_parameters_passwords
     }
 
     baseline_ec2_autoscaling_groups = {

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -5,9 +5,9 @@ locals {
   test_config = {
 
     baseline_ssm_parameters = {
-      "oracle/database/EMREP"   = local.ssm_parameters_passwords
-      "oracle/database/TRCVCAT" = local.ssm_parameters_passwords
-      "oracle/database/TRCVCAT" = local.ssm_parameters_passwords
+      "oracle/database/EMREP"   = local.oem_ssm_parameters_passwords
+      "oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
+      "oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
     }
 
     baseline_ec2_autoscaling_groups = {

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -6,9 +6,12 @@ locals {
 
     baseline_ec2_autoscaling_groups = {
       test-oem = merge(local.oem_ec2_default, {
+        autoscaling_group = merge(local.oem_ec2_default.autoscaling_group, {
+          desired_capacity = 0
+        })
         user_data_cloud_init = merge(local.oem_ec2_default.user_data_cloud_init, {
           args = merge(local.oem_ec2_default.user_data_cloud_init.args, {
-            branch = "DSOS-2151-asm-password-new-code"
+            branch = "main"
           })
         })
         tags = merge(local.oem_ec2_default.tags, {

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -4,12 +4,6 @@ locals {
   # baseline config
   test_config = {
 
-    baseline_ssm_parameters = {
-      "/oracle/database/EMREP"   = local.oem_ssm_parameters_passwords
-      "/oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
-      "/oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
-    }
-
     baseline_ec2_autoscaling_groups = {
       test-oem = merge(local.oem_ec2_default, {
         user_data_cloud_init = merge(local.oem_ec2_default.user_data_cloud_init, {

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -5,9 +5,9 @@ locals {
   test_config = {
 
     baseline_ssm_parameters = {
-      "oracle/database/EMREP"   = local.oem_ssm_parameters_passwords
-      "oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
-      "oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
+      "/oracle/database/EMREP"   = local.oem_ssm_parameters_passwords
+      "/oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
+      "/oracle/database/TRCVCAT" = local.oem_ssm_parameters_passwords
     }
 
     baseline_ec2_autoscaling_groups = {

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -20,7 +20,7 @@ locals {
       test-oem = merge(local.oem_ec2_default, {
         user_data_cloud_init = merge(local.oem_ec2_default.user_data_cloud_init, {
           args = merge(local.oem_ec2_default.user_data_cloud_init.args, {
-            branch = "main"
+            branch = "DSOS-2151-asm-password-new-code"
           })
         })
         tags = merge(local.oem_ec2_default.tags, {

--- a/terraform/environments/nomis-combined-reporting/locals_database.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_database.tf
@@ -32,20 +32,7 @@ locals {
     route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
 
     ssm_parameters = {
-      ASMSYS = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSYS password"
-      }
-      ASMSNMP = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSNMP password"
-      }
+      asm-passwords = {}
     }
 
     tags = {

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -291,22 +291,8 @@ locals {
       create_external_record = true
     }
 
-    # See DSOS-1975: these random passwords cannot start with a digit
     ssm_parameters = {
-      ASMSYS = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSYS password"
-      }
-      ASMSNMP = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSNMP password"
-      }
+      asm-passwords = {}
     }
 
     tags = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -181,32 +181,6 @@ locals {
       })
     }
 
-    baseline_ec2_instances = {
-      dev-nomis-db-1-a = merge(local.database_ec2_a, {
-        tags = merge(local.database_ec2_a.tags, {
-          nomis-environment   = "dev"
-          description         = "dev database"
-          oracle-sids         = ""
-        })
-        config = merge(local.database_ec2_a.config, {
-          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
-        })
-        user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
-          args = merge(local.database_ec2_a.user_data_cloud_init.args, {
-            branch = "DSOS-2151-asm-password-new-code"
-          })
-        })
-        ebs_volumes = merge(local.database_ec2_a.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.database_ec2_a.ebs_volume_config, {
-          data  = { total_size = 500 }
-          flash = { total_size = 50 }
-        })
-      })
-    }
-
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -182,7 +182,7 @@ locals {
     }
 
     baseline_ec2_instances = {
-      dev-nomis-db-1-a = merge(local.database_ec2_a, {
+      dev-nomis-db-1-b = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {
           nomis-environment   = "dev"
           description         = "dev database"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -182,7 +182,7 @@ locals {
     }
 
     baseline_ec2_instances = {
-      dev-nomis-db-1-b = merge(local.database_ec2_a, {
+      dev-nomis-db-1-a = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {
           nomis-environment   = "dev"
           description         = "dev database"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -181,6 +181,32 @@ locals {
       })
     }
 
+    baseline_ec2_instances = {
+      dev-nomis-db-1-a = merge(local.database_ec2_a, {
+        tags = merge(local.database_ec2_a.tags, {
+          nomis-environment   = "dev"
+          description         = "dev database"
+          oracle-sids         = ""
+        })
+        config = merge(local.database_ec2_a.config, {
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+        })
+        user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
+          args = merge(local.database_ec2_a.user_data_cloud_init.args, {
+            branch = "DSOS-2151-asm-password-new-code"
+          })
+        })
+        ebs_volumes = merge(local.database_ec2_a.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 100 }
+        })
+        ebs_volume_config = merge(local.database_ec2_a.ebs_volume_config, {
+          data  = { total_size = 500 }
+          flash = { total_size = 50 }
+        })
+      })
+    }
+
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -172,20 +172,7 @@ locals {
     }
     route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
     ssm_parameters = {
-      ASMSYS = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSYS password"
-      }
-      ASMSNMP = {
-        random = {
-          length  = 30
-          special = false
-        }
-        description = "ASMSNMP password"
-      }
+      asm-passwords = {}
     }
     # Example target group setup below
     lb_target_groups = {}

--- a/terraform/modules/baseline_presets/ec2_instance.tf
+++ b/terraform/modules/baseline_presets/ec2_instance.tf
@@ -20,7 +20,7 @@ locals {
         subnet_name                   = "data"
         ebs_volumes_copy_all_from_ami = true
         user_data_raw                 = null
-        ssm_parameters_prefix         = "database/"
+        ssm_parameters_prefix         = "ec2/"
         iam_resource_names_prefix     = "ec2-database"
         instance_profile_policies     = local.iam_policies_ec2_default
       }

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -38,7 +38,6 @@ locals {
           variable = "aws:PrincipalArn"
           values = [
             "arn:aws:iam::${var.environment.account_id}:role/ec2-*",
-            "arn:aws:iam::${var.environment.account_id}:role/database-*",
           ]
         }]
       }]


### PR DESCRIPTION
Simplify SSM params:
- Replace individual user/password parameters with a single password parameter which will be JSON and managed by ansible. This way, DBAs can rotate passwords, add new users etc without touching terraform.
- Moved all EC2 scoped parameters under /ec2 prefix.  All shared /oracle stuff under /oracle.
I'll update the parameters as necessary after terraform runs.