### PR TITLE
DSOS-2358: correct S3 permissions for audit and backup

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -85,16 +85,6 @@ locals {
     s3-bucket = {
       iam_policies = module.baseline_presets.s3_iam_policies
     }
-    nomis-audit-archives = {
-      custom_kms_key = module.environment.kms_keys["general"].arn
-      bucket_policy_v2 = [
-        module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-      ]
-      iam_policies = module.baseline_presets.s3_iam_policies
-      lifecycle_rule = [
-        module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
-      ]
-    }
   }
 
   baseline_secretsmanager_secrets = {}

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -15,12 +15,13 @@ locals {
     cloudwatch_metric_alarms_dbnames_misload = []
 
     baseline_s3_buckets = {
+      nomis-audit-archives = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies = module.baseline_presets.s3_iam_policies
+      }
       nomis-db-backup-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
-        ]
       }
       syscon-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -8,12 +8,16 @@ locals {
     cloudwatch_metric_alarms_dbnames_misload = []
 
     baseline_s3_buckets = {
+      nomis-audit-archives = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [
+          module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
+        ]
+      }
       nomis-db-backup-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
-        ]
       }
     }
 
@@ -50,6 +54,7 @@ locals {
             ]
             resources = [
               "arn:aws:s3:::nomis-db-backup-bucket*",
+              "arn:aws:s3:::nomis-audit-archives*",
             ]
           },
           {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -8,12 +8,22 @@ locals {
     cloudwatch_metric_alarms_dbnames_misload = []
 
     baseline_s3_buckets = {
-      nomis-db-backup-bucket = {
+      nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
         ]
+        iam_policies = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [
+          module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
+        ]
+      }
+      nomis-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+        iam_policies   = module.baseline_presets.s3_iam_policies
       }
     }
 

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -19,6 +19,14 @@ locals {
     ]
 
     baseline_s3_buckets = {
+      nomis-audit-archives = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+        iam_policies = module.baseline_presets.s3_iam_policies
+      }
+
       nomis-db-backup-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies


### PR DESCRIPTION
Simplified and fixed S3 permissions.  Allows preprod servers read access to the prod audit S3 bucket.
Only test and production need bucket policies set to allow sharing into development/preproduction respectively.  Otherwise default permissions are good enough.