### PR TITLE
Planetfm/dsos 2398/preprod lb

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -164,28 +164,6 @@ locals {
         enable_cross_zone_load_balancing = true
 
         instance_target_groups = {
-          web-45-80 = {
-            port     = 80
-            protocol = "HTTP"
-            health_check = {
-              enabled             = true
-              path                = "/"
-              healthy_threshold   = 3
-              unhealthy_threshold = 5
-              timeout             = 5
-              interval            = 30
-              matcher             = "200-399"
-              port                = 80
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              { ec2_instance_name = "pp-cafm-w-4-b" },
-              { ec2_instance_name = "pp-cafm-w-5-a" },
-            ]
-          }
           web-23-80 = {
             port     = 80
             protocol = "HTTP"
@@ -206,6 +184,28 @@ locals {
             attachments = [
               { ec2_instance_name = "pp-cafm-w-2-b" },
               { ec2_instance_name = "pp-cafm-w-3-a" },
+            ]
+          }
+          web-45-80 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              path                = "/"
+              healthy_threshold   = 3
+              unhealthy_threshold = 5
+              timeout             = 5
+              interval            = 30
+              matcher             = "200-399"
+              port                = 80
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-cafm-w-4-b" },
+              { ec2_instance_name = "pp-cafm-w-5-a" },
             ]
           }
         }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -189,8 +189,8 @@ locals {
         }
         listeners = {
           https = {
-            port            = 443
-            protocol        = "HTTPS"
+            port                   = 443
+            protocol               = "HTTPS"
             certificate_arn_lookup = "planetfm_wildcard_cert"
             default_action = {
               type              = "forward"

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -215,7 +215,7 @@ locals {
             protocol               = "HTTPS"
             certificate_arn_lookup = "planetfm_wildcard_cert"
             default_action = {
-              type              = "fixed-response"
+              type = "fixed-response"
               fixed_response = {
                 content_type = "text/plain"
                 message_body = "Not implemented"

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -222,30 +222,30 @@ locals {
                 status_code  = "501"
               }
             }
-          }
-          rules = {
-            web-23-80 = {
-              priority = 2380
-              actions = [{
-                type              = "forward"
-                target_group_name = "web-23-80"
-              }]
-              conditions = [{
-                field  = "host-header"
-                values = ["pp-cafmtx.az.justice.gov.uk"]
-              }]
-            }
-            web-45-80 = {
-              priority = 4580
-              actions = [{
-                type              = "forward"
-                target_group_name = "web-45-80"
-              }]
-              conditions = [{
-                field  = "host-header"
-                values = ["pp-cafmwebx.az.justice.gov.uk"]
-              }]
-            }
+            rules = {
+              web-23-80 = {
+                priority = 2380
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-23-80"
+                }]
+                conditions = [{
+                  field  = "host-header"
+                  values = ["pp-cafmtx.az.justice.gov.uk"]
+                }]
+              }
+              web-45-80 = {
+                priority = 4580
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "web-45-80"
+                }]
+                conditions = [{
+                  field  = "host-header"
+                  values = ["pp-cafmwebx.az.justice.gov.uk"]
+                }]
+              }
+            }  
           }
         }
       }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -154,7 +154,7 @@ locals {
       })
     }
     baseline_lbs = {
-      webx = {
+      private = {
         internal_lb                      = true
         enable_delete_protection         = false
         loadbalancer_type                = "application"
@@ -259,7 +259,8 @@ locals {
           # { name = "ppplanet-b", type = "CNAME", ttl = "300", records = ["pp-cafm-db-a.planetfm.hmpps-preproduction.modernisation-platform.service.justice.gov.uk"] },
         ]
         lb_alias_records = [
-          # { name = "cafmtwebx", type = "A", lbs_map_key = "webx" } Create in subsequent PR to LB webx
+          # { name = "cafmtx", type = "A", lbs_map_key = "private" } Create in subsequent PR to LB private deployment
+          # { name = "cafmtwebx", type = "A", lbs_map_key = "private" } Create in subsequent PR to LB private deployment
         ]
       }
     }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -154,7 +154,7 @@ locals {
       })
     }
     baseline_lbs = {
-      pp-webx = {
+      webx = {
         internal_lb                      = true
         enable_delete_protection         = false
         loadbalancer_type                = "application"
@@ -191,10 +191,10 @@ locals {
           https = {
             port            = 443
             protocol        = "HTTPS"
-            certificate_arn = module.baseline_presets.acm_certificates.planetfm_wildcard_cert.arn
+            certificate_arn_lookup = "planetfm_wildcard_cert"
             default_action = {
-              type             = "forward"
-              target_group_arn = module.baseline_presets.lbs.pp-web.instance_target_groups.pp-web-80.arn
+              type              = "forward"
+              target_group_name = "pp-web-80"
             }
           }
         }
@@ -203,13 +203,13 @@ locals {
     baseline_route53_zones = {
       "pp.planetfm.service.justice.gov.uk" = {
         records = [
-          # set to PPFDW0030 PP SQL server for planetfm
+          # set to PPFDW0030 PP SQL server for planetfm, not applied as not used previously in testing
           # { name = "ppplanet", type = "A", ttl = "300", records = ["10.40.50.132"] },
           # { name = "ppplanet-a", type = "A", ttl = "300", records = ["10.40.42.132"] },
           # { name = "ppplanet-b", type = "CNAME", ttl = "300", records = ["pp-cafm-db-a.planetfm.hmpps-preproduction.modernisation-platform.service.justice.gov.uk"] },
         ]
         lb_alias_records = [
-          { name = "cafmtwebx", type = "A", lbs_map = "pp-webx" }
+          # { name = "cafmtwebx", type = "A", lbs_map_key = "webx" } Create in subsequent PR to LB webx
         ]
       }
     }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -164,7 +164,7 @@ locals {
         enable_cross_zone_load_balancing = true
 
         instance_target_groups = {
-          pp-web-80 = {
+          web-45-80 = {
             port     = 80
             protocol = "HTTP"
             health_check = {
@@ -186,6 +186,28 @@ locals {
               { ec2_instance_name = "pp-cafm-w-5-a" },
             ]
           }
+          web-23-80 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              path                = "/"
+              healthy_threshold   = 3
+              unhealthy_threshold = 5
+              timeout             = 5
+              interval            = 30
+              matcher             = "200-399"
+              port                = 80
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "pp-cafm-w-2-b" },
+              { ec2_instance_name = "pp-cafm-w-3-a" },
+            ]
+          }
         }
         listeners = {
           https = {
@@ -193,8 +215,36 @@ locals {
             protocol               = "HTTPS"
             certificate_arn_lookup = "planetfm_wildcard_cert"
             default_action = {
-              type              = "forward"
-              target_group_name = "pp-web-80"
+              type              = "fixed-response"
+              fixed_response = {
+                content_type = "text/plain"
+                message_body = "Not implemented"
+                status_code  = "501"
+              }
+            }
+          }
+          rules = {
+            web-23-80 = {
+              priority = 2380
+              actions = [{
+                type              = "forward"
+                target_group_name = "web-23-80"
+              }]
+              conditions = [{
+                field  = "host-header"
+                values = ["pp-cafmtx.az.justice.gov.uk"]
+              }]
+            }
+            web-45-80 = {
+              priority = 4580
+              actions = [{
+                type              = "forward"
+                target_group_name = "web-45-80"
+              }]
+              conditions = [{
+                field  = "host-header"
+                values = ["pp-cafmwebx.az.justice.gov.uk"]
+              }]
             }
           }
         }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -230,8 +230,11 @@ locals {
                   target_group_name = "web-23-80"
                 }]
                 conditions = [{
-                  field  = "host-header"
-                  values = ["pp-cafmtx.az.justice.gov.uk"]
+                  field = "host-header"
+                  values = [
+                    "cafmtx.pp.planetfm.service.justice.gov.uk",
+                    "pp-cafmtx.az.justice.gov.uk",
+                  ]
                 }]
               }
               web-45-80 = {
@@ -241,11 +244,14 @@ locals {
                   target_group_name = "web-45-80"
                 }]
                 conditions = [{
-                  field  = "host-header"
-                  values = ["pp-cafmwebx.az.justice.gov.uk"]
+                  field = "host-header"
+                  values = [
+                    "cafmtwebx.pp.planetfm.service.justice.gov.uk",
+                    "pp-cafmtwebx.az.justice.gov.uk",
+                  ]
                 }]
               }
-            }  
+            }
           }
         }
       }


### PR DESCRIPTION
- webx ALB for planetfm web portal servers
- listens on Port 443 and redirects to 80
- certificate sits on the ALB