### PR TITLE
DPR2-250: Configure jobs to use current domain config

### DIFF
--- a/terraform/environments/digital-prison-reporting/data_ingestion_pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/data_ingestion_pipeline.tf
@@ -136,8 +136,10 @@ module "data_ingestion_pipeline" {
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
             "JobName" : "${module.glue_reporting_hub_batch_job.name}",
-            "--dpr.config.s3.bucket" : module.s3_glue_job_bucket.bucket_id,
-            "--dpr.config.key" : "current"
+            "Arguments" : {
+              "--dpr.config.s3.bucket" : module.s3_glue_job_bucket.bucket_id,
+              "--dpr.config.key" : "current"
+            }
           },
           "Next" : "Invoke S3 File Transfer Lambda"
         },

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -119,6 +119,7 @@ module "glue_reporting_hub_batch_job" {
     "--dpr.curated.s3.path"                 = "s3://${module.s3_curated_bucket.bucket_id}/"
     "--dpr.contract.registryName"           = module.s3_schema_registry_bucket.bucket_id
     "--dpr.config.s3.bucket"                = module.s3_glue_job_bucket.bucket_id
+    "--dpr.config.key"                      = "current"
     "--dpr.datastorage.retry.maxAttempts"   = local.reporting_hub_batch_job_retry_max_attempts
     "--dpr.datastorage.retry.minWaitMillis" = local.reporting_hub_batch_job_retry_min_wait_millis
     "--dpr.datastorage.retry.maxWaitMillis" = local.reporting_hub_batch_job_retry_max_wait_millis
@@ -181,6 +182,7 @@ module "glue_reporting_hub_cdc_job" {
     "--enable-job-insights"                 = true
     "--dpr.contract.registryName"           = module.s3_schema_registry_bucket.bucket_id
     "--dpr.config.s3.bucket"                = module.s3_glue_job_bucket.bucket_id
+    "--dpr.config.key"                      = "current"
     "--dpr.domain.registry"                 = "${local.project}-domain-registry-${local.environment}"
     "--dpr.schema.cache.max.size"           = local.reporting_hub_cdc_job_schema_cache_max_size
     "--dpr.log.level"                       = local.reporting_hub_cdc_job_log_level

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -162,7 +162,8 @@ resource "aws_iam_policy" "dynamodb_access_policy" {
         "Action" : [
           "dynamodb:PutItem",
           "dynamodb:DescribeTable",
-          "dynamodb:GetItem"
+          "dynamodb:GetItem",
+          "dynamodb:DeleteItem"
         ],
         "Effect" : "Allow",
         "Resource" : [


### PR DESCRIPTION
This PR:
- Configures the glue jobs and file transfer lambda to use the group of six tables we currently ingest
- Adds missing `dynamo:DeleteObject` permission to the step-function notify lambda thereby enabling it to delete tokens it already used from DynamoDB.