### PR TITLE
DSOS-2406: tweak baseline secrets

### DIFF
--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -105,10 +105,7 @@ output "secretsmanager" {
   value = {
     secrets = aws_secretsmanager_secret.this
     secret_versions = {
-      for key, value in merge(
-        aws_secretsmanager_secret_version.fixed,
-        aws_secretsmanager_secret_version.placeholder
-        ) : key => {
+      for key, value in aws_secretsmanager_secret_version.fixed : key => {
         arn            = value.arn
         id             = value.id
         secret_id      = value.secret_id

--- a/terraform/modules/baseline/secretsmanager.tf
+++ b/terraform/modules/baseline/secretsmanager.tf
@@ -2,6 +2,9 @@
 # between SSM parameters and SecretManager Secrets
 # Use Secrets if you need to share a parameter across accounts.
 
+# For placeholder values, we just create a Secret resource without
+# any secret value
+
 locals {
   secretsmanager_secrets_list = flatten([
     for sm_key, sm_value in var.secretsmanager_secrets : [
@@ -120,15 +123,4 @@ resource "aws_secretsmanager_secret_version" "fixed" {
 
   secret_id     = aws_secretsmanager_secret.this[each.key]
   secret_string = each.value.value
-}
-
-resource "aws_secretsmanager_secret_version" "placeholder" {
-  for_each = local.secretsmanager_secrets_default
-
-  secret_id     = aws_secretsmanager_secret.this[each.key].id
-  secret_string = each.value.value
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
 }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -878,7 +878,7 @@ variable "secretsmanager_secrets" {
         values   = list(string)
       })), [])
     })))
-    recovery_window_in_days = optional(number, 0)
+    recovery_window_in_days = optional(number)
     secrets = map(object({
       description = optional(string)
       file        = optional(string)

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -859,7 +859,7 @@ variable "secretsmanager_secrets" {
   # /database/my_db2_2/asm_password
   # /database/my_db2_2/sys_password
   #
-  description = "Create a placeholder SecretManager secret, or a secret with a given value (randomly generated, from file, or value set directly).  Use this instead of SSM Parameters secure strings if you need to share the secret across accounts.  The top-level key is used as a prefix for the secret name, e.g. /database/db1.  Then define a map of secrets to create underneath that prefix.  Secret name is {prefix}{top-level-map-key}{postfix}{secrets-map-key}"
+  description = "Create a placeholder SecretManager secret, or a secret with a given value (randomly generated, from file, or value set directly).  The top-level key is used as a prefix for the secret name, e.g. /database/db1.  Then define a map of secrets to create underneath that prefix.  Secret name is {prefix}{top-level-map-key}{postfix}{secrets-map-key}.  Set recovery_window_in_days to zero if you want to delete secret immediately"
   type = map(object({
     prefix     = optional(string, "")
     postfix    = optional(string, "/")
@@ -878,7 +878,7 @@ variable "secretsmanager_secrets" {
         values   = list(string)
       })), [])
     })))
-    recovery_window_in_days = optional(number, 0)
+    recovery_window_in_days = optional(number)
     secrets = map(object({
       description = optional(string)
       file        = optional(string)

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -878,7 +878,7 @@ variable "secretsmanager_secrets" {
         values   = list(string)
       })), [])
     })))
-    recovery_window_in_days = optional(number)
+    recovery_window_in_days = optional(number, 0)
     secrets = map(object({
       description = optional(string)
       file        = optional(string)


### PR DESCRIPTION
Revert secrets recovery_window_in_days back to 30 days (default) to ensure secrets are not accidentally deleted.
For placeholder secrets (those whose values are managed outside of terraform), don't both creating a secret_version.  This keeps things consistent with EC2 instance and ASG modules.  I've tested this in nomis to make sure we are not losing any secret values