### PR TITLE
Hide shutdown / restart buttons in start menu

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+terraform/environments/nomis/templates/jumpserver-user-data.yaml.tftpl linguist-language=YAML

--- a/terraform/environments/nomis/templates/jumpserver-user-data.yaml.tftpl
+++ b/terraform/environments/nomis/templates/jumpserver-user-data.yaml.tftpl
@@ -241,3 +241,14 @@ tasks:
 
             $sourc.Save()       
           }
+
+      - frequency: once
+        type: powershell
+        runAs: admin
+        # Hide shutdown and restart buttons in start menu
+        content: |-
+          $registryStartMenuPath = "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\Start\"
+          if(Test-Path -Path $registryStartMenuPath){
+            Set-ItemProperty -Path "$($registryStartMenuPath)HideRestart" -Name "value" -Value 1
+            Set-ItemProperty -Path "$($registryStartMenuPath)HideShutDown" -Name "value" -Value 1
+          }


### PR DESCRIPTION
To prevent accidental shutdown
https://dsdmoj.atlassian.net/browse/DSOS-2143

.gitattributes config was added to attempt to force github to display this particular file as a YAML file - this is to make it more readable as currently when viewing the file on github it is being viewed as text with no syntax highlighting.