### PR TITLE
tweak alarm threshold for t1 weblogic

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -231,7 +231,13 @@ locals {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = merge(
+          local.weblogic_cloudwatch_metric_alarms, {
+            high-memory-usage = merge(local.weblogic_cloudwatch_metric_alarms["high-memory-usage"], {
+              threshold = "99" # Remove this if we decide to increase the EC2 size
+            })
+          }
+        )
         config = merge(local.weblogic_ec2.config, {
           ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
           instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [


### PR DESCRIPTION
Up the memory alarm threshold for T1 weblogic.  The environment isn't used much and is still performing OK despite occasionally exceeding 95% memory usage.