### PR TITLE
DSOS-2359: re-enable nomis cloudwatch alarms

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -58,13 +58,8 @@ locals {
     local.database_cloudwatch_log_groups,
   )
 
-  baseline_cloudwatch_metric_alarms = merge(
-    ## local.database_cloudwatch_metric_alarms,
-  )
-
-  baseline_cloudwatch_log_metric_filters = merge(
-    local.database_cloudwatch_log_metric_filters,
-  )
+  baseline_cloudwatch_metric_alarms      = {}
+  baseline_cloudwatch_log_metric_filters = {}
 
   baseline_ec2_autoscaling_groups   = {}
   baseline_ec2_instances            = {}

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -42,148 +42,10 @@ locals {
     }
   }
 
-  database_cloudwatch_log_metric_filters = {
-    rman-backup-status = {
-      pattern        = "[month, day, time, hostname, process, message = rman-backup-result, dbname, value]"
-      log_group_name = "cwagent-var-log-messages"
-      metric_transformation = {
-        name      = "RmanBackupStatus"
-        namespace = "Database" # custom namespace
-        value     = "$value"
-        dimensions = {
-          dbname = "$dbname"
-        }
-      }
-    }
-    misload-status = {
-      pattern        = "[month, day, time, hostname, process, message1 = misload-status, dbname, value, message2 = \"last-triggered:\", yearmonthday, utctime]"
-      log_group_name = "cwagent-var-log-messages"
-      metric_transformation = {
-        name      = "MisloadStatus"
-        namespace = "Database" # custom namespace
-        value     = "$value"
-        dimensions = {
-          dbname = "$dbname"
-        }
-      }
-    }
-  }
-
-  # Alarms created directly by baseline module, i.e. without EC2 dimension
-  database_cloudwatch_metric_alarms = {
-    rman-backup-failed = {
-      comparison_operator = "LessThanOrEqualToThreshold"
-      evaluation_periods  = 2
-      metric_name         = "RmanBackupStatus"
-      namespace           = "Database"
-      period              = "3600"
-      statistic           = "Maximum"
-      threshold           = "0"
-      alarm_description   = "Triggers if there has been no successful rman backup"
-      alarm_actions       = ["dba_pagerduty"]
-      datapoints_to_alarm = 1
-      split_by_dimension = {
-        dimension_name   = "dbname"
-        dimension_values = local.baseline_environment_config.cloudwatch_metric_alarms_dbnames
-      }
-    }
-    misload-failed = {
-      comparison_operator = "GreaterThanOrEqualToThreshold"
-      evaluation_periods  = 2
-      metric_name         = "MisloadStatus"
-      namespace           = "Database"
-      period              = "3600"
-      statistic           = "Maximum"
-      threshold           = "1"
-      alarm_description   = "Triggers if misload failed"
-      alarm_actions       = ["dba_pagerduty"]
-      datapoints_to_alarm = 2
-      split_by_dimension = {
-        dimension_name   = "dbname"
-        dimension_values = local.baseline_environment_config.cloudwatch_metric_alarms_dbnames_misload
-      }
-    }
-  }
-
-  # Alarms created directly by ec2-instance module
-  # TODO: - change alarm actions to dba_pagerduty once alarms proven out
   database_ec2_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
-    {
-      # FIXME: metric name needs changing to collectd_dbconnected_value as part of DSOS-2092, remove dimensions
-      oracle-db-disconnected = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "collectd_exec_value"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
-        alarm_actions       = ["dba_pagerduty"]
-        dimensions = {
-          instance = "db_connected"
-        }
-      }
-      # FIXME: metric name needs changing to collectd_nomisbatchfailure_value as part of DSOS-2092, remove dimensions
-      oracle-batch-failure = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "collectd_exec_value"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        treat_missing_data  = "notBreaching"
-        alarm_description   = "Oracle db has recorded a failed batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4295000327/Batch+Failure for remediation steps."
-        alarm_actions       = ["dba_pagerduty"]
-        dimensions = {
-          instance = "nomis_batch_failure_status"
-        }
-      }
-      # FIXME: metric name needs changing to collectd_nomislongrunningbatch_value as part of DSOS-2092, remove dimensions
-      oracle-long-running-batch = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "collectd_exec_value"
-        namespace           = "CWAgent"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        treat_missing_data  = "notBreaching"
-        alarm_description   = "Oracle db has recorded a long-running batch status. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325966186/Long+Running+Batch for remediation steps."
-        alarm_actions       = ["dba_pagerduty"]
-        dimensions = {
-          instance = "nomis_long_running_batch"
-        }
-      }
-      oracleasm-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_oracleasm_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "oracleasm service has stopped"
-        alarm_actions       = ["dba_pagerduty"]
-      }
-      oracle-ohasd-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_oracleohasd_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "oracle ohasd service has stopped"
-        alarm_actions       = ["dba_pagerduty"]
-      }
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status, {
       cpu-utilization-high = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "120"
@@ -194,41 +56,59 @@ locals {
         statistic           = "Maximum"
         threshold           = "95"
         alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 2 hours on a nomis-db instance"
-        alarm_actions       = ["dba_pagerduty"]
+        alarm_actions       = ["dso_pagerduty"]
       }
   })
-  database_ec2_cloudwatch_metric_alarms_high_priority = {
-    # FIXME: metric name needs changing to collectd_dbconnected_value as part of DSOS-2092, remove dimensions
-    oracle-db-disconnected = {
-      comparison_operator = "GreaterThanOrEqualToThreshold"
-      evaluation_periods  = "5"
-      datapoints_to_alarm = "5"
-      metric_name         = "collectd_exec_value"
-      namespace           = "CWAgent"
-      period              = "60"
-      statistic           = "Average"
-      threshold           = "1"
-      alarm_description   = "Oracle db connection to a particular SID is not working. See: https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698/Oracle+db+connection+alarm for remediation steps."
-      alarm_actions       = ["dba_high_priority_pagerduty"]
-      dimensions = {
-        instance = "db_connected"
-      }
-    }
-  }
-  # FIXME: metric name needs changing to collectd_fixngoconnected_value as part of DSOS-2093, remove dimensions
-  fixngo_connection_cloudwatch_metric_alarms = {
-    fixngo-connection = {
+
+  database_ec2_misload_cloudwatch_metric_alarms = {
+    misload_error = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = "3"
+      datapoints_to_alarm = "3"
       namespace           = "CWAgent"
-      metric_name         = "collectd_exec_value"
+      metric_name         = "collectd_textfile_monitoring_value"
       period              = "60"
-      statistic           = "Average"
+      statistic           = "Maximum"
       threshold           = "1"
-      alarm_description   = "this EC2 instance no longer has a connection to the Oracle Enterprise Manager in FixNGo of the connection-target machine"
+      alarm_description   = "Triggers if misload process failed. See nomis-misload and collectd-textfile-monitoring ansible roles"
       alarm_actions       = ["dso_pagerduty"]
       dimensions = {
-        instance = "fixngo_connected" # required dimension value for this metric
+        type          = "gauge"
+        type_instance = "misload_status"
+      }
+    }
+    misload_metric_not_updated = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      datapoints_to_alarm = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_textfile_monitoring_seconds"
+      period              = "129600"
+      statistic           = "Maximum"
+      threshold           = "1"
+      treat_missing_data  = "breaching"
+      alarm_description   = "Triggers if misload status metric missing or not updated or over 36 hours"
+      alarm_actions       = ["dso_pagerduty"]
+      dimensions = {
+        type          = "duration"
+        type_instance = "misload_status"
+      }
+    }
+    misload_long_running = {
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = "3"
+      datapoints_to_alarm = "3"
+      namespace           = "CWAgent"
+      metric_name         = "collectd_textfile_monitoring_seconds"
+      period              = "14400"
+      statistic           = "Maximum"
+      threshold           = "1"
+      treat_missing_data  = "notBreaching"
+      alarm_description   = "Triggers if misload process is taking longer than 4 hours"
+      alarm_actions       = ["dso_pagerduty"]
+      dimensions = {
+        type          = "duration"
+        type_instance = "misload_running"
       }
     }
   }

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -63,11 +63,11 @@ locals {
   database_ec2_misload_cloudwatch_metric_alarms = {
     misload_error = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      evaluation_periods  = "3"
-      datapoints_to_alarm = "3"
+      evaluation_periods  = "1"
+      datapoints_to_alarm = "1"
       namespace           = "CWAgent"
       metric_name         = "collectd_textfile_monitoring_value"
-      period              = "60"
+      period              = "300"
       statistic           = "Maximum"
       threshold           = "1"
       alarm_description   = "Triggers if misload process failed. See nomis-misload and collectd-textfile-monitoring ansible roles"
@@ -79,13 +79,13 @@ locals {
     }
     misload_metric_not_updated = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      evaluation_periods  = "3"
-      datapoints_to_alarm = "3"
+      evaluation_periods  = "1"
+      datapoints_to_alarm = "1"
       namespace           = "CWAgent"
       metric_name         = "collectd_textfile_monitoring_seconds"
-      period              = "129600"
+      period              = "300"
       statistic           = "Maximum"
-      threshold           = "1"
+      threshold           = "129600"
       treat_missing_data  = "breaching"
       alarm_description   = "Triggers if misload status metric missing or not updated or over 36 hours"
       alarm_actions       = ["dso_pagerduty"]
@@ -96,13 +96,13 @@ locals {
     }
     misload_long_running = {
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      evaluation_periods  = "3"
-      datapoints_to_alarm = "3"
+      evaluation_periods  = "1"
+      datapoints_to_alarm = "1"
       namespace           = "CWAgent"
       metric_name         = "collectd_textfile_monitoring_seconds"
-      period              = "14400"
+      period              = "300"
       statistic           = "Maximum"
-      threshold           = "1"
+      threshold           = "14400"
       treat_missing_data  = "notBreaching"
       alarm_description   = "Triggers if misload process is taking longer than 4 hours"
       alarm_actions       = ["dso_pagerduty"]

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -11,9 +11,6 @@ locals {
   # baseline config
   development_config = {
 
-    cloudwatch_metric_alarms_dbnames         = []
-    cloudwatch_metric_alarms_dbnames_misload = []
-
     baseline_s3_buckets = {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -4,9 +4,6 @@ locals {
   # baseline config
   preproduction_config = {
 
-    cloudwatch_metric_alarms_dbnames         = []
-    cloudwatch_metric_alarms_dbnames_misload = []
-
     baseline_s3_buckets = {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn
@@ -125,7 +122,7 @@ locals {
           desired_capacity = 2
           max_size         = 2
         })
-        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -202,7 +199,10 @@ locals {
 
     baseline_ec2_instances = {
       preprod-nomis-db-2-a = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = {}
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
           availability_zone = "${local.region}a"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -4,9 +4,6 @@ locals {
   # baseline config
   production_config = {
 
-    cloudwatch_metric_alarms_dbnames         = []
-    cloudwatch_metric_alarms_dbnames_misload = []
-
     baseline_s3_buckets = {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn
@@ -184,7 +181,7 @@ locals {
           desired_capacity = 2
           max_size         = 2
         })
-        # cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
 
@@ -233,7 +230,10 @@ locals {
 
     baseline_ec2_instances = {
       prod-nomis-db-1-b = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = {}
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
           availability_zone = "${local.region}b"
@@ -260,10 +260,12 @@ locals {
       })
 
       prod-nomis-db-2 = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = merge(
-        ##   local.database_ec2_cloudwatch_metric_alarms,
-        ##   local.fixngo_connection_cloudwatch_metric_alarms
-        ## )
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_connectivity_test,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring,
+        )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [
@@ -290,7 +292,10 @@ locals {
       })
 
       prod-nomis-db-2-b = merge(local.database_ec2, {
-        cloudwatch_metric_alarms = {}
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
           availability_zone = "${local.region}b"
@@ -317,10 +322,10 @@ locals {
       })
 
       prod-nomis-db-3 = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = merge(
-        ##   local.database_ec2_cloudwatch_metric_alarms,
-        ##   local.database_ec2_cloudwatch_metric_alarms_high_priority
-        ## )
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+        )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -4,20 +4,6 @@ locals {
   # baseline config
   test_config = {
 
-    cloudwatch_metric_alarms_dbnames = [
-      "T1CNOM",
-      "T1NDH",
-      "T1MIS",
-      "T1CNMAUD",
-      "T2CNOM",
-      "T2NDH",
-      "T3CNOM"
-    ]
-
-    cloudwatch_metric_alarms_dbnames_misload = [
-      "T1MIS"
-    ]
-
     baseline_s3_buckets = {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn
@@ -266,7 +252,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        ## cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -317,7 +303,7 @@ locals {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        ## cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -371,7 +357,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        # cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -422,7 +408,7 @@ locals {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        ## cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -477,7 +463,7 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        # cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
@@ -537,7 +523,11 @@ locals {
 
     baseline_ec2_instances = {
       t1-nomis-db-1-a = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -562,7 +552,12 @@ locals {
       })
 
       t1-nomis-db-2-a = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          local.database_ec2_misload_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -588,7 +583,11 @@ locals {
       })
 
       t2-nomis-db-1-a = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
+        )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-06-23T16-28-48.100Z"
           availability_zone = "${local.region}a"
@@ -613,7 +612,11 @@ locals {
       })
 
       t3-nomis-db-1 = merge(local.database_ec2, {
-        ## cloudwatch_metric_alarms = local.database_ec2_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = merge(
+          local.database_ec2_cloudwatch_metric_alarms,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
+        )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -109,20 +109,7 @@ locals {
   weblogic_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
-    {
-      weblogic-healthcheck = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_weblogichealthcheck_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "weblogic-healthcheck has found an unhealthy service"
-        alarm_actions       = ["dso_pagerduty"]
-      }
-    }
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status,
   )
 
   weblogic_cloudwatch_log_groups = {

--- a/terraform/environments/nomis/locals_xtag.tf
+++ b/terraform/environments/nomis/locals_xtag.tf
@@ -14,42 +14,7 @@ locals {
   xtag_cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms.ec2,
     module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd,
-    {
-      xtag-wls-nodemanager-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_wlsnodemanager_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "wls_nodemanager.service has stopped"
-        alarm_actions       = ["dso_pagerduty"]
-      }
-      xtag-wls-adminserver-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_wlsadminserver_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "wls_adminserver.service has stopped"
-        alarm_actions       = ["dso_pagerduty"]
-      }
-      xtag-wls-managedserver-service = {
-        comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        namespace           = "CWAgent"
-        metric_name         = "collectd_wlsmanagedserver_value"
-        period              = "60"
-        statistic           = "Average"
-        threshold           = "1"
-        alarm_description   = "wls_managedserver.service has stopped"
-        alarm_actions       = ["dso_pagerduty"]
-      }
-    }
+    module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status,
   )
 
   xtag_ec2 = {

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -141,41 +141,111 @@ locals {
       }
     }
 
-    ec2_instance_cwagent_collectd = {
-      chronyd-stopped = {
+    ec2_instance_cwagent_collectd_service_status = {
+      service_status_error_os_layer = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_chronyd_value"
+        metric_name         = "collectd_service_status_os_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "Triggers if the chronyd service has stopped"
+        alarm_description   = "Triggers if an os-layer linux service such as chronyd or amazon-ssm-agent is stopped or in error. See collectd-service-metrics ansible role"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
-      cloudwatch-agent-stopped = {
+      service_status_error_app_layer = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_amazoncloudwatchagent_value"
+        metric_name         = "collectd_service_status_app_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "Triggers if the cloudwatch agent service has stopped"
+        alarm_description   = "Triggers if an application-layer linux service such as weblogic is stopped or in error. See collectd-service-metrics ansible role"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
-      ssm-agent-stopped = {
+    }
+    ec2_instance_cwagent_collectd_connectivity_test = {
+      connectivity_test_failed = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
-        metric_name         = "collectd_amazonssmagent_value"
+        metric_name         = "collectd_connectivity_test_value"
         period              = "60"
         statistic           = "Maximum"
         threshold           = "1"
-        alarm_description   = "Triggers if the ssm agent service has stopped"
+        alarm_description   = "Triggers if a connectivity test failed. See connectivity-tests ec2 instance tag and collectd-connectivity-test ansible role"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
+    ec2_instance_cwagent_collectd_textfile_monitoring = {
+      textfile_monitoring_metric_error = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_textfile_monitoring_value"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "1"
+        alarm_description   = "Triggers if any metric collected via /opt/textfile_monitoring is in error, e.g. nomis batch or misload. See collectd-textfile-monitoring ansible role"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+      textfile_monitoring_metric_not_updated = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_textfile_monitoring_seconds"
+        period              = "129600"
+        statistic           = "Maximum"
+        threshold           = "1"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if any metric in /opt/textfile_monitoring hasn't been updated for over 36 hours"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
+    ec2_instance_cwagent_collectd_oracle_db_connected = {
+      oracle_db_disconnected = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_oracle_db_connected_value"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "1"
+        alarm_description   = "Triggers if an oracle database is disconnected. See oracle-sids ec2 instance tag and collectd-oracle-db-connected ansible role"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
+    ec2_instance_cwagent_collectd_oracle_db_backup = {
+      oracle_db_rman_backup_error = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_textfile_monitoring_rman_backup_value"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "1"
+        alarm_description   = "Triggers if a scheduled oracle rman db backup has failed. See collectd-textfile-monitoring and oracle-db-backup role"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+      oracle_db_rman_backup_did_not_run = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        namespace           = "CWAgent"
+        metric_name         = "collectd_textfile_monitoring_rman_backup_seconds"
+        period              = "129600"
+        statistic           = "Maximum"
+        threshold           = "1"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if rman_backup metric not collected or not updated for over 36 hours"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -168,16 +168,16 @@ locals {
       }
     }
     ec2_instance_cwagent_collectd_connectivity_test = {
-      connectivity_test_failed = {
+      connectivity_test_all_failed = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
         evaluation_periods  = "3"
         datapoints_to_alarm = "3"
         namespace           = "CWAgent"
         metric_name         = "collectd_connectivity_test_value"
         period              = "60"
-        statistic           = "Maximum"
+        statistic           = "Minimum"
         threshold           = "1"
-        alarm_description   = "Triggers if a connectivity test failed. See connectivity-tests ec2 instance tag and collectd-connectivity-test ansible role"
+        alarm_description   = "Triggers if all connectivity tests fail on a host. See connectivity-tests ec2 instance tag and collectd-connectivity-test ansible role"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
@@ -196,13 +196,13 @@ locals {
       }
       textfile_monitoring_metric_not_updated = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        datapoints_to_alarm = "3"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
         namespace           = "CWAgent"
         metric_name         = "collectd_textfile_monitoring_seconds"
-        period              = "129600"
+        period              = "300"
         statistic           = "Maximum"
-        threshold           = "1"
+        threshold           = "129600"
         treat_missing_data  = "breaching"
         alarm_description   = "Triggers if any metric in /opt/textfile_monitoring hasn't been updated for over 36 hours"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
@@ -225,11 +225,11 @@ locals {
     ec2_instance_cwagent_collectd_oracle_db_backup = {
       oracle_db_rman_backup_error = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        datapoints_to_alarm = "3"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
         namespace           = "CWAgent"
         metric_name         = "collectd_textfile_monitoring_rman_backup_value"
-        period              = "60"
+        period              = "300"
         statistic           = "Maximum"
         threshold           = "1"
         alarm_description   = "Triggers if a scheduled oracle rman db backup has failed. See collectd-textfile-monitoring and oracle-db-backup role"
@@ -237,13 +237,13 @@ locals {
       }
       oracle_db_rman_backup_did_not_run = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "3"
-        datapoints_to_alarm = "3"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
         namespace           = "CWAgent"
         metric_name         = "collectd_textfile_monitoring_rman_backup_seconds"
-        period              = "129600"
+        period              = "300"
         statistic           = "Maximum"
-        threshold           = "1"
+        threshold           = "129600"
         treat_missing_data  = "breaching"
         alarm_description   = "Triggers if rman_backup metric not collected or not updated for over 36 hours"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions


### PR DESCRIPTION
Re-enable nomis cloudwatch alarms based on the new style collectd metrics.  Make more use of dimensions so no need to have a separate alarm configured for each service or database.
