### PR TITLE
Widen Network Range for Security Groups

### DIFF
--- a/terraform/environments/mojfin/application_variables.json
+++ b/terraform/environments/mojfin/application_variables.json
@@ -3,7 +3,7 @@
     "development": {
       "landing_zone_vpc_cidr": "10.202.0.0/20",
       "analytic_platform_cidr": "10.200.0.0/16",
-      "cp_vpc_cidr": "172.20.0.0/20",
+      "cp_vpc_cidr": "172.20.0.0/16",
       "london_workspace_cidr": "10.200.0.0/20",
       "mojfinrdssnapshotid": "mojfin-04jul20231459-finalsnapshot",
       "deletion_protection": "false",
@@ -20,7 +20,7 @@
     "production": {
       "landing_zone_vpc_cidr": "10.205.0.0/20",
       "analytic_platform_cidr": "10.201.0.0/16",
-      "cp_vpc_cidr": "172.20.0.0/20",
+      "cp_vpc_cidr": "172.20.0.0/16",
       "london_workspace_cidr": "10.200.16.0/20",
       "deletion_protection": "true",
       "pagerduty_integration_key_name": "laa_mojfin_prod_alarms"


### PR DESCRIPTION
This will fix the connectivity, however not sure why it was initially put at 20 not 16 and if there is a reason. Luke will talk to the 2 team members who manage this and get their input including Vincents. 

Initial request - https://moj.enterprise.slack.com/archives/C01A7QK5VM1/p1700503498654209