### PR TITLE
Nomis: tweak alarm thresholds

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -55,7 +55,7 @@ locals {
         period              = "60"
         statistic           = "Maximum"
         threshold           = "95"
-        alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 2 hours on a nomis-db instance"
+        alarm_description   = "Triggers if the average cpu remains at 95% utilization or above"
         alarm_actions       = ["dso_pagerduty"]
       }
   })

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -55,7 +55,7 @@ locals {
         period              = "60"
         statistic           = "Maximum"
         threshold           = "95"
-        alarm_description   = "Triggers if the average cpu remains at 95% utilization or above"
+        alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 2 hours on a nomis-db instance"
         alarm_actions       = ["dso_pagerduty"]
       }
   })

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -67,7 +67,7 @@ locals {
       "/oracle/database/qa11r" = local.database_nomis_ssm_parameters
     }
     baseline_secretsmanager_secrets = {
-      "/azure"                 = {
+      "/azure" = {
         secrets = {
           sas_token = {}
         }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -619,6 +619,7 @@ locals {
             cpu-utilization-high = merge(local.database_ec2_cloudwatch_metric_alarms["cpu-utilization-high"], {
               evaluation_periods  = "300" # CPU can spike for 5 hours during DB restore
               datapoints_to_alarm = "300"
+              alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 5 hours on a test nomis-db instance"
             })
           }
         )

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -615,7 +615,12 @@ locals {
         cloudwatch_metric_alarms = merge(
           local.database_ec2_cloudwatch_metric_alarms,
           module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
-          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup, {
+            cpu-utilization-high = merge(local.database_ec2_cloudwatch_metric_alarms["cpu-utilization-high"], {
+              evaluation_periods  = "300" # CPU can spike for 5 hours during DB restore
+              datapoints_to_alarm = "300"
+            })
+          }
         )
         config = merge(local.database_ec2.config, {
           availability_zone = "${local.region}a"


### PR DESCRIPTION
CPU can peak for long time on DB restore.  Extend threshold. Plus terraform fmt