### PR TITLE
DSOS-2190: Reduce EC2 SSM permissions

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -16,6 +16,7 @@ locals {
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
+    enable_ec2_reduced_ssm_policy                = true
     enable_ec2_self_provision                    = true
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_ec2_user_keypair                      = true


### PR DESCRIPTION
Reduce scope of EC2 SSM access.  Previously EC2s could access all secrets, now they can only access secrets that they need.