### PR TITLE
DSOS-2209: use arn not key_id

### DIFF
--- a/terraform/environments/nomis/iam.tf
+++ b/terraform/environments/nomis/iam.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "sas_token_rotator" {
       "kms:Encrypt",
     ]
     resources = [
-      data.aws_kms_key.general_shared.key_id,
+      data.aws_kms_key.general_shared.arn,
     ]
   }
 }


### PR DESCRIPTION
specify the resource by the full arn and not the key_id