### PR TITLE
DSOS-2359: update oracle DB monitoring tags

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -105,6 +105,7 @@ locals {
           os-type     = "Linux"
           component   = "test"
           server-type = "csr-db"
+          oracle-sids = "PPIWFM"
         }
       })
 

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -224,7 +224,7 @@ locals {
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "preprod"
           description       = "PreProduction NOMIS MIS and Audit database"
-          oracle-sids       = ""
+          oracle-sids       = "PPCNMAUD"
         })
       })
     }

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -255,7 +255,7 @@ locals {
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "prod"
           description       = "Disaster-Recovery/High-Availability production databases for CNOM and NDH"
-          oracle-sids       = ""
+          oracle-sids       = "DRCNOM DRNDH DRTRDAT"
         })
       })
 
@@ -284,7 +284,7 @@ locals {
         tags = merge(local.database_ec2.tags, {
           nomis-environment  = "prod"
           description        = "Production NOMIS MIS and Audit database to replace Azure PDPDL00036 and PDPDL00038"
-          oracle-sids        = "CNMAUD"
+          oracle-sids        = "PCNMAUD"
           connectivity-tests = "10.40.0.136:4903 10.40.129.79:22"
         })
       })
@@ -312,7 +312,7 @@ locals {
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "prod"
           description       = "Disaster-Recovery/High-Availability production databases for AUDIT/MIS"
-          oracle-sids       = ""
+          oracle-sids       = "DRMIS"
         })
       })
 

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -138,6 +138,7 @@ locals {
           "${local.application_name}-environment" = "t2"
           bip-db-name                             = "T2BIPINF"
           instance-scheduling                     = "skip-scheduling"
+          oracle-sids                             = "T2BIPINF T2MISTRN T2OASREP T2OASYS T2ONRAUD T2ONRBDS T2ONRSYS"
         })
       })
       # "t2-${local.application_name}-db-b" = merge(local.database_b, {
@@ -186,6 +187,7 @@ locals {
           "${local.application_name}-environment" = "t1"
           bip-db-name                             = "T1BIPINF"
           instance-scheduling                     = "skip-scheduling"
+          oracle-sids                             = "T1BIPINF T1MISTRN T1OASREP T1OASYS T1ONRAUD T1ONRBDS T1ONRSYS"
         })
       })
 


### PR DESCRIPTION
Update oracle-sids tag to reflect what should be monitored on the EC2 instances