### PR TITLE
infra and vars for update schema endpoint

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -320,7 +320,7 @@ resource "aws_api_gateway_integration" "update_schema_for_data_product_table_nam
   rest_api_id             = aws_api_gateway_rest_api.data_platform.id
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = module.get_schema_lambda.lambda_function_invoke_arn
+  uri                     = module.data_product_update_schema_lambda.lambda_function_invoke_arn
 
   request_parameters = {
     "integration.request.path.data-product-name" = "method.request.path.data-product-name",

--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -31,6 +31,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       aws_api_gateway_method.create_schema_for_data_product_table_name,
       aws_api_gateway_method.get_schema_for_data_product_table_name,
       aws_api_gateway_method.update_data_product,
+      aws_api_gateway_method.update_schema_for_data_product_table_name,
       aws_api_gateway_integration.docs_to_lambda,
       aws_api_gateway_integration.upload_data_for_data_product_table_name_to_lambda,
       aws_api_gateway_integration.proxy_to_lambda,
@@ -39,7 +40,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       aws_api_gateway_integration.register_data_product_to_lambda,
       aws_api_gateway_integration.create_schema_for_data_product_table_name_to_lambda,
       aws_api_gateway_integration.get_schema_for_data_product_table_name_to_lambda,
-      aws_api_gateway_integration.update_data_product_to_lambda
+      aws_api_gateway_integration.update_data_product_to_lambda,
+      aws_api_gateway_integration.update_schema_for_data_product_table_name_to_lambda
     ]))
   }
 
@@ -284,6 +286,36 @@ resource "aws_api_gateway_method" "get_schema_for_data_product_table_name" {
 # /data-product/{data-product-name}/table/{table-name}/schema lambda integration
 resource "aws_api_gateway_integration" "get_schema_for_data_product_table_name_to_lambda" {
   http_method             = aws_api_gateway_method.get_schema_for_data_product_table_name.http_method
+  resource_id             = aws_api_gateway_resource.schema_for_data_product_table_name.id
+  rest_api_id             = aws_api_gateway_rest_api.data_platform.id
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = module.get_schema_lambda.lambda_function_invoke_arn
+
+  request_parameters = {
+    "integration.request.path.data-product-name" = "method.request.path.data-product-name",
+    "integration.request.path.table-name"        = "method.request.path.table-name",
+  }
+}
+
+# /data-product/{data-product-name}/table/{table-name}/schema PUT method
+resource "aws_api_gateway_method" "update_schema_for_data_product_table_name" {
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.authorizer.id
+  http_method   = "PUT"
+  resource_id   = aws_api_gateway_resource.schema_for_data_product_table_name.id
+  rest_api_id   = aws_api_gateway_rest_api.data_platform.id
+
+  request_parameters = {
+    "method.request.header.Authorization"   = true,
+    "method.request.path.data-product-name" = true,
+    "method.request.path.table-name"        = true,
+  }
+}
+
+# /data-product/{data-product-name}/table/{table-name}/schema lambda integration
+resource "aws_api_gateway_integration" "update_schema_for_data_product_table_name_to_lambda" {
+  http_method             = aws_api_gateway_method.update_schema_for_data_product_table_name.http_method
   resource_id             = aws_api_gateway_resource.schema_for_data_product_table_name.id
   rest_api_id             = aws_api_gateway_rest_api.data_platform.id
   integration_http_method = "POST"

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -1,9 +1,9 @@
 {
   "docs_versions": {
-    "development": "1.0.5",
-    "test": "1.0.5",
-    "preproduction": "1.0.5",
-    "production": "1.0.5"
+    "development": "1.0.8",
+    "test": "1.0.8",
+    "preproduction": "1.0.8",
+    "production": "1.0.8"
   },
   "authorizer_versions": {
     "development": "1.0.0",

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -70,5 +70,11 @@
     "test": "1.0.1",
     "preproduction": "1.0.1",
     "production": "1.0.1"
+  },
+  "update_schema_versions": {
+    "development": "1.0.0",
+    "test": "1.0.0",
+    "preproduction": "1.0.0",
+    "production": "1.0.0"
   }
 }

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -72,9 +72,9 @@
     "production": "1.0.1"
   },
   "update_schema_versions": {
-    "development": "1.0.0",
-    "test": "1.0.0",
-    "preproduction": "1.0.0",
-    "production": "1.0.0"
+    "development": "1.0.1",
+    "test": "1.0.1",
+    "preproduction": "1.0.1",
+    "production": "1.0.1"
   }
 }

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -586,17 +586,7 @@ data "aws_iam_policy_document" "iam_policy_document_for_resync_unprocessed_files
   }
 }
 
-data "aws_iam_policy_document" "iam_policy_document_for_create_schema_lambda" {
-  source_policy_documents = [
-    data.aws_iam_policy_document.log_to_bucket.json,
-    data.aws_iam_policy_document.read_metadata.json,
-    data.aws_iam_policy_document.write_metadata.json,
-    data.aws_iam_policy_document.create_write_lambda_logs.json,
-  ]
-}
-
-
-data "aws_iam_policy_document" "iam_policy_document_for_update_metadata_lambda" {
+data "aws_iam_policy_document" "iam_policy_document_for_write_metadata_and_schema" {
   source_policy_documents = [
     data.aws_iam_policy_document.log_to_bucket.json,
     data.aws_iam_policy_document.read_metadata.json,

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -264,7 +264,7 @@ module "data_product_create_schema_lambda" {
   tags                           = local.tags
   description                    = "Lambda to create the first version of a json schema file for a data product"
   role_name                      = "data_product_schema_lambda_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_create_schema_lambda.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_write_metadata_and_schema.json
   policy_json_attached           = true
   function_name                  = "data_product_create_schema_${local.environment}"
   create_role                    = true
@@ -321,7 +321,7 @@ module "data_product_update_metadata_lambda" {
   tags                           = local.tags
   description                    = "Fetch the schema for a table from S3"
   role_name                      = "update_metadata_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_update_metadata_lambda.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_write_metadata_and_schema.json
   policy_json_attached           = true
   function_name                  = "data_product_update_metadata_${local.environment}"
   create_role                    = true
@@ -350,7 +350,7 @@ module "data_product_update_schema_lambda" {
   tags                           = local.tags
   description                    = "Update the schema for a table in a data product"
   role_name                      = "update_schema_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_update_metadata_lambda.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_write_metadata_and_schema.json
   policy_json_attached           = true
   function_name                  = "data_product_update_schema_${local.environment}"
   create_role                    = true

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -368,7 +368,7 @@ module "data_product_update_schema_lambda" {
     AllowExecutionFromAPIGateway = {
       action     = "lambda:InvokeFunction"
       principal  = "apigateway.amazonaws.com"
-      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.update_schema_for_data_product_table_name.http_method}${aws_api_gateway_resource.data_product_name.path}"
+      source_arn = "arn:aws:execute-api:${local.region}:${local.account_id}:${aws_api_gateway_rest_api.data_platform.id}/*/${aws_api_gateway_method.update_schema_for_data_product_table_name.http_method}${aws_api_gateway_resource.schema_for_data_product_table_name.path}"
     }
   }
 }

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -38,6 +38,7 @@ locals {
   create_schema_version            = lookup(var.create_schema_versions, local.environment)
   landing_to_raw_version           = lookup(var.landing_to_raw_versions, local.environment)
   update_metadata_version          = lookup(var.update_metadata_versions, local.environment)
+  update_schema_version            = lookup(var.update_schema_versions, local.environment)
 
   # Environment vars that are used by many lambdas
   logger_environment_vars = {

--- a/terraform/environments/data-platform/variables.tf
+++ b/terraform/environments/data-platform/variables.tf
@@ -45,3 +45,7 @@ variable "get_schema_versions" {
 variable "update_metadata_versions" {
   type = map(any)
 }
+
+variable "update_schema_versions" {
+  type = map(any)
+}


### PR DESCRIPTION
adds api gateway infra for the PUT method for `/data-product/{data-product-name}/table/{table-name}/schema` which is used to update a table schema

Also adds lambda function to be invoked and variables for image.

Also updated docs version.