### PR TITLE
fix ouPath syntax error

### DIFF
--- a/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
@@ -79,7 +79,7 @@ mainSteps:
           }
 
           # parse ouPath parameter
-          if (ouPath -eq "default") {
+          if ($ouPath -eq "default") {
             $ouPath = $environments[$domain]["oudefault"]
           } else {
             $ouPath = ($ou.Split("/") | ForEach-Object { "OU=" + $_ })


### PR DESCRIPTION
didn't include the $ for the ouPath variable in the if ( ) 