### PR TITLE
DSOS-2309 | Reference latest load balancer module

### DIFF
--- a/terraform/modules/baseline/lb.tf
+++ b/terraform/modules/baseline/lb.tf
@@ -97,7 +97,7 @@ module "lb" {
 
   for_each = var.lbs
 
-  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer.git?ref=v3.1.2"
+  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer.git?ref=v3.3.0"
 
   providers = {
     aws.bucket-replication = aws


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/DSOS-2309

Latest lb module = https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer/releases/tag/v3.3.0