### PR TITLE
remove lb logs collection

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -591,6 +591,7 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups      = ["load-balancer"]
+        access_logs          = false
 
         instance_target_groups = {
           pp-csr-w-56-80 = {


### PR DESCRIPTION
- return c-s-r-preprod apply to a 'good' state by removing apply NLB access_logs feature which doesn't work