### PR TITLE
CSR network lb only accepts http requests so logging isn't useful

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -643,9 +643,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122143942200000001"
 
         instance_target_groups = {
           pp-csr-w-12-80 = {
@@ -812,9 +811,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122143942200000001"
 
         instance_target_groups = {
           pp-csr-w-56-80 = {
@@ -981,9 +979,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122143942200000001"
 
         instance_target_groups = {
           pp-csr-w-78-80 = {
@@ -1150,9 +1147,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122143942200000001"
 
         instance_target_groups = {
           pp-csr-w-34-80 = {

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -547,9 +547,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122125199500000001"
 
         instance_target_groups = {
           pd-csr-w-12-80 = {
@@ -716,9 +715,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122125199500000001"
 
         instance_target_groups = {
           pd-csr-w-34-80 = {
@@ -885,9 +883,8 @@ locals {
           module.environment.subnet["private"]["eu-west-2b"].id,
         ]
         security_groups                  = ["load-balancer"]
-        access_logs                      = true
+        access_logs                      = false
         enable_cross_zone_load_balancing = true
-        existing_bucket_name             = "nlb-logs-bucket20240104122125199500000001"
 
         instance_target_groups = {
           pd-csr-w-56-80 = {


### PR DESCRIPTION
- remove logging from csr network load balancers 

network loadbalancers only tls traffic but in this case we're only using http listeners so nothing is going to be logged anyway