### PR TITLE
add all pre-prod web instance rules to LB

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -683,6 +683,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
+              { ec2_instance_name = "pp-csr-w-1-a" },
               { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
@@ -705,6 +706,29 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-6-b" },
+            ]
+          }
+          web-78-7770 = {
+            port     = 7770
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 30
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 7770
+              timeout             = 5
+              unhealthy_threshold = 5
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-csr-w-7-a" },
+              { ec2_instance_name = "pp-csr-w-8-b" },
             ]
           }
           web-12-7771 = {
@@ -725,6 +749,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
+              { ec2_instance_name = "pp-csr-w-1-a" },
               { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
@@ -747,6 +772,29 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-6-b" },
+            ]
+          }
+          web-78-7771 = {
+            port     = 7771
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 30
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 7771
+              timeout             = 5
+              unhealthy_threshold = 5
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-csr-w-7-a" },
+              { ec2_instance_name = "pp-csr-w-8-b" },
             ]
           }
           web-12-7780 = {
@@ -767,6 +815,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
+              { ec2_instance_name = "pp-csr-w-1-a" },
               { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
@@ -789,6 +838,29 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-6-b" },
+            ]
+          }
+          web-78-7780 = {
+            port     = 7780
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 30
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 7780
+              timeout             = 5
+              unhealthy_threshold = 5
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-csr-w-7-a" },
+              { ec2_instance_name = "pp-csr-w-8-b" },
             ]
           }
           web-12-7781 = {
@@ -809,6 +881,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
+              { ec2_instance_name = "pp-csr-w-1-a" },
               { ec2_instance_name = "pp-csr-w-2-b" },
             ]
           }
@@ -831,6 +904,29 @@ locals {
             }
             attachments = [
               { ec2_instance_name = "pp-csr-w-5-a" },
+              { ec2_instance_name = "pp-csr-w-6-b" },
+            ]
+          }
+          web-78-7781 = {
+            port     = 7781
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 30
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 7781
+              timeout             = 5
+              unhealthy_threshold = 5
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-csr-w-7-a" },
+              { ec2_instance_name = "pp-csr-w-8-b" },
             ]
           }
         }
@@ -879,6 +975,20 @@ locals {
                   }
                 }]
               }
+              web-78-7770 = {
+                priority = 7870
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-78-7770"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "r5.pp.csr.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
               web-12-7771 = {
                 priority = 1271
                 actions = [{
@@ -903,6 +1013,20 @@ locals {
                   host_header = {
                     values = [
                       "r4.pp.csr.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+              web-78-7771 = {
+                priority = 7871
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-78-7771"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "r6.pp.csr.service.justice.gov.uk",
                     ]
                   }
                 }]
@@ -952,6 +1076,20 @@ locals {
                   }
                 }]
               }
+              web-78-7780 = {
+                priority = 7880
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-78-7780"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "r5.pp.csr.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           }
           http-7781 = {
@@ -997,6 +1135,20 @@ locals {
                   }
                 }]
               }
+              web-78-7781 = {
+                priority = 7881
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-78-7781"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "r6.pp.csr.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           }
         }
@@ -1017,6 +1169,8 @@ locals {
           { name = "r2", type = "A", lbs_map_key = "private" },
           { name = "r3", type = "A", lbs_map_key = "private" },
           { name = "r4", type = "A", lbs_map_key = "private" },
+          { name = "r5", type = "A", lbs_map_key = "private" },
+          { name = "r6", type = "A", lbs_map_key = "private" },
         ]
       }
     }


### PR DESCRIPTION
- add pre-prod web rules to LB for latest servers
- training instances for pre-prod are not included yet
- extends @GlennBarber handy diagram so should be correct! Suggest referring to this when reviewing

![Screenshot 2023-11-02 at 14 01 40](https://github.com/ministryofjustice/modernisation-platform-environments/assets/7058678/85a6674e-ed92-4a5a-9b2f-57f26c83d736)
