### PR TITLE
🌐 Add Data Platform front door CNAME

### DIFF
--- a/terraform/environments/data-platform/infra_route53.tf
+++ b/terraform/environments/data-platform/infra_route53.tf
@@ -96,7 +96,7 @@ resource "aws_route53_record" "data_platform_user_guidance" {
 }
 
 # Front Door on GitHub Pages
-resource "aws_route53_record" "data_platform_user_guidance" {
+resource "aws_route53_record" "data_platform_front_door" {
   count = terraform.workspace == "data-platform-production" ? 1 : 0
 
   zone_id = aws_route53_zone.data_platform_service_justice_gov_uk[0].zone_id

--- a/terraform/environments/data-platform/infra_route53.tf
+++ b/terraform/environments/data-platform/infra_route53.tf
@@ -95,6 +95,17 @@ resource "aws_route53_record" "data_platform_user_guidance" {
   records = ["ministryofjustice.github.io."]
 }
 
+# Front Door on GitHub Pages
+resource "aws_route53_record" "data_platform_user_guidance" {
+  count = terraform.workspace == "data-platform-production" ? 1 : 0
+
+  zone_id = aws_route53_zone.data_platform_service_justice_gov_uk[0].zone_id
+  name    = "data-platform.service.justice.gov.uk"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["ministryofjustice.github.io."]
+}
+
 # PagerDuty Status Page (HTTP Traffic)
 resource "aws_route53_record" "http_traffic_status_data_platform_service_justice_gov_uk" {
   count = terraform.workspace == "data-platform-production" ? 1 : 0


### PR DESCRIPTION
data-platform.service.justice.gov.uk points to GitHub Pages