### PR TITLE
Csr/dsos 2175/security groups

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -70,6 +70,7 @@ locals {
     migration-web-sg  = local.security_groups.Web-SG-migration
     migration-app-sg  = local.security_groups.App-SG-migration
     domain-controller = local.security_groups.domain-controller-access
+    domain            = local.security_groups.domain
   }
 
   baseline_sns_topics     = {}

--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -75,6 +75,7 @@ locals {
     app               = local.security_groups.app
     load-balancer     = local.security_groups.load-balancer
     database          = local.security_groups.database
+    jumpserver        = local.security_groups.jumpserver
   }
 
   baseline_sns_topics     = {}

--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -71,6 +71,10 @@ locals {
     migration-app-sg  = local.security_groups.App-SG-migration
     domain-controller = local.security_groups.domain-controller-access
     domain            = local.security_groups.domain
+    web               = local.security_groups.web
+    app               = local.security_groups.app
+    load-balancer     = local.security_groups.load-balancer
+    database          = local.security_groups.database
   }
 
   baseline_sns_topics     = {}

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -74,11 +74,11 @@ locals {
         }
 
         tags = {
-          description = "PP CSR DB server"
-          ami         = "base_ol_8_5"
-          os-type     = "Linux"
-          component   = "test"
-          server-type = "csr-db"
+          description         = "PP CSR DB server"
+          ami                 = "base_ol_8_5"
+          os-type             = "Linux"
+          component           = "test"
+          server-type         = "csr-db"
           instance-scheduling = "skip-scheduling"
         }
       }

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -1,7 +1,7 @@
 locals {
   security_group_cidrs_devtest = {
     core = module.ip_addresses.azure_fixngo_cidrs.devtest_core
-    ssh = module.ip_addresses.azure_fixngo_cidrs.devtest
+    ssh  = module.ip_addresses.azure_fixngo_cidrs.devtest
     https = flatten([
       "10.0.0.0/8",
       module.ip_addresses.azure_fixngo_cidrs.devtest,
@@ -39,7 +39,7 @@ locals {
       # AllowProdStudioHostingSshInBound from 10.244.0.0/22 not included
       module.ip_addresses.azure_fixngo_cidrs.prod_core,
       module.ip_addresses.azure_fixngo_cidrs.prod, # NOTE: may need removing at some point
-    ]) 
+    ])
     https = flatten([
       "10.0.0.0/8",
       module.ip_addresses.azure_fixngo_cidrs.prod,
@@ -585,33 +585,33 @@ locals {
           cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
         }
         netbios_tcp_domain = {
-          description     = "137-139: TCP NetBIOS ingress from Azure DC and Jumpserver"
-          from_port       = 137
-          to_port         = 139
-          protocol        = "TCP"
-          cidr_blocks     = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          description = "137-139: TCP NetBIOS ingress from Azure DC and Jumpserver"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "TCP"
+          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
         }
         netbios_udp_domain = {
-          description     = "137-139: UDP NetBIOS ingress from Azure DC and Jumpserver"
-          from_port       = 137
-          to_port         = 139
-          protocol        = "UDP"
-          cidr_blocks     = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          description = "137-139: UDP NetBIOS ingress from Azure DC and Jumpserver"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "UDP"
+          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
         }
         ldap_tcp_domain = {
-          description     = "389: TCP Allow LDAP ingress from Azure DC"
-          from_port       = 389
-          to_port         = 389
-          protocol        = "TCP"
-          cidr_blocks     = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          description = "389: TCP Allow LDAP ingress from Azure DC"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "TCP"
+          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
           # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
         }
         ldap_udp_domain = {
-          description     = "389: UDP Allow LDAP ingress from Azure DC"
-          from_port       = 389
-          to_port         = 389
-          protocol        = "UDP"
-          cidr_blocks     = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          description = "389: UDP Allow LDAP ingress from Azure DC"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "UDP"
+          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
           # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
         }
 
@@ -955,25 +955,25 @@ locals {
         }
         # IMPORTANT: check if an 'allow all from load-balancer' rule is required
         echo_core_tcp_db = {
-          description     = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port       = 7
-          to_port         = 7
-          protocol        = "TCP"
-          cidr_blocks     = local.security_group_cidrs.core
+          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
+          from_port   = 7
+          to_port     = 7
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.core
         }
         echo_core_udp_db = {
-          description     = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port       = 7
-          to_port         = 7
-          protocol        = "UDP"
-          cidr_blocks     = local.security_group_cidrs.core
+          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
+          from_port   = 7
+          to_port     = 7
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs.core
         }
         ssh-db = {
-          description     = "22: SSH allow ingress"
-          from_port       = 22
-          to_port         = 22
-          protocol        = "tcp"
-          cidr_blocks     = local.security_group_cidrs.ssh
+          description = "22: SSH allow ingress"
+          from_port   = 22
+          to_port     = 22
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs.ssh
         }
         rpc_udp_db = {
           description = "135: UDP MS-RPC AD connect ingress from Azure DC and Jumpserver"
@@ -990,11 +990,11 @@ locals {
           cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
         }
         oracle_1521_db = {
-          description = "Allow oracle database 1521 ingress"
-          from_port   = "1521"
-          to_port     = "1521"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_db
+          description     = "Allow oracle database 1521 ingress"
+          from_port       = "1521"
+          to_port         = "1521"
+          protocol        = "TCP"
+          cidr_blocks     = local.security_group_cidrs.oracle_db
           security_groups = ["web", "app"]
         }
         oracleoem_3872_db = {

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -997,7 +997,7 @@ locals {
           from_port   = 445
           to_port     = 445
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.jumpserver_controllers)
+          cidr_blocks = local.security_group_cidrs.jumpservers
         }
         rpc_dynamic_udp_jumpserver = {
           description = "49152-65535: UDP Dynamic Port rang from Azure Jumpservers"

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -719,7 +719,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rpc_dynamic_tcp_web = {
@@ -727,7 +727,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
       }
@@ -783,7 +783,7 @@ locals {
           from_port       = 445
           to_port         = 445
           protocol        = "UDP"
-          security_groups = ["app", "databaseb"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         http_2109_csr = {
@@ -814,7 +814,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "UDP"
-          security_groups = ["app", "databaseb"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rpc_dynamic_tcp_app = {
@@ -822,7 +822,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "TCP"
-          security_groups = ["app", "databaseb"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
       }

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -847,39 +847,39 @@ locals {
           self        = true
         }
         rpc_udp_domain = {
-          description = "135: UDP MS-RPC AD connect ingress from Azure DC and Jumpserver"
+          description = "135: UDP MS-RPC AD connect ingress from Azure DC"
           from_port   = 135
           to_port     = 135
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         rpc_tcp_domain = {
-          description = "135: TCP MS-RPC AD connect ingress from Azure DC and Jumpserver"
+          description = "135: TCP MS-RPC AD connect ingress from Azure DC"
           from_port   = 135
           to_port     = 135
           protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         netbios_tcp_domain = {
-          description = "137-139: TCP NetBIOS ingress from Azure DC and Jumpserver"
+          description = "137-139: TCP NetBIOS ingress from Azure DC"
           from_port   = 137
           to_port     = 139
           protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         netbios_udp_domain = {
-          description = "137-139: UDP NetBIOS ingress from Azure DC and Jumpserver"
+          description = "137-139: UDP NetBIOS ingress from Azure DC"
           from_port   = 137
           to_port     = 139
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         ldap_tcp_domain = {
           description = "389: TCP Allow LDAP ingress from Azure DC"
           from_port   = 389
           to_port     = 389
           protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
           # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
         }
         ldap_udp_domain = {
@@ -887,7 +887,7 @@ locals {
           from_port   = 389
           to_port     = 389
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
           # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
         }
 
@@ -896,28 +896,122 @@ locals {
           from_port   = 445
           to_port     = 445
           protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         smb_udp_domain = {
           description = "445: UDP SMB ingress from Azure DC"
           from_port   = 445
           to_port     = 445
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         rpc_dynamic_udp_domain = {
           description = "49152-65535: UDP Dynamic Port range"
           from_port   = 49152
           to_port     = 65535
           protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
         }
         rpc_dynamic_tcp_domain = {
           description = "49152-65535: TCP Dynamic Port range"
           from_port   = 49152
           to_port     = 65535
           protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
+          cidr_blocks = local.security_group_cidrs.domain_controllers
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all traffic outbound"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    jumpserver = {
+      description = "New security group for jump-servers"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        rpc_udp_jumpserver = {
+          description = "135: UDP MS-RPC AD connect ingress from Azure Jumpservers"
+          from_port   = 135
+          to_port     = 135
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        rpc_tcp_jumpserver = {
+          description = "135: TCP MS-RPC AD connect ingress from Azure Jumpservers"
+          from_port   = 135
+          to_port     = 135
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        netbios_tcp_jumpserver = {
+          description = "137-139: TCP NetBIOS ingress from Azure Jumpservers"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        netbios_udp_jumpserver = {
+          description = "137-139: UDP NetBIOS ingress from Azure Jumpservers"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        ldap_tcp_jumpserver = {
+          description = "389: TCP Allow LDAP ingress from Azure Jumpservers"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+          # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
+        }
+        ldap_udp_jumpserver = {
+          description = "389: UDP Allow LDAP ingress from Azure Jumpservers"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+          # NOTE: not completely clear this is needed as it's not in the existing Azure SG's
+        }
+
+        smb_tcp_jumpserver = {
+          description = "445: TCP SMB ingress from Azure Jumpservers"
+          from_port   = 445
+          to_port     = 445
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        smb_udp_jumpserver = {
+          description = "445: UDP SMB ingress from Azure Jumpservers"
+          from_port   = 445
+          to_port     = 445
+          protocol    = "UDP"
+          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.jumpserver_controllers)
+        }
+        rpc_dynamic_udp_jumpserver = {
+          description = "49152-65535: UDP Dynamic Port rang from Azure Jumpservers"
+          from_port   = 49152
+          to_port     = 65535
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
+        }
+        rpc_dynamic_tcp_jumpserver = {
+          description = "49152-65535: TCP Dynamic Port range from Azure Jumpservers"
+          from_port   = 49152
+          to_port     = 65535
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.jumpservers
         }
       }
       egress = {

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -5,6 +5,7 @@ locals {
     enduserclient = [
       "10.0.0.0/8"
     ]
+    # NOTE: REMOVE THIS WHEN MOVE TO NEW SG's
     http7xxx = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
@@ -40,6 +41,7 @@ locals {
     enduserclient = [
       "10.0.0.0/8"
     ]
+    # NOTE: REMOVE THIS WHEN MOVE TO NEW SG's
     http7xxx = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
@@ -591,14 +593,14 @@ locals {
           from_port   = 7770
           to_port     = 7771
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.http7xxx
+          cidr_blocks = local.security_group_cidrs.enduserclient
         }
         http7780_7781_lb = {
           description = "Allow http 7780-7781 ingress"
           from_port   = 7780
           to_port     = 7781
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.http7xxx
+          cidr_blocks = local.security_group_cidrs.enduserclient
         }
       }
       egress = {
@@ -699,7 +701,7 @@ locals {
           from_port       = 7770
           to_port         = 7771
           protocol        = "TCP"
-          cidr_blocks     = local.security_group_cidrs.http7xxx
+          cidr_blocks     = local.security_group_cidrs.enduserclient
           security_groups = ["load-balancer"]
           # NOTE: will need to be changed to include client access but load-balancer access allowed in
         }
@@ -708,7 +710,7 @@ locals {
           from_port       = 7780
           to_port         = 7781
           protocol        = "TCP"
-          cidr_blocks     = local.security_group_cidrs.http7xxx
+          cidr_blocks     = local.security_group_cidrs.enduserclient
           security_groups = ["load-balancer"]
           # NOTE: will need to be changed to include client access but load-balancer access allowed in
         }
@@ -944,7 +946,7 @@ locals {
           from_port   = 7
           to_port     = 7
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.core
+          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
         }
         echo_core_udp_db = {
           description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -638,7 +638,7 @@ locals {
           from_port       = 135
           to_port         = 135
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rpc_tcp_web = {
@@ -646,7 +646,7 @@ locals {
           from_port       = 135
           to_port         = 135
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         https_web = {
@@ -663,7 +663,7 @@ locals {
           from_port       = 445
           to_port         = 445
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         smb_udp_web = {
@@ -671,7 +671,7 @@ locals {
           from_port       = 445
           to_port         = 445
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rdp_tcp_web = {
@@ -759,7 +759,7 @@ locals {
           from_port       = 135
           to_port         = 135
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rpc_tcp_app = {
@@ -767,7 +767,7 @@ locals {
           from_port       = 135
           to_port         = 135
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         smb_tcp_app = {
@@ -775,7 +775,7 @@ locals {
           from_port       = 445
           to_port         = 445
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "database"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         smb_udp_app = {
@@ -783,7 +783,7 @@ locals {
           from_port       = 445
           to_port         = 445
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "databaseb"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         http_2109_csr = {
@@ -814,7 +814,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "UDP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "databaseb"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
         rpc_dynamic_tcp_app = {
@@ -822,7 +822,7 @@ locals {
           from_port       = 49152
           to_port         = 65535
           protocol        = "TCP"
-          security_groups = ["app", "db"]
+          security_groups = ["app", "databaseb"]
           # NOTE: csr_clientaccess will need to be added here to cidr_blocks
         }
       }

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -43,12 +43,106 @@ locals {
     noms_test_dr_vnet         = "10.111.0.0/16"
     noms_mgmt_dr_vnet         = "10.112.0.0/16"
 
-
     noms_transit_live_fw_devtest    = "52.142.189.87/32"
     noms_transit_live_fw_prod       = "52.142.189.118/32"
     noms_transit_live_dr_fw_devtest = "20.90.217.135/32"
     noms_transit_live_dr_fw_prod    = "20.90.217.127/32"
+  }
 
+  noms_live_subnet = {
+    noms_live_core                                = "10.40.0.128/26"
+    hmpps_prod_ukwest_clientaccess_appgateway1    = "10.40.2.0/27"
+    hmpps_prod_ukwest_clientaccess_appgateway2    = "10.40.2.32/27"
+    hmpps_preprod_ukwest_clientaccess_appgateway1 = "10.40.2.64/27"
+    hmpps_prod_ukwest_clientaccess_appgateway3    = "10.40.2.160/27"
+    pd_prisonnomis_clientaccess                   = "10.40.3.0/26"
+    pd_prisonnomis_app                            = "10.40.3.64/26"
+    pd_prisonnomis_db                             = "10.40.3.128/26"
+    pd_prisonnomis_ndh                            = "10.40.3.192/26"
+    pd_prisonnomis_clientaccess_gateway           = "10.40.4.0/26"
+    pd_oasys_clientaccess                         = "10.40.6.0/26"
+    pd_oasys_app                                  = "10.40.6.64/26"
+    pd_oasys_db                                   = "10.40.6.128/26"
+    pd_oasys_clientaccess_gateway                 = "10.40.6.192/26"
+    pd_csr_clientaccess                           = "10.40.8.0/26"
+    pd_csr_app                                    = "10.40.8.64/26"
+    pd_csr_db                                     = "10.40.8.128/26"
+    pd_csr_clientaccess_gateway                   = "10.40.8.192/26"
+    pd_noncore_db                                 = "10.40.10.128/26"
+    pp_noncore_db                                 = "10.40.11.128/26"
+    pd_cafm_clientaccess                          = "10.40.15.0/26"
+    pd_cafm_app                                   = "10.40.15.64/26"
+    pd_cafm_db                                    = "10.40.15.128/26"
+    pd_cafm_clientaccess_gateway                  = "10.40.15.192/26"
+    pp_prisonnomis_clientaccess                   = "10.40.37.0/26"
+    pp_prisonnomis_app                            = "10.40.37.64/26"
+    pp_prisonnomis_db                             = "10.40.37.128/26"
+    pp_prisonnomis_ndh                            = "10.40.37.192/26"
+    pp_prisonnomis_clientaccess_gateway           = "10.40.38.0/26"
+    pp_oasys_clientaccess                         = "10.40.40.0/26"
+    pp_oasys_app                                  = "10.40.40.64/26"
+    pp_oasys_db                                   = "10.40.40.128/26"
+    pp_oasys_clientaccess_gateway                 = "10.40.40.192/26"
+    pp_csr_clientaccess                           = "10.40.42.0/26"
+    pp_csr_app                                    = "10.40.42.64/26"
+    pp_csr_db                                     = "10.40.42.128/26"
+    pp_csr_clientaccess_gateway                   = "10.40.42.192/26"
+    ls_prisonnomis_clientaccess                   = "10.40.44.0/27"
+    ls_prisonnomis_app                            = "10.40.44.32/27"
+    ls_prisonnomis_db                             = "10.40.44.64/27"
+    ls_prisonnomis_ndh                            = "10.40.44.96/27"
+    pp_cafm_clientaccess                          = "10.40.50.0/26"
+    pp_cafm_app                                   = "10.40.50.64/26"
+    pp_cafm_db                                    = "10.40.50.128/26"
+    pp_cafm_clientaccess_gateway                  = "10.40.50.192/26"
+    pp_mercury                                    = "10.40.54.0/24"
+    pd_mercury                                    = "10.40.55.0/24"
+    pd_lss                                        = "10.40.56.0/28"
+  }
+
+  noms_mgmt_live_subnet = {
+    noms_mgmt_live_remoteaccess = "10.40.128.128/26"
+    noms_mgmt_live_core         = "10.40.128.192/26"
+    noms_mgmt_live_tools        = "10.40.129.0/26"
+    noms_mgmt_live_jumpservers  = "10.40.129.64/26"
+    noms_mgmt_live_tvm          = "10.40.130.16/28"
+  }
+  noms_test_subnet = {
+    noms_test_core                                = "10.101.0.128/26"
+    hmpps_devtest_ukwest_clientaccess_appgateway1 = "10.101.2.0/27"
+    hmpps_devtest_ukwest_clientaccess_appgateway2 = "10.101.2.32/27"
+    hmpps_devtest_ukwest_clientaccess_appgateway3 = "10.101.2.64/27"
+    t1_prisonnomis_clientaccess                   = "10.101.3.0/26"
+    t1_prisonnomis_app                            = "10.101.3.64/26"
+    t1_prisonnomis_db                             = "10.101.3.128/26"
+    t1_prisonnomis_ndh                            = "10.101.3.192/26"
+    t1_oasys_clientaccess                         = "10.101.6.0/26"
+    t1_oasys_app                                  = "10.101.6.64/26"
+    t1_oasys_db                                   = "10.101.6.128/26"
+    t1_noncore_app                                = "10.101.11.64/26"
+    t2_prisonnomis_clientaccess                   = "10.101.33.0/26"
+    t2_prisonnomis_db                             = "10.101.33.128/26"
+    t2_prisonnomis_ndh                            = "10.101.33.192/26"
+    t2_oasys_clientaccess                         = "10.101.36.0/26"
+    t2_oasys_app                                  = "10.101.36.64/26"
+    t2_oasys_db                                   = "10.101.36.128/26"
+    t3_prisonnomis_clientaccess                   = "10.101.63.0/26"
+    t3_prisonnomis_db                             = "10.101.63.128/26"
+    t3_csr_clientaccess                           = "10.101.69.0/26"
+    t3_csr_app                                    = "10.101.69.64/26"
+    t3_csr_db                                     = "10.101.69.128/26"
+    sd_prisonnomis                                = "10.101.93.0/24"
+  }
+  noms_mgmt_subnet = {
+    nomsmgmt_remoteaccess         = "10.102.0.128/26"
+    nomsmgmt_core                 = "10.102.0.192/26"
+    nomsmgmt_tools                = "10.102.1.0/26"
+    nomsmgmt_jumpservers_test     = "10.102.1.64/26"
+    nomsmgmt_patchacquisition     = "10.102.1.128/26"
+    nomsmgmtjumpservers_test_temp = "10.102.1.192/26"
+    nomsmgmt_proxy_inner          = "10.102.3.0/26"
+    nomsmgmt_proxy_outer          = "10.102.3.64/26"
+    noms_mgmt_tvm                 = "10.102.5.0/28"
   }
 
   azure_fixngo_cidrs = {
@@ -60,11 +154,22 @@ locals {
       local.azure_fixngo_cidr.noms_mgmt_dr_vnet,
     ]
 
+    devtest_jumpservers = [
+      local.noms_mgmt_subnet.nomsmgmt_jumpservers_test,
+      local.noms_mgmt_subnet.nomsmgmtjumpservers_test_temp,
+      local.noms_mgmt_subnet.nomsmgmt_remoteaccess,
+    ]
+
     prod = [
       local.azure_fixngo_cidr.noms_live_vnet,
       local.azure_fixngo_cidr.noms_mgmt_live_vnet,
       local.azure_fixngo_cidr.noms_live_dr_vnet,
       local.azure_fixngo_cidr.noms_mgmt_live_dr_vnet,
+    ]
+
+    prod_jumpservers = [
+      local.noms_mgmt_live_subnet.noms_mgmt_live_jumpservers,
+      local.noms_mgmt_live_subnet.noms_mgmt_live_remoteaccess,
     ]
 
     internet_egress = [

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -156,6 +156,10 @@ locals {
 
   azure_fixngo_cidrs = {
 
+    devtest_core = [
+      local.noms_test_subnet.noms_test_core,
+    ]
+
     devtest = [
       local.azure_fixngo_cidr.noms_test_vnet,
       local.azure_fixngo_cidr.noms_mgmt_vnet,
@@ -173,6 +177,10 @@ locals {
       local.noms_mgmt_subnet.nomsmgmt_jumpservers_test,
       local.noms_mgmt_subnet.nomsmgmtjumpservers_test_temp,
       local.noms_mgmt_subnet.nomsmgmt_remoteaccess,
+    ]
+
+    prod_core = [
+      local.noms_live_subnet.noms_live_core,
     ]
 
     prod = [

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -47,6 +47,15 @@ locals {
     noms_transit_live_fw_prod       = "52.142.189.118/32"
     noms_transit_live_dr_fw_devtest = "20.90.217.135/32"
     noms_transit_live_dr_fw_prod    = "20.90.217.127/32"
+
+    noms_prod_domain_controller_PCMCW0011 = "10.40.128.196/32"
+    noms_prod_domain_controller_PCMCW0012 = "10.40.0.133/32"
+    noms_prod_domain_controller_pcmcw1011 = "10.40.144.196/32"
+    noms_prod_domain_controller_pcmcw1012 = "10.40.64.133/32"
+
+    noms_devtest_domain_controller_MGMCW0002 = "10.102.0.196/32"
+    noms_devtest_domain_controller_tc_mgt_dc_01 = "10.102.0.199/32"
+    noms_devtest_domain_controller_tc_mgt_dc_02 = "10.102.0.200/32"
   }
 
   noms_live_subnet = {
@@ -154,6 +163,12 @@ locals {
       local.azure_fixngo_cidr.noms_mgmt_dr_vnet,
     ]
 
+    devtest_domain_controllers = [
+      local.azure_fixngo_cidr.noms_devtest_domain_controller_MGMCW0002,
+      local.azure_fixngo_cidr.noms_devtest_domain_controller_tc_mgt_dc_01,
+      local.azure_fixngo_cidr.noms_devtest_domain_controller_tc_mgt_dc_02,
+    ]
+
     devtest_jumpservers = [
       local.noms_mgmt_subnet.nomsmgmt_jumpservers_test,
       local.noms_mgmt_subnet.nomsmgmtjumpservers_test_temp,
@@ -165,6 +180,13 @@ locals {
       local.azure_fixngo_cidr.noms_mgmt_live_vnet,
       local.azure_fixngo_cidr.noms_live_dr_vnet,
       local.azure_fixngo_cidr.noms_mgmt_live_dr_vnet,
+    ]
+
+    prod_domain_controllers = [
+      local.azure_fixngo_cidr.noms_prod_domain_controller_PCMCW0011,
+      local.azure_fixngo_cidr.noms_prod_domain_controller_PCMCW0012,
+      local.azure_fixngo_cidr.noms_prod_domain_controller_pcmcw1011,
+      local.azure_fixngo_cidr.noms_prod_domain_controller_pcmcw1012,
     ]
 
     prod_jumpservers = [


### PR DESCRIPTION
- web, app, domain, load-balancer, database, jumpserver security groups
- imported (many) cidr ranges to help access fixngo more cleanly
- tidied up new security groups so they work outside of dev/test environment