### PR TITLE
DSOS-2359: remove unused dbs

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -276,25 +276,25 @@ locals {
     }
 
     baseline_ec2_instances = {
-      dev-nomis-db-1-a = merge(local.database_ec2, {
-        config = merge(local.database_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
-          availability_zone = "${local.region}a"
-        })
-        ebs_volumes = merge(local.database_ec2.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
-          data  = { total_size = 500 }
-          flash = { total_size = 50 }
-        })
-        tags = merge(local.database_ec2.tags, {
-          nomis-environment   = "dev"
-          description         = "temporary DB to test DB restore"
-          oracle-sids         = ""
-        })
-      })
+      #dev-nomis-db-1-a = merge(local.database_ec2, {
+      #  config = merge(local.database_ec2.config, {
+      #    ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
+      #    availability_zone = "${local.region}a"
+      #  })
+      #  ebs_volumes = merge(local.database_ec2.ebs_volumes, {
+      #    "/dev/sdb" = { label = "app", size = 100 }
+      #    "/dev/sdc" = { label = "app", size = 100 }
+      #  })
+      #  ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
+      #    data  = { total_size = 500 }
+      #    flash = { total_size = 50 }
+      #  })
+      #  tags = merge(local.database_ec2.tags, {
+      #    nomis-environment   = "dev"
+      #    description         = "temporary DB to test DB restore"
+      #    oracle-sids         = ""
+      #  })
+      #})
     }
 
     baseline_lbs = {

--- a/terraform/environments/oasys/locals_development.tf
+++ b/terraform/environments/oasys/locals_development.tf
@@ -16,7 +16,7 @@ locals {
     baseline_s3_buckets = {}
 
     baseline_ec2_instances = {
-      "dev-${local.application_name}-db-a" = local.database_a
+      # "dev-${local.application_name}-db-a" = local.database_a
 
     }
 


### PR DESCRIPTION
Comment out DBs in nomis and oasys development accounts as they are not currently used. There's likely to be a requirement in future hence why they are commented out and not deleted.