### PR TITLE
DPR2-146: Increase max workers in prod

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -208,7 +208,7 @@
       "reporting_hub_spark_executor_mem": "26g",
       "reporting_hub_spark_log_level": "WARN",
       "reporting_hub_worker_type": "G.2X",
-      "reporting_hub_num_workers": 4,
+      "reporting_hub_num_workers": 6,
       "reporting_hub_batch_duration_seconds": 40,
       "refresh_job_worker_type": "G.1X",
       "refresh_job_num_workers": 2,


### PR DESCRIPTION
During the release, the initial job run took over a day before it was manually terminated. The performance degradation is due to the incremental domain refresh trying to load records and apply them to the domain. This was made worse because the CDC events were processed before the load events were completed thereby creating multiple errors.

This PR increases the number of workers to 6 thereby decreasing the run duration to 11 hours (down from over 2 days).