### PR TITLE
Disable RDS instance scheduling for overnight jobs to run

### DIFF
--- a/terraform/environments/performance-hub/database.tf
+++ b/terraform/environments/performance-hub/database.tf
@@ -44,7 +44,8 @@ resource "aws_db_instance" "database" {
   tags = merge(
     local.tags,
     {
-      Name = "${local.application_name}-database"
+      Name                = "${local.application_name}-database",
+      instance-scheduling = "skip-scheduling"
     }
   )
 }


### PR DESCRIPTION
Unfortunately we need the app running for overnight jobs (automated data imports, de-activating unused user accounts ...)

EC2 is part of an ASG, so no tag needed