### PR TITLE
add r4 instance as pp-csr-w-2-b to LB

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -334,6 +334,7 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
           web-56-7771 = {
@@ -351,6 +352,7 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
           web-56-7780 = {
@@ -368,6 +370,7 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
           web-56-7781 = {
@@ -385,6 +388,7 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
         }
@@ -512,6 +516,7 @@ locals {
         ]
         lb_alias_records = [
           { name = "r3", type = "A", lbs_map_key = "private" },
+          { name = "r4", type = "A", lbs_map_key = "private" },
         ]
       }
     }


### PR DESCRIPTION
- add pp-csr-w-2-b as webserver for r4
- awaiting config of this and pp-csr-a-14-b
- test with http://r3.pp.csr.service.justice.gov.uk/isps/index.html?2057 from prod-jumpserver(s) to ensure LB works