### PR TITLE
CSR: allow azure csrpp3 azure hostname through the load balancer

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -971,6 +971,7 @@ locals {
                   host_header = {
                     values = [
                       "r3.pp.csr.service.justice.gov.uk",
+                      "csrppr3.az.justice.gov.uk",
                     ]
                   }
                 }]
@@ -1072,6 +1073,7 @@ locals {
                   host_header = {
                     values = [
                       "r3.pp.csr.service.justice.gov.uk",
+                      "csrppr3.az.justice.gov.uk",
                     ]
                   }
                 }]


### PR DESCRIPTION
Configure the existing Azure domain for R3 Preprod csrppr3.az.justice.gov.uk on the AWS load balancer.  This will allow us to temporarily use this URL for testing R3 preprod on a Mojo device.