### PR TITLE
Add explicit depends on

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -53,6 +53,8 @@ resource "aws_api_gateway_stage" "default_stage" {
   rest_api_id   = aws_api_gateway_rest_api.data_platform.id
   stage_name    = local.environment
 
+  depends_on = [aws_api_gateway_account.api_gateway_account]
+
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.data_platform_api.arn
     format = jsonencode({


### PR DESCRIPTION
To enable logging to cloudwatch in API gateway, a role needs to be set on the API gateway account resource.

It seems like terraform gets confused the first time this is run, as it tries to apply default_stage before the role is set on the account.

Hopefully adding this depends_on will prevent this from recurring in the future.