### PR TITLE
Fix smoketest

### DIFF
--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -78,10 +78,10 @@
     "production": "2.0.1"
   },
   "delete_table_for_data_product_versions": {
-    "development": "1.0.1",
-    "test": "1.0.1",
-    "preproduction": "1.0.1",
-    "production": "1.0.1"
+    "development": "2.1.0",
+    "test": "2.1.0",
+    "preproduction": "2.1.0",
+    "production": "2.1.0"
   },
   "push_to_catalogue_versions": {
     "development": "1.1.0",

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -121,18 +121,6 @@ class APIClient:
 
 
 def run_test(client):
-    # register_response = client.register()
-    # if register_response.status_code != 200:
-    #     print(f"Unable to create data product. Code: {register_response.status_code}")
-    #     print(f"Error creating data product. Response: {register_response.text}")
-    #     return
-
-    # schema_response = client.create_schema()
-    # if schema_response.status_code != 200:
-    #     print(f"Unable to create schema. Code: {schema_response.status_code}")
-    #     print(f"Error creating schema. Response: {schema_response.text}")
-    #     return
-
     upload_response = client.upload_file()
     print(upload_response.status_code, upload_response.text)
     print(f"Waiting for {data_product_name}.{table_name} to create in athena")
@@ -146,12 +134,5 @@ def run_test(client):
         raise e
 
 
-try:
-    client = APIClient(base_url, auth_token)
-    run_test(client)
-finally:
-    # response = client.delete_data_product()
-    # if response.status_code != 200:
-    #     print(f"Unable to delete data product code: {response.status_code}")
-    #     print(f"Error deleting data product. Response: {response.text}")
-    pass
+client = APIClient(base_url, auth_token)
+run_test(client)

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -12,8 +12,6 @@ filename = "test_data.csv"
 data_product_name = "example_prison_data_product"
 table_name = "testing"
 base_url = "https://hsolkci589.execute-api.eu-west-2.amazonaws.com/development"
-presigned_url = f"/data-product/{data_product_name}/table/{table_name}/upload"
-url = base_url + presigned_url
 glue = boto3.client("glue")
 
 try:
@@ -34,53 +32,125 @@ def md5_hash_file_contents(file) -> str:
 
     return contents_md5
 
+class APIClient:
+    def __init__(self, base_url, auth_token):
+        self.table_url = base_url + f"/data-product/{data_product_name}/table/{table_name}"
+        self.data_product_url = base_url + f"/data-product/{data_product_name}"
+        self.register_url = base_url + f"/data-product/register"
+        self.presigned_url = base_url + f"/data-product/{data_product_name}/table/{table_name}/upload"
+        self.headers = {"authorizationToken": auth_token}
+        
+    def register(self):
+        print("Registering data product...")
 
-file_md5_hash = md5_hash_file_contents(filename)
+        metadata = {
+            "name": "example_prison_data_product",
+            "description": "just testing the metadata json validation/registration",
+            "domain": "MoJ",
+            "dataProductOwner": "matthew.laverty@justice.gov.uk",
+            "dataProductOwnerDisplayName": "matt laverty",
+            "email": "matthew.laverty@justice.gov.uk",
+            "status": "draft",
+            "dpiaRequired": False,
+            "retentionPeriod": 3650
+        }
 
-body = {
-    "filename": filename,
-    "contentMD5": file_md5_hash,
-}
+        return requests.post(
+            url=self.register_url,
+            headers=self.headers,
+            json={
+                "metadata": metadata
+            }
+        )
 
-headers = {"authorizationToken": auth_token}
+    def delete_data_product(self):
+        print("Deleting data product...")
+        return requests.delete(
+            url=self.data_product_url,
+            headers=self.headers,
+        )
 
-# Get presigned url
-response = requests.post(
-    url=url,
-    json=body,
-    headers=headers,
-)
+    def create_schema(self):
+        print("Creating a schema...")
+        return requests.post(
+            url=self.table_url + "/schema",
+            headers=self.headers,
+            json={
+                "schema": {
+                    "tableDescription": "just a test table",
+                    "columns": [
+                        {"name": "col_0", "type": "double", "description": "just a test column"},
+                        {"name": "col_1", "type": "double", "description": "just a test column"},
+                        {"name": "col_2", "type": "double", "description": "just a test column"},
+                        {"name": "col_3", "type": "double", "description": "just a test column"},
+                    ]
+                }
+            }
+        )
 
-if response.status_code != 200:
-    print(f"Error getting presigned url. Status code: {response.status_code}")
-    print(f"Error getting presigned url. Response: {response.text}")
-    print("Exiting...")
-    sys.exit(1)
+    def upload_file(self):
+        file_md5_hash = md5_hash_file_contents(filename)
 
-response_json = response.json()
-post_policy_form_data = response_json["URL"]["fields"]
-multipart_form_data = {
-    **post_policy_form_data,
-    "file": (post_policy_form_data["key"], open(filename, "r")),
-}
+        body = {
+            "filename": filename,
+            "contentMD5": file_md5_hash,
+        }
 
-# Upload data
-print("Uploading data")
-upload_response = requests.post(response_json["URL"]["url"], files=multipart_form_data)
-print(upload_response.status_code, upload_response.text)
-print(f"Waiting for {data_product_name}.{table_name} to create in athena")
-time.sleep(10)
+        # Get presigned url
+        response = requests.post(
+            url=self.presigned_url,
+            json=body,
+            headers=self.headers,
+        )
 
-# Check for created table
+        if response.status_code != 200:
+            print(f"Error getting presigned url. Status code: {response.status_code}")
+            print(f"Error getting presigned url. Response: {response.text}")
+            raise Exception('Error getting presigned URL')
+        
+        response_json = response.json()
+        post_policy_form_data = response_json["URL"]["fields"]
+        multipart_form_data = {
+            **post_policy_form_data,
+            "file": (post_policy_form_data["key"], open(filename, "r")),
+        }
+
+        # Upload data
+        print("Uploading data")
+        return requests.post(response_json["URL"]["url"], files=multipart_form_data)
+
+
+def run_test(client):
+    register_response = client.register()
+    if register_response.status_code != 200:
+        print(f"Unable to create data product. Code: {register_response.status_code}")
+        print(f"Error creating data product. Response: {register_response.text}")
+        return
+
+    schema_response = client.create_schema()
+    if schema_response.status_code != 200:
+        print(f"Unable to create schema. Code: {schema_response.status_code}")
+        print(f"Error creating schema. Response: {schema_response.text}")
+        return
+
+    upload_response = client.upload_file()
+    print(response.status_code, upload_response.text)
+    print(f"Waiting for {data_product_name}.{table_name} to create in athena")
+    time.sleep(10)
+
+    # Check for created table
+    try:
+        glue.get_table(DatabaseName=data_product_name, Name=table_name)
+        print(f"{data_product_name}.{table_name} found in glue")
+    except Exception as e:
+        raise e
+
+
 try:
-    glue.get_table(DatabaseName=data_product_name, Name=table_name)
-    print(f"{data_product_name}.{table_name} found in glue")
-except Exception as e:
-    raise e
-
-# Clean up created table
-try:
-    glue.delete_table(DatabaseName=data_product_name, Name=table_name)
-    print(f"{data_product_name}.{table_name} deleted from glue")
-except Exception as e:
-    raise e
+    client = APIClient(base_url, auth_token)
+    run_test(client)
+finally:
+    response = client.delete_data_product()
+    if response.status_code != 200:
+        print(f"Unable to delete data product code: {response.status_code}")
+        print(f"Error deleting data product. Response: {response.text}")

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -121,20 +121,20 @@ class APIClient:
 
 
 def run_test(client):
-    register_response = client.register()
-    if register_response.status_code != 200:
-        print(f"Unable to create data product. Code: {register_response.status_code}")
-        print(f"Error creating data product. Response: {register_response.text}")
-        return
+    # register_response = client.register()
+    # if register_response.status_code != 200:
+    #     print(f"Unable to create data product. Code: {register_response.status_code}")
+    #     print(f"Error creating data product. Response: {register_response.text}")
+    #     return
 
-    schema_response = client.create_schema()
-    if schema_response.status_code != 200:
-        print(f"Unable to create schema. Code: {schema_response.status_code}")
-        print(f"Error creating schema. Response: {schema_response.text}")
-        return
+    # schema_response = client.create_schema()
+    # if schema_response.status_code != 200:
+    #     print(f"Unable to create schema. Code: {schema_response.status_code}")
+    #     print(f"Error creating schema. Response: {schema_response.text}")
+    #     return
 
     upload_response = client.upload_file()
-    print(response.status_code, upload_response.text)
+    print(upload_response.status_code, upload_response.text)
     print(f"Waiting for {data_product_name}.{table_name} to create in athena")
     time.sleep(10)
 
@@ -150,7 +150,8 @@ try:
     client = APIClient(base_url, auth_token)
     run_test(client)
 finally:
-    response = client.delete_data_product()
-    if response.status_code != 200:
-        print(f"Unable to delete data product code: {response.status_code}")
-        print(f"Error deleting data product. Response: {response.text}")
+    # response = client.delete_data_product()
+    # if response.status_code != 200:
+    #     print(f"Unable to delete data product code: {response.status_code}")
+    #     print(f"Error deleting data product. Response: {response.text}")
+    pass


### PR DESCRIPTION
The previous approach of deleting the glue table didn't work becuase it left the files in s3, and in this scenario, athena load thinks there is something wrong, and we need to reload the data product.

Ideally, the test should register the data product itself and delete everything when done, so that this won't get stuck in a broken state again if something goes wrong with a previous test run.

However, I found that the delete data product endpoint is a bit unreliable at the moment, so we can't include this at the moment. I've left this commented out for now so we can enable it later.

1. If the glue table is missing, delete data product doesn't work. This happened before because the tests used to delete the glue table itself, but it could happen again if we manually delete glue tables for any reason, or the delete data product lambda fails part way through
2. Delete data product seems to be deleting schemas but is preserving metadata.json, so currently a subsequent register call will fail

I also noticed that if OpenMetadata has the data product already, but we don't have the metadata in the s3 bucket any more, then we get strange results (register succeeds, but with an error message). This may need a closer look as we want the two systems to become eventually consistent even if OpenMetadata is out of date for some reason.