### PR TITLE
Update all the things

### DIFF
--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -12,16 +12,16 @@
     "production": "1.2.0"
   },
   "presigned_url_versions": {
-    "development": "1.6.0",
-    "test": "1.6.0",
-    "preproduction": "1.6.0",
-    "production": "1.6.0"
+    "development": "1.7.0",
+    "test": "1.7.0",
+    "preproduction": "1.7.0",
+    "production": "1.7.0"
   },
   "athena_load_versions": {
-    "development": "1.4.0",
-    "test": "1.4.0",
-    "preproduction": "1.4.0",
-    "production": "1.4.0"
+    "development": "1.5.0",
+    "test": "1.5.0",
+    "preproduction": "1.5.0",
+    "production": "1.5.0"
   },
   "create_metadata_versions": {
     "development": "2.2.0",
@@ -30,22 +30,22 @@
     "production": "2.2.0"
   },
   "resync_unprocessed_files_versions": {
-    "development": "2.1.0",
-    "test": "2.1.0",
-    "preproduction": "2.1.0",
-    "production": "2.1.0"
+    "development": "2.2.0",
+    "test": "2.2.0",
+    "preproduction": "2.2.0",
+    "production": "2.2.0"
   },
   "reload_data_product_versions": {
-    "development": "2.1.0",
-    "test": "2.1.0",
-    "preproduction": "2.1.0",
-    "production": "2.1.0"
+    "development": "2.2.0",
+    "test": "2.2.0",
+    "preproduction": "2.2.0",
+    "production": "2.2.0"
   },
   "landing_to_raw_versions": {
-    "development": "1.4.0",
-    "test": "1.4.0",
-    "preproduction": "1.4.0",
-    "production": "1.4.0"
+    "development": "1.5.0",
+    "test": "1.5.0",
+    "preproduction": "1.5.0",
+    "production": "1.5.0"
   },
   "create_schema_versions": {
     "development": "1.2.0",
@@ -72,16 +72,16 @@
     "production": "1.1.0"
   },
   "preview_data_versions": {
-    "development": "2.1.1",
-    "test": "2.1.1",
-    "preproduction": "2.1.1",
-    "production": "2.1.1"
+    "development": "2.2.0",
+    "test": "2.2.0",
+    "preproduction": "2.2.0",
+    "production": "2.2.0"
   },
   "delete_table_for_data_product_versions": {
-    "development": "2.1.0",
-    "test": "2.1.0",
-    "preproduction": "2.1.0",
-    "production": "2.1.0"
+    "development": "2.2.0",
+    "test": "2.2.0",
+    "preproduction": "2.2.0",
+    "production": "2.2.0"
   },
   "push_to_catalogue_versions": {
     "development": "1.1.0",
@@ -90,9 +90,9 @@
     "production": "1.1.0"
   },
   "delete_data_product_versions": {
-    "development": "1.2.0",
-    "test": "1.2.0",
-    "preproduction": "1.2.0",
-    "production": "1.2.0"
+    "development": "1.3.0",
+    "test": "1.3.0",
+    "preproduction": "1.3.0",
+    "production": "1.3.0"
   }
 }

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -72,10 +72,10 @@
     "production": "1.1.0"
   },
   "preview_data_versions": {
-    "development": "2.1.0",
-    "test": "2.1.0",
-    "preproduction": "2.1.0",
-    "production": "2.1.0"
+    "development": "2.1.1",
+    "test": "2.1.1",
+    "preproduction": "2.1.1",
+    "production": "2.1.1"
   },
   "delete_table_for_data_product_versions": {
     "development": "2.1.0",

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -6,10 +6,10 @@
     "production": "1.0.12"
   },
   "authorizer_versions": {
-    "development": "1.0.0",
-    "test": "1.0.0",
-    "preproduction": "1.0.0",
-    "production": "1.0.0"
+    "development": "1.2.0",
+    "test": "1.2.0",
+    "preproduction": "1.2.0",
+    "production": "1.2.0"
   },
   "presigned_url_versions": {
     "development": "1.6.0",
@@ -18,64 +18,64 @@
     "production": "1.6.0"
   },
   "athena_load_versions": {
-    "development": "1.2.3",
-    "test": "1.2.3",
-    "preproduction": "1.2.3",
-    "production": "1.2.3"
+    "development": "1.4.0",
+    "test": "1.4.0",
+    "preproduction": "1.4.0",
+    "production": "1.4.0"
   },
   "create_metadata_versions": {
-    "development": "2.1.1",
-    "test": "2.1.1",
-    "preproduction": "2.1.1",
-    "production": "2.1.1"
+    "development": "2.2.0",
+    "test": "2.2.0",
+    "preproduction": "2.2.0",
+    "production": "2.2.0"
   },
   "resync_unprocessed_files_versions": {
-    "development": "2.0.0",
-    "test": "2.0.0",
-    "preproduction": "2.0.0",
-    "production": "2.0.0"
+    "development": "2.1.0",
+    "test": "2.1.0",
+    "preproduction": "2.1.0",
+    "production": "2.1.0"
   },
   "reload_data_product_versions": {
-    "development": "2.0.0",
-    "test": "2.0.0",
-    "preproduction": "2.0.0",
-    "production": "2.0.0"
+    "development": "2.1.0",
+    "test": "2.1.0",
+    "preproduction": "2.1.0",
+    "production": "2.1.0"
   },
   "landing_to_raw_versions": {
-    "development": "1.3.1",
-    "test": "1.3.1",
-    "preproduction": "1.3.1",
-    "production": "1.3.1"
+    "development": "1.4.0",
+    "test": "1.4.0",
+    "preproduction": "1.4.0",
+    "production": "1.4.0"
   },
   "create_schema_versions": {
+    "development": "1.2.0",
+    "test": "1.2.0",
+    "preproduction": "1.2.0",
+    "production": "1.2.0"
+  },
+  "get_schema_versions": {
+    "development": "1.3.0",
+    "test": "1.3.0",
+    "preproduction": "1.3.0",
+    "production": "1.3.0"
+  },
+  "update_metadata_versions": {
     "development": "1.1.0",
     "test": "1.1.0",
     "preproduction": "1.1.0",
     "production": "1.1.0"
   },
-  "get_schema_versions": {
-    "development": "1.0.0",
-    "test": "1.0.0",
-    "preproduction": "1.0.0",
-    "production": "1.0.0"
-  },
-  "update_metadata_versions": {
-    "development": "1.0.1",
-    "test": "1.0.1",
-    "preproduction": "1.0.1",
-    "production": "1.0.1"
-  },
   "update_schema_versions": {
-    "development": "1.0.1",
-    "test": "1.0.1",
-    "preproduction": "1.0.1",
-    "production": "1.0.1"
+    "development": "1.1.0",
+    "test": "1.1.0",
+    "preproduction": "1.1.0",
+    "production": "1.1.0"
   },
   "preview_data_versions": {
-    "development": "2.0.1",
-    "test": "2.0.1",
-    "preproduction": "2.0.1",
-    "production": "2.0.1"
+    "development": "2.1.0",
+    "test": "2.1.0",
+    "preproduction": "2.1.0",
+    "production": "2.1.0"
   },
   "delete_table_for_data_product_versions": {
     "development": "2.1.0",

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -1,9 +1,9 @@
 {
   "docs_versions": {
-    "development": "1.0.12",
-    "test": "1.0.12",
-    "preproduction": "1.0.12",
-    "production": "1.0.12"
+    "development": "1.0.13",
+    "test": "1.0.13",
+    "preproduction": "1.0.13",
+    "production": "1.0.13"
   },
   "authorizer_versions": {
     "development": "1.2.0",

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -5,14 +5,12 @@ import os
 import sys
 import time
 
-import boto3
 import requests
 
 filename = "test_data.csv"
 data_product_name = "example_prison_data_product"
 table_name = "testing"
 base_url = "https://hsolkci589.execute-api.eu-west-2.amazonaws.com/development"
-glue = boto3.client("glue")
 
 try:
     auth_token = json.loads(os.environ["API_AUTH"])
@@ -133,13 +131,6 @@ def run_test(client):
     print(upload_response.status_code, upload_response.text)
     print(f"Waiting for {data_product_name}.{table_name} to create in athena")
     time.sleep(10)
-
-    # Check for created table
-    try:
-        glue.get_table(DatabaseName=data_product_name, Name=table_name)
-        print(f"{data_product_name}.{table_name} found in glue")
-    except Exception as e:
-        raise e
 
 
 client = APIClient(base_url, auth_token)

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -136,7 +136,9 @@ def parse_first_line_of_data(output):
 
     col1, col2, col3, col4, extraction_timestamp = fields[1:-1]
 
-    age = datetime.fromisoformat(extraction_timestamp) - datetime.now(timezone.utc)
+    parsed_datetime = datetime.strptime(extraction_timestamp, r'%Y%m%dT%H%M%SZ')
+    age = parsed_datetime - datetime.now()
+
     return col1, col2, col3, col4, age
 
 

--- a/terraform/environments/data-platform/tests/run_smoke_tests.py
+++ b/terraform/environments/data-platform/tests/run_smoke_tests.py
@@ -36,7 +36,8 @@ class APIClient:
     def __init__(self, base_url, auth_token):
         self.table_url = base_url + f"/data-product/{data_product_name}/table/{table_name}"
         self.data_product_url = base_url + f"/data-product/{data_product_name}"
-        self.register_url = base_url + f"/data-product/register"
+        self.register_url = base_url + "/data-product/register"
+        self.preview_data_url = self.table_url + "/preview"
         self.presigned_url = base_url + f"/data-product/{data_product_name}/table/{table_name}/upload"
         self.headers = {"authorizationToken": auth_token}
         
@@ -67,6 +68,13 @@ class APIClient:
         print("Deleting data product...")
         return requests.delete(
             url=self.data_product_url,
+            headers=self.headers,
+        )
+
+    def preview_data(self):
+        print("Fetching data")
+        return requests.get(
+            url=self.preview_data_url,
             headers=self.headers,
         )
 


### PR DESCRIPTION
This updates all the lambdas to pick up recent changes to the base image, including logging changes and renaming glue databases to include version numbers.

As a side effect of this, we can no longer look up the glue table in the smoketest, so I've replaced it with a call to the preview endpoint.