### PR TITLE
DSOS-2358: permission changes to DB backup buckets for cross-account access

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -63,10 +63,6 @@ locals {
     s3-bucket = {
       iam_policies = module.baseline_presets.s3_iam_policies
     }
-    csr-db-backup-bucket = {
-      custom_kms_key = module.environment.kms_keys["general"].arn
-      iam_policies   = module.baseline_presets.s3_iam_policies
-    }
   }
 
   baseline_secretsmanager_secrets = {}

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -4,6 +4,13 @@ locals {
   # baseline config
   preproduction_config = {
 
+    baseline_s3_buckets = {
+      csr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
+    }
+
     baseline_ssm_parameters = {
       "/oracle/database/PPIWFM" = local.database_ssm_parameters
     }
@@ -15,6 +22,18 @@ locals {
       Ec2PreprodDatabasePolicy = {
         description = "Permissions required for Preprod Database EC2s"
         statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetBucketLocation",
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucket",
+            ]
+            resources = [
+              "arn:aws:s3:::csr-db-backup-bucket*",
+            ]
+          },
           {
             effect = "Allow"
             actions = [

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -4,6 +4,16 @@ locals {
   # baseline config
   production_config = {
 
+    baseline_s3_buckets = {
+      csr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+        iam_policies = module.baseline_presets.s3_iam_policies
+      }
+    }
+
     baseline_iam_policies = {
       Ec2ProdDatabasePolicy = {
         description = "Permissions required for prod Database EC2s"

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -43,10 +43,6 @@ locals {
     s3-bucket = {
       iam_policies = module.baseline_presets.s3_iam_policies
     }
-    ncr-db-backup-bucket = {
-      custom_kms_key = module.environment.kms_keys["general"].arn
-      iam_policies   = module.baseline_presets.s3_iam_policies
-    }
   }
   environment_config = local.environment_configs[local.environment]
 

--- a/terraform/environments/nomis-combined-reporting/locals_development.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_development.tf
@@ -1,5 +1,11 @@
 locals {
   development_config = {
+    baseline_s3_buckets = {
+      ncr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
+    }
     baseline_route53_zones = {
       "development.reporting.nomis.service.justice.gov.uk" = {
       }

--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -1,5 +1,11 @@
 locals {
   preproduction_config = {
+    baseline_s3_buckets = {
+      ncr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
+    }
     baseline_route53_zones = {
       "preproduction.reporting.nomis.service.justice.gov.uk" = {
       }

--- a/terraform/environments/nomis-combined-reporting/locals_production.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_production.tf
@@ -1,6 +1,16 @@
 locals {
   production_config = {
 
+    baseline_s3_buckets = {
+      ncr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
+    }
+
     baseline_route53_zones = {
       "reporting.nomis.service.justice.gov.uk" = {
         ns_records = [

--- a/terraform/environments/nomis-combined-reporting/locals_test.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_test.tf
@@ -19,6 +19,13 @@ locals {
         ]
         iam_policies = module.baseline_presets.s3_iam_policies
       }
+      ncr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        bucket_policy_v2 = [
+          module.baseline_presets.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy,
+        ]
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
     }
 
     baseline_acm_certificates = {

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -48,6 +48,7 @@ locals {
           {
             effect = "Allow"
             actions = [
+              "s3:GetBucketLocation",
               "s3:GetObject",
               "s3:GetObjectTagging",
               "s3:ListBucket",


### PR DESCRIPTION
Changes to support cross-account DB refresh, e.g. preprod refresh from backup in production account
- Add S3 bucket policy to allow prod DB backup S3 buckets to be accessed read-only from preprod, and test S3 buckets to be accessed read-only from Dev
- Add required IAM policy to preprod DBs