### PR TITLE
Roll out update metadata API and new version of create_schema

### DIFF
--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -54,10 +54,10 @@
     "production": "1.1.0"
   },
   "create_schema_versions": {
-    "development": "1.0.1",
-    "test": "1.0.1",
-    "preproduction": "1.0.1",
-    "production": "1.0.1"
+    "development": "1.0.2",
+    "test": "1.0.2",
+    "preproduction": "1.0.2",
+    "production": "1.0.2"
   },
   "get_schema_versions": {
     "development": "1.0.0",

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -64,5 +64,11 @@
     "test": "1.0.0",
     "preproduction": "1.0.0",
     "production": "1.0.0"
+  },
+  "update_metadata_versions": {
+    "development": "1.0.0",
+    "test": "1.0.0",
+    "preproduction": "1.0.0",
+    "production": "1.0.0"
   }
 }

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -66,9 +66,9 @@
     "production": "1.0.0"
   },
   "update_metadata_versions": {
-    "development": "1.0.0",
-    "test": "1.0.0",
-    "preproduction": "1.0.0",
-    "production": "1.0.0"
+    "development": "1.0.1",
+    "test": "1.0.1",
+    "preproduction": "1.0.1",
+    "production": "1.0.1"
   }
 }

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -589,3 +589,13 @@ data "aws_iam_policy_document" "iam_policy_document_for_create_schema_lambda" {
     data.aws_iam_policy_document.create_write_lambda_logs.json,
   ]
 }
+
+
+data "aws_iam_policy_document" "iam_policy_document_for_update_metadata_lambda" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.log_to_bucket.json,
+    data.aws_iam_policy_document.read_metadata.json,
+    data.aws_iam_policy_document.write_metadata.json,
+    data.aws_iam_policy_document.create_write_lambda_logs.json,
+  ]
+}

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -310,7 +310,7 @@ module "get_schema_lambda" {
     AllowExecutionFromAPIGateway = {
       action     = "lambda:InvokeFunction"
       principal  = "apigateway.amazonaws.com"
-      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.update_data_product.http_method}${aws_api_gateway_resource.schema_for_data_product_table_name.path}"
+      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.get_schema_for_data_product_table_name.http_method}${aws_api_gateway_resource.schema_for_data_product_table_name.path}"
     }
   }
 }

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -310,7 +310,36 @@ module "get_schema_lambda" {
     AllowExecutionFromAPIGateway = {
       action     = "lambda:InvokeFunction"
       principal  = "apigateway.amazonaws.com"
-      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.get_schema_for_data_product_table_name.http_method}${aws_api_gateway_resource.schema_for_data_product_table_name.path}"
+      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.update_data_product.http_method}${aws_api_gateway_resource.schema_for_data_product_table_name.path}"
+    }
+  }
+}
+
+module "data_product_update_metadata_lambda" {
+  source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=a4392c1" # ref for V2.1
+  application_name               = "data_product_update_metadata"
+  tags                           = local.tags
+  description                    = "Fetch the schema for a table from S3"
+  role_name                      = "update_metadata_role_${local.environment}"
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_update_metadata_lambda.json
+  policy_json_attached           = true
+  function_name                  = "data_product_update_metadata_${local.environment}"
+  create_role                    = true
+  reserved_concurrent_executions = 1
+
+  image_uri    = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/data-platform-update-metadata-lambda-ecr-repo:${local.update_metadata_version}"
+  timeout      = 600
+  tracing_mode = "Active"
+  memory_size  = 128
+
+  environment_variables = merge(local.logger_environment_vars, local.storage_environment_vars)
+
+  allowed_triggers = {
+
+    AllowExecutionFromAPIGateway = {
+      action     = "lambda:InvokeFunction"
+      principal  = "apigateway.amazonaws.com"
+      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.update_data_product.http_method}${aws_api_gateway_resource.data_product_name.path}"
     }
   }
 }

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -37,6 +37,7 @@ locals {
   get_schema_version               = lookup(var.get_schema_versions, local.environment)
   create_schema_version            = lookup(var.create_schema_versions, local.environment)
   landing_to_raw_version           = lookup(var.landing_to_raw_versions, local.environment)
+  update_metadata_version          = lookup(var.update_metadata_versions, local.environment)
 
   # Environment vars that are used by many lambdas
   logger_environment_vars = {

--- a/terraform/environments/data-platform/variables.tf
+++ b/terraform/environments/data-platform/variables.tf
@@ -41,3 +41,7 @@ variable "create_schema_versions" {
 variable "get_schema_versions" {
   type = map(any)
 }
+
+variable "update_metadata_versions" {
+  type = map(any)
+}


### PR DESCRIPTION
https://github.com/ministryofjustice/data-platform/issues/1657

This deploys the changes from
 https://github.com/ministryofjustice/data-platform/pull/2020
and https://github.com/ministryofjustice/data-platform/pull/2079