### PR TITLE
load_balancer_type variable spelt incorrectly

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -154,7 +154,7 @@ locals {
       private = {
         internal_lb                      = true
         enable_delete_protection         = false
-        loadbalancer_type                = "application"
+        load_balancer_type               = "application"
         idle_timeout                     = 3600
         security_groups                  = ["loadbalancer"]
         subnets                          = module.environment.subnets["private"].ids


### PR DESCRIPTION
this resource defaults to 'application' load balancer type but that's why this typo wasn't picked up earlier