### PR TITLE
Add API gateway logging to cloudwatch

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -52,6 +52,42 @@ resource "aws_api_gateway_stage" "default_stage" {
   deployment_id = aws_api_gateway_deployment.deployment.id
   rest_api_id   = aws_api_gateway_rest_api.data_platform.id
   stage_name    = local.environment
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.data_platform_api.arn
+    format = jsonencode({
+      requestId        = "$context.requestId"
+      requestTime      = "$context.requestTime"
+      requestTimeEpoch = "$context.requestTimeEpoch"
+      ip               = "$context.identity.sourceIp"
+      caller           = "$context.identity.caller"
+      user             = "$context.identity.user"
+      path             = "$context.path"
+      resourcePath     = "$context.resourcePath"
+      method           = "$context.httpMethod"
+      status           = "$context.status"
+      protocol         = "$context.protocol"
+      responseLength   = "$context.responseLength"
+    })
+  }
+}
+
+resource "aws_cloudwatch_log_group" "data_platform_api" {
+  name = "data_platform_api"
+}
+
+resource "aws_api_gateway_account" "api_gateway_account" {
+  cloudwatch_role_arn = aws_iam_role.api_gateway_cloud_watch_role.arn
+}
+
+resource "aws_api_gateway_method_settings" "api_gateway_log_settings" {
+  rest_api_id = aws_api_gateway_rest_api.data_platform.id
+  stage_name  = local.environment
+  method_path = "*/*"
+
+  settings {
+    logging_level = "INFO"
+  }
 }
 
 resource "aws_api_gateway_authorizer" "authorizer" {

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -604,3 +604,14 @@ data "aws_iam_policy_document" "iam_policy_document_for_update_metadata_lambda" 
     data.aws_iam_policy_document.create_write_lambda_logs.json,
   ]
 }
+
+resource "aws_iam_role" "api_gateway_cloud_watch_role" {
+  name               = "data_platform_apigateway_log_${local.environment}"
+  assume_role_policy = data.aws_iam_policy_document.apigateway_trust_policy.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatchlogs" {
+  role       = aws_iam_role.api_gateway_cloud_watch_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+}


### PR DESCRIPTION
This is taken from @LavMatt's draft PR https://github.com/ministryofjustice/modernisation-platform-environments/pull/3481/commits/cd40e9d471a0d8eb8d98901c25a07e977033ffa7

I took out the x-ray part as I don't think we need that at the moment (can always add it back later)

https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html

This adds access logs under the `data_platform_api` group and execution logs available under the `API-Gateway-Execution-Logs_hsolkci589/development` group. The former is a group managed by us, so we can change the name if anyone has a better suggestion. The latter is managed by AWS, we've just enabled it for all requests.

Example access logs:

```
2023-10-27T14:40:57.744+01:00

{
    "caller": "-",
    "ip": "51.14.4.225",
    "method": "POST",
    "path": "/development/data-product/test_product1/table/%c2%a3/schema",
    "protocol": "HTTP/1.1",
    "requestId": "a4188e34-1104-424e-9907-eebbf55dd662",
    "requestTime": "27/Oct/2023:13:40:57 +0000",
    "requestTimeEpoch": "1698414057744",
    "resourcePath": "/data-product/{data-product-name}/table/{table-name}/schema",
    "responseLength": "87",
    "status": "400",
    "user": "-"
}
```

Example execution logs:

```
2023-10-27T14:40:57.744+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Extended Request Id: NdqckF1PLPEEhug=
-- | --
  | 2023-10-27T14:40:57.753+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Starting authorizer: xclzr8 for request: a4188e34-1104-424e-9907-eebbf55dd662
  | 2023-10-27T14:40:57.753+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Incoming identity: ********ykLGPz
  | 2023-10-27T14:40:58.348+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Using valid authorizer policy for principal: ***123
  | 2023-10-27T14:40:58.348+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Successfully completed authorizer execution
  | 2023-10-27T14:40:58.348+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Verifying Usage Plan for request: a4188e34-1104-424e-9907-eebbf55dd662. API Key: API Stage: hsolkci589/development
  | 2023-10-27T14:40:58.350+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) API Key authorized because method 'POST /data-product/{data-product-name}/table/{table-name}/schema' does not require API Key. Request will not contribute to throttle or quota limits
  | 2023-10-27T14:40:58.350+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Usage Plan check succeeded for API Key and API Stage hsolkci589/development
  | 2023-10-27T14:40:58.350+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Starting execution for request: a4188e34-1104-424e-9907-eebbf55dd662
  | 2023-10-27T14:40:58.350+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) HTTP Method: POST, Resource Path: /data-product/test_product1/table/%c2%a3/schema
  | 2023-10-27T14:41:00.608+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Successfully completed execution
  | 2023-10-27T14:41:00.608+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) Method completed with status: 400
  | 2023-10-27T14:41:00.608+01:00 | (a4188e34-1104-424e-9907-eebbf55dd662) AWS Integration Endpoint RequestId : f9410fb4-5282-4827-b8d2-7fdd1a7c3b7c
```