### PR TITLE
ndh: DSOS-2421: add secrets

### DIFF
--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -26,6 +26,7 @@ locals {
     "ndh_harkemsadmin_ssl_pass",
   ]
 
+  baseline_secretsmanager_secrets = {}
   baseline_ssm_parameters = {}
 
   baseline_s3_buckets = {
@@ -34,6 +35,12 @@ locals {
     }
   }
   baseline_route53_zones = {}
+
+  ndh_secretsmanager_secrets = {
+    secrets = {
+      shared = { description = "NDH secrets for both ems and app components" }
+    }
+  }
 
   ndh_app_a = {
     config = merge(module.baseline_presets.ec2_instance.config.default, {

--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -27,7 +27,7 @@ locals {
   ]
 
   baseline_secretsmanager_secrets = {}
-  baseline_ssm_parameters = {}
+  baseline_ssm_parameters         = {}
 
   baseline_s3_buckets = {
     s3-bucket = {

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -16,13 +16,13 @@ locals {
       })
 
       test-ndh-app-a = merge(local.ndh_app_a, {
-        tags = merge(local.management_server_2022.tags, {
+        tags = merge(local.ndh_app_a.tags, {
           ndh-environment = "test"
         })
       })
 
       test-ndh-ems-a = merge(local.ndh_ems_a, {
-        tags = merge(local.management_server_2022.tags, {
+        tags = merge(local.ndh_ems_a.tags, {
           ndh-environment = "test"
         })
       })

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -1,13 +1,31 @@
 locals {
   test_config = {
 
+    baseline_secretsmanager_secrets = {
+      "/ndh/t1"   = local.ndh_secretsmanager_secrets
+      "/ndh/t2"   = local.ndh_secretsmanager_secrets
+      "/ndh/test" = local.ndh_secretsmanager_secrets
+    }
+
     baseline_ec2_instances = {
 
-      test-management-server-2022 = local.management_server_2022
+      test-management-server-2022 = merge(local.management_server_2022, {
+        tags = merge(local.management_server_2022.tags, {
+          ndh-environment   = "test"
+        })
+      })
 
-      test-ndh-app-a = local.ndh_app_a
+      test-ndh-app-a = merge(local.ndh_app_a, {
+        tags = merge(local.management_server_2022.tags, {
+          ndh-environment   = "test"
+        })
+      })
 
-      test-ndh-ems-a = local.ndh_ems_a
+      test-ndh-ems-a = merge(local.ndh_ems_a, {
+        tags = merge(local.management_server_2022.tags, {
+          ndh-environment   = "test"
+        })
+      })
 
     }
     baseline_ec2_autoscaling_groups = {

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -11,19 +11,19 @@ locals {
 
       test-management-server-2022 = merge(local.management_server_2022, {
         tags = merge(local.management_server_2022.tags, {
-          ndh-environment   = "test"
+          ndh-environment = "test"
         })
       })
 
       test-ndh-app-a = merge(local.ndh_app_a, {
         tags = merge(local.management_server_2022.tags, {
-          ndh-environment   = "test"
+          ndh-environment = "test"
         })
       })
 
       test-ndh-ems-a = merge(local.ndh_ems_a, {
         tags = merge(local.management_server_2022.tags, {
-          ndh-environment   = "test"
+          ndh-environment = "test"
         })
       })
 

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -71,6 +71,11 @@ module "baseline" {
   ec2_autoscaling_groups = lookup(local.environment_config, "baseline_ec2_autoscaling_groups", {})
   lbs                    = lookup(local.environment_config, "baseline_lbs", {})
 
+  secretsmanager_secrets = merge(
+    local.baseline_secretsmanager_secrets,
+    lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
+  )
+
   ssm_parameters = merge(
     module.baseline_presets.ssm_parameters,
     local.baseline_ssm_parameters,


### PR DESCRIPTION
Add NDH secrets for future T1, T2 setup plus existing test.
Added ndh-environment tag to EC2s.  To be used in ansible.