### PR TITLE
Dsos 2432 observability platform integration

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -3,6 +3,7 @@ locals {
 
   # baseline presets config
   test_baseline_presets_options = {
+    enable_observability_platform_monitoring = true
     sns_topics = {
       pagerduty_integrations = {
         dso_pagerduty               = "nomis_nonprod_alarms"

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -15,14 +15,24 @@ locals {
   business_unit  = "hmpps"
   networking_set = "general"
 
-  accounts = {
+  environment_baseline_presets_options = {
+    development   = local.development_baseline_presets_options
+    test          = local.test_baseline_presets_options
+    preproduction = local.preproduction_baseline_presets_options
+    production    = local.production_baseline_presets_options
+  }
+
+  environment_configs = {
     development   = local.development_config
     test          = local.test_config
     preproduction = local.preproduction_config
     production    = local.production_config
   }
 
-  environment_config = local.accounts[local.environment]
+  environment_config = local.environment_configs[local.environment]
+  
+  baseline_environment_presets_options = local.environment_baseline_presets_options[local.environment]
+  baseline_environment_config          = local.environment_configs[local.environment]
 
   region            = "eu-west-2"
   availability_zone = "eu-west-2a"

--- a/terraform/environments/oasys/locals_development.tf
+++ b/terraform/environments/oasys/locals_development.tf
@@ -1,5 +1,8 @@
 # environment specific settings
 locals {
+
+  development_baseline_presets_options = {}
+  
   development_config = {
 
     ec2_common = {

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -1,5 +1,8 @@
 # environment specific settings
 locals {
+
+  preproduction_baseline_presets_options = {}
+
   preproduction_config = {
     ec2_common = {
       patch_approval_delay_days = 3

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -1,5 +1,8 @@
 # environment specific settings
 locals {
+  
+  production_baseline_presets_options = {}
+  
   production_config = {
 
     ec2_common = {

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -1,5 +1,12 @@
 # environment specific settings
 locals {
+
+  # baseline presets config
+  test_baseline_presets_options = {
+    enable_observability_platform_monitoring = true
+  }
+
+  # baseline config
   test_config = {
 
     ec2_common = {

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -35,7 +35,7 @@ module "baseline_presets" {
     enable_ec2_user_keypair                      = true
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
-    enable_observability_platform_monitoring     = local.environment_baseline_presets_options[local.environment].enable_observability_platform_monitoring
+    enable_observability_platform_monitoring     = lookup(local.baseline_environment_presets_options, "enable_observability_platform_monitoring", false)
     db_backup_s3                                 = true # adds db backup buckets
     iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -35,11 +35,11 @@ module "baseline_presets" {
     enable_ec2_user_keypair                      = true
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_shared_s3                             = true # adds permissions to ec2s to interact with devtest or prodpreprod buckets
+    enable_observability_platform_monitoring     = local.environment_baseline_presets_options[local.environment].enable_observability_platform_monitoring
     db_backup_s3                                 = true # adds db backup buckets
     iam_policies_ec2_default                     = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
     s3_iam_policies                              = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     iam_policies_filter                          = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy", "Ec2OracleEnterpriseManagerPolicy"]
-
     sns_topics = {
       pagerduty_integrations = {
         dso_pagerduty = contains(["development", "test"], local.environment) ? "oasys_nonprod_alarms" : "oasys_alarms"

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -3,6 +3,7 @@ locals {
   iam_roles_filter = flatten([
     var.options.enable_image_builder ? ["EC2ImageBuilderDistributionCrossAccountRole"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
+    var.options.enable_observability_platform_monitoring ? ["observability-platform"] : [],
   ])
 
   iam_roles = {
@@ -44,6 +45,21 @@ locals {
       policy_attachments = [
         "OracleEnterpriseManagementSecretsPolicy",
         "BusinessUnitKmsCmkPolicy",
+      ]
+    }
+
+    # allow Observability Plaform read-only access to Cloudwatch metrics
+    observability-platform = {
+      assume_role_policy = [{
+        effect  = "Allow"
+        actions = ["sts:AssumeRole"]
+        principals = {
+          type        = "AWS"
+          identifiers = ["observability-platform-production"]
+        }
+      }]
+      policy_attachments = [
+        "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
       ]
     }
   }

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -28,6 +28,7 @@ variable "options" {
     enable_ec2_oracle_enterprise_manager         = optional(bool, false)
     enable_ec2_user_keypair                      = optional(bool, false)
     enable_shared_s3                             = optional(bool, false)
+    enable_observability_platform_monitoring     = optional(bool, false)
     db_backup_s3                                 = optional(bool, false)
     route53_resolver_rules                       = optional(map(list(string)), {})
     iam_policies_filter                          = optional(list(string), [])


### PR DESCRIPTION
- Option to enable observability platform monitoring
- IAM role to be created for observability-platform created in baseline_presets module (has to be named specifically as per [https://registry.terraform.io/modules/ministryofjustice/observability-platform-tenant/aws/latest?tab=inputs]
- nomis-test and oasys-test to enable observability platform monitoring only