### PR TITLE
Send cloudtrail events to cloudwatch

### DIFF
--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -48,6 +48,7 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
   }
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.data_platform_s3_putobject_trail.arn}:*" # CloudTrail requires the Log Stream wildcard
+  cloud_watch_logs_role_arn  = "arn:aws:iam::${local.account_id}:role/cloudtrail"
 }
 
 resource "aws_cloudwatch_log_group" "data_platform_s3_putobject_trail" {

--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -48,7 +48,7 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
   }
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.data_platform_s3_putobject_trail.arn}:*" # CloudTrail requires the Log Stream wildcard
-  cloud_watch_logs_role_arn  = aws_iam_role.cloud_trail_cloud_watch_role.arn
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_cloudwatch_role.arn
 }
 
 resource "aws_cloudwatch_log_group" "data_platform_s3_putobject_trail" {

--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -47,4 +47,9 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
     }
   }
 
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.data_platform_s3_putobject_trail.arn}:*" # CloudTrail requires the Log Stream wildcard
+}
+
+resource "aws_cloudwatch_log_group" "data_platform_s3_putobject_trail" {
+  name = "/aws/cloudtrail/data_platform_s3_putobject_trail_${local.environment}"
 }

--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -48,7 +48,7 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
   }
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.data_platform_s3_putobject_trail.arn}:*" # CloudTrail requires the Log Stream wildcard
-  cloud_watch_logs_role_arn  = "arn:aws:iam::${local.account_id}:role/cloudtrail"
+  cloud_watch_logs_role_arn  = aws_iam_role.cloud_trail_cloud_watch_role.arn
 }
 
 resource "aws_cloudwatch_log_group" "data_platform_s3_putobject_trail" {

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -533,6 +533,26 @@ resource "aws_iam_role" "api_gateway_cloud_watch_role" {
   tags               = local.tags
 }
 
+data "aws_iam_policy_document" "cloudtrail_policy" {
+  statement {
+    sid    = "cloudtrailToCloudwatch"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      "arn:aws:logs:${local.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.data_platform_s3_putobject_trail.name}:log-stream:${local.account_id}_CloudTrail_${local.region}*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "cloud_trail_cloud_watch_role" {
+  name               = "data_platform_cloudtrail_log_${local.environment}"
+  assume_role_policy = data.aws_iam_policy_document.cloudtrail_policy.json
+  tags               = local.tags
+}
+
 resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatchlogs" {
   role       = aws_iam_role.api_gateway_cloud_watch_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"


### PR DESCRIPTION
These PutObject events are quite useful as they tell us when an upload has reached each "zone" (landing -> raw -> curated)

The events are currently queryable via athena but not via cloudwatch.

If the data is available in cloudwatch I'll be able to visualise them in grafana.
(https://github.com/ministryofjustice/data-platform/issues/2016)