### PR TITLE
:sparkles: Create upload for data product components

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -114,9 +114,6 @@ resource "aws_api_gateway_method" "ingest_data_for_data_product" {
 
   request_parameters = {
     "method.request.header.Authorization"   = true,
-    "method.request.querystring.database"   = true,
-    "method.request.querystring.table"      = true,
-    "method.request.querystring.contentMD5" = true,
     "method.request.path.data-product-name" = true,
   }
 }
@@ -131,9 +128,6 @@ resource "aws_api_gateway_integration" "ingest_data_for_data_product_to_lambda" 
   uri                     = module.data_product_presigned_url_lambda.lambda_function_invoke_arn
 
   request_parameters = {
-    "integration.request.querystring.database"   = "method.request.querystring.database",
-    "integration.request.querystring.table"      = "method.request.querystring.table",
-    "integration.request.querystring.contentMD5" = "method.request.querystring.contentMD5",
     "integration.request.path.data-product-name" = "method.request.path.data-product-name",
   }
 }

--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -15,17 +15,18 @@ resource "aws_api_gateway_deployment" "deployment" {
     #       resources will show a difference after the initial implementation.
     #       It will stabilize to only change when resources change afterwards.
     redeployment = sha1(jsonencode([
-      aws_api_gateway_resource.upload_data,
       aws_api_gateway_resource.get_glue_metadata,
       aws_api_gateway_resource.docs,
       aws_api_gateway_resource.data_product,
+      aws_api_gateway_resource.data_product_name,
       aws_api_gateway_resource.register_data_product,
-      aws_api_gateway_method.upload_data_get,
+      aws_api_gateway_resource.ingest_data_for_data_product,
       aws_api_gateway_method.docs,
       aws_api_gateway_method.get_glue_metadata,
       aws_api_gateway_method.register_data_product,
+      aws_api_gateway_method.ingest_data_for_data_product,
       aws_api_gateway_integration.docs_to_lambda,
-      aws_api_gateway_integration.upload_data_to_lambda,
+      aws_api_gateway_integration.ingest_data_for_data_product_to_lambda,
       aws_api_gateway_integration.proxy_to_lambda,
       aws_api_gateway_integration.docs_lambda_root,
       aws_api_gateway_integration.get_glue_metadata,

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -118,7 +118,7 @@ module "data_product_presigned_url_lambda" {
       action        = "lambda:InvokeFunction"
       function_name = "data_product_presigned_url_${local.environment}"
       principal     = "apigateway.amazonaws.com"
-      source_arn    = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.upload_data_get.http_method}${aws_api_gateway_resource.upload_data.path}"
+      source_arn    = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.ingest_data_for_data_product.http_method}${aws_api_gateway_resource.ingest_data_for_data_product.path}"
     }
   }
 

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -118,7 +118,7 @@ module "data_product_presigned_url_lambda" {
       action        = "lambda:InvokeFunction"
       function_name = "data_product_presigned_url_${local.environment}"
       principal     = "apigateway.amazonaws.com"
-      source_arn    = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.ingest_data_for_data_product.http_method}${aws_api_gateway_resource.ingest_data_for_data_product.path}"
+      source_arn    = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.upload_data_for_data_product_table_name.http_method}${aws_api_gateway_resource.upload_data_for_data_product_table_name.path}"
     }
   }
 


### PR DESCRIPTION
This PR seeks to do the following:

# Resources
Defines "/data-product/{data-product-name}"
Defines "/data-product/{data-product-name}/table"
Defines "/data-product/{data-product-name}/table/{table-name}"
Defines "/data-product/{data-product-name}/table/{table-name}/upload"
Removes /upload_data"

# Methods
Defines "/data-product/{data-product-name}/table/{table-name}/upload" POST and makes {data-product-name} & {table-name} path variables available.
Removes "upload_data" and removes former querystring parameters.

# Integrations
Defines "/data-product/{data-product-name}/table/{table-name}/upload" POST
Removes "upload_data_to_lambda"
