### PR TITLE
Data Platform - new lambda infra for push-to-catalogue

### DIFF
--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -88,5 +88,11 @@
     "test": "1.0.1",
     "preproduction": "1.0.1",
     "production": "1.0.1"
+  },
+  "push_to_catalogue_versions": {
+    "development": "1.0.0",
+    "test": "1.0.0",
+    "preproduction": "1.0.0",
+    "production": "1.0.0"
   }
 }

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -259,20 +259,6 @@ resource "aws_iam_role_policy_attachment" "attach_allow_invoke_authoriser_lambda
 # TO BE REMOVED
 data "aws_iam_policy_document" "data_platform_product_bucket_policy_document" {
   statement {
-    sid    = "AllowPutFromCiUser"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cicd-member-user"]
-    }
-
-    actions = ["s3:PutObject", "s3:ListBucket"]
-
-    resources = [module.s3-bucket.bucket.arn, "${module.s3-bucket.bucket.arn}/*"]
-  }
-
-  statement {
     sid       = "DenyNonFullControlObjects"
     effect    = "Deny"
     actions   = ["s3:PutObject"]
@@ -295,20 +281,6 @@ data "aws_iam_policy_document" "data_platform_product_bucket_policy_document" {
 }
 
 data "aws_iam_policy_document" "data_s3_bucket_policy_document" {
-  statement {
-    sid    = "AllowPutFromCiUser"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cicd-member-user"]
-    }
-
-    actions = ["s3:PutObject", "s3:ListBucket"]
-
-    resources = [module.data_s3_bucket.bucket.arn, "${module.data_s3_bucket.bucket.arn}/*"]
-  }
-
   statement {
     sid       = "DenyNonFullControlObjects"
     effect    = "Deny"
@@ -334,20 +306,6 @@ data "aws_iam_policy_document" "data_s3_bucket_policy_document" {
 
 data "aws_iam_policy_document" "data_landing_s3_bucket_policy_document" {
   statement {
-    sid    = "AllowPutFromCiUser"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cicd-member-user"]
-    }
-
-    actions = ["s3:PutObject", "s3:ListBucket"]
-
-    resources = [module.data_landing_s3_bucket.bucket.arn, "${module.data_landing_s3_bucket.bucket.arn}/*"]
-  }
-
-  statement {
     sid       = "DenyNonFullControlObjects"
     effect    = "Deny"
     actions   = ["s3:PutObject"]
@@ -372,20 +330,6 @@ data "aws_iam_policy_document" "data_landing_s3_bucket_policy_document" {
 
 data "aws_iam_policy_document" "metadata_s3_bucket_policy_document" {
   statement {
-    sid    = "AllowPutFromCiUser"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cicd-member-user"]
-    }
-
-    actions = ["s3:PutObject", "s3:ListBucket"]
-
-    resources = [module.metadata_s3_bucket.bucket.arn, "${module.metadata_s3_bucket.bucket.arn}/*"]
-  }
-
-  statement {
     sid       = "DenyNonFullControlObjects"
     effect    = "Deny"
     actions   = ["s3:PutObject"]
@@ -409,26 +353,6 @@ data "aws_iam_policy_document" "metadata_s3_bucket_policy_document" {
 }
 
 data "aws_iam_policy_document" "logs_s3_bucket_policy_document" {
-  statement {
-    sid    = "AllowPutFromCiUser"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cicd-member-user"]
-    }
-
-    actions = [
-      "s3:PutObject",
-      "s3:ListBucket"
-    ]
-
-    resources = [
-      module.logs_s3_bucket.bucket.arn,
-      "${module.logs_s3_bucket.bucket.arn}/*",
-    ]
-  }
-
   statement {
     sid    = "AllowPutFromCloudtrail"
     effect = "Allow"

--- a/terraform/environments/data-platform/iam.tf
+++ b/terraform/environments/data-platform/iam.tf
@@ -16,6 +16,14 @@ data "aws_iam_policy_document" "log_to_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "read_openmetadata_secrets" {
+  statement {
+    sid     = "openmetdataSecretsManager"
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.openmetadata.id]
+  }
+}
 data "aws_iam_policy_document" "read_metadata" {
   statement {
     sid     = "s3ReadMetadata"

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -452,22 +452,22 @@ module "data_product_push_to_catalogue_lambda" {
 
   allowed_triggers = {
 
-    AllowExecutionFromLambda = {
+    AllowExecutionFromLambda1 = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_create_metadata_${local.environment}"
     }
-    AllowExecutionFromLambda = {
+    AllowExecutionFromLambda2 = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_create_schema_${local.environment}"
     }
-    AllowExecutionFromLambda = {
+    AllowExecutionFromLambda3 = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_update_schema_${local.environment}"
     }
-    AllowExecutionFromLambda = {
+    AllowExecutionFromLambda4 = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_update_metadata_${local.environment}"

--- a/terraform/environments/data-platform/lambda.tf
+++ b/terraform/environments/data-platform/lambda.tf
@@ -452,25 +452,30 @@ module "data_product_push_to_catalogue_lambda" {
 
   allowed_triggers = {
 
-    AllowExecutionFromLambda1 = {
+    AllowExecutionFromCreateMetadataLambda = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_create_metadata_${local.environment}"
     }
-    AllowExecutionFromLambda2 = {
+    AllowExecutionFromCreateSchemaLambda = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_create_schema_${local.environment}"
     }
-    AllowExecutionFromLambda3 = {
+    AllowExecutionFromUpdateSchemaLambda = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_update_schema_${local.environment}"
     }
-    AllowExecutionFromLambda4 = {
+    AllowExecutionFromUpdateMetadataLambda = {
       action     = "lambda:InvokeFunction"
       principal  = "lambda.amazonaws.com"
       source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:data_product_update_metadata_${local.environment}"
+    }
+    AllowExecutionFromDeleteTableLambda = {
+      action     = "lambda:InvokeFunction"
+      principal  = "lambda.amazonaws.com"
+      source_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:delete_table_for_data_product_${local.environment}"
     }
   }
 }

--- a/terraform/environments/data-platform/locals.tf
+++ b/terraform/environments/data-platform/locals.tf
@@ -41,6 +41,7 @@ locals {
   update_schema_version                 = lookup(var.update_schema_versions, local.environment)
   preview_data_version                  = lookup(var.preview_data_versions, local.environment)
   delete_table_for_data_product_version = lookup(var.delete_table_for_data_product_versions, local.environment)
+  push_to_catalogue_version             = lookup(var.push_to_catalogue_versions, local.environment)
 
   # Environment vars that are used by many lambdas
   logger_environment_vars = {
@@ -52,5 +53,10 @@ locals {
     CURATED_DATA_BUCKET = module.data_s3_bucket.bucket.id
     METADATA_BUCKET     = module.metadata_s3_bucket.bucket.id
     LANDING_ZONE_BUCKET = module.data_landing_s3_bucket.bucket.id
+  }
+
+    openmetadata_environment_vars = {
+    OPENMETADATA_JWT_SECRET_ARN = aws_secretsmanager_secret.openmetadata.id
+    OPENMETADATA_DEV_API_URL = "https://catalogue.apps-tools.development.data-platform.service.justice.gov.uk/api"
   }
 }

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -14,8 +14,3 @@ resource "aws_secretsmanager_secret" "openmetadata" {
   name = "data-platform-openmetadata-token"
   tags = local.tags
 }
-
-## add this in after created
-# data "aws_secretsmanager_secret_version" "openmetadata" {
-#   secret_id = aws_secretsmanager_secret.openmetadata.id
-# }

--- a/terraform/environments/data-platform/variables.tf
+++ b/terraform/environments/data-platform/variables.tf
@@ -57,3 +57,7 @@ variable "preview_data_versions" {
 variable "delete_table_for_data_product_versions" {
   type = map(any)
 }
+
+variable "push_to_catalogue_versions" {
+  type = map(any)
+}


### PR DESCRIPTION
This PR adds a new lambda container function that is triggered by the create/update metadata/schema lambdas. It has permissions to get the secret api token from secrets manager in a new policy

Removed secret versions as we'll be manually rotating secrets for openmetadata.

Added two env vars to locals for openmetadata:

`OPENMETADTA_JWT_SECRET_ARN` the arn of the secret in secrets manager holding the jwt
`OPENMETADATA_DEV_API_URL` the url for api calls to our dev openmetadata