### PR TITLE
DPAT: Adding OpenSearch domain for DataHub

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/cloudwatch-logs.tf
+++ b/terraform/environments/data-platform-apps-and-tools/cloudwatch-logs.tf
@@ -27,6 +27,6 @@ data "aws_iam_policy_document" "opensearch_cloudwatch_logs" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "opensearch_cloudwatch_logs" {
-  policy_name     = "opensearch-cloudwatch-logs"
+  policy_name     = "opensearch-cloudwatch-logs-datahub"
   policy_document = data.aws_iam_policy_document.opensearch_cloudwatch_logs.json
 }

--- a/terraform/environments/data-platform-apps-and-tools/cloudwatch-logs.tf
+++ b/terraform/environments/data-platform-apps-and-tools/cloudwatch-logs.tf
@@ -1,0 +1,32 @@
+module "datahub_opensearch_cloudwatch_log_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "~> 4.0"
+
+  name              = "/aws/opensearch/datahub"
+  retention_in_days = 400
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "opensearch_cloudwatch_logs" {
+  statement {
+    sid    = "AllowOpenSearchPublishCloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+    resources = ["${module.datahub_opensearch_cloudwatch_log_group.cloudwatch_log_group_arn}*"]
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_cloudwatch_logs" {
+  policy_name     = "opensearch-cloudwatch-logs"
+  policy_document = data.aws_iam_policy_document.opensearch_cloudwatch_logs.json
+}

--- a/terraform/environments/data-platform-apps-and-tools/data.tf
+++ b/terraform/environments/data-platform-apps-and-tools/data.tf
@@ -40,4 +40,10 @@ data "aws_iam_policy_document" "datahub" {
     actions   = ["sts:AssumeRole"]
     resources = formatlist("arn:aws:iam::%s:role/${local.environment_configuration.datahub_role}", local.environment_configuration.datahub_target_accounts)
   }
+  statement {
+    sid       = "AllowOpenSearch"
+    effect    = "Allow"
+    actions   = ["es:*"]
+    resources = ["*"]
+  }
 }

--- a/terraform/environments/data-platform-apps-and-tools/kms.tf
+++ b/terraform/environments/data-platform-apps-and-tools/kms.tf
@@ -11,3 +11,17 @@ module "datahub_rds_kms" {
 
   tags = local.tags
 }
+
+module "datahub_opensearch_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 2.0"
+
+  aliases               = ["opensearch/datahub"]
+  description           = "Open Metadata OpenSearch"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}

--- a/terraform/environments/data-platform-apps-and-tools/opensearch.tf
+++ b/terraform/environments/data-platform-apps-and-tools/opensearch.tf
@@ -1,0 +1,90 @@
+resource "aws_opensearch_domain" "datahub" {
+  domain_name    = "datahub"
+  engine_version = "OpenSearch_2.7"
+
+  vpc_options {
+    subnet_ids         = data.aws_subnets.dedicated["private"].ids
+    security_group_ids = [module.opensearch_security_group.security_group_id]
+  }
+
+  cluster_config {
+    dedicated_master_enabled = true
+    dedicated_master_count   = 3
+    dedicated_master_type    = "m6g.large.search"
+    instance_count           = 6
+    instance_type            = "r6g.large.search"
+    zone_awareness_enabled   = true
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+  }
+
+  log_publishing_options {
+    enabled                  = true
+    cloudwatch_log_group_arn = module.datahub_opensearch_cloudwatch_log_group.cloudwatch_log_group_arn
+    log_type                 = "AUDIT_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = module.datahub_opensearch_cloudwatch_log_group.cloudwatch_log_group_arn
+    log_type                 = "ES_APPLICATION_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = module.datahub_opensearch_cloudwatch_log_group.cloudwatch_log_group_arn
+    log_type                 = "SEARCH_SLOW_LOGS"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = module.datahub_opensearch_cloudwatch_log_group.cloudwatch_log_group_arn
+    log_type                 = "INDEX_SLOW_LOGS"
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = module.datahub_opensearch_kms.key_id
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = true
+    master_user_options {
+      master_user_name     = "datahub"
+      master_user_password = random_password.opensearch.result
+    }
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 100
+  }
+}
+
+data "aws_iam_policy_document" "opensearch_domain" {
+  # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ac.html
+  #checkov:skip=CKV_AWS_283:
+  statement {
+    effect  = "Allow"
+    actions = ["es:ESHttp*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = ["${aws_opensearch_domain.datahub.arn}/*"]
+  }
+}
+
+resource "aws_opensearch_domain_policy" "datahub" {
+  domain_name     = aws_opensearch_domain.datahub.domain_name
+  access_policies = data.aws_iam_policy_document.opensearch_domain.json
+}

--- a/terraform/environments/data-platform-apps-and-tools/opensearch.tf
+++ b/terraform/environments/data-platform-apps-and-tools/opensearch.tf
@@ -88,3 +88,7 @@ resource "aws_opensearch_domain_policy" "datahub" {
   domain_name     = aws_opensearch_domain.datahub.domain_name
   access_policies = data.aws_iam_policy_document.opensearch_domain.json
 }
+
+output "endpoit" {
+  value = aws_opensearch_domain.datahub.endpoint
+}

--- a/terraform/environments/data-platform-apps-and-tools/random.tf
+++ b/terraform/environments/data-platform-apps-and-tools/random.tf
@@ -2,3 +2,12 @@ resource "random_password" "datahub_rds" {
   length  = 32
   special = false
 }
+resource "random_password" "opensearch" {
+  length           = 64
+  special          = true
+  override_special = "_%@"
+  min_numeric      = 1
+  min_lower        = 1
+  min_upper        = 1
+  min_special      = 1
+}

--- a/terraform/environments/data-platform-apps-and-tools/security-groups.tf
+++ b/terraform/environments/data-platform-apps-and-tools/security-groups.tf
@@ -19,3 +19,22 @@ module "datahub_rds_security_group" {
 
   tags = local.tags
 }
+
+module "opensearch_security_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name = "datahub-opensearch"
+
+  vpc_id = data.aws_vpc.dedicated.id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = join(",", [for subnet in data.aws_subnet.private : subnet.cidr_block])
+    },
+  ]
+}


### PR DESCRIPTION
https://github.com/ministryofjustice/data-platform/issues/2454

Adding OpenSearch and dependent components.

As with the previous PR, the components defined in MP repo have been retrieved via TF datasource calls.