### PR TITLE
Nomis: DSOS-2467: move xtag from ASG to instance

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -293,7 +293,7 @@ locals {
       preprod-nomis-xtag-a = merge(local.xtag_ec2, {
         # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
             "Ec2PreprodWeblogicPolicy",

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -175,30 +175,6 @@ locals {
           deployment           = "green"
         })
       })
-      preprod-nomis-xtag-a = merge(local.xtag_ec2, {
-        autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
-          desired_capacity = 1
-        })
-        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
-        config = merge(local.xtag_ec2.config, {
-          ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
-          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
-            "Ec2PreprodWeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
-          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-        tags = merge(local.xtag_ec2.tags, {
-          nomis-environment    = "preprod"
-          oracle-db-hostname-a = "ppnomis-a.preproduction.nomis.service.justice.gov.uk"
-          oracle-db-hostname-b = "ppnomis-b.preproduction.nomis.service.justice.gov.uk"
-          oracle-db-name       = "PPCNOM"
-          ndh-ems-hostname     = "PPPML00009.azure.hmpp.root" # preprod NDH is currently down/broken
-        })
-      })
 
       preprod-jumpserver-a = merge(local.jumpserver_ec2, {
         config = merge(local.jumpserver_ec2.config, {
@@ -311,6 +287,29 @@ locals {
           description       = "PreProduction NOMIS MIS and Audit database"
           oracle-sids       = "PPMIS PPCNMAUD"
           misload-dbname    = "PPMIS"
+        })
+      })
+
+      preprod-nomis-xtag-a = merge(local.xtag_ec2, {
+        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        config = merge(local.xtag_ec2.config, {
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          availability_zone = "${local.region}a"
+          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
+            "Ec2PreprodWeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
+          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
+            branch = "main"
+          })
+        })
+        tags = merge(local.xtag_ec2.tags, {
+          nomis-environment    = "preprod"
+          oracle-db-hostname-a = "ppnomis-a.preproduction.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "ppnomis-b.preproduction.nomis.service.justice.gov.uk"
+          oracle-db-name       = "PPCNOM"
+          ndh-ems-hostname     = "PPPML00009.azure.hmpp.root" # preprod NDH is currently down/broken
         })
       })
     }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -291,7 +291,7 @@ locals {
       })
 
       preprod-nomis-xtag-a = merge(local.xtag_ec2, {
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -539,7 +539,7 @@ locals {
       t1-nomis-xtag-a = merge(local.xtag_ec2, {
         # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
             "Ec2T1WeblogicPolicy",
@@ -591,7 +591,7 @@ locals {
       t2-nomis-xtag-a = merge(local.xtag_ec2, {
         # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
-          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
             "Ec2T2WeblogicPolicy",

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -271,31 +271,6 @@ locals {
         })
       })
 
-      t1-nomis-xtag-b = merge(local.xtag_ec2, {
-        autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
-          desired_capacity = 1
-        })
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
-        config = merge(local.xtag_ec2.config, {
-          ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
-          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
-            "Ec2T1WeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
-          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-        tags = merge(local.xtag_ec2.tags, {
-          nomis-environment    = "t1"
-          oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
-          oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
-          oracle-db-name       = "T1CNOM"
-          ndh-ems-hostname     = "t1-ems.test.ndh.nomis.service.justice.gov.uk"
-        })
-      })
-
       # NOT-ACTIVE (blue deployment)
       t2-nomis-web-a = merge(local.weblogic_ec2, {
         autoscaling_group = merge(local.weblogic_ec2.autoscaling_group, {
@@ -355,31 +330,6 @@ locals {
           oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
           oracle-db-name       = "T2CNOM"
           deployment           = "green"
-        })
-      })
-
-      t2-nomis-xtag-b = merge(local.xtag_ec2, {
-        autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
-          desired_capacity = 1
-        })
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
-        config = merge(local.xtag_ec2.config, {
-          ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
-          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
-            "Ec2T2WeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
-          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-        tags = merge(local.xtag_ec2.tags, {
-          nomis-environment    = "t2"
-          oracle-db-hostname-a = "t2nomis-a.test.nomis.service.justice.gov.uk"
-          oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
-          oracle-db-name       = "T2CNOM"
-          ndh-ems-hostname     = "t2-ems.test.ndh.nomis.service.justice.gov.uk"
         })
       })
 
@@ -537,7 +487,7 @@ locals {
       })
 
       t1-nomis-xtag-a = merge(local.xtag_ec2, {
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"
@@ -589,7 +539,7 @@ locals {
       })
 
       t2-nomis-xtag-a = merge(local.xtag_ec2, {
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -271,35 +271,11 @@ locals {
         })
       })
 
-      t1-nomis-xtag-a = merge(local.xtag_ec2, {
-        autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
-          desired_capacity = 0
-        })
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
-        config = merge(local.xtag_ec2.config, {
-          ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_*"
-          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
-            "Ec2T1WeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
-          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-        tags = merge(local.xtag_ec2.tags, {
-          nomis-environment    = "t1"
-          oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
-          oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
-          oracle-db-name       = "T1CNOM"
-          ndh-ems-hostname     = "t1-ems.test.ndh.nomis.service.justice.gov.uk"
-        })
-      })
       t1-nomis-xtag-b = merge(local.xtag_ec2, {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -382,35 +358,11 @@ locals {
         })
       })
 
-      t2-nomis-xtag-a = merge(local.xtag_ec2, {
-        autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
-          desired_capacity = 0
-        })
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
-        config = merge(local.xtag_ec2.config, {
-          ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_*"
-          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
-            "Ec2T2WeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
-          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-        tags = merge(local.xtag_ec2.tags, {
-          nomis-environment    = "t2"
-          oracle-db-hostname-a = "t2nomis-a.test.nomis.service.justice.gov.uk"
-          oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
-          oracle-db-name       = "T2CNOM"
-          ndh-ems-hostname     = "t2-ems.test.ndh.nomis.service.justice.gov.uk"
-        })
-      })
       t2-nomis-xtag-b = merge(local.xtag_ec2, {
         autoscaling_group = merge(local.xtag_ec2.autoscaling_group, {
           desired_capacity = 1
         })
-        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
           instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
@@ -584,6 +536,29 @@ locals {
         })
       })
 
+      t1-nomis-xtag-a = merge(local.xtag_ec2, {
+        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        config = merge(local.xtag_ec2.config, {
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          availability_zone = "${local.region}a"
+          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
+            "Ec2T1WeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
+          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
+            branch = "main"
+          })
+        })
+        tags = merge(local.xtag_ec2.tags, {
+          nomis-environment    = "t1"
+          oracle-db-hostname-a = "t1nomis-a.test.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "t1nomis-b.test.nomis.service.justice.gov.uk"
+          oracle-db-name       = "T1CNOM"
+          ndh-ems-hostname     = "t1-ems.test.ndh.nomis.service.justice.gov.uk"
+        })
+      })
+
       t2-nomis-db-1-a = merge(local.database_ec2, {
         cloudwatch_metric_alarms = merge(
           local.database_ec2_cloudwatch_metric_alarms.standard,
@@ -610,6 +585,29 @@ locals {
           description         = "T2 NOMIS database"
           oracle-sids         = "T2CNOM T2NDH T2TRDAT"
           instance-scheduling = "skip-scheduling"
+        })
+      })
+
+      t2-nomis-xtag-a = merge(local.xtag_ec2, {
+        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        config = merge(local.xtag_ec2.config, {
+          ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"
+          availability_zone = "${local.region}a"
+          instance_profile_policies = concat(local.xtag_ec2.config.instance_profile_policies, [
+            "Ec2T2WeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.xtag_ec2.user_data_cloud_init, {
+          args = merge(local.xtag_ec2.user_data_cloud_init.args, {
+            branch = "main"
+          })
+        })
+        tags = merge(local.xtag_ec2.tags, {
+          nomis-environment    = "t2"
+          oracle-db-hostname-a = "t2nomis-a.test.nomis.service.justice.gov.uk"
+          oracle-db-hostname-b = "t2nomis-b.test.nomis.service.justice.gov.uk"
+          oracle-db-name       = "T2CNOM"
+          ndh-ems-hostname     = "t2-ems.test.ndh.nomis.service.justice.gov.uk"
         })
       })
 


### PR DESCRIPTION
Following discussion with DBAs, re-configure XTAG as a standalone EC2. 
I've applied in nomis-test already and it works and is resilient to reboots.