### PR TITLE
Nomis: preprod db build

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -188,6 +188,35 @@ locals {
     }
 
     baseline_ec2_instances = {
+      preprod-nomis-db-1-a = merge(local.database_ec2, {
+        # cloudwatch_metric_alarms = merge(
+        #   local.database_ec2_cloudwatch_metric_alarms.standard,
+        # )
+        config = merge(local.database_ec2.config, {
+          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+          availability_zone = "${local.region}a"
+          instance_profile_policies = concat(local.database_ec2.config.instance_profile_policies, [
+            "Ec2PreprodDatabasePolicy",
+          ])
+        })
+        ebs_volumes = merge(local.database_ec2.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 1000 }
+        })
+        ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
+          data  = { total_size = 4000 }
+          flash = { total_size = 1000 }
+        })
+        instance = merge(local.database_ec2.instance, {
+          instance_type = "r6i.2xlarge"
+        })
+        tags = merge(local.database_ec2.tags, {
+          nomis-environment = "preprod"
+          description       = "pre-production database for CNOMPP"
+          oracle-sids       = "" # TODO
+        })
+      })
+
       preprod-nomis-db-1-b = merge(local.database_ec2, {
         # cloudwatch_metric_alarms = merge(
         #   local.database_ec2_cloudwatch_metric_alarms.standard,

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -20,7 +20,7 @@ locals {
       path                = "/"
       port                = 7001
       timeout             = 5
-      unhealthy_threshold = 5
+      unhealthy_threshold = 2
     }
     stickiness = {
       enabled = true
@@ -35,13 +35,13 @@ locals {
     deregistration_delay = 30
     health_check = {
       enabled             = true
-      interval            = 30
+      interval            = 10
       healthy_threshold   = 3
       matcher             = "200-399"
       path                = "/keepalive.htm"
       port                = 7777
       timeout             = 5
-      unhealthy_threshold = 5
+      unhealthy_threshold = 2
     }
     stickiness = {
       enabled = true


### PR DESCRIPTION
Add preprod-nomis-db-1-a in prep for moving preprod DBs
Updated weblogic healthchecks to speed up time of detecting unhealthy hosts from 2mins 30 to under 30 seconds