### PR TITLE
DSOS-2358: restore csr db-backup bucket

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -4,13 +4,6 @@ locals {
   # baseline config
   test_config = {
 
-    baseline_s3_buckets = {
-      csr-db-backup-bucket = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     baseline_ec2_instances = {}
 
     baseline_ec2_autoscaling_groups = {}
@@ -28,6 +21,11 @@ locals {
           module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
         ]
         iam_policies = module.baseline_presets.s3_iam_policies
+      }
+
+      csr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
       }
     }
   }

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -4,6 +4,13 @@ locals {
   # baseline config
   test_config = {
 
+    baseline_s3_buckets = {
+      csr-db-backup-bucket = {
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+      }
+    }
+
     baseline_ec2_instances = {}
 
     baseline_ec2_autoscaling_groups = {}


### PR DESCRIPTION
Looks like there is a DB backup in CSR test even though rest of the account is empty.  Restore the bucket for the time being.