### PR TITLE
Bump version

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply_test.yml
+++ b/.github/workflows/reusable_terraform_plan_apply_test.yml
@@ -41,7 +41,7 @@ on:
         type: string
         required: false
         description: "The terraform version to use"
-        default: "~1.5"
+        default: "~1.6"
       plan_apply_tfargs:
         type: string
         required: false

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -18,10 +18,10 @@
     "production": "1.7.0"
   },
   "athena_load_versions": {
-    "development": "2.0.0",
-    "test": "2.0.0",
-    "preproduction": "2.0.0",
-    "production": "2.0.0"
+    "development": "3.0.0",
+    "test": "3.0.0",
+    "preproduction": "3.0.0",
+    "production": "3.0.0"
   },
   "create_metadata_versions": {
     "development": "2.2.0",

--- a/terraform/environments/data-platform/application_variables.auto.tfvars.json
+++ b/terraform/environments/data-platform/application_variables.auto.tfvars.json
@@ -18,10 +18,10 @@
     "production": "1.7.0"
   },
   "athena_load_versions": {
-    "development": "3.0.0",
-    "test": "3.0.0",
-    "preproduction": "3.0.0",
-    "production": "3.0.0"
+    "development": "3.0.1",
+    "test": "3.0.1",
+    "preproduction": "3.0.1",
+    "production": "3.0.1"
   },
   "create_metadata_versions": {
     "development": "2.2.0",


### PR DESCRIPTION
Deploys https://github.com/ministryofjustice/data-platform/pull/2821

to change `extraction_timestamp` to `load_timestamp` in athena tables