### PR TITLE
DSOS-2406: update policies to use secrets instead of ssm

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -46,18 +46,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*PP/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/PP*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/*",

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -35,18 +35,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*P/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/P*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*P/*",

--- a/terraform/environments/nomis-combined-reporting/locals_test.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_test.tf
@@ -59,14 +59,68 @@ locals {
       "/oracle/database/T1BIPAUD" = local.database_secretsmanager_secrets
     }
 
+    baseline_iam_policies = {
+      Ec2T1DatabasePolicy = {
+        description = "Permissions required for T1 Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/azure/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T1*/*",
+            ]
+          }
+        ]
+      }
+      Ec2T1BipPolicy = {
+        description = "Permissions required for T1 Weblogic EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/t1-ncr-bip-cmc/*",
+              "arn:aws:secretsmanager:*:*:secret:/t1-ncr-bip/*",
+              "arn:aws:secretsmanager:*:*:secret:/t1-ncr-tomcat/*",
+            ]
+          }
+        ]
+      }
+    }
+
     baseline_ec2_instances = {
       t1-ncr-bip-cmc = merge(local.bip_cmc_ec2_default, {
+        config = merge(local.bip_cmc_ec2_default.config, {
+          instance_profile_policies = concat(local.bip_cmc_ec2_default.config.instance_profile_policies, [
+            "Ec2T1BipPolicy",
+          ])
+        })
         tags = merge(local.bip_cmc_ec2_default.tags, {
           description                          = "For testing SAP BI CMC installation and configurations"
           nomis-combined-reporting-environment = "t1"
         })
       })
       t1-ncr-db-1-a = merge(local.database_ec2_default, {
+        config = merge(local.database_ec2_default.config, {
+          instance_profile_policies = concat(local.database_ec2_default.config.instance_profile_policies, [
+            "Ec2T1DatabasePolicy",
+          ])
+        })
         tags = merge(local.database_ec2_default.tags, {
           description                          = "T1 NCR DATABASE"
           nomis-combined-reporting-environment = "t1"
@@ -84,6 +138,11 @@ locals {
           max_size            = 2
           vpc_zone_identifier = module.environment.subnets["private"].ids
         }
+        config = merge(local.tomcat_ec2_default.config, {
+          instance_profile_policies = concat(local.tomcat_ec2_default.config.instance_profile_policies, [
+            "Ec2T1BipPolicy",
+          ])
+        })
         tags = merge(local.tomcat_ec2_default.tags, {
           description                          = "For testing BIP tomcat installation and configurations"
           nomis-combined-reporting-environment = "t1"
@@ -96,6 +155,11 @@ locals {
           max_size            = 2
           vpc_zone_identifier = module.environment.subnets["private"].ids
         }
+        config = merge(local.bip_ec2_default.config, {
+          instance_profile_policies = concat(local.bip_ec2_default.config.instance_profile_policies, [
+            "Ec2T1BipPolicy",
+          ])
+        })
         tags = merge(local.bip_ec2_default.tags, {
           description                          = "For testing BIP 4.3 installation and configurations"
           nomis-combined-reporting-environment = "t1"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -55,7 +55,7 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/qa11r/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/qa11r/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/qa11r/weblogic-*",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -50,12 +50,12 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/qa11r/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/qa11r/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/qa11r/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/qa11r/weblogic-passwords",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -88,8 +88,8 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/preprod/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/PP*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/PP*/weblogic-*",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -59,18 +59,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*PP/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/PP*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/*",
@@ -85,13 +83,13 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/preprod/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*PP/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/PP*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/preprod/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/PP*/weblogic-passwords",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -83,10 +83,10 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/prod/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/P*/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*P/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/DR*/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*DR/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/P*/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*P/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/DR*/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*DR/weblogic-*",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -52,20 +52,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*P/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/P*/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*DR/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/DR*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*P/*",
@@ -82,15 +78,15 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/prod/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/P*/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*P/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/DR*/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*DR/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/prod/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/P*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*P/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/DR*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*DR/weblogic-passwords",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -157,6 +157,7 @@ locals {
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t2/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/weblogic-passwords",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2CNOM/weblogic-passwords,
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -157,7 +157,7 @@ locals {
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t2/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/weblogic-passwords",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2CNOM/weblogic-passwords,
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2CNOM/weblogic-passwords",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -59,18 +59,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T1/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T1*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/*",
@@ -86,18 +84,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T2/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T2*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/*",
@@ -113,18 +109,16 @@ locals {
             effect = "Allow"
             actions = [
               "ssm:GetParameter",
-              "ssm:PutParameter",
             ]
             resources = [
               "arn:aws:ssm:*:*:parameter/azure/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T3/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T3*/*",
             ]
           },
           {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T3/*",
@@ -139,13 +133,13 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/t1/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T1/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T1*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t1/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T1*/weblogic-passwords",
             ]
           }
         ]
@@ -156,13 +150,13 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/t2/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T2/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T2*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/weblogic-passwords",
             ]
           }
         ]
@@ -173,13 +167,13 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-              "ssm:PutParameter",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:ssm:*:*:parameter/oracle/weblogic/t3/*",
-              "arn:aws:ssm:*:*:parameter/oracle/database/*T3/weblogic-passwords",
-              "arn:aws:ssm:*:*:parameter/oracle/database/T3*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t3/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T3/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T3*/weblogic-passwords",
             ]
           }
         ]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -138,8 +138,8 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t1/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T1*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T1*/weblogic-*",
             ]
           }
         ]
@@ -155,9 +155,8 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t2/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2CNOM/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/weblogic-*",
             ]
           }
         ]
@@ -173,8 +172,8 @@ locals {
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/weblogic/t3/*",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T3/weblogic-passwords",
-              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T3*/weblogic-passwords",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T3/weblogic-*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T3*/weblogic-*",
             ]
           }
         ]

--- a/terraform/environments/nomis/scripts/get-secretsmanager-secrets.sh
+++ b/terraform/environments/nomis/scripts/get-secretsmanager-secrets.sh
@@ -34,7 +34,7 @@ for secret in $secrets; do
       exit 1
     fi
     echo aws secretsmanager get-secret-value --secret-id $arn --query SecretString --output text --profile $PROFILE >&2
-    value=$(aws secretsmanager get-secret-value --secret-id $arn --query SecretString --output text --profile $PROFILE)
+    value=$(aws secretsmanager get-secret-value --secret-id $arn --query SecretString --output text --profile $PROFILE || true)
     dir=$(dirname secretsmanager-secrets/$PROFILE/$secret)
     mkdir -p $dir
     echo "$value" > secretsmanager-secrets/$PROFILE/$secret

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -26,12 +26,22 @@ locals {
             effect = "Allow"
             actions = [
               "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
             ]
             resources = [
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*PP/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/PP*/*",
             ]
-          }
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/azure/*",
+            ]
+          },
         ]
       }
     }

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -116,6 +116,56 @@ locals {
           }
         ]
       }
+      Ec2T1DatabasePolicy = {
+        description = "Permissions required for T1 Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/azure/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T1/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T1*/*",
+            ]
+          }
+        ]
+      }
+      Ec2T2DatabasePolicy = {
+        description = "Permissions required for T2 Database EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "ssm:GetParameter",
+            ]
+            resources = [
+              "arn:aws:ssm:*:*:parameter/azure/*",
+            ]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*T2/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/T2*/*",
+            ]
+          }
+        ]
+      }
     }
 
     baseline_ec2_instances = {
@@ -123,6 +173,11 @@ locals {
       ## T2
       ##
       "t2-${local.application_name}-db-a" = merge(local.database_a, {
+        config = merge(local.database_a.config, {
+          instance_profile_policies = concat(local.database_a.config.instance_profile_policies, [
+            "Ec2T2DatabasePolicy",
+          ])
+        })
         tags = merge(local.database_a.tags, {
           description                             = "t2 ${local.application_name} database"
           "${local.application_name}-environment" = "t2"
@@ -172,6 +227,11 @@ locals {
       ## T1
       ##
       "t1-${local.application_name}-db-a" = merge(local.database_a, {
+        config = merge(local.database_a.config, {
+          instance_profile_policies = concat(local.database_a.config.instance_profile_policies, [
+            "Ec2T1DatabasePolicy",
+          ])
+        })
         tags = merge(local.database_a.tags, {
           description                             = "t1 ${local.application_name} database"
           "${local.application_name}-environment" = "t1"


### PR DESCRIPTION
Add permissions to access secrets across nomis, oasys, CSR and NCR