### PR TITLE
change r3 and r4 targets to use NLB r34 instead

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_database.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_database.tf
@@ -54,7 +54,7 @@ locals {
       }
     }
 
-    route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
+    route53_records      = module.baseline_presets.ec2_instance.route53_records.internal_and_external
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ansible
   }
 }

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -561,7 +561,7 @@ locals {
     }
 
     baseline_lbs = {
-      r56 = {
+      r34 = {
         internal_lb              = true
         enable_delete_protection = false
         load_balancer_type       = "network"
@@ -574,7 +574,7 @@ locals {
         access_logs     = false
 
         instance_target_groups = {
-          pp-csr-w-56-80 = {
+          pp-csr-w-34-80 = {
             port     = 80
             protocol = "TCP"
             health_check = {
@@ -595,7 +595,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-56-7770 = {
+          pp-csr-w-34-7770 = {
             port     = 7770
             protocol = "TCP"
             health_check = {
@@ -617,7 +617,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-56-7771 = {
+          pp-csr-w-34-7771 = {
             port     = 7771
             protocol = "TCP"
             health_check = {
@@ -639,7 +639,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-56-7780 = {
+          pp-csr-w-34-7780 = {
             port     = 7780
             protocol = "TCP"
             health_check = {
@@ -661,7 +661,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-56-7781 = {
+          pp-csr-w-34-7781 = {
             port     = 7781
             protocol = "TCP"
             health_check = {
@@ -691,7 +691,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-56-80"
+              target_group_name = "pp-csr-w-34-80"
             }
           }
           http-7770 = {
@@ -699,7 +699,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-56-7770"
+              target_group_name = "pp-csr-w-34-7770"
             }
           }
           http-7771 = {
@@ -707,7 +707,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-56-7771"
+              target_group_name = "pp-csr-w-34-7771"
             }
           }
           http-7780 = {
@@ -715,7 +715,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-56-7780"
+              target_group_name = "pp-csr-w-34-7780"
             }
           }
           http-7781 = {
@@ -723,7 +723,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-56-7781"
+              target_group_name = "pp-csr-w-34-7781"
             }
           }
         }
@@ -1388,8 +1388,8 @@ locals {
         lb_alias_records = [
           { name = "r1", type = "A", lbs_map_key = "private" },
           { name = "r2", type = "A", lbs_map_key = "private" },
-          { name = "r3", type = "A", lbs_map_key = "private" },
-          { name = "r4", type = "A", lbs_map_key = "private" },
+          { name = "r3", type = "A", lbs_map_key = "r34" },
+          { name = "r4", type = "A", lbs_map_key = "r34" },
           { name = "r5", type = "A", lbs_map_key = "private" },
           { name = "r6", type = "A", lbs_map_key = "private" },
           { name = "traina", type = "A", lbs_map_key = "private" },

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -91,11 +91,11 @@ locals {
 
       pp-csr-a-13-a = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-13-a"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-a-13-a"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -119,11 +119,11 @@ locals {
 
       pp-csr-a-14-b = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-14-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-a-14-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -147,11 +147,11 @@ locals {
 
       pp-csr-a-17-a = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-17-a"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-a-17-a"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -175,11 +175,11 @@ locals {
 
       pp-csr-a-18-b = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-18-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-a-18-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -203,11 +203,11 @@ locals {
 
       pp-csr-a-2-b = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-2-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-a-2-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -229,11 +229,11 @@ locals {
 
       pp-csr-a-3-a = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-3-a"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-a-3-a"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -255,11 +255,11 @@ locals {
 
       pp-csr-a-15-a = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-15-a"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-a-15-a"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -283,11 +283,11 @@ locals {
 
       pp-csr-a-16-b = {
         config = merge(local.defaults_app_ec2.config, {
-          ami_name                      = "pp-csr-a-16-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-a-16-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_app_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -311,11 +311,11 @@ locals {
 
       pp-csr-w-1-a = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "PPCWW00001"
-          availability_zone             = "${local.region}a"
+          ami_name          = "PPCWW00001"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -339,11 +339,11 @@ locals {
 
       pp-csr-w-2-b = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-2-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-w-2-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -367,11 +367,11 @@ locals {
 
       pp-csr-w-5-a = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "PPCWW00005"
-          availability_zone             = "${local.region}a"
+          ami_name          = "PPCWW00005"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -394,11 +394,11 @@ locals {
 
       pp-csr-w-6-b = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-6-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-w-6-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -422,11 +422,11 @@ locals {
 
       pp-csr-w-7-a = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-7-b"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-w-7-b"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -448,11 +448,11 @@ locals {
 
       pp-csr-w-8-b = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-8-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-w-8-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 200 }
@@ -474,11 +474,11 @@ locals {
 
       pp-csr-w-3-a = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-3-a"
-          availability_zone             = "${local.region}a"
+          ami_name          = "pp-csr-w-3-a"
+          availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }
@@ -502,11 +502,11 @@ locals {
 
       pp-csr-w-4-b = {
         config = merge(local.defaults_web_ec2.config, {
-          ami_name                      = "pp-csr-w-4-b"
-          availability_zone             = "${local.region}b"
+          ami_name          = "pp-csr-w-4-b"
+          availability_zone = "${local.region}b"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type           = "m5.2xlarge"
+          instance_type = "m5.2xlarge"
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -574,7 +574,7 @@ locals {
         access_logs     = false
 
         instance_target_groups = {
-          pp-csr-w-34-80 = {
+          pp-csr-w-56-80 = {
             port     = 80
             protocol = "TCP"
             health_check = {
@@ -595,7 +595,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-34-7770 = {
+          pp-csr-w-56-7770 = {
             port     = 7770
             protocol = "TCP"
             health_check = {
@@ -617,7 +617,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-34-7771 = {
+          pp-csr-w-56-7771 = {
             port     = 7771
             protocol = "TCP"
             health_check = {
@@ -639,7 +639,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-34-7780 = {
+          pp-csr-w-56-7780 = {
             port     = 7780
             protocol = "TCP"
             health_check = {
@@ -661,7 +661,7 @@ locals {
               { ec2_instance_name = "pp-csr-w-6-b" },
             ]
           }
-          pp-csr-w-34-7781 = {
+          pp-csr-w-56-7781 = {
             port     = 7781
             protocol = "TCP"
             health_check = {
@@ -691,7 +691,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-34-80"
+              target_group_name = "pp-csr-w-56-80"
             }
           }
           http-7770 = {
@@ -699,7 +699,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-34-7770"
+              target_group_name = "pp-csr-w-56-7770"
             }
           }
           http-7771 = {
@@ -707,7 +707,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-34-7771"
+              target_group_name = "pp-csr-w-56-7771"
             }
           }
           http-7780 = {
@@ -715,7 +715,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-34-7780"
+              target_group_name = "pp-csr-w-56-7780"
             }
           }
           http-7781 = {
@@ -723,7 +723,7 @@ locals {
             protocol = "TCP"
             default_action = {
               type              = "forward"
-              target_group_name = "pp-csr-w-34-7781"
+              target_group_name = "pp-csr-w-56-7781"
             }
           }
         }


### PR DESCRIPTION
- NLB r34 added
- in use for r3.pp.csr.service.justice.gov.uk and r4.pp.csr.service.justice.gov.uk
- equates to EC2 instances pp-csr-w-5-a and pp-csr-w-6-b
- requires separate IIS config changes that aren't in code 