### PR TITLE
re-adding the ssm doc resource

### DIFF
--- a/terraform/environments/corporate-staff-rostering/ec2_common.tf
+++ b/terraform/environments/corporate-staff-rostering/ec2_common.tf
@@ -40,8 +40,7 @@ resource "aws_ssm_document" "cloud_watch_agent" {
   )
 }
 
-# commented out for now as this currently returns an error on apply
-/* resource "aws_ssm_document" "ami_build" {
+resource "aws_ssm_document" "ami_build" {
   name            = "ami-build"
   document_type   = "Command"
   document_format = "YAML"
@@ -53,4 +52,4 @@ resource "aws_ssm_document" "cloud_watch_agent" {
       Name = "ami-build"
     },
   )
-} */
+}


### PR DESCRIPTION
re-adding the resource to build the ssm doc for ami builds
checked doc manually in AWS CSR Dev account and it deploys