### PR TITLE
DSOS-2476: RemoteDesktop spike

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -67,12 +67,7 @@ locals {
   }
 
   baseline_secretsmanager_secrets = {}
-
-  baseline_security_groups = {
-    private-dc    = local.security_groups.private_dc
-    load-balancer = local.security_groups.load-balancer
-  }
-
-  baseline_sns_topics     = {}
-  baseline_ssm_parameters = {}
+  baseline_security_groups        = local.security_groups
+  baseline_sns_topics             = {}
+  baseline_ssm_parameters         = {}
 }

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -42,6 +42,20 @@ locals {
             "public-lb",
           ]
         }
+        http-from-euc = {
+          description = "Allow direct http access for testing"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
+        https-from-euc = {
+          description = "Allow direct https access for testing"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
         all-from-azure-vnets-vnet = {
           description = "Allow all from azure vnets"
           from_port   = 0

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -61,6 +61,15 @@ locals {
           protocol    = -1
           self        = true
         }
+        http_lb = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "TCP"
+          security_groups = [
+            "load-balancer",
+          ]
+        }
         all-from-noms-test-vnet = {
           description = "Allow all from noms test vnet"
           from_port   = 0

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -1,46 +1,10 @@
 locals {
 
   security_group_cidrs_devtest = {
-    core = module.ip_addresses.azure_fixngo_cidrs.devtest_core
-    ssh  = module.ip_addresses.azure_fixngo_cidrs.devtest
-    enduserclient = [
-      "10.0.0.0/8"
-    ]
-    # NOTE: REMOVE THIS WHEN MOVE TO NEW SG's
-    http7xxx = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.devtest,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
-    ])
-    rdp = {
-      inbound = ["10.40.165.0/26", "10.112.3.0/26", "10.102.0.0/16"]
-    }
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
+    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.devtest
   }
-
   security_group_cidrs_preprod_prod = {
-    core = module.ip_addresses.azure_fixngo_cidrs.prod_core
-    ssh = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
-      # AllowProdStudioHostingSshInBound from 10.244.0.0/22 not included
-      module.ip_addresses.azure_fixngo_cidrs.prod_core,
-      module.ip_addresses.azure_fixngo_cidrs.prod, # NOTE: may need removing at some point
-    ])
-    enduserclient = [
-      "10.0.0.0/8"
-    ]
-    # NOTE: REMOVE THIS WHEN MOVE TO NEW SG's
-    http7xxx = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
-    ])
-    rdp = {
-      inbound = flatten([
-        module.ip_addresses.azure_fixngo_cidrs.prod,
-      ])
-    }
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
+    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.prod
   }
   security_group_cidrs_by_environment = {
     development   = local.security_group_cidrs_devtest
@@ -48,10 +12,130 @@ locals {
     preproduction = local.security_group_cidrs_preprod_prod
     production    = local.security_group_cidrs_preprod_prod
   }
-  security_group_cidrs = local.security_group_cidrs_by_environment[local.environment]
+  security_group_cidrs = merge(local.security_group_cidrs_by_environment[local.environment], {
+    enduserclient_internal = [
+      "10.0.0.0/8"
+    ]
+    enduserclient_public = flatten([
+      module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public
+    ])
+  })
 
   security_groups = {
-    private_dc = {
+    rds-ec2s = {
+      description = "Security group for Remote Desktop Service EC2s"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http-from-lb = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "TCP"
+          security_groups = [
+            "load-balancer",
+            "private-lb",
+            "public-lb",
+          ]
+        }
+        all-from-azure-vnets-vnet = {
+          description = "Allow all from azure vnets"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = local.security_group_cidrs.azure_vnets
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
+
+    public-lb = {
+      description = "Security group for public load-balancer"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http_lb = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_public
+        }
+        https_lb = {
+          description = "Allow enduserclient https ingress"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_public
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all traffic outbound"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+
+    private-lb = {
+      description = "Security group for internal load-balancer"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http_lb = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
+        https_lb = {
+          description = "Allow enduserclient https ingress"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all traffic outbound"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+
+    private-dc = {
       description = "Security group for Domain Controllers"
       ingress = {
         all-from-self = {
@@ -111,7 +195,6 @@ locals {
       }
     }
 
-    ############ NEWLY DEFINED SGs ############
 
     load-balancer = {
       description = "New security group for load-balancer"
@@ -123,27 +206,19 @@ locals {
           protocol    = -1
           self        = true
         }
-        # IMPORTANT: check if an 'allow all from azure' rule is required, rather than subsequent load-balancer rules
-        /* all-from-fixngo = {
-          description = "Allow all ingress from fixngo"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        } */
         http_lb = {
           description = "Allow http ingress"
           from_port   = 80
           to_port     = 80
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
         }
         https_lb = {
           description = "Allow enduserclient https ingress"
           from_port   = 443
           to_port     = 443
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
         }
       }
       egress = {

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -38,7 +38,6 @@ locals {
           to_port     = 80
           protocol    = "TCP"
           security_groups = [
-            "load-balancer",
             "private-lb",
             "public-lb",
           ]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -277,7 +277,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-              # { ec2_instance_name = "test-rds-1-a" },
+              { ec2_instance_name = "test-rds-1-b" },
             ]
           }
           test-rdweb-https = {
@@ -299,7 +299,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-              # { ec2_instance_name = "test-rds-1-a" },
+              { ec2_instance_name = "test-rds-1-b" },
             ]
           }
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -373,8 +373,10 @@ locals {
     baseline_route53_zones = {
       "hmpps-test.modernisation-platform.service.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "rdgateway.hmpps-domain-services", type = "A", lbs_map_key = "private" },
-          { name = "rdweb.hmpps-domain-services", type = "A", lbs_map_key = "private" },
+          { name = "rdgateway-int.hmpps-domain-services", type = "A", lbs_map_key = "private" },
+          { name = "rdweb-int.hmpps-domain-services", type = "A", lbs_map_key = "private" },
+          { name = "rdgateway.hmpps-domain-services", type = "A", lbs_map_key = "public" },
+          { name = "rdweb.hmpps-domain-services", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -260,6 +260,23 @@ locals {
         ]
 
         instance_target_groups = {
+          rds-gateway-80 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 5
+              healthy_threshold   = 3
+              port                = 80
+              protocol            = "HTTP"
+              timeout             = 4
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+          }
           test-rds-1 = {
             port     = 80
             protocol = "HTTP"

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -260,26 +260,19 @@ locals {
         ]
 
         instance_target_groups = {
-          rds-gateway-80 = {
+          test-rds-1 = {
             port     = 80
             protocol = "HTTP"
             health_check = {
               enabled             = true
-              interval            = 5
+              interval            = 10
               healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
               port                = 80
-              protocol            = "HTTP"
-              timeout             = 4
+              timeout             = 5
               unhealthy_threshold = 2
             }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-          }
-          test-rds-1 = {
-            port     = 80
-            protocol = "HTTP"
             stickiness = {
               enabled = true
               type    = "lb_cookie"
@@ -319,7 +312,8 @@ locals {
     baseline_route53_zones = {
       "test.hmpps-domain-services.service.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "private", type = "A", lbs_map_key = "private" },
+          { name = "rdgateway", type = "A", lbs_map_key = "private" },
+          { name = "rdweb", type = "A", lbs_map_key = "private" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -1,4 +1,4 @@
-# nomis-test environment settings
+ nomis-test environment settings
 locals {
 
   # baseline config
@@ -183,46 +183,46 @@ locals {
     }
 
     baseline_ec2_instances = {
-#     test-rds-1-a = {
-#       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-#       config = merge(module.baseline_presets.ec2_instance.config.default, {
-#         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-#         availability_zone             = "eu-west-2a"
-#         ebs_volumes_copy_all_from_ami = false
-#         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-#       })
-#       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-#         vpc_security_group_ids = ["rds-ec2s"]
-#       })
-#       ebs_volumes = {
-#         "/dev/sda1" = { type = "gp3", size = 100 }
-#       }
-#       tags = {
-#         description = "Remote Desktop Gateway and Web Access Server"
-#         os-type     = "Windows"
-#         component   = "remotedesktop"
-#       }
-#     }
-#     test-rds-2-a = {
-#       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-#       config = merge(module.baseline_presets.ec2_instance.config.default, {
-#         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-#         availability_zone             = "eu-west-2a"
-#         ebs_volumes_copy_all_from_ami = false
-#         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-#       })
-#       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-#         vpc_security_group_ids = ["rds-ec2s"]
-#       })
-#       ebs_volumes = {
-#         "/dev/sda1" = { type = "gp3", size = 100 }
-#       }
-#       tags = {
-#         description = "Remote Desktop License Manager and Session Broker"
-#         os-type     = "Windows"
-#         component   = "remotedesktop"
-#       }
-#     }
+      #     test-rds-1-a = {
+      #       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+      #       config = merge(module.baseline_presets.ec2_instance.config.default, {
+      #         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+      #         availability_zone             = "eu-west-2a"
+      #         ebs_volumes_copy_all_from_ami = false
+      #         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+      #       })
+      #       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+      #         vpc_security_group_ids = ["rds-ec2s"]
+      #       })
+      #       ebs_volumes = {
+      #         "/dev/sda1" = { type = "gp3", size = 100 }
+      #       }
+      #       tags = {
+      #         description = "Remote Desktop Gateway and Web Access Server"
+      #         os-type     = "Windows"
+      #         component   = "remotedesktop"
+      #       }
+      #     }
+      #     test-rds-2-a = {
+      #       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+      #       config = merge(module.baseline_presets.ec2_instance.config.default, {
+      #         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+      #         availability_zone             = "eu-west-2a"
+      #         ebs_volumes_copy_all_from_ami = false
+      #         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+      #       })
+      #       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+      #         vpc_security_group_ids = ["rds-ec2s"]
+      #       })
+      #       ebs_volumes = {
+      #         "/dev/sda1" = { type = "gp3", size = 100 }
+      #       }
+      #       tags = {
+      #         description = "Remote Desktop License Manager and Session Broker"
+      #         os-type     = "Windows"
+      #         component   = "remotedesktop"
+      #       }
+      #     }
     }
 
     baseline_lbs = {
@@ -258,7 +258,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-            # { ec2_instance_name = "test-rds-1-a" },
+              # { ec2_instance_name = "test-rds-1-a" },
             ]
           }
           test-rds-1-https = {
@@ -280,7 +280,50 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-            # { ec2_instance_name = "test-rds-1-a" },
+              # { ec2_instance_name = "test-rds-1-a" },
+            ]
+          }
+          test-rdgateway-http = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 80
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              # { ec2_instance_name = "test-rds-1-a" },
+            ]
+          }
+          test-rdweb-https = {
+            port     = 443
+            protocol = "HTTPS"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 443
+              protocol            = "HTTPS"
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              # { ec2_instance_name = "test-rds-1-a" },
             ]
           }
         }
@@ -303,20 +346,38 @@ locals {
             ssl_policy                = "ELBSecurityPolicy-2016-08"
             certificate_names_or_arns = ["application_environment_wildcard_cert"]
             default_action = {
-              type              = "forward"
-              target_group_name = "test-rds-1-https"
+              type = "fixed-response"
+              fixed_response = {
+                content_type = "text/plain"
+                message_body = "Not implemented"
+                status_code  = "501"
+              }
             }
             rules = {
               test-rdgateway = {
                 priority = 300
                 actions = [{
                   type              = "forward"
-                  target_group_name = "test-rds-1-http"
+                  target_group_name = "test-rdgateway-http"
                 }]
                 conditions = [{
                   host_header = {
                     values = [
                       "rdgateway.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+              test-rdweb = {
+                priority = 400
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdweb-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -345,74 +345,11 @@ locals {
           }
         }
       }
-      private = {
-        access_logs                      = false
-        enable_cross_zone_load_balancing = true
-        enable_delete_protection         = false
-        force_destroy_bucket             = true
-        internal_lb                      = true
-        load_balancer_type               = "application"
-        security_groups                  = ["private-lb"]
-        subnets = [
-          module.environment.subnet["private"]["eu-west-2a"].id,
-          module.environment.subnet["private"]["eu-west-2b"].id,
-        ]
-
-        instance_target_groups = {
-          test-rds-1 = {
-            port     = 80
-            protocol = "HTTP"
-            health_check = {
-              enabled             = true
-              interval            = 10
-              healthy_threshold   = 3
-              matcher             = "200-399"
-              path                = "/"
-              port                = 80
-              timeout             = 5
-              unhealthy_threshold = 2
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              { ec2_instance_name = "test-rds-1-a" },
-            ]
-          }
-        }
-        listeners = {
-          http = {
-            port     = 80
-            protocol = "HTTP"
-            default_action = {
-              type = "redirect"
-              redirect = {
-                port        = 443
-                protocol    = "HTTPS"
-                status_code = "HTTP_301"
-              }
-            }
-          }
-          https = {
-            port                      = 443
-            protocol                  = "HTTPS"
-            ssl_policy                = "ELBSecurityPolicy-2016-08"
-            certificate_names_or_arns = ["application_environment_wildcard_cert"]
-            default_action = {
-              type              = "forward"
-              target_group_name = "test-rds-1"
-            }
-          }
-        }
-      }
     }
 
     baseline_route53_zones = {
       "hmpps-test.modernisation-platform.service.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "rdgateway-int.hmpps-domain-services", type = "A", lbs_map_key = "private" },
-          { name = "rdweb-int.hmpps-domain-services", type = "A", lbs_map_key = "private" },
           { name = "rdgateway.hmpps-domain-services", type = "A", lbs_map_key = "public" },
           { name = "rdweb.hmpps-domain-services", type = "A", lbs_map_key = "public" },
         ]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -290,7 +290,7 @@ locals {
               healthy_threshold   = 3
               matcher             = "200-399"
               path                = "/"
-              port                = 443
+              port                = 80
               timeout             = 5
               unhealthy_threshold = 2
             }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -189,7 +189,7 @@ locals {
           ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
           availability_zone             = "eu-west-2a"
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["private-dc"]
@@ -198,7 +198,47 @@ locals {
           "/dev/sda1" = { type = "gp3", size = 100 }
         }
         tags = {
-          description = "Windows Server 2022 for Remote Desktop Services"
+          description = "Remote Desktop Gateway and Web Access Server"
+          os-type     = "Windows"
+          component   = "remotedesktop"
+        }
+      }
+      test-rds-2-a = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2a"
+          ebs_volumes_copy_all_from_ami = false
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["private-dc"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Remote Desktop License Manager and Session Broker"
+          os-type     = "Windows"
+          component   = "remotedesktop"
+        }
+      }
+      test-rds-3-a = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2a"
+          ebs_volumes_copy_all_from_ami = false
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["private-dc"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Test Remote Desktop Session Host"
           os-type     = "Windows"
           component   = "test"
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -420,7 +420,7 @@ locals {
                 priority = 600
                 actions = [{
                   type              = "forward"
-                  target_group_name = "test-rdweb-https"
+                  target_group_name = "test-rdweb-https2"
                 }]
                 conditions = [{
                   host_header = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -261,8 +261,8 @@ locals {
 
         instance_target_groups = {
           public-test-rds-1 = {
-            port     = 80
-            protocol = "HTTP"
+            port     = 443
+            protocol = "HTTPS"
             health_check = {
               enabled             = true
               interval            = 10

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -1,4 +1,3 @@
- nomis-test environment settings
 locals {
 
   # baseline config

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -290,7 +290,8 @@ locals {
               healthy_threshold   = 3
               matcher             = "200-399"
               path                = "/"
-              port                = 80
+              port                = 443
+              protocol            = "HTTPS"
               timeout             = 5
               unhealthy_threshold = 2
             }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -261,6 +261,27 @@ locals {
 
         instance_target_groups = {
           public-test-rds-1 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 80
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "test-rds-1-a" },
+            ]
+          }
+          test-rds-1-https = {
             port     = 443
             protocol = "HTTPS"
             health_check = {
@@ -269,7 +290,7 @@ locals {
               healthy_threshold   = 3
               matcher             = "200-399"
               path                = "/"
-              port                = 80
+              port                = 443
               timeout             = 5
               unhealthy_threshold = 2
             }
@@ -302,7 +323,7 @@ locals {
             certificate_names_or_arns = ["application_environment_wildcard_cert"]
             default_action = {
               type              = "forward"
-              target_group_name = "public-test-rds-1"
+              target_group_name = "test-rds-1-https"
             }
           }
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -182,13 +182,13 @@ locals {
     }
 
     baseline_ec2_instances = {
-      test-rds-1-a = {
+      test-rds-1-b = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2a"
+          availability_zone             = "eu-west-2b"
           ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["rds-ec2s"]
@@ -202,13 +202,13 @@ locals {
           component   = "remotedesktop"
         }
       }
-      test-rds-2-b = {
+      test-rds-2-c = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2b"
+          availability_zone             = "eu-west-2c"
           ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["rds-ec2s"]
@@ -222,13 +222,13 @@ locals {
           component   = "remotedesktop"
         }
       }
-      test-rds-3-c = {
+      test-rds-3-b = {
         # ami has unwanted ephemeral device, don't copy all the ebs_volumess
         config = merge(module.baseline_presets.ec2_instance.config.default, {
           ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2c"
+          availability_zone             = "eu-west-2b"
           ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["rds-ec2s"]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -256,6 +256,7 @@ locals {
         subnets = [
           module.environment.subnet["public"]["eu-west-2a"].id,
           module.environment.subnet["public"]["eu-west-2b"].id,
+          module.environment.subnet["public"]["eu-west-2c"].id,
         ]
 
         instance_target_groups = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -310,10 +310,10 @@ locals {
     }
 
     baseline_route53_zones = {
-      "test.hmpps-domain-services.service.justice.gov.uk" = {
+      "hmpps-test.modernisation-platform.service.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "rdgateway", type = "A", lbs_map_key = "private" },
-          { name = "rdweb", type = "A", lbs_map_key = "private" },
+          { name = "rdgateway.hmpps-domain-services", type = "A", lbs_map_key = "private" },
+          { name = "rdweb.hmpps-domain-services", type = "A", lbs_map_key = "private" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -303,49 +303,49 @@ locals {
               { ec2_instance_name = "test-rds-1-b" },
             ]
           }
-#         test-rdgateway-http2 = {
-#           port     = 80
-#           protocol = "HTTP"
-#           health_check = {
-#             enabled             = true
-#             interval            = 10
-#             healthy_threshold   = 3
-#             matcher             = "200-399"
-#             path                = "/"
-#             port                = 80
-#             timeout             = 5
-#             unhealthy_threshold = 2
-#           }
-#           stickiness = {
-#             enabled = true
-#             type    = "lb_cookie"
-#           }
-#           attachments = [
-#             { ec2_instance_name = "test-rds-2-c" },
-#           ]
-#         }
-#         test-rdweb-https2 = {
-#           port     = 443
-#           protocol = "HTTPS"
-#           health_check = {
-#             enabled             = true
-#             interval            = 10
-#             healthy_threshold   = 3
-#             matcher             = "200-399"
-#             path                = "/"
-#             port                = 443
-#             protocol            = "HTTPS"
-#             timeout             = 5
-#             unhealthy_threshold = 2
-#           }
-#           stickiness = {
-#             enabled = true
-#             type    = "lb_cookie"
-#           }
-#           attachments = [
-#             { ec2_instance_name = "test-rds-2-c" },
-#           ]
-#         }
+          test-rdgateway-http2 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 80
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "test-rds-2-c" },
+            ]
+          }
+          test-rdweb-https2 = {
+            port     = 443
+            protocol = "HTTPS"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 443
+              protocol            = "HTTPS"
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "test-rds-2-c" },
+            ]
+          }
         }
         listeners = {
           http = {
@@ -402,34 +402,34 @@ locals {
                   }
                 }]
               }
-#             test-rdgateway2 = {
-#               priority = 500
-#               actions = [{
-#                 type              = "forward"
-#                 target_group_name = "test-rdgateway-http2"
-#               }]
-#               conditions = [{
-#                 host_header = {
-#                   values = [
-#                     "rdgateway2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
-#                   ]
-#                 }
-#               }]
-#             }
-#             test-rdweb2 = {
-#               priority = 600
-#               actions = [{
-#                 type              = "forward"
-#                 target_group_name = "test-rdweb-https"
-#               }]
-#               conditions = [{
-#                 host_header = {
-#                   values = [
-#                     "rdweb2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
-#                   ]
-#                 }
-#               }]
-#             }
+              test-rdgateway2 = {
+                priority = 500
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdgateway-http2"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+              test-rdweb2 = {
+                priority = 600
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdweb-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           }
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -302,6 +302,49 @@ locals {
               { ec2_instance_name = "test-rds-1-b" },
             ]
           }
+          test-rdgateway-http2 = {
+            port     = 80
+            protocol = "HTTP"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 80
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "test-rds-2-c" },
+            ]
+          }
+          test-rdweb-https2 = {
+            port     = 443
+            protocol = "HTTPS"
+            health_check = {
+              enabled             = true
+              interval            = 10
+              healthy_threshold   = 3
+              matcher             = "200-399"
+              path                = "/"
+              port                = 443
+              protocol            = "HTTPS"
+              timeout             = 5
+              unhealthy_threshold = 2
+            }
+            stickiness = {
+              enabled = true
+              type    = "lb_cookie"
+            }
+            attachments = [
+              { ec2_instance_name = "test-rds-2-c" },
+            ]
+          }
         }
         listeners = {
           http = {
@@ -358,6 +401,34 @@ locals {
                   }
                 }]
               }
+              test-rdgateway2 = {
+                priority = 500
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdgateway-http2"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+              test-rdweb2 = {
+                priority = 600
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdweb-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           }
         }
@@ -369,6 +440,8 @@ locals {
         lb_alias_records = [
           { name = "rdgateway.hmpps-domain-services", type = "A", lbs_map_key = "public" },
           { name = "rdweb.hmpps-domain-services", type = "A", lbs_map_key = "public" },
+          { name = "rdgateway2.hmpps-domain-services", type = "A", lbs_map_key = "public" },
+          { name = "rdweb2.hmpps-domain-services", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -303,49 +303,49 @@ locals {
               { ec2_instance_name = "test-rds-1-b" },
             ]
           }
-          test-rdgateway-http2 = {
-            port     = 80
-            protocol = "HTTP"
-            health_check = {
-              enabled             = true
-              interval            = 10
-              healthy_threshold   = 3
-              matcher             = "200-399"
-              path                = "/"
-              port                = 80
-              timeout             = 5
-              unhealthy_threshold = 2
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              { ec2_instance_name = "test-rds-2-c" },
-            ]
-          }
-          test-rdweb-https2 = {
-            port     = 443
-            protocol = "HTTPS"
-            health_check = {
-              enabled             = true
-              interval            = 10
-              healthy_threshold   = 3
-              matcher             = "200-399"
-              path                = "/"
-              port                = 443
-              protocol            = "HTTPS"
-              timeout             = 5
-              unhealthy_threshold = 2
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              { ec2_instance_name = "test-rds-2-c" },
-            ]
-          }
+#         test-rdgateway-http2 = {
+#           port     = 80
+#           protocol = "HTTP"
+#           health_check = {
+#             enabled             = true
+#             interval            = 10
+#             healthy_threshold   = 3
+#             matcher             = "200-399"
+#             path                = "/"
+#             port                = 80
+#             timeout             = 5
+#             unhealthy_threshold = 2
+#           }
+#           stickiness = {
+#             enabled = true
+#             type    = "lb_cookie"
+#           }
+#           attachments = [
+#             { ec2_instance_name = "test-rds-2-c" },
+#           ]
+#         }
+#         test-rdweb-https2 = {
+#           port     = 443
+#           protocol = "HTTPS"
+#           health_check = {
+#             enabled             = true
+#             interval            = 10
+#             healthy_threshold   = 3
+#             matcher             = "200-399"
+#             path                = "/"
+#             port                = 443
+#             protocol            = "HTTPS"
+#             timeout             = 5
+#             unhealthy_threshold = 2
+#           }
+#           stickiness = {
+#             enabled = true
+#             type    = "lb_cookie"
+#           }
+#           attachments = [
+#             { ec2_instance_name = "test-rds-2-c" },
+#           ]
+#         }
         }
         listeners = {
           http = {
@@ -402,34 +402,34 @@ locals {
                   }
                 }]
               }
-              test-rdgateway2 = {
-                priority = 500
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rdgateway-http2"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdgateway2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-              test-rdweb2 = {
-                priority = 600
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rdweb-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+#             test-rdgateway2 = {
+#               priority = 500
+#               actions = [{
+#                 type              = "forward"
+#                 target_group_name = "test-rdgateway-http2"
+#               }]
+#               conditions = [{
+#                 host_header = {
+#                   values = [
+#                     "rdgateway2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+#                   ]
+#                 }
+#               }]
+#             }
+#             test-rdweb2 = {
+#               priority = 600
+#               actions = [{
+#                 type              = "forward"
+#                 target_group_name = "test-rdweb-https"
+#               }]
+#               conditions = [{
+#                 host_header = {
+#                   values = [
+#                     "rdweb2.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+#                   ]
+#                 }
+#               }]
+#             }
             }
           }
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -182,46 +182,66 @@ locals {
     }
 
     baseline_ec2_instances = {
-      #     test-rds-1-a = {
-      #       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-      #       config = merge(module.baseline_presets.ec2_instance.config.default, {
-      #         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-      #         availability_zone             = "eu-west-2a"
-      #         ebs_volumes_copy_all_from_ami = false
-      #         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-      #       })
-      #       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-      #         vpc_security_group_ids = ["rds-ec2s"]
-      #       })
-      #       ebs_volumes = {
-      #         "/dev/sda1" = { type = "gp3", size = 100 }
-      #       }
-      #       tags = {
-      #         description = "Remote Desktop Gateway and Web Access Server"
-      #         os-type     = "Windows"
-      #         component   = "remotedesktop"
-      #       }
-      #     }
-      #     test-rds-2-a = {
-      #       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-      #       config = merge(module.baseline_presets.ec2_instance.config.default, {
-      #         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-      #         availability_zone             = "eu-west-2a"
-      #         ebs_volumes_copy_all_from_ami = false
-      #         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-      #       })
-      #       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-      #         vpc_security_group_ids = ["rds-ec2s"]
-      #       })
-      #       ebs_volumes = {
-      #         "/dev/sda1" = { type = "gp3", size = 100 }
-      #       }
-      #       tags = {
-      #         description = "Remote Desktop License Manager and Session Broker"
-      #         os-type     = "Windows"
-      #         component   = "remotedesktop"
-      #       }
-      #     }
+      test-rds-1-a = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2a"
+          ebs_volumes_copy_all_from_ami = false
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["rds-ec2s"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Remote Desktop Services test server 1"
+          os-type     = "Windows"
+          component   = "remotedesktop"
+        }
+      }
+      test-rds-2-b = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2b"
+          ebs_volumes_copy_all_from_ami = false
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["rds-ec2s"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Remote Desktop Services test server 2"
+          os-type     = "Windows"
+          component   = "remotedesktop"
+        }
+      }
+      test-rds-3-c = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2c"
+          ebs_volumes_copy_all_from_ami = false
+          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["rds-ec2s"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Remote Desktop Services test server 3"
+          os-type     = "Windows"
+          component   = "remotedesktop"
+        }
+      }
     }
 
     baseline_lbs = {
@@ -239,49 +259,6 @@ locals {
         ]
 
         instance_target_groups = {
-          test-rds-1-http = {
-            port     = 80
-            protocol = "HTTP"
-            health_check = {
-              enabled             = true
-              interval            = 10
-              healthy_threshold   = 3
-              matcher             = "200-399"
-              path                = "/"
-              port                = 80
-              timeout             = 5
-              unhealthy_threshold = 2
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              # { ec2_instance_name = "test-rds-1-a" },
-            ]
-          }
-          test-rds-1-https = {
-            port     = 443
-            protocol = "HTTPS"
-            health_check = {
-              enabled             = true
-              interval            = 10
-              healthy_threshold   = 3
-              matcher             = "200-399"
-              path                = "/"
-              port                = 443
-              protocol            = "HTTPS"
-              timeout             = 5
-              unhealthy_threshold = 2
-            }
-            stickiness = {
-              enabled = true
-              type    = "lb_cookie"
-            }
-            attachments = [
-              # { ec2_instance_name = "test-rds-1-a" },
-            ]
-          }
           test-rdgateway-http = {
             port     = 80
             protocol = "HTTP"

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -182,6 +182,29 @@ locals {
       }
     }
 
+    baseline_ec2_instances = {
+      test-rds-1-a = {
+        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+          availability_zone             = "eu-west-2a"
+          ebs_volumes_copy_all_from_ami = false
+          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+        })
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          vpc_security_group_ids = ["private-dc"]
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 100 }
+        }
+        tags = {
+          description = "Windows Server 2022 for Remote Desktop Services"
+          os-type     = "Windows"
+          component   = "test"
+        }
+      }
+    }
+
     baseline_lbs = {
       private = {
         internal_lb              = true

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -183,66 +183,46 @@ locals {
     }
 
     baseline_ec2_instances = {
-      test-rds-1-a = {
-        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2a"
-          ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-        })
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["rds-ec2s"]
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 100 }
-        }
-        tags = {
-          description = "Remote Desktop Gateway and Web Access Server"
-          os-type     = "Windows"
-          component   = "remotedesktop"
-        }
-      }
-      test-rds-2-a = {
-        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2a"
-          ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-        })
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["rds-ec2s"]
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 100 }
-        }
-        tags = {
-          description = "Remote Desktop License Manager and Session Broker"
-          os-type     = "Windows"
-          component   = "remotedesktop"
-        }
-      }
-      test-rds-3-a = {
-        # ami has unwanted ephemeral device, don't copy all the ebs_volumess
-        config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
-          availability_zone             = "eu-west-2a"
-          ebs_volumes_copy_all_from_ami = false
-          # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
-        })
-        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["rds-ec2s"]
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 100 }
-        }
-        tags = {
-          description = "Test Remote Desktop Session Host"
-          os-type     = "Windows"
-          component   = "test"
-        }
-      }
+#     test-rds-1-a = {
+#       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+#       config = merge(module.baseline_presets.ec2_instance.config.default, {
+#         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+#         availability_zone             = "eu-west-2a"
+#         ebs_volumes_copy_all_from_ami = false
+#         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+#       })
+#       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+#         vpc_security_group_ids = ["rds-ec2s"]
+#       })
+#       ebs_volumes = {
+#         "/dev/sda1" = { type = "gp3", size = 100 }
+#       }
+#       tags = {
+#         description = "Remote Desktop Gateway and Web Access Server"
+#         os-type     = "Windows"
+#         component   = "remotedesktop"
+#       }
+#     }
+#     test-rds-2-a = {
+#       # ami has unwanted ephemeral device, don't copy all the ebs_volumess
+#       config = merge(module.baseline_presets.ec2_instance.config.default, {
+#         ami_name                      = "hmpps_windows_server_2022_release_2023-12-02T00-00-15.711Z"
+#         availability_zone             = "eu-west-2a"
+#         ebs_volumes_copy_all_from_ami = false
+#         # user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+#       })
+#       instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+#         vpc_security_group_ids = ["rds-ec2s"]
+#       })
+#       ebs_volumes = {
+#         "/dev/sda1" = { type = "gp3", size = 100 }
+#       }
+#       tags = {
+#         description = "Remote Desktop License Manager and Session Broker"
+#         os-type     = "Windows"
+#         component   = "remotedesktop"
+#       }
+#     }
     }
 
     baseline_lbs = {
@@ -278,7 +258,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-              { ec2_instance_name = "test-rds-1-a" },
+            # { ec2_instance_name = "test-rds-1-a" },
             ]
           }
           test-rds-1-https = {
@@ -300,7 +280,7 @@ locals {
               type    = "lb_cookie"
             }
             attachments = [
-              { ec2_instance_name = "test-rds-1-a" },
+            # { ec2_instance_name = "test-rds-1-a" },
             ]
           }
         }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -260,7 +260,7 @@ locals {
         ]
 
         instance_target_groups = {
-          public-test-rds-1 = {
+          test-rds-1-http = {
             port     = 80
             protocol = "HTTP"
             health_check = {
@@ -324,6 +324,22 @@ locals {
             default_action = {
               type              = "forward"
               target_group_name = "test-rds-1-https"
+            }
+            rules = {
+              test-rdgateway = {
+                priority = 300
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-1-http"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway.hmpps-domain-services.hmpps-test.modernisation-platform.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           }
         }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -257,6 +257,7 @@ variable "ec2_autoscaling_groups" {
         matcher             = optional(string)
         path                = optional(string)
         port                = optional(number)
+        protocol            = optional(string)
         timeout             = optional(number)
         unhealthy_threshold = optional(number)
       }))


### PR DESCRIPTION
Miscellaneous fixes to support remote desktop in hmpps-domain-services account:
- Created a public load balancer and revamped the associated security groups
- Created 3 standalone EC2 instances for RDS testing
- Fixed the target groups and DNS entries for the load balancer