### PR TITLE
nomis: DSOS-2466: add misload alarms for preprod-nomis-db-2-a

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -2,13 +2,20 @@ locals {
   business_unit = var.networking[0].business-unit
   region        = "eu-west-2"
 
+  environment_baseline_presets_options = {
+    development   = local.development_baseline_presets_options
+    test          = local.test_baseline_presets_options
+    preproduction = local.preproduction_baseline_presets_options
+    production    = local.production_baseline_presets_options
+  }
   environment_configs = {
     development   = local.development_config
     test          = local.test_config
     preproduction = local.preproduction_config
     production    = local.production_config
   }
-  baseline_environment_config = local.environment_configs[local.environment]
+  baseline_environment_presets_options = local.environment_baseline_presets_options[local.environment]
+  baseline_environment_config          = local.environment_configs[local.environment]
 
   baseline_presets_options = {
     enable_application_environment_wildcard_cert = false
@@ -27,13 +34,8 @@ locals {
     iam_policies_filter      = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_ec2_default = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies          = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
-    sns_topics = {
-      pagerduty_integrations = {
-        dso_pagerduty               = contains(["development", "test"], local.environment) ? "nomis_nonprod_alarms" : "nomis_alarms"
-        dba_pagerduty               = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_low_priority"
-        dba_high_priority_pagerduty = contains(["development", "test"], local.environment) ? "hmpps_shef_dba_non_prod" : "hmpps_shef_dba_high_priority"
-      }
-    }
+
+    # sns_topics are defined in locals_${environment}.tf
   }
 
   baseline_acm_certificates = {}

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -1,10 +1,14 @@
 # nomis-development environment settings
 locals {
-  nomis_development = {
-    # vars common across ec2 instances
-    ec2_common = {
-      patch_approval_delay_days = 3
-      patch_day                 = "TUE"
+
+  # baseline presets config
+  development_baseline_presets_options = {
+    sns_topics = {
+      pagerduty_integrations = {
+        dso_pagerduty               = "nomis_nonprod_alarms"
+        dba_pagerduty               = "hmpps_shef_dba_non_prod"
+        dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
+      }
     }
   }
 

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -275,6 +275,7 @@ locals {
         cloudwatch_metric_alarms = merge(
           local.database_ec2_cloudwatch_metric_alarms.standard,
           local.database_ec2_cloudwatch_metric_alarms.db_connected,
+          local.database_ec2_cloudwatch_metric_alarms.misload,
         )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -1,6 +1,17 @@
 # nomis-preproduction environment settings
 locals {
 
+  # baseline presets config
+  preproduction_baseline_presets_options = {
+    sns_topics = {
+      pagerduty_integrations = {
+        dso_pagerduty               = "nomis_alarms"
+        dba_pagerduty               = "hmpps_shef_dba_low_priority"
+        dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
+      }
+    }
+  }
+
   # baseline config
   preproduction_config = {
 

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -1,6 +1,17 @@
 # nomis-production environment settings
 locals {
 
+  # baseline presets config
+  production_baseline_presets_options = {
+    sns_topics = {
+      pagerduty_integrations = {
+        dso_pagerduty               = "nomis_alarms"
+        dba_pagerduty               = "hmpps_shef_dba_low_priority"
+        dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
+      }
+    }
+  }
+
   # baseline config
   production_config = {
 

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -1,6 +1,17 @@
 # nomis-test environment settings
 locals {
 
+  # baseline presets config
+  test_baseline_presets_options = {
+    sns_topics = {
+      pagerduty_integrations = {
+        dso_pagerduty               = "nomis_nonprod_alarms"
+        dba_pagerduty               = "hmpps_shef_dba_non_prod"
+        dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
+      }
+    }
+  }
+
   # baseline config
   test_config = {
 

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -27,7 +27,11 @@ module "baseline_presets" {
 
   environment  = module.environment
   ip_addresses = module.ip_addresses
-  options      = local.baseline_presets_options
+
+  options = merge(
+    local.baseline_presets_options,
+    local.baseline_environment_presets_options,
+  )
 }
 
 module "baseline" {


### PR DESCRIPTION
Misload metrics are being populated correctly and it ran successfully yesterday.  Adding in the corresponding alarms.
Also made sure preprod account doesn't alert to the Sheffield High Priority pagerduty service