### PR TITLE
🚑 Fix RDS perpetual update

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/rds.tf
+++ b/terraform/environments/data-platform-apps-and-tools/rds.tf
@@ -28,8 +28,9 @@ module "openmetadata_airflow_rds" {
 
   parameters = [
     {
-      name  = "rds.force_ssl"
-      value = 1
+      name         = "rds.force_ssl"
+      value        = 1
+      apply_method = "pending-reboot"
     },
     {
       name  = "log_statement"
@@ -94,8 +95,9 @@ module "openmetadata_rds" {
 
   parameters = [
     {
-      name  = "rds.force_ssl"
-      value = 1
+      name         = "rds.force_ssl"
+      value        = 1
+      apply_method = "pending-reboot"
     },
     {
       name  = "log_statement"
@@ -167,8 +169,9 @@ module "datahub_rds" {
 
   parameters = [
     {
-      name  = "rds.force_ssl"
-      value = 1
+      name         = "rds.force_ssl"
+      value        = 1
+      apply_method = "pending-reboot"
     },
     {
       name  = "log_statement"


### PR DESCRIPTION
This pull request adds `apply_method = "pending-reboot"` (the default) to `rds.force_ssl` to fix the perpetual diff we were seeing

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>