### PR TITLE
oasys db skip instance scheduling

### DIFF
--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -137,7 +137,7 @@ locals {
           description                             = "t2 ${local.application_name} database"
           "${local.application_name}-environment" = "t2"
           bip-db-name                             = "T2BIPINF"
-          # instance-scheduling                     = "skip-scheduling"
+          instance-scheduling                     = "skip-scheduling"
         })
       })
       # "t2-${local.application_name}-db-b" = merge(local.database_b, {
@@ -185,6 +185,7 @@ locals {
           description                             = "t1 ${local.application_name} database"
           "${local.application_name}-environment" = "t1"
           bip-db-name                             = "T1BIPINF"
+          instance-scheduling                     = "skip-scheduling"
         })
       })
 


### PR DESCRIPTION
oasys db skip instance scheduling

need the db up before web and bip, no time control in instance-scheduling so need db up all the time