### PR TITLE
Implement Terraform state locking for member accounts

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -41,12 +41,7 @@ on:
         type: string
         required: false
         description: "The terraform version to use"
-        default: "~1.5"
-      init_plan_apply_tfargs:
-        type: string
-        required: false
-        description: "Any terraform arguments to be passed into terrafrom init, plan and apply, e.g. --lock-timeout=300s"
-        default: "-input=false -lock-timeout=300s"
+        default: "~1.6"
       plan_apply_tfargs:
         type: string
         required: false
@@ -99,6 +94,11 @@ jobs:
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
 
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
         with:
@@ -116,8 +116,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init ${{ inputs.init_plan_apply_tfargs }}"
-          terraform init ${{ inputs.init_plan_apply_tfargs }}
+          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
+          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
 
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -264,6 +264,11 @@ jobs:
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
 
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
         with:
@@ -281,8 +286,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init ${{ inputs.init_plan_apply_tfargs }}"
-          terraform init ${{ inputs.init_plan_apply_tfargs }}
+          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
+          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
 
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/.github/workflows/reusable_terraform_plan_apply_test.yml
+++ b/.github/workflows/reusable_terraform_plan_apply_test.yml
@@ -42,11 +42,6 @@ on:
         required: false
         description: "The terraform version to use"
         default: "~1.5"
-      init_plan_apply_tfargs:
-        type: string
-        required: false
-        description: "Any terraform arguments to be passed into terrafrom init, plan and apply, e.g. --lock-timeout=300s"
-        default: "-input=false -lock-timeout=300s"
       plan_apply_tfargs:
         type: string
         required: false
@@ -97,6 +92,12 @@ jobs:
         run: |
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
@@ -114,12 +115,14 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init ${{ inputs.init_plan_apply_tfargs }}"
-          terraform init ${{ inputs.init_plan_apply_tfargs }}
+          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
+          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
+
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
+
       - name: Terraform State Refresh (Optional)
         if: inputs.do_state_refresh_on_plan == true
         working-directory: "terraform/environments/${{ inputs.application }}"
@@ -128,6 +131,7 @@ jobs:
           tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           echo "terraform apply -refresh-only -auto-approve ${tf_args}"
           terraform apply -refresh-only -auto-approve ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
+
       - name: Terraform Plan
         id: plan
         env:
@@ -144,6 +148,7 @@ jobs:
           echo "exitcode=${exitcode}"  # 0=clean plan, 1=error, 2=stuff in plan
           echo "exitcode=${exitcode}" >> $GITHUB_OUTPUT
           (( exitcode == 1 )) && exit 1 || exit 0
+
       - name: Create Plan PR message (Optional)
         if: github.event_name == 'pull_request' && steps.plan.outputs.exitcode == '2' && inputs.post_plan_to_pr == true
         working-directory: "terraform/environments/${{ inputs.application }}"
@@ -164,6 +169,7 @@ jobs:
           echo 'TF_PLAN_OUT<<EOF' >> $GITHUB_ENV
           comment >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+
       - name: Hide Previous PR comment (Optional)
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: "scripts/minimise-comments"
@@ -173,6 +179,7 @@ jobs:
         run: |
           go build
           ./minimise-comments
+
       - name: Post Plan to PR (Optional)
         if: github.event_name == 'pull_request' && steps.plan.outputs.exitcode == '2' && inputs.post_plan_to_pr == true
         env:
@@ -184,6 +191,7 @@ jobs:
             -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             -d '{"body":'"${escaped_message}"'}'
+
   terratest:
     name: "terratest"
     needs: plan
@@ -197,6 +205,12 @@ jobs:
         run: |
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
@@ -223,6 +237,12 @@ jobs:
         run: |
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
@@ -240,12 +260,14 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init ${{ inputs.init_plan_apply_tfargs }}"
-          terraform init ${{ inputs.init_plan_apply_tfargs }}
+          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
+          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
+
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform workspace select "${WORKSPACE_NAME}"
+
       - name: Terraform Plan
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
@@ -253,6 +275,7 @@ jobs:
           tf_args="-out x.tfplan ${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }}"
           echo "terraform plan ${tf_args}"
           terraform plan ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
+
       - name: Terraform Apply
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
@@ -260,6 +283,7 @@ jobs:
           tf_args="${{ inputs.init_plan_apply_tfargs }} ${{ inputs.plan_apply_tfargs }} x.tfplan"
           echo "terraform apply ${tf_args}"
           terraform apply ${tf_args} | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh
+
   smoketest:
     name: "smoketest"
     needs: apply
@@ -273,6 +297,12 @@ jobs:
         run: |
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:

--- a/terraform/environments/apex/platform_backend.tf
+++ b/terraform/environments/apex/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/ccms-ebs-upgrade/platform_backend.tf
+++ b/terraform/environments/ccms-ebs-upgrade/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/ccms-ebs/platform_backend.tf
+++ b/terraform/environments/ccms-ebs/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/cdpt-chaps/platform_backend.tf
+++ b/terraform/environments/cdpt-chaps/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/cdpt-ifs/platform_backend.tf
+++ b/terraform/environments/cdpt-ifs/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/cooker/platform_backend.tf
+++ b/terraform/environments/cooker/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/corporate-staff-rostering/platform_backend.tf
+++ b/terraform/environments/corporate-staff-rostering/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/dacp/platform_backend.tf
+++ b/terraform/environments/dacp/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/data-and-insights-wepi/platform_backend.tf
+++ b/terraform/environments/data-and-insights-wepi/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/data-platform-apps-and-tools/platform_backend.tf
+++ b/terraform/environments/data-platform-apps-and-tools/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/data-platform/platform_backend.tf
+++ b/terraform/environments/data-platform/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/delius-core/platform_backend.tf
+++ b/terraform/environments/delius-core/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/delius-iaps/platform_backend.tf
+++ b/terraform/environments/delius-iaps/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/delius-jitbit/platform_backend.tf
+++ b/terraform/environments/delius-jitbit/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/digital-prison-reporting/platform_backend.tf
+++ b/terraform/environments/digital-prison-reporting/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/equip/platform_backend.tf
+++ b/terraform/environments/equip/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/eric/platform_backend.tf
+++ b/terraform/environments/eric/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/example/platform_backend.tf
+++ b/terraform/environments/example/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/hmpps-domain-services/platform_backend.tf
+++ b/terraform/environments/hmpps-domain-services/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/hmpps-intelligence-management/platform_backend.tf
+++ b/terraform/environments/hmpps-intelligence-management/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/hmpps-oem/platform_backend.tf
+++ b/terraform/environments/hmpps-oem/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_backend.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/laa-oem/platform_backend.tf
+++ b/terraform/environments/laa-oem/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/long-term-storage/platform_backend.tf
+++ b/terraform/environments/long-term-storage/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/maat/platform_backend.tf
+++ b/terraform/environments/maat/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/maatdb/platform_backend.tf
+++ b/terraform/environments/maatdb/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/mlra/platform_backend.tf
+++ b/terraform/environments/mlra/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/mojfin/platform_backend.tf
+++ b/terraform/environments/mojfin/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/ncas/platform_backend.tf
+++ b/terraform/environments/ncas/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/nomis-combined-reporting/platform_backend.tf
+++ b/terraform/environments/nomis-combined-reporting/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/nomis-data-hub/platform_backend.tf
+++ b/terraform/environments/nomis-data-hub/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/nomis/platform_backend.tf
+++ b/terraform/environments/nomis/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/oas/platform_backend.tf
+++ b/terraform/environments/oas/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/oasys/platform_backend.tf
+++ b/terraform/environments/oasys/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/observability-platform/platform_backend.tf
+++ b/terraform/environments/observability-platform/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/performance-hub/platform_backend.tf
+++ b/terraform/environments/performance-hub/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/planetfm/platform_backend.tf
+++ b/terraform/environments/planetfm/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/portal/platform_backend.tf
+++ b/terraform/environments/portal/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/ppud/platform_backend.tf
+++ b/terraform/environments/ppud/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/pra-register/platform_backend.tf
+++ b/terraform/environments/pra-register/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/refer-monitor/platform_backend.tf
+++ b/terraform/environments/refer-monitor/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/sprinkler/platform_backend.tf
+++ b/terraform/environments/sprinkler/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/tariff/platform_backend.tf
+++ b/terraform/environments/tariff/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/tipstaff/platform_backend.tf
+++ b/terraform/environments/tipstaff/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/tribunals/platform_backend.tf
+++ b/terraform/environments/tribunals/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/wardship/platform_backend.tf
+++ b/terraform/environments/wardship/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"

--- a/terraform/environments/xhibit-portal/platform_backend.tf
+++ b/terraform/environments/xhibit-portal/platform_backend.tf
@@ -5,6 +5,7 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
+    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform/issues/5534, this PR does the following:
* Sets the minor Terraform version in use to `1.6`
* Updates the reusable job to assume a backend role in the Modernisation Platform account when `terraform init` is run
* Removes the ability for customers to set custom `Terraform init` input values
* Configures a state locking table to be used when Terraform is running for all customers