### PR TITLE
Implement backend state locking for Sprinkler

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -65,8 +65,6 @@ on:
     secrets:
       modernisation_platform_environments:
         required: true
-      modernisation_platform_account_id:
-        required: false
       pipeline_github_token:
         required: true
 

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -49,10 +49,11 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      init_plan_apply_tfargs: "-backend-config=assume_role={role_arn=\"arn:aws:iam::${{ secrets.modernisation_platform_account_id }}:role/modernisation-account-terraform-state-member-access\"}"
+      init_plan_apply_tfargs:  "-backend-config=assume_role={role_arn=\"arn:aws:iam::$modernisation_platform_account_id:role/modernisation-account-terraform-state-member-access\"}"
+    env:
+      modernisation_platform_account_id: "${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
-      modernisation_platform_account_id: "${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"
 
   destroy-development:


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/5534, this PR adds `platform_backend.tf` configuration for a dynamodb state table, and sets a GitHub action to assume a role in a remote account.