### PR TITLE
DSOS-2332: baesline fix for adding secrets to EC2

### DIFF
--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -49,7 +49,7 @@ module "ec2_instance" {
       }
     )
   }
-  secretsmanager_secrets = each.value.secretsmanager_secrets == null ? null : {
+  secretsmanager_secrets = each.value.secretsmanager_secrets == null ? {} : {
     for key, value in each.value.secretsmanager_secrets : key => merge(value,
       value.kms_key_id == null ? { kms_key_id = null } : { kms_key_id = try(var.environment.kms_keys[value.kms_key_id].arn, value.kms_key_id) }
     )


### PR DESCRIPTION
The EC2 instance module doesn't support null for this parameter.  Setting it to empty dict instead