### PR TITLE
Nit 858 Connection with EC2 based DB 

### DIFF
--- a/terraform/environments/delius-core/modules/environment_all_components/db_ec2.tf
+++ b/terraform/environments/delius-core/modules/environment_all_components/db_ec2.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "db_ec2_primary_instance" {
   #checkov:skip=CKV2_AWS_41:"IAM role is not implemented for this example EC2. SSH/AWS keys are not used either."
   instance_type               = var.db_config.instance.instance_type
   ami                         = data.aws_ami.oracle_db_ami.id
-  vpc_security_group_ids      = [aws_security_group.db_ec2_instance_sg.id]
+  vpc_security_group_ids      = [aws_security_group.db_ec2_instance_sg.id, aws_security_group.delius_db_security_group.id]
   subnet_id                   = var.account_config.data_subnet_a_id
   iam_instance_profile        = aws_iam_instance_profile.db_ec2_instanceprofile.name
   associate_public_ip_address = false

--- a/terraform/environments/delius-core/modules/environment_all_components/db_iam.tf
+++ b/terraform/environments/delius-core/modules/environment_all_components/db_iam.tf
@@ -84,6 +84,31 @@ data "aws_iam_policy_document" "ec2_access_for_ansible" {
   }
 }
 
+data "aws_iam_policy_document" "allow_access_to_ssm_parameter_store" {
+  statement {
+    sid     = "AllowAccessToSsmParameterStore"
+    effect  = "Allow"
+    actions = [
+      "ssm:PutParameter"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "allow_access_to_ssm_parameter_store" {
+  name   = format("%s-%s-allow_access_to_ssm_parameter_store", var.env_name, var.db_config.name)
+  path   = "/"
+  policy = data.aws_iam_policy_document.allow_access_to_ssm_parameter_store.json
+  tags = merge(local.tags,
+    { Name = format("%s-%s-ec2_access_for_ansible", var.env_name, var.db_config.name) }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "allow_access_to_ssm_parameter_store" {
+  role       = aws_iam_role.db_ec2_instance_iam_role.name
+  policy_arn = aws_iam_policy.allow_access_to_ssm_parameter_store.arn
+}
+
 resource "aws_iam_policy" "ec2_access_for_ansible" {
   name   = format("%s-%s-ec2_access_for_ansible", var.env_name, var.db_config.name)
   path   = "/"

--- a/terraform/environments/delius-core/modules/environment_all_components/db_s3.tf
+++ b/terraform/environments/delius-core/modules/environment_all_components/db_s3.tf
@@ -49,6 +49,31 @@ data "aws_iam_policy_document" "oracledb_backup_bucket_access" {
       "${module.s3_bucket_oracledb_backups.bucket.arn}/*"
     ]
   }
+
+  statement {
+    sid    = "AllowAccessToS3OracleBackups"
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+    resources = [
+      "arn:aws:s3:::eu-west-2-dlc-${var.env_name}-oracledb-backups",
+      "arn:aws:s3:::eu-west-2-dlc-${var.env_name}-oracledb-backups/*"
+    ]
+  }
+
+  statement {
+    sid    = "listAllBuckets"
+    effect = "Allow"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      "arn:aws:s3:::*"
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "oracledb_backup_bucket_access_policy" {


### PR DESCRIPTION
- Added IAM policy document that was previously created manually to test permissions
- Added SG to EC2 DB to allow inbound traffic from ECS frontend service on Oracle port 