### PR TITLE
DSOS-2359: temporarily remove alarms

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -59,7 +59,7 @@ locals {
   )
 
   baseline_cloudwatch_metric_alarms = merge(
-    local.database_cloudwatch_metric_alarms,
+    ## local.database_cloudwatch_metric_alarms,
   )
 
   baseline_cloudwatch_log_metric_filters = merge(

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -275,6 +275,28 @@ locals {
       })
     }
 
+    baseline_ec2_instances = {
+      dev-nomis-db-1-a = merge(local.database_ec2, {
+        config = merge(local.database_ec2.config, {
+          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+          availability_zone = "${local.region}a"
+        })
+        ebs_volumes = merge(local.database_ec2.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 100 }
+        })
+        ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
+          data  = { total_size = 500 }
+          flash = { total_size = 50 }
+        })
+        tags = merge(local.database_ec2.tags, {
+          nomis-environment   = "dev"
+          description         = "temporary DB to test DB restore"
+          oracle-sids         = ""
+        })
+      })
+    }
+
     baseline_lbs = {
       # AWS doesn't let us call it internal
       private = {

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -124,7 +124,7 @@ locals {
           desired_capacity = 2
           max_size         = 2
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -154,7 +154,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 0
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_*"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -232,34 +232,6 @@ locals {
     }
 
     baseline_ec2_instances = {
-      preprod-nomis-db-2 = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
-        config = merge(local.database_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2022-10-03T12-51-25.032Z"
-          availability_zone = "${local.region}a"
-          instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [
-            "Ec2ProdDatabasePolicy",
-          ])
-        })
-        ebs_volumes = merge(local.database_ec2.ebs_volumes, {
-          # reduce sdc to 1000 when we move into preprod subscription
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 5120 }
-        })
-        ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
-          data  = { total_size = 4000 }
-          flash = { total_size = 1000 }
-        })
-        instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.2xlarge"
-        })
-        tags = merge(local.database_ec2.tags, {
-          nomis-environment = "preprod"
-          description       = "PreProduction NOMIS MIS and Audit database to replace Azure PPPDL00017"
-          oracle-sids       = "PPCNMAUD"
-        })
-      })
-
       prod-nomis-db-1-b = merge(local.database_ec2, {
         cloudwatch_metric_alarms = {}
         config = merge(local.database_ec2.config, {
@@ -288,10 +260,10 @@ locals {
       })
 
       prod-nomis-db-2 = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = merge(
-          local.database_ec2_cloudwatch_metric_alarms,
-          local.fixngo_connection_cloudwatch_metric_alarms
-        )
+        ## cloudwatch_metric_alarms = merge(
+        ##   local.database_ec2_cloudwatch_metric_alarms,
+        ##   local.fixngo_connection_cloudwatch_metric_alarms
+        ## )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [
@@ -310,10 +282,10 @@ locals {
           instance_type = "r6i.2xlarge"
         })
         tags = merge(local.database_ec2.tags, {
-          nomis-environment         = "prod"
-          description               = "Production NOMIS MIS and Audit database to replace Azure PDPDL00036 and PDPDL00038"
-          oracle-sids               = "CNMAUD"
-          fixngo-connection-targets = "10.40.0.136 4903 10.40.129.79 22" # fixngo connection alarm
+          nomis-environment  = "prod"
+          description        = "Production NOMIS MIS and Audit database to replace Azure PDPDL00036 and PDPDL00038"
+          oracle-sids        = "CNMAUD"
+          connectivity-tests = "10.40.0.136:4903 10.40.129.79:22"
         })
       })
 
@@ -345,10 +317,10 @@ locals {
       })
 
       prod-nomis-db-3 = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = merge(
-          local.database_ec2_cloudwatch_metric_alarms,
-          local.database_ec2_cloudwatch_metric_alarms_high_priority
-        )
+        ## cloudwatch_metric_alarms = merge(
+        ##   local.database_ec2_cloudwatch_metric_alarms,
+        ##   local.database_ec2_cloudwatch_metric_alarms_high_priority
+        ## )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -238,7 +238,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 0
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        # cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_*"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -266,7 +266,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        # cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -317,7 +317,7 @@ locals {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -343,7 +343,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 0
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_*"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -422,7 +422,7 @@ locals {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -448,7 +448,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 0
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_*"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -537,7 +537,7 @@ locals {
 
     baseline_ec2_instances = {
       t1-nomis-db-1-a = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -562,7 +562,7 @@ locals {
       })
 
       t1-nomis-db-2-a = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -588,7 +588,7 @@ locals {
       })
 
       t2-nomis-db-1-a = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -613,7 +613,7 @@ locals {
       })
 
       t2-nomis-db-2-a = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -651,7 +651,7 @@ locals {
       })
 
       t3-nomis-db-1 = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -612,44 +612,6 @@ locals {
         })
       })
 
-      t2-nomis-db-2-a = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
-        config = merge(local.database_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
-          availability_zone = "${local.region}a"
-          instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [
-            "Ec2T2DatabasePolicy",
-          ])
-        })
-        user_data_cloud_init = {
-          args = {
-            lifecycle_hook_name  = "ready-hook"
-            branch               = "oracle-11g-secrets" #### changed
-            ansible_repo         = "modernisation-platform-configuration-management"
-            ansible_repo_basedir = "ansible"
-            ansible_args         = "--tags ec2provision"
-          }
-          scripts = [
-            "ansible-ec2provision.sh.tftpl",
-            "post-ec2provision.sh.tftpl"
-          ]
-        }
-        ebs_volumes = merge(local.database_ec2.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
-          data  = { total_size = 500 }
-          flash = { total_size = 50 }
-        })
-        tags = merge(local.database_ec2.tags, {
-          nomis-environment   = "t2"
-          description         = "Wills test server"
-          oracle-sids         = "T2CNOM T2NDH T2TRDAT"
-          instance-scheduling = "skip-scheduling"
-        })
-      })
-
       t3-nomis-db-1 = merge(local.database_ec2, {
         ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
         config = merge(local.database_ec2.config, {


### PR DESCRIPTION
Temporarily remove alarms.  Need to re-run ansible on the servers which will change some of the metrics slightly.  Will re-add them back in after this.

Also remove unused preprod audit DB which has been moved into preproduction account