### PR TITLE
DSOS-2198: nomis: fix s3 permission so aws s3 sync works

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -49,7 +49,7 @@ locals {
               "s3:ListBucket",
             ]
             resources = [
-              "arn:aws:s3:::nomis-db-backup-bucket*/*",
+              "arn:aws:s3:::nomis-db-backup-bucket*",
             ]
           },
           {


### PR DESCRIPTION
This should allow s3 sync to work with the backup bucket in prod account.  