### PR TITLE
remove un-needed coalesce from s3 module in baseline

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -154,7 +154,7 @@ locals {
       private = {
         internal_lb                      = true
         enable_delete_protection         = false
-        loadbalancer_type                = "application"
+        load_balancer_type               = "application"
         idle_timeout                     = 3600
         security_groups                  = ["loadbalancer"]
         subnets                          = module.environment.subnets["private"].ids

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -154,7 +154,7 @@ locals {
       private = {
         internal_lb                      = true
         enable_delete_protection         = false
-        load_balancer_type               = "application"
+        loadbalancer_type                = "application"
         idle_timeout                     = 3600
         security_groups                  = ["loadbalancer"]
         subnets                          = module.environment.subnets["private"].ids

--- a/terraform/modules/baseline/s3_bucket.tf
+++ b/terraform/modules/baseline/s3_bucket.tf
@@ -44,8 +44,8 @@ module "s3_bucket" {
   replication_region         = coalesce(each.value.replication_region, var.environment.region)
   bucket_policy              = each.value.bucket_policy
   bucket_policy_v2           = each.value.bucket_policy_v2
-  custom_kms_key             = coalesce(each.value.custom_kms_key, var.environment.kms_keys["general"].arn)
-  custom_replication_kms_key = coalesce(each.value.custom_replication_kms_key, var.environment.kms_keys["general"].arn)
+  custom_kms_key             = each.value.custom_kms_key
+  custom_replication_kms_key = each.value.custom_replication_kms_key
   lifecycle_rule             = each.value.lifecycle_rule
   log_bucket                 = each.value.log_bucket
   log_prefix                 = each.value.log_prefix


### PR DESCRIPTION
- remove un-needed coalesce from s3_bucket module ref in baseline
  - uncovered as part of the loadbalancer module changes