### PR TITLE
Dpl add openmetadata token secret

### DIFF
--- a/terraform/environments/data-platform/api.tf
+++ b/terraform/environments/data-platform/api.tf
@@ -458,7 +458,7 @@ resource "aws_api_gateway_method" "preview_data_from_data_product" {
 
 # /data-product/{data-product-name}/table/{table-name}/preview  lambda integration
 resource "aws_api_gateway_integration" "preview_data_from_data_product_lambda" {
-  http_method             = aws_api_gateway_method.preview_data_from_data_product.id
+  http_method             = aws_api_gateway_method.preview_data_from_data_product.http_method
   resource_id             = aws_api_gateway_resource.data_product_preview.id
   rest_api_id             = aws_api_gateway_rest_api.data_platform.id
   integration_http_method = "POST"

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -78,9 +78,9 @@
     "production": "1.0.1"
   },
   "preview_data_versions": {
-    "development": "1.0.0",
-    "test": "1.0.0",
-    "preproduction": "1.0.0",
-    "production": "1.0.0"
+    "development": "1.0.1",
+    "test": "1.0.1",
+    "preproduction": "1.0.1",
+    "production": "1.0.1"
   }
 }

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -375,17 +375,17 @@ module "data_product_update_schema_lambda" {
 
 module "preview_data_lambda" {
   source                         = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function?ref=a4392c1" # ref for V2.1
-  application_name               = "preview_data"
+  application_name               = "data_product_preview_data"
   tags                           = local.tags
   description                    = "Query small sample of data through athena "
   role_name                      = "preview_data_role_${local.environment}"
   policy_json                    = data.aws_iam_policy_document.iam_policy_document_for_preview_data.json
   policy_json_attached           = true
-  function_name                  = "preview_data_${local.environment}"
+  function_name                  = "data_product_preview_data_${local.environment}"
   create_role                    = true
   reserved_concurrent_executions = 1
 
-  image_uri    = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/data-platform-query-data-lambda-ecr-repo:${local.preview_data_version}"
+  image_uri    = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/data-platform-preview-data-lambda-ecr-repo:${local.preview_data_version}"
   timeout      = 600
   tracing_mode = "Active"
   memory_size  = 128

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -15,6 +15,7 @@ resource "aws_secretsmanager_secret" "openmetadata" {
   tags = local.tags
 }
 
-data "aws_secretsmanager_secret_version" "openmetadata" {
-  secret_id = aws_secretsmanager_secret.openmetadata.id
-}
+## add this in after created
+# data "aws_secretsmanager_secret_version" "openmetadata" {
+#   secret_id = aws_secretsmanager_secret.openmetadata.id
+# }

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -8,3 +8,13 @@ resource "aws_secretsmanager_secret" "api_auth" {
 data "aws_secretsmanager_secret_version" "api_auth" {
   secret_id = aws_secretsmanager_secret.api_auth.id
 }
+
+# openmeta jwt for api
+resource "aws_secretsmanager_secret" "openmetadata" {
+  name = "data-platform-openmetadata-token"
+  tags = local.tags
+}
+
+data "aws_secretsmanager_secret_version" "openmetadata" {
+  secret_id = aws_secretsmanager_secret.openmetadata.id
+}


### PR DESCRIPTION
Adds a place in secrets manager to store openemetadata jwt to use for api auth.

Also fixes an error that crept through with preview api integration and renames a lambda and ecr repo for it