### PR TITLE
📌 Bump module versions

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/cloudwatch-log-groups.tf
+++ b/terraform/environments/data-platform-apps-and-tools/cloudwatch-log-groups.tf
@@ -1,7 +1,7 @@
 module "openmetadata_opensearch_cloudwatch_log_group" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   name              = "/aws/opensearch/openmetadata"
   retention_in_days = 400

--- a/terraform/environments/data-platform-apps-and-tools/observability-platform.tf
+++ b/terraform/environments/data-platform-apps-and-tools/observability-platform.tf
@@ -2,7 +2,7 @@ module "observability_platform_tenant" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "ministryofjustice/observability-platform-tenant/aws"
-  version = "0.0.3"
+  version = "0.1.0"
 
   observability_platform_account_id = local.environment_configuration.observability_platform_account_id
 }


### PR DESCRIPTION
This pull request:

- Bumps `terraform-aws-modules/cloudwatch/aws` to `~> 5.0`
- Bumps `ministryofjustice/observability-platform-tenant/aws` to `0.1.0`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>