### PR TITLE
DSOS-2402: give GHA permission to run Ansible via SSM

### DIFF
--- a/terraform/environments/hmpps-oem/iam.tf
+++ b/terraform/environments/hmpps-oem/iam.tf
@@ -1,0 +1,37 @@
+#####################
+# DB Refresher Role #
+#####################
+
+resource "aws_iam_role" "db_refresher" {
+  count              = local.is-development || local.is-test ? 1 : 0
+  name               = "db-refresher"
+  assume_role_policy = data.aws_iam_policy_document.db_refresher_role.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "db_refresher_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+    condition {
+      test     = "StringLike"
+      values   = ["repo:ministryofjustice/dso-modernisation-platform-automation:main"]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "db_refresher_ssm_access" {
+  role = aws_iam_role.db_refresher[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+}


### PR DESCRIPTION
using a builtin policy to give the GHA runner permission to run Ansible via SSM