### PR TITLE
set recovery window for sprinkler mmad secret to 0

### DIFF
--- a/terraform/environments/sprinkler/directory-service.tf
+++ b/terraform/environments/sprinkler/directory-service.tf
@@ -17,6 +17,7 @@ resource "aws_directory_service_directory" "mmad" {
 
 resource "aws_secretsmanager_secret" "mmad" {
   name = "active-directory_sprinkler.modernisation-platform.internal"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "mmad" {


### PR DESCRIPTION
A recent pipeline run for creating MMAD in sprinkler failed with a message around secret deletion.

This PR sets the recovery window to 0 days to allow immediate secret deletion / recreation