### PR TITLE
Include object copies in our custom cloudtrail for s3

### DIFF
--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -21,7 +21,8 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
       field = "eventName"
 
       equals = [
-        "PutObject"
+        "PutObject",
+        "CopyObject"
       ]
     }
 

--- a/terraform/environments/data-platform/cloudtrail.tf
+++ b/terraform/environments/data-platform/cloudtrail.tf
@@ -22,7 +22,8 @@ resource "aws_cloudtrail" "data_s3_put_objects" {
 
       equals = [
         "PutObject",
-        "CopyObject"
+        "CopyObject",
+        "CompleteMultipartUpload"
       ]
     }
 


### PR DESCRIPTION
We want to have a record of all writes into our s3 buckets. This allows us to monitor flow of data through the conformance zones.

Currently we log PutObject, but in the landing-to-raw lambda we copy files from landing to the data bucket, using a raw/ or fail/ prefix. This goes via boto's copy method, rather than put_object. It will use either the copy api or the multipart upload api.

So in order to get raw and fail events logged, we need to include the corresponding events.

[This explains why both figures are missing recent data in the grafana dashboard.](https://g-e937f84aea.grafana-workspace.eu-west-2.amazonaws.com/d/H-9kBpVSk/ingestion-overview?orgId=1)

However, it doesn't explain why cloudwatch returns a count of 330 for both when the time span is set to the last year.