### PR TITLE
csr: DSOS-2327: update R3 preprod DNS entry

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -508,7 +508,10 @@ locals {
           { name = "ppiwfm", type = "A", ttl = "300", records = ["10.40.42.132"] },
           { name = "ppiwfm-a", type = "A", ttl = "300", records = ["10.40.42.132"] },
           { name = "ppiwfm-b", type = "CNAME", ttl = "300", records = ["pp-csr-db-a.corporate-staff-rostering.hmpps-preproduction.modernisation-platform.service.justice.gov.uk"] },
-          { name = "r3", type = "CNAME", ttl = "300", records = ["pp-csr-w-5-a.corporate-staff-rostering.hmpps-preproduction.modernisation-platform.service.justice.gov.uk"] },
+          # { name = "r3", type = "CNAME", ttl = "300", records = ["pp-csr-w-5-a.corporate-staff-rostering.hmpps-preproduction.modernisation-platform.service.justice.gov.uk"] },
+        ]
+        lb_alias_records = [
+          { name = "r3", type = "A", lbs_map_key = "private" },
         ]
       }
     }


### PR DESCRIPTION
load balancer seems to be working at first glance.  Update the R3 preprod DNS entry so it can be properly tested.