### PR TITLE
Deploy latest version of athena load lambda

### DIFF
--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -24,10 +24,10 @@
     "production": "1.2.7"
   },
   "athena_load_versions": {
-    "development": "1.2.1",
-    "test": "1.2.1",
-    "preproduction": "1.2.1",
-    "production": "1.2.1"
+    "development": "1.2.3",
+    "test": "1.2.3",
+    "preproduction": "1.2.3",
+    "production": "1.2.3"
   },
   "create_metadata_versions": {
     "development": "2.0.0",


### PR DESCRIPTION
This changes extract_timestamp to load_timestamp in paths. Hopefully this should fix the smoketest 🤞🏻 