### PR TITLE
Dp 1843 query apiendpoint

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -206,11 +206,6 @@ resource "aws_api_gateway_resource" "schema_for_data_product_table_name" {
   rest_api_id = aws_api_gateway_rest_api.data_platform.id
 }
 
-moved {
-  from = aws_api_gateway_resource.create_schema_for_data_product_table_name
-  to   = aws_api_gateway_resource.schema_for_data_product_table_name
-}
-
 # /data-product/{data-product-name}/table/{table-name}/upload POST method
 resource "aws_api_gateway_method" "upload_data_for_data_product_table_name" {
   authorization = "CUSTOM"

--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -20,10 +20,12 @@ resource "aws_api_gateway_deployment" "deployment" {
       aws_api_gateway_resource.data_product,
       aws_api_gateway_resource.register_data_product,
       aws_api_gateway_resource.data_product_name,
+      aws_api_gateway_resource.data_product_data,
       aws_api_gateway_resource.data_product_table,
       aws_api_gateway_resource.data_product_table_name,
       aws_api_gateway_resource.upload_data_for_data_product_table_name,
       aws_api_gateway_resource.schema_for_data_product_table_name,
+      aws_api_gateway_resource.preview_data_from_data_product,
       aws_api_gateway_method.docs,
       aws_api_gateway_method.get_glue_metadata,
       aws_api_gateway_method.register_data_product,
@@ -41,7 +43,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       aws_api_gateway_integration.create_schema_for_data_product_table_name_to_lambda,
       aws_api_gateway_integration.get_schema_for_data_product_table_name_to_lambda,
       aws_api_gateway_integration.update_data_product_to_lambda,
-      aws_api_gateway_integration.update_schema_for_data_product_table_name_to_lambda
+      aws_api_gateway_integration.update_schema_for_data_product_table_name_to_lambda,
+      aws_api_gateway_resource.preview_data_from_data_product_lambda,
     ]))
   }
 
@@ -432,3 +435,44 @@ resource "aws_api_gateway_integration" "get_glue_metadata" {
     "integration.request.querystring.table"    = "method.request.querystring.table"
   }
 }
+
+# Preview data 
+
+# /data-product/{data-product-name}/table/{table-name}/preview resource
+resource "aws_api_gateway_resource" "data_product_data" {
+  parent_id   = aws_api_gateway_resource.data_product_table_name.id
+  path_part   = "preview"
+  rest_api_id = aws_api_gateway_rest_api.data_platform.id
+}
+
+
+# /data-product/{data-product-name}/table/{table-name}/preview GET method
+resource "aws_api_gateway_method" "preview_data_from_data_product" {
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.authorizer.id
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.data_product_data
+  rest_api_id   = aws_api_gateway_rest_api.data_platform.id
+
+  request_parameters = {
+    "method.request.header.Authorization"   = true,
+    "method.request.path.data-product-name" = true,
+    "method.request.path.table-name"        = true,
+  }
+}
+
+# /data-product/{data-product-name}/table/{table-name}/preview  lambda integration
+resource "aws_api_gateway_integration" "preview_data_from_data_product_lambda" {
+  http_method             = aws_api_gateway_method.preview_data_from_data_product
+  resource_id             = aws_api_gateway_resource.data_product_data
+  rest_api_id             = aws_api_gateway_rest_api.data_platform.id
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = module.preview_data_lambda.lambda_function_invoke_arn
+
+  request_parameters = {
+    "integration.request.path.data-product-name" = "method.request.path.data-product-name",
+    "integration.request.path.table-name"        = "method.request.path.table-name",
+  }
+}
+

--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -20,7 +20,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       aws_api_gateway_resource.data_product,
       aws_api_gateway_resource.register_data_product,
       aws_api_gateway_resource.data_product_name,
-      aws_api_gateway_resource.data_product_data,
+      aws_api_gateway_resource.data_product_preview,
       aws_api_gateway_resource.data_product_table,
       aws_api_gateway_resource.data_product_table_name,
       aws_api_gateway_resource.upload_data_for_data_product_table_name,
@@ -434,7 +434,7 @@ resource "aws_api_gateway_integration" "get_glue_metadata" {
 # Preview data 
 
 # /data-product/{data-product-name}/table/{table-name}/preview resource
-resource "aws_api_gateway_resource" "data_product_data" {
+resource "aws_api_gateway_resource" "data_product_preview" {
   parent_id   = aws_api_gateway_resource.data_product_table_name.id
   path_part   = "preview"
   rest_api_id = aws_api_gateway_rest_api.data_platform.id
@@ -446,7 +446,7 @@ resource "aws_api_gateway_method" "preview_data_from_data_product" {
   authorization = "CUSTOM"
   authorizer_id = aws_api_gateway_authorizer.authorizer.id
   http_method   = "GET"
-  resource_id   = aws_api_gateway_resource.data_product_data
+  resource_id   = aws_api_gateway_resource.data_product_preview
   rest_api_id   = aws_api_gateway_rest_api.data_platform.id
 
   request_parameters = {
@@ -459,7 +459,7 @@ resource "aws_api_gateway_method" "preview_data_from_data_product" {
 # /data-product/{data-product-name}/table/{table-name}/preview  lambda integration
 resource "aws_api_gateway_integration" "preview_data_from_data_product_lambda" {
   http_method             = aws_api_gateway_method.preview_data_from_data_product
-  resource_id             = aws_api_gateway_resource.data_product_data
+  resource_id             = aws_api_gateway_resource.data_product_preview
   rest_api_id             = aws_api_gateway_rest_api.data_platform.id
   integration_http_method = "POST"
   type                    = "AWS_PROXY"

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -76,5 +76,11 @@
     "test": "1.0.1",
     "preproduction": "1.0.1",
     "production": "1.0.1"
+  },
+  "preview_data_versions": {
+    "development": "1.0.0",
+    "test": "1.0.0",
+    "preproduction": "1.0.0",
+    "production": "1.0.0"
   }
 }

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -621,9 +621,31 @@ data "aws_iam_policy_document" "iam_policy_document_for_preview_data" {
     ]
     resources = [
       "${module.data_s3_bucket.bucket.arn}/curated/*",
-      "${module.data_s3_bucket.bucket.arn}",
+      "${module.data_s3_bucket.bucket.arn}"
+    ]
+  }
+  statement {
+    sid    = "s3AthenaAccess"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
       "${module.s3_athena_query_results_bucket.bucket.arn}",
       "${module.s3_athena_query_results_bucket.bucket.arn}/*"
+    ]
+  }
+  statement {
+    sid    = "GluePermissions"
+    effect = "Allow"
+    actions = [
+      "glue:GetPartitions",
+      "glue:GetTable"
+    ]
+    resources = [
+      "*"
     ]
   }
   statement {

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -115,8 +115,7 @@ data "aws_iam_policy_document" "athena_load_lambda_function_policy" {
     sid = "AthenaQueryAccess"
     actions = [
       "athena:StartQueryExecution",
-      "athena:GetQueryExecution",
-      "athena:GetQueryResults",
+      "athena:GetQueryExecution"
     ]
     resources = [
       aws_athena_workgroup.data_product_athena_workgroup.arn

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -606,3 +606,36 @@ resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatchlogs" {
   role       = aws_iam_role.api_gateway_cloud_watch_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
+
+data "aws_iam_policy_document" "iam_policy_document_for_preview_data" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.log_to_bucket.json,
+    data.aws_iam_policy_document.create_write_lambda_logs.json,
+  ]
+
+  statement {
+    sid    = "s3Access"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "${module.data_s3_bucket.bucket.arn}/curated/*",
+      "${module.data_s3_bucket.bucket.arn}",
+      "${module.s3_athena_query_results_bucket.bucket.arn}",
+      "${module.s3_athena_query_results_bucket.bucket.arn}/*"
+    ]
+  }
+  statement {
+    sid = "AthenaQueryAccess"
+    actions = [
+      "athena:StartQueryExecution",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+    ]
+    resources = [
+      aws_athena_workgroup.data_product_athena_workgroup.arn
+    ]
+  }
+}

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -611,7 +611,6 @@ data "aws_iam_policy_document" "iam_policy_document_for_preview_data" {
     data.aws_iam_policy_document.log_to_bucket.json,
     data.aws_iam_policy_document.create_write_lambda_logs.json,
   ]
-
   statement {
     sid    = "s3Access"
     effect = "Allow"

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -115,7 +115,8 @@ data "aws_iam_policy_document" "athena_load_lambda_function_policy" {
     sid = "AthenaQueryAccess"
     actions = [
       "athena:StartQueryExecution",
-      "athena:GetQueryExecution"
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
     ]
     resources = [
       aws_athena_workgroup.data_product_athena_workgroup.arn

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -379,7 +379,7 @@ module "preview_data_lambda" {
   tags                           = local.tags
   description                    = "Query small sample of data through athena "
   role_name                      = "preview_data_role_${local.environment}"
-  policy_json                    = data.aws_iam_policy_document.athena_load_lambda_function_policy.json
+  policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_preview_data.json
   policy_json_attached           = true
   function_name                  = "preview_data_${local.environment}"
   create_role                    = true

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -39,6 +39,7 @@ locals {
   landing_to_raw_version           = lookup(var.landing_to_raw_versions, local.environment)
   update_metadata_version          = lookup(var.update_metadata_versions, local.environment)
   update_schema_version            = lookup(var.update_schema_versions, local.environment)
+  preview_data_version             = lookup(var.preview_data_versions, local.environment)
 
   # Environment vars that are used by many lambdas
   logger_environment_vars = {

--- a/terraform/environments/data-platform/variables.tf
+++ b/terraform/environments/data-platform/variables.tf
@@ -49,3 +49,8 @@ variable "update_metadata_versions" {
 variable "update_schema_versions" {
   type = map(any)
 }
+
+variable "preview_data_versions" {
+  type = map(any)
+}
+


### PR DESCRIPTION
As a user, I want to confirm the successful creation of my data product. This feature eliminates the need for users to possess AWS accounts or tools in order to access and view the data.

This will create infrastructure for query api