### PR TITLE
change variable to look up cert name

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -211,9 +211,9 @@ locals {
         }
         listeners = {
           https = {
-            port                   = 443
-            protocol               = "HTTPS"
-            certificate_arn_lookup = "planetfm_wildcard_cert"
+            port                      = 443
+            protocol                  = "HTTPS"
+            certificate_names_or_arns = ["planetfm_wildcard_cert"]
             default_action = {
               type = "fixed-response"
               fixed_response = {

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -213,6 +213,7 @@ locals {
           https = {
             port                      = 443
             protocol                  = "HTTPS"
+            ssl_policy                = "ELBSecurityPolicy-2016-08"
             certificate_names_or_arns = ["planetfm_wildcard_cert"]
             default_action = {
               type = "fixed-response"


### PR DESCRIPTION
- certificate_names_or_arns is the only var defined in baseline, not certificate_arn_lookup