### PR TITLE
DSOS-2203: support standalone ec2 target groups

### DIFF
--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -254,11 +254,6 @@ variable "ec2_autoscaling_groups" {
         cookie_duration = optional(number)
         cookie_name     = optional(string)
       }))
-      attachments = optional(list(object({
-        target_id         = string
-        port              = optional(number)
-        availability_zone = optional(string)
-      })), [])
     })), {})
     cloudwatch_metric_alarms = optional(map(object({
       comparison_operator = string
@@ -555,10 +550,35 @@ variable "lbs" {
     load_balancer_type       = optional(string, "application")
     security_groups          = list(string)
     public_subnets           = list(string)
+    instance_target_groups = optional(map(object({
+      port                 = optional(number)
+      protocol             = optional(string)
+      deregistration_delay = optional(number)
+      health_check = optional(object({
+        enabled             = optional(bool)
+        interval            = optional(number)
+        healthy_threshold   = optional(number)
+        matcher             = optional(string)
+        path                = optional(string)
+        port                = optional(number)
+        timeout             = optional(number)
+        unhealthy_threshold = optional(number)
+      }))
+      stickiness = optional(object({
+        enabled         = optional(bool)
+        type            = string
+        cookie_duration = optional(number)
+        cookie_name     = optional(string)
+      }))
+      attachments = optional(list(object({
+        ec2_instance_name = string
+        port              = optional(number)
+        availability_zone = optional(string)
+      })), [])
+    })), {})
     existing_target_groups = optional(map(object({
       arn = string
     })), {})
-    tags = optional(map(string), {})
     lb_target_groups = optional(map(object({
       port                 = optional(number)
       deregistration_delay = optional(number)
@@ -670,6 +690,27 @@ variable "lbs" {
       })), {})
       tags = optional(map(string), {})
     })), {})
+    lb_target_groups = optional(map(object({
+      port                 = optional(number)
+      deregistration_delay = optional(number)
+      health_check = optional(object({
+        enabled             = optional(bool)
+        interval            = optional(number)
+        healthy_threshold   = optional(number)
+        matcher             = optional(string)
+        path                = optional(string)
+        port                = optional(number)
+        timeout             = optional(number)
+        unhealthy_threshold = optional(number)
+      }))
+      stickiness = optional(object({
+        enabled         = optional(bool)
+        type            = string
+        cookie_duration = optional(number)
+        cookie_name     = optional(string)
+      }))
+    })), {})
+    tags = optional(map(string), {})
   }))
   default = {}
 }


### PR DESCRIPTION
Add support for standalone EC2 target groups in baseline.  Will be needed for both Nomis and CSR.  Tested in a separate branch but seems good.