### PR TITLE
DSOS-2241: Add restore object permissions to S3 policies

### DIFF
--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -109,6 +109,7 @@ locals {
         "s3:PutObject",
         "s3:PutObjectAcl",
         "s3:PutObjectTagging",
+        "s3:RestoreObject",
       ]
       principals = {
         type = "AWS"
@@ -142,6 +143,7 @@ locals {
         "s3:PutObject",
         "s3:PutObjectAcl",
         "s3:PutObjectTagging",
+        "s3:RestoreObject",
       ]
       principals = {
         type = "AWS"
@@ -161,6 +163,7 @@ locals {
         "s3:PutObjectAcl",
         "s3:PutObjectTagging",
         "s3:DeleteObject",
+        "s3:RestoreObject",
       ]
       principals = {
         type = "AWS"
@@ -196,6 +199,7 @@ locals {
         "s3:PutObjectTagging",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:RestoreObject",
       ]
       principals = {
         type = "AWS"
@@ -227,6 +231,7 @@ locals {
           "s3:PutObject",
           "s3:PutObjectAcl",
           "s3:PutObjectTagging",
+          "s3:RestoreObject",
         ]
       }
     ]
@@ -241,6 +246,7 @@ locals {
           "s3:PutObjectAcl",
           "s3:PutObjectTagging",
           "s3:DeleteObject",
+          "s3:RestoreObject",
         ]
       }
     ]


### PR DESCRIPTION
We've got lifecycle rules to put stuff into glacier storage but no permissions to restore.  Adding restore permissions to anything that has write access.