### PR TITLE
DSOS-2195: update backup plans

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -12,6 +12,7 @@ locals {
 
   baseline_presets_options = {
     enable_application_environment_wildcard_cert = false
+    enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -17,6 +17,9 @@ locals {
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
           monitoring                   = true
           vpc_security_group_ids       = ["data-db"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
 
         user_data_cloud_init = {
@@ -88,6 +91,9 @@ locals {
           disable_api_termination = true
           monitoring              = true
           vpc_security_group_ids  = ["migration-web-sg", "domain-controller"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -113,6 +119,9 @@ locals {
           disable_api_termination = true
           monitoring              = true
           vpc_security_group_ids  = ["migration-web-sg", "domain-controller"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 200 }
@@ -138,6 +147,9 @@ locals {
           disable_api_termination = true
           monitoring              = true
           vpc_security_group_ids  = ["migration-web-sg", "domain-controller"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 200 }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -16,6 +16,9 @@ locals {
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
           monitoring                   = true
           vpc_security_group_ids       = ["data-db"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
 
         user_data_cloud_init = {
@@ -71,6 +74,7 @@ locals {
           os-type     = "Linux"
           component   = "data"
           server-type = "csr-db"
+          backup      = "false" # opt out of mod platform default backup plan
         }
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -74,7 +74,7 @@ locals {
           os-type     = "Linux"
           component   = "data"
           server-type = "csr-db"
-          backup      = "false" # opt out of mod platform default backup plan
+          backup      = "false" # opt out of mod platform default backup plan
         }
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -17,6 +17,9 @@ locals {
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
           monitoring                   = true
           vpc_security_group_ids       = ["data-db"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
 
         user_data_cloud_init = {
@@ -112,6 +115,9 @@ locals {
 
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["migration-app-sg"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 256 }
@@ -137,6 +143,9 @@ locals {
 
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["migration-app-sg"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 256 }

--- a/terraform/environments/hmpps-oem/locals_oem.tf
+++ b/terraform/environments/hmpps-oem/locals_oem.tf
@@ -100,7 +100,7 @@ locals {
 
     tags = {
       ami                  = "hmpps_ol_8_5_oracledb_19c" # not including as hardening role seems to cause an issue
-      backup               = "false"                     # opt out of mod platform default backup plan
+      backup               = "false"                     # opt out of mod platform default backup plan
       component            = "data"
       instance-scheduling  = "skip-scheduling"
       server-type          = "hmpps-oem"

--- a/terraform/environments/hmpps-oem/locals_oem.tf
+++ b/terraform/environments/hmpps-oem/locals_oem.tf
@@ -100,6 +100,7 @@ locals {
 
     tags = {
       ami                  = "hmpps_ol_8_5_oracledb_19c" # not including as hardening role seems to cause an issue
+      backup               = "false"                     # opt out of mod platform default backup plan
       component            = "data"
       instance-scheduling  = "skip-scheduling"
       server-type          = "hmpps-oem"

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -9,6 +9,7 @@ locals {
   }
   baseline_preset_options = {
     enable_application_environment_wildcard_cert = false
+    enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true

--- a/terraform/environments/nomis-combined-reporting/locals_bip.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_bip.tf
@@ -127,7 +127,7 @@ locals {
     tags = {
       description = "ncr bip webtier component"
       ami         = "base_rhel_8_5"
-      backup      = "false" # opt out of mod platform default backup plan
+      backup      = "false" # opt out of mod platform default backup plan
       os-type     = "Linux"
       server-type = "ncr-bip"
       component   = "web"

--- a/terraform/environments/nomis-combined-reporting/locals_bip.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_bip.tf
@@ -102,6 +102,10 @@ locals {
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
       instance_type          = "t3.large"
       vpc_security_group_ids = ["private"]
+
+      tags = {
+        backup-plan = "daily-and-weekly"
+      }
     })
 
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
@@ -123,6 +127,7 @@ locals {
     tags = {
       description = "ncr bip webtier component"
       ami         = "base_rhel_8_5"
+      backup      = "false" # opt out of mod platform default backup plan
       os-type     = "Linux"
       server-type = "ncr-bip"
       component   = "web"

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -12,6 +12,9 @@ locals {
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 100 }
@@ -28,7 +31,11 @@ locals {
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name = "nomis_data_hub_rhel_7_9_app_release_2023-05-02T00-00-47.783Z"
         })
-        instance             = merge(module.baseline_presets.ec2_instance.instance.default, {})
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
+        })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         tags = {
           description = "Standalone EC2 for testing RHEL7.9 NDH App"
@@ -42,7 +49,11 @@ locals {
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name = "nomis_data_hub_rhel_7_9_ems_test_2023-04-02T00-00-21.281Z"
         })
-        instance             = merge(module.baseline_presets.ec2_instance.instance.default, {})
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
+        })
         user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
         tags = {
           description = "Standalone EC2 for testing RHEL7.9 NDH ems"

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -105,7 +105,11 @@ locals {
       ami_owner         = "self"
       availability_zone = "${local.region}a"
     })
-    instance              = module.baseline_presets.ec2_instance.instance.default_db
+    instance = merge(module.baseline_presets.ec2_instance.instance.default_db, {
+      tags = {
+        backup-plan = "daily-and-weekly"
+      }
+    })
     autoscaling_schedules = {}
     autoscaling_group     = module.baseline_presets.ec2_autoscaling_group.default
     user_data_cloud_init  = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags
@@ -177,6 +181,7 @@ locals {
     # Example target group setup below
     lb_target_groups = {}
     tags = {
+      backup                                  = "false" # opt out of mod platform default backup plan
       component                               = "data"
       oracle-sids                             = "OASPROD BIPINFRA"
       os-type                                 = "Linux"
@@ -209,6 +214,9 @@ locals {
       instance_type          = "t3.xlarge"
       monitoring             = true
       vpc_security_group_ids = ["bip"]
+      tags = {
+        backup-plan = "daily-and-weekly"
+      }
     })
     cloudwatch_metric_alarms = {}
     user_data_cloud_init     = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags
@@ -216,6 +224,7 @@ locals {
     autoscaling_group        = module.baseline_presets.ec2_autoscaling_group.default
     lb_target_groups         = {}
     tags = {
+      backup            = "false" # opt out of mod platform default backup plan
       component         = "bip"
       description       = "${local.environment} ${local.application_name} bip"
       os-type           = "Linux"

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -11,7 +11,7 @@ locals {
 
     baseline_ec2_autoscaling_groups = {
       "pp-${local.application_name}-db-a" = merge(local.database_a, {
-        user_data_cloud_init  = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags, {
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_ansible_no_tags.args, {
             branch = "main"
           })

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -27,6 +27,7 @@ module "baseline_presets" {
     cloudwatch_log_groups                        = null
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
     enable_application_environment_wildcard_cert = true
+    enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -12,6 +12,7 @@ locals {
 
   baseline_presets_options = {
     enable_application_environment_wildcard_cert = false
+    enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true


### PR DESCRIPTION
Align backups across DSO accounts:
- enable daily backup (7 day retention) + weekly backup (4 week retention) plan
- opt out of mod platform plan (30 day backup + backs up EBS volumes twice)

Enable backup on EC2 instances across our estate
- CSR migrated servers
- Combined Reporting standalone EC2 instances
- NDH test EC2 instances
- OASys databases and BIP