### PR TITLE
add openmetadata env vars to locals for use in lambdas that need

### DIFF
--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -197,9 +197,12 @@ module "data_product_create_metadata_lambda" {
   tracing_mode = "Active"
   memory_size  = 128
 
-  environment_variables = merge(local.logger_environment_vars, local.storage_environment_vars, {
-    ENVIRONMENT = local.environment
-  })
+  environment_variables = merge(
+    local.logger_environment_vars,
+    local.storage_environment_vars,
+    local.openmetadata_environment_vars,
+    {ENVIRONMENT = local.environment}
+  )
 
   allowed_triggers = {
 
@@ -275,7 +278,11 @@ module "data_product_create_schema_lambda" {
   tracing_mode = "Active"
   memory_size  = 128
 
-  environment_variables = merge(local.logger_environment_vars, local.storage_environment_vars)
+  environment_variables = merge(
+    local.logger_environment_vars,
+    local.storage_environment_vars,
+    local.openmetadata_environment_vars
+  )
   allowed_triggers = {
 
     AllowExecutionFromAPIGateway = {
@@ -332,7 +339,11 @@ module "data_product_update_metadata_lambda" {
   tracing_mode = "Active"
   memory_size  = 128
 
-  environment_variables = merge(local.logger_environment_vars, local.storage_environment_vars)
+  environment_variables = merge(
+    local.logger_environment_vars,
+    local.storage_environment_vars,
+    local.openmetadata_environment_vars
+  )
 
   allowed_triggers = {
 
@@ -361,7 +372,11 @@ module "data_product_update_schema_lambda" {
   tracing_mode = "Active"
   memory_size  = 128
 
-  environment_variables = merge(local.logger_environment_vars, local.storage_environment_vars)
+  environment_variables = merge(
+    local.logger_environment_vars,
+    local.storage_environment_vars,
+    local.openmetadata_environment_vars
+  )
 
   allowed_triggers = {
 

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -54,7 +54,7 @@ locals {
   }
 
   openmetadata_environment_vars = {
-    OPENMETADATA_JWT = aws_secretsmanager_secret.openmetadata.id
+    OPENMETADATA_JWT_SECRET = aws_secretsmanager_secret.openmetadata.id
     OPENMETADATA_DEV_API_URL = "https://catalogue.apps-tools.development.data-platform.service.justice.gov.uk/api"
   }
 }

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -54,7 +54,7 @@ locals {
   }
 
   openmetadata_environment_vars = {
-    OPENMETADATA_JWT_SECRET = aws_secretsmanager_secret.openmetadata.id
+    OPENMETADATA_JWT_SECRET_ARN = aws_secretsmanager_secret.openmetadata.id
     OPENMETADATA_DEV_API_URL = "https://catalogue.apps-tools.development.data-platform.service.justice.gov.uk/api"
   }
 }

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -52,4 +52,9 @@ locals {
     METADATA_BUCKET     = module.metadata_s3_bucket.bucket.id
     LANDING_ZONE_BUCKET = module.data_landing_s3_bucket.bucket.id
   }
+
+  openmetadata_environment_vars = {
+    OPENMETADATA_JWT = aws_secretsmanager_secret.openmetadata.id
+    OPENMETADATA_DEV_API_URL = "https://catalogue.apps-tools.development.data-platform.service.justice.gov.uk/api"
+  }
 }

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -14,8 +14,3 @@ resource "aws_secretsmanager_secret" "openmetadata" {
   name = "data-platform-openmetadata-token"
   tags = local.tags
 }
-
-## add this in after created
-# data "aws_secretsmanager_secret_version" "openmetadata" {
-#   secret_id = aws_secretsmanager_secret.openmetadata.id
-# }


### PR DESCRIPTION
Removed secret versions as we'll be manually rotating secrets for openmetadata.

Added two env vars to locals for openmetadata:
- `OPENMETADTA_JWT_SECRET_ARN` the arn of the secret in secrets manager holding the jwt
- `OPENMETADATA_DEV_API_URL` the url for api calls to our dev openmetadata