### PR TITLE
Updated description for domain join ssm document password requirement

### DIFF
--- a/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
@@ -14,7 +14,7 @@ parameters:
     description: "Username with domain join permissions"
   domainJoinPassword:
     type: "String"
-    description: "Password for domain join user"
+    description: "Password for domain join user (NOTE: Do not use a password containing quotes)"
   newHostname:
     type: "String"
     description: "If over-written, the hostname will be changed to this value. If un-changed the existing hostname will be kept. The new hostname must be 15 characters or less"

--- a/terraform/environments/hmpps-domain-services/ssm-documents/windows-domain-join.yaml
+++ b/terraform/environments/hmpps-domain-services/ssm-documents/windows-domain-join.yaml
@@ -14,7 +14,7 @@ parameters:
     description: "Username with domain join permissions"
   domainJoinPassword:
     type: "String"
-    description: "Password for domain join user"
+    description: "Password for domain join user (NOTE: Do not use a password containing quotes)"
   newHostname:
     type: "String"
     description: "If over-written, the hostname will be changed to this value. If un-changed the existing hostname will be kept. The new hostname must be 15 characters or less"

--- a/terraform/environments/planetfm/ssm-documents/windows-domain-join.yaml
+++ b/terraform/environments/planetfm/ssm-documents/windows-domain-join.yaml
@@ -14,7 +14,7 @@ parameters:
     description: "Username with domain join permissions"
   domainJoinPassword:
     type: "String"
-    description: "Password for domain join user"
+    description: "Password for domain join user (NOTE: Do not use a password containing quotes)"
   newHostname:
     type: "String"
     description: "If over-written, the hostname will be changed to this value. If un-changed the existing hostname will be kept. The new hostname must be 15 characters or less"


### PR DESCRIPTION
The SSM document cannot handle taking in password with quotes