### PR TITLE
DSOS-2483: test permissive SSM get

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -89,6 +89,7 @@ locals {
           ]
           resources = [
             "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/ansible/*",
+            "*",
           ]
         },
       ]


### PR DESCRIPTION
Testing a permissive SSM get, the SSM module in Ansible is unhappy with the current permissions