### PR TITLE
nomis: add misload ssm param

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -12,6 +12,12 @@ locals {
       weblogic-passwords = { description = "passwords available to weblogic servers" }
     }
   }
+  database_mis_ssm_parameters = {
+    parameters = {
+      passwords      = { description = "database passwords" }
+      misload-config = { description = "misload username, password and hostname" }
+    }
+  }
   database_ssm_parameters = {
     parameters = {
       passwords = { description = "database passwords" }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -92,7 +92,7 @@ locals {
       "/oracle/database/PPNDH"    = local.database_ssm_parameters
       "/oracle/database/PPTRDAT"  = local.database_ssm_parameters
       "/oracle/database/PPCNMAUD" = local.database_ssm_parameters
-      "/oracle/database/PPMIS"    = local.database_ssm_parameters
+      "/oracle/database/PPMIS"    = local.database_mis_ssm_parameters
 
       # OLD
       "/oracle/database/CNOMPP" = local.database_nomis_ssm_parameters
@@ -173,6 +173,7 @@ locals {
 
     baseline_ec2_instances = {
       preprod-nomis-db-2-a = merge(local.database_ec2_a, {
+        cloudwatch_metric_alarms = {}
         tags = merge(local.database_ec2_a.tags, {
           nomis-environment = "preprod"
           description       = "PreProduction NOMIS MIS and Audit database"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -85,12 +85,12 @@ locals {
       "/oracle/database/PNDH"     = local.database_ssm_parameters
       "/oracle/database/PTRDAT"   = local.database_ssm_parameters
       "/oracle/database/PCNMAUD"  = local.database_ssm_parameters
-      "/oracle/database/PMIS"     = local.database_ssm_parameters
+      "/oracle/database/PMIS"     = local.database_mis_ssm_parameters
       "/oracle/database/DRCNOM"   = local.database_nomis_ssm_parameters
       "/oracle/database/DRNDH"    = local.database_ssm_parameters
       "/oracle/database/DRTRDAT"  = local.database_ssm_parameters
       "/oracle/database/DRCNMAUD" = local.database_ssm_parameters
-      "/oracle/database/DRMIS"    = local.database_ssm_parameters
+      "/oracle/database/DRMIS"    = local.database_mis_ssm_parameters
 
       # OLD
       "/oracle/database/CNOMP" = local.database_nomis_ssm_parameters
@@ -211,6 +211,7 @@ locals {
       })
 
       prod-nomis-db-1-b = merge(local.database_ec2_b, {
+        cloudwatch_metric_alarms = {}
         tags = merge(local.database_ec2_b.tags, {
           nomis-environment = "prod"
           description       = "Disaster-Recovery/High-Availability production databases for CNOM and NDH"
@@ -271,6 +272,7 @@ locals {
       })
 
       prod-nomis-db-2-b = merge(local.database_ec2_b, {
+        cloudwatch_metric_alarms = {}
         tags = merge(local.database_ec2_b.tags, {
           nomis-environment = "prod"
           description       = "Disaster-Recovery/High-Availability production databases for AUDIT/MIS"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -171,7 +171,7 @@ locals {
       "/oracle/database/T1NDH"    = local.database_ssm_parameters
       "/oracle/database/T1TRDAT"  = local.database_ssm_parameters
       "/oracle/database/T1CNMAUD" = local.database_ssm_parameters
-      "/oracle/database/T1MIS"    = local.database_ssm_parameters
+      "/oracle/database/T1MIS"    = local.database_mis_ssm_parameters
       "/oracle/database/T1ORSYS"  = local.database_ssm_parameters
       "/oracle/database/T2CNOM"   = local.database_nomis_ssm_parameters
       "/oracle/database/T2NDH"    = local.database_nomis_ssm_parameters


### PR DESCRIPTION
Create additional SSM parameter for MIS load configuration
Temporarily drop monitoring from new nomis DBs until they are fully configured