### PR TITLE
DSOS-2194: fix bug when NS records automatically added from parent zone

### DIFF
--- a/terraform/modules/baseline/route53.tf
+++ b/terraform/modules/baseline/route53.tf
@@ -31,7 +31,7 @@ locals {
           zone_key = zone_name
           provider = local.route53_zones[zone_name].provider
           type     = "NS"
-          records  = local.route53_zones[zone_name].name_servers
+          records  = local.route53_zones["${record.name}.${zone_name}"].name_servers
           alias    = null
         })
       }]


### PR DESCRIPTION
Spotted this when preparing to move nomis zone. NS records not set correctly when using ns_records option.  Only affects nomis.