### PR TITLE
oasys: rename test BIP ASG to t2

### DIFF
--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -213,7 +213,7 @@ locals {
       #   })
       # })
 
-      "test-${local.application_name}-bip-b" = merge(local.bip_b, {
+      "t2-${local.application_name}-bip-b" = merge(local.bip_b, {
         autoscaling_group = merge(local.bip_b.autoscaling_group, {
           desired_capacity = 1
         })


### PR DESCRIPTION
Update naming for consistency, this is part of the T2 environment so should be named as such.