### PR TITLE
Nomis: DSOS-2205: policies for DB SSM params

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -84,10 +84,6 @@ locals {
     s3-bucket = {
       iam_policies = module.baseline_presets.s3_iam_policies
     }
-    nomis-db-backup-bucket = {
-      custom_kms_key = module.environment.kms_keys["general"].arn
-      iam_policies   = module.baseline_presets.s3_iam_policies
-    }
     nomis-audit-archives = {
       custom_kms_key = module.environment.kms_keys["general"].arn
       bucket_policy_v2 = [

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -14,6 +14,16 @@ locals {
     cloudwatch_metric_alarms_dbnames         = []
     cloudwatch_metric_alarms_dbnames_misload = []
 
+    baseline_s3_buckets = {
+      nomis-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+      }
+    }
+
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -38,6 +38,33 @@ locals {
     }
 
     baseline_iam_policies = {
+      Ec2PreprodDatabasePolicy = {
+        description = "Permissions required for Preprod Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+              "ssm:PutParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/oracle/database/*PP/*",
+              "arn:aws:ssm:*:*:parameter/oracle/database/PP*/*",
+            ]
+          }
+        ]
+      }
       Ec2PreprodWeblogicPolicy = {
         description = "Permissions required for Preprod Weblogic EC2s"
         statements = [

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -7,6 +7,16 @@ locals {
     cloudwatch_metric_alarms_dbnames         = []
     cloudwatch_metric_alarms_dbnames_misload = []
 
+    baseline_s3_buckets = {
+      nomis-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+      }
+    }
+
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -44,17 +44,6 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:ListBucket",
-            ]
-            resources = [
-              "arn:aws:s3:::nomis-db-backup-bucket*/*",
-            ]
-          },
-          {
-            effect = "Allow"
-            actions = [
               "ssm:GetParameter",
               "ssm:PutParameter",
             ]

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -38,6 +38,33 @@ locals {
     }
 
     baseline_iam_policies = {
+      Ec2ProdDatabasePolicy = {
+        description = "Permissions required for prod Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+              "ssm:PutParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/oracle/database/*P/*",
+              "arn:aws:ssm:*:*:parameter/oracle/database/P*/*",
+            ]
+          }
+        ]
+      }
       Ec2ProdWeblogicPolicy = {
         description = "Permissions required for prod Weblogic EC2s"
         statements = [
@@ -117,8 +144,8 @@ locals {
             "Ec2ProdWeblogicPolicy",
           ])
         })
-        user_data_cloud_init = merge(local.database_ec2_b.user_data_cloud_init, {
-          args = merge(local.database_ec2_b.user_data_cloud_init.args, {
+        user_data_cloud_init = merge(local.weblogic_ec2_b.user_data_cloud_init, {
+          args = merge(local.weblogic_ec2_b.user_data_cloud_init.args, {
             branch = "2468978f69041b1204ffa3dc55dfb81c1a2ad3e1" # 2023-09-25 new SSM params
           })
         })
@@ -163,6 +190,9 @@ locals {
         })
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2ProdDatabasePolicy",
+          ])
         })
         instance = merge(local.database_ec2_a.instance, {
           instance_type = "r6i.2xlarge"
@@ -185,9 +215,11 @@ locals {
           oracle-sids       = ""
           is-production     = "true-no-default-backup-workaround"
         })
-        config = merge(module.baseline_presets.ec2_instance.config.db, {
-          ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          ami_owner = "self"
+        config = merge(local.database_ec2_b.config, {
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+          instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
+            "Ec2ProdDatabasePolicy",
+          ])
         })
         instance = merge(local.database_ec2_b.instance, {
           instance_type = "r6i.2xlarge"
@@ -210,6 +242,11 @@ locals {
           oracle-sids               = "CNMAUD"
           fixngo-connection-targets = "10.40.0.136 4903 10.40.129.79 22" # fixngo connection alarm
           is-production             = "true-no-default-backup-workaround"
+        })
+        config = merge(local.database_ec2_a.config, {
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2ProdDatabasePolicy",
+          ])
         })
         instance = merge(local.database_ec2_a.instance, {
           instance_type = "r6i.2xlarge"
@@ -235,9 +272,11 @@ locals {
           oracle-sids       = ""
           is-production     = "true-no-default-backup-workaround"
         })
-        config = merge(module.baseline_presets.ec2_instance.config.db, {
-          ami_name  = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          ami_owner = "self"
+        config = merge(local.database_ec2_b.config, {
+          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+          instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
+            "Ec2ProdDatabasePolicy",
+          ])
         })
         instance = merge(local.database_ec2_b.instance, {
           instance_type = "r6i.2xlarge"
@@ -259,6 +298,11 @@ locals {
           description       = "Production NOMIS HA database to replace Azure PDPDL00062"
           oracle-sids       = "PCNOMHA"
           is-production     = "true-no-default-backup-workaround"
+        })
+        config = merge(local.database_ec2_a.config, {
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2ProdDatabasePolicy",
+          ])
         })
         instance = merge(local.database_ec2_a.instance, {
           instance_type = "r6i.4xlarge"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -7,6 +7,16 @@ locals {
     cloudwatch_metric_alarms_dbnames         = []
     cloudwatch_metric_alarms_dbnames_misload = []
 
+    baseline_s3_buckets = {
+      nomis-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+      }
+    }
+
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -197,32 +197,32 @@ locals {
         })
       })
 
-      prod-nomis-db-1-b = merge(local.database_ec2_b, {
-        tags = merge(local.database_ec2_b.tags, {
-          nomis-environment = "prod"
-          description       = "Disaster-Recovery/High-Availability production databases for CNOM and NDH"
-          oracle-sids       = ""
-          is-production     = "true-no-default-backup-workaround"
-        })
-        config = merge(local.database_ec2_b.config, {
-          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
-            "Ec2ProdDatabasePolicy",
-          ])
-        })
-        instance = merge(local.database_ec2_b.instance, {
-          instance_type = "r6i.2xlarge"
-        })
-        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 3000 }
-        })
-        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
-          data  = { total_size = 4000 }
-          flash = { total_size = 1000 }
-        })
-        cloudwatch_metric_alarms = {}
-      })
+      # prod-nomis-db-1-b = merge(local.database_ec2_b, {
+      #   tags = merge(local.database_ec2_b.tags, {
+      #     nomis-environment = "prod"
+      #     description       = "Disaster-Recovery/High-Availability production databases for CNOM and NDH"
+      #     oracle-sids       = ""
+      #     is-production     = "true-no-default-backup-workaround"
+      #   })
+      #   config = merge(local.database_ec2_b.config, {
+      #     ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+      #     instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
+      #       "Ec2ProdDatabasePolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.database_ec2_b.instance, {
+      #     instance_type = "r6i.2xlarge"
+      #   })
+      #   ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
+      #     "/dev/sdb" = { label = "app", size = 100 }
+      #     "/dev/sdc" = { label = "app", size = 3000 }
+      #   })
+      #   ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
+      #     data  = { total_size = 4000 }
+      #     flash = { total_size = 1000 }
+      #   })
+      #   cloudwatch_metric_alarms = {}
+      # })
 
       prod-nomis-db-2 = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {
@@ -254,32 +254,32 @@ locals {
         )
       })
 
-      prod-nomis-db-2-b = merge(local.database_ec2_b, {
-        tags = merge(local.database_ec2_b.tags, {
-          nomis-environment = "prod"
-          description       = "Disaster-Recovery/High-Availability production databases for AUDIT/MIS"
-          oracle-sids       = ""
-          is-production     = "true-no-default-backup-workaround"
-        })
-        config = merge(local.database_ec2_b.config, {
-          ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
-            "Ec2ProdDatabasePolicy",
-          ])
-        })
-        instance = merge(local.database_ec2_b.instance, {
-          instance_type = "r6i.2xlarge"
-        })
-        ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 3000 }
-        })
-        ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
-          data  = { total_size = 4000 }
-          flash = { total_size = 1000 }
-        })
-        cloudwatch_metric_alarms = {}
-      })
+      # prod-nomis-db-2-b = merge(local.database_ec2_b, {
+      #   tags = merge(local.database_ec2_b.tags, {
+      #     nomis-environment = "prod"
+      #     description       = "Disaster-Recovery/High-Availability production databases for AUDIT/MIS"
+      #     oracle-sids       = ""
+      #     is-production     = "true-no-default-backup-workaround"
+      #   })
+      #   config = merge(local.database_ec2_b.config, {
+      #     ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+      #     instance_profile_policies = concat(local.database_ec2_b.config.instance_profile_policies, [
+      #       "Ec2ProdDatabasePolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.database_ec2_b.instance, {
+      #     instance_type = "r6i.2xlarge"
+      #   })
+      #   ebs_volumes = merge(local.database_ec2_b.ebs_volumes, {
+      #     "/dev/sdb" = { label = "app", size = 100 }
+      #     "/dev/sdc" = { label = "app", size = 3000 }
+      #   })
+      #   ebs_volume_config = merge(local.database_ec2_b.ebs_volume_config, {
+      #     data  = { total_size = 4000 }
+      #     flash = { total_size = 1000 }
+      #   })
+      #   cloudwatch_metric_alarms = {}
+      # })
 
       prod-nomis-db-3 = merge(local.database_ec2_a, {
         tags = merge(local.database_ec2_a.tags, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -64,17 +64,6 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:ListBucket",
-            ]
-            resources = [
-              "arn:aws:s3:::nomis-db-backup-bucket*/*",
-            ]
-          },
-          {
-            effect = "Allow"
-            actions = [
               "ssm:GetParameter",
               "ssm:PutParameter",
             ]
@@ -91,17 +80,6 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:ListBucket",
-            ]
-            resources = [
-              "arn:aws:s3:::nomis-db-backup-bucket*/*",
-            ]
-          },
-          {
-            effect = "Allow"
-            actions = [
               "ssm:GetParameter",
               "ssm:PutParameter",
             ]
@@ -115,17 +93,6 @@ locals {
       Ec2T3DatabasePolicy = {
         description = "Permissions required for T3 Database EC2s"
         statements = [
-          {
-            effect = "Allow"
-            actions = [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:ListBucket",
-            ]
-            resources = [
-              "arn:aws:s3:::nomis-db-backup-bucket*/*",
-            ]
-          },
           {
             effect = "Allow"
             actions = [

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -59,7 +59,7 @@ locals {
 
     baseline_iam_policies = {
       Ec2T1DatabasePolicy = {
-        description = "Permissions required for T1 Weblogic EC2s"
+        description = "Permissions required for T1 Database EC2s"
         statements = [
           {
             effect = "Allow"
@@ -81,6 +81,60 @@ locals {
             resources = [
               "arn:aws:ssm:*:*:parameter/oracle/database/*T1/*",
               "arn:aws:ssm:*:*:parameter/oracle/database/T1*/*",
+            ]
+          }
+        ]
+      }
+      Ec2T2DatabasePolicy = {
+        description = "Permissions required for T2 Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+              "ssm:PutParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/oracle/database/*T2/*",
+              "arn:aws:ssm:*:*:parameter/oracle/database/T2*/*",
+            ]
+          }
+        ]
+      }
+      Ec2T3DatabasePolicy = {
+        description = "Permissions required for T3 Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+              "ssm:PutParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/oracle/database/*T3/*",
+              "arn:aws:ssm:*:*:parameter/oracle/database/T3*/*",
             ]
           }
         ]
@@ -446,6 +500,9 @@ locals {
         })
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2T2DatabasePolicy",
+          ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
           args = merge(local.database_ec2_a.user_data_cloud_init.args, {
@@ -468,6 +525,11 @@ locals {
           description         = "T3 NOMIS database to replace Azure T3PDL0070"
           oracle-sids         = "T3CNOM"
           instance-scheduling = "skip-scheduling"
+        })
+        config = merge(local.database_ec2_a.config, {
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2T3DatabasePolicy",
+          ])
         })
         ebs_volumes = merge(local.database_ec2_a.ebs_volumes, {
           "/dev/sdb" = { label = "app", size = 100 }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -48,6 +48,33 @@ locals {
     }
 
     baseline_iam_policies = {
+      Ec2T1DatabasePolicy = {
+        description = "Permissions required for T1 Weblogic EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+              "ssm:PutParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/oracle/database/*T1/*",
+              "arn:aws:ssm:*:*:parameter/oracle/database/T1*/*",
+            ]
+          }
+        ]
+      }
       Ec2T1WeblogicPolicy = {
         description = "Permissions required for T1 Weblogic EC2s"
         statements = [
@@ -352,6 +379,9 @@ locals {
         })
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2T1DatabasePolicy",
+          ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
           args = merge(local.database_ec2_a.user_data_cloud_init.args, {
@@ -378,6 +408,9 @@ locals {
         })
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+          instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
+            "Ec2T1DatabasePolicy",
+          ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
           args = merge(local.database_ec2_a.user_data_cloud_init.args, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -18,6 +18,16 @@ locals {
       "T1MIS"
     ]
 
+    baseline_s3_buckets = {
+      nomis-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+      }
+    }
+
     baseline_acm_certificates = {
       nomis_wildcard_cert = {
         # domain_name limited to 64 chars so use modernisation platform domain for this

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -58,7 +58,7 @@ locals {
     }
 
     baseline_iam_policies = {
-      Ec2T1DatabasePolicyTmp = {
+      Ec2T1DatabasePolicy = {
         description = "Permissions required for T1 Database EC2s"
         statements = [
           {
@@ -411,7 +411,7 @@ locals {
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicyTmp",
+            "Ec2T1DatabasePolicy",
           ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
@@ -440,7 +440,7 @@ locals {
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicyTmp",
+            "Ec2T1DatabasePolicy",
           ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -26,6 +26,16 @@ locals {
           module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
         ]
       }
+
+      # use this bucket for storing artefacts for use across all accounts
+      ec2-image-builder-nomis = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
+          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
+        ]
+        iam_policies = module.baseline_presets.s3_iam_policies
+      }
     }
 
     baseline_acm_certificates = {
@@ -714,18 +724,6 @@ locals {
           { name = "t3-nomis-web-b", type = "A", lbs_map_key = "private" },
           { name = "c-t3", type = "A", lbs_map_key = "private" },
         ]
-      }
-    }
-
-    baseline_s3_buckets = {
-      # use this bucket for storing artefacts for use across all accounts
-      ec2-image-builder-nomis = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
       }
     }
   }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -58,7 +58,7 @@ locals {
     }
 
     baseline_iam_policies = {
-      Ec2T1DatabasePolicy = {
+      Ec2T1DatabasePolicyTmp = {
         description = "Permissions required for T1 Database EC2s"
         statements = [
           {
@@ -411,7 +411,7 @@ locals {
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicy",
+            "Ec2T1DatabasePolicyTmp",
           ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {
@@ -440,7 +440,7 @@ locals {
         config = merge(local.database_ec2_a.config, {
           ami_name = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           instance_profile_policies = concat(local.database_ec2_a.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicy",
+            "Ec2T1DatabasePolicyTmp",
           ])
         })
         user_data_cloud_init = merge(local.database_ec2_a.user_data_cloud_init, {

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -118,6 +118,21 @@ locals {
       }
     }
 
+    ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy = {
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:ListBucket",
+      ]
+      principals = {
+        type = "AWS"
+        identifiers = [for account_name in var.environment.prodpreprod_account_names :
+          var.environment.account_root_arns[account_name]
+        ]
+      }
+    }
+
     ProdPreprodEnvironmentsWriteAccessBucketPolicy = {
       effect = "Allow"
       actions = [
@@ -150,6 +165,21 @@ locals {
       principals = {
         type = "AWS"
         identifiers = [for account_name in var.environment.account_names :
+          var.environment.account_root_arns[account_name]
+        ]
+      }
+    }
+
+    DevTestEnvironmentsReadOnlyAccessBucketPolicy = {
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:ListBucket",
+      ]
+      principals = {
+        type = "AWS"
+        identifiers = [for account_name in var.environment.devtest_account_names :
           var.environment.account_root_arns[account_name]
         ]
       }


### PR DESCRIPTION
Add policy to database backups to enable read-only access from paired accounts (e.g. dev and test, preprod and prod)
Add policy to allow preprod EC2 databases to access production backups
Add policy for all other databases to scope access to environment specific SSM parameters
Comment out the new DR databases as accidentally created in wrong availability zone (sorry, should be a separate PR really but noticed it was wrong when doing this)