### PR TITLE
Nomis: DSOS-2358: oracle secure backup fix

### DIFF
--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -75,6 +75,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket"
       ]
       principals = {
@@ -92,6 +93,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket"
       ]
       principals = {
@@ -108,6 +110,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -128,6 +131,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
       ]
       principals = {
@@ -144,6 +148,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -164,6 +169,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -185,6 +191,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
       ]
       principals = {
@@ -201,6 +208,7 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
+        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -226,6 +234,7 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
+          "s3:ListAllMyBuckets",
           "s3:ListBucket",
         ]
       }
@@ -237,6 +246,7 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
+          "s3:ListAllMyBuckets",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",
@@ -252,6 +262,7 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
+          "s3:ListAllMyBuckets",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -225,7 +225,6 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
-          "s3:ListAllMyBuckets",
           "s3:ListBucket",
         ]
       }
@@ -237,7 +236,6 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
-          "s3:ListAllMyBuckets",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",
@@ -253,7 +251,6 @@ locals {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
-          "s3:ListAllMyBuckets",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -72,6 +72,7 @@ locals {
     AllEnvironmentsReadOnlyAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket"
@@ -88,6 +89,7 @@ locals {
     PreprodReadOnlyAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket"
@@ -103,6 +105,7 @@ locals {
     AllEnvironmentsWriteAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -122,6 +125,7 @@ locals {
     ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -137,6 +141,7 @@ locals {
     ProdPreprodEnvironmentsWriteAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -156,6 +161,7 @@ locals {
     AllEnvironmentsWriteAndDeleteAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -176,6 +182,7 @@ locals {
     DevTestEnvironmentsReadOnlyAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -191,6 +198,7 @@ locals {
     DevTestEnvironmentsWriteAndDeleteAccessBucketPolicy = {
       effect = "Allow"
       actions = [
+        "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
         "s3:ListBucket",
@@ -215,6 +223,7 @@ locals {
       {
         effect = "Allow"
         actions = [
+          "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
           "s3:ListBucket",
@@ -225,6 +234,7 @@ locals {
       {
         effect = "Allow"
         actions = [
+          "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
           "s3:ListBucket",
@@ -239,6 +249,7 @@ locals {
       {
         effect = "Allow"
         actions = [
+          "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:GetObjectTagging",
           "s3:ListBucket",

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -75,7 +75,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket"
       ]
       principals = {
@@ -93,7 +92,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket"
       ]
       principals = {
@@ -110,7 +108,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -131,7 +128,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
       ]
       principals = {
@@ -148,7 +144,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -169,7 +164,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",
@@ -191,7 +185,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
       ]
       principals = {
@@ -208,7 +201,6 @@ locals {
         "s3:GetBucketLocation",
         "s3:GetObject",
         "s3:GetObjectTagging",
-        "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutObjectAcl",

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -214,7 +214,6 @@ locals {
         "s3:PutObjectAcl",
         "s3:PutObjectTagging",
         "s3:DeleteObject",
-        "s3:DeleteObjectVersion",
         "s3:RestoreObject",
       ]
       principals = {


### PR DESCRIPTION
Add additional permission required for Oracle Secure Backup to our default policies.
Remove the DeleteObjectVersion permission from DevTest role. This should not be included for security reasons.