### PR TITLE
♻️ Remove random suffix from Open Metadata target role

### DIFF
--- a/terraform/environments/data-platform/iam-roles.tf
+++ b/terraform/environments/data-platform/iam-roles.tf
@@ -4,7 +4,7 @@ module "openmetadata_iam_role" {
 
   create_role = true
 
-  role_name_prefix  = "openmetadata"
+  role_name         = "openmetadata"
   role_requires_mfa = false
 
   trusted_role_arns = ["arn:aws:iam::${local.environment_configuration.apps_tools_account_id}:root"]


### PR DESCRIPTION
Allows us to build a policy in the Data Platform Apps and Tools account without looking up the role in Data Platform first because it currently is suffixed with a random string