### PR TITLE
ndh: DSOS-2421: add secret policy for test environment

### DIFF
--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -26,6 +26,7 @@ locals {
     "ndh_harkemsadmin_ssl_pass",
   ]
 
+  baseline_iam_policies           = {}
   baseline_secretsmanager_secrets = {}
   baseline_ssm_parameters         = {}
 

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -7,6 +7,23 @@ locals {
       "/ndh/test" = local.ndh_secretsmanager_secrets
     }
 
+    baseline_iam_policies = {
+      Ec2TestPolicy = {
+        description = "Permissions required for Test EC2s"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/ndh/test/*",
+            ]
+          }
+        ]
+      }
+    }
+
     baseline_ec2_instances = {
 
       test-management-server-2022 = merge(local.management_server_2022, {
@@ -16,12 +33,22 @@ locals {
       })
 
       test-ndh-app-a = merge(local.ndh_app_a, {
+        config = merge(local.ndh_app_a.config, {
+          instance_profile_policies = concat(local.ndh_app_a.config.instance_profile_policies, [
+            "Ec2TestPolicy",
+          ])
+        })
         tags = merge(local.ndh_app_a.tags, {
           ndh-environment = "test"
         })
       })
 
       test-ndh-ems-a = merge(local.ndh_ems_a, {
+        config = merge(local.ndh_ems_a.config, {
+          instance_profile_policies = concat(local.ndh_ems_a.config.instance_profile_policies, [
+            "Ec2TestPolicy",
+          ])
+        })
         tags = merge(local.ndh_ems_a.tags, {
           ndh-environment = "test"
         })

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -53,10 +53,16 @@ module "baseline" {
 
   environment = module.environment
 
-  security_groups          = local.baseline_security_groups
-  acm_certificates         = module.baseline_presets.acm_certificates
-  cloudwatch_log_groups    = module.baseline_presets.cloudwatch_log_groups
-  iam_policies             = module.baseline_presets.iam_policies
+  security_groups       = local.baseline_security_groups
+  acm_certificates      = module.baseline_presets.acm_certificates
+  cloudwatch_log_groups = module.baseline_presets.cloudwatch_log_groups
+
+  iam_policies = merge(
+    module.baseline_presets.iam_policies,
+    local.baseline_iam_policies,
+    lookup(local.baseline_environment_config, "baseline_iam_policies", {})
+  )
+
   iam_roles                = module.baseline_presets.iam_roles
   iam_service_linked_roles = module.baseline_presets.iam_service_linked_roles
   key_pairs                = module.baseline_presets.key_pairs


### PR DESCRIPTION
Add policy to allow EC2 to read Secrets.  Separate policies can be created for T1/T2 when the time comes.