### PR TITLE
🔐 Add Grafana API key secret

### DIFF
--- a/terraform/environments/observability-platform/data.tf
+++ b/terraform/environments/observability-platform/data.tf
@@ -1,1 +1,3 @@
-#### This file can be used to store data specific to the member account ####
+data "aws_secretsmanager_secret_version" "grafana_api_key" {
+  secret_id = aws_secretsmanager_secret.grafana_api_key.id
+}

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -37,32 +37,6 @@ module "managed_grafana" {
   tags = local.tags
 }
 
-/* Grafana API */
-locals {
-  grafana_api_key_expiration_days    = 30
-  grafana_api_key_expiration_seconds = 60 * 60 * 24 * local.grafana_api_key_expiration_days
-}
-
-resource "time_rotating" "grafana_api_key_rotation" {
-  rotation_days = local.grafana_api_key_expiration_days
-}
-
-resource "time_static" "grafana_api_key_rotation" {
-  rfc3339 = time_rotating.grafana_api_key_rotation.rfc3339
-}
-
-resource "aws_grafana_workspace_api_key" "automation_key" {
-  workspace_id = module.managed_grafana.workspace_id
-
-  key_name        = "automation"
-  key_role        = "ADMIN"
-  seconds_to_live = local.grafana_api_key_expiration_seconds
-
-  lifecycle {
-    replace_triggered_by = [time_static.grafana_api_key_rotation]
-  }
-}
-
 /* Prometheus Source */
 resource "grafana_data_source" "observability_platform_prometheus" {
   type       = "prometheus"

--- a/terraform/environments/observability-platform/providers.tf
+++ b/terraform/environments/observability-platform/providers.tf
@@ -1,4 +1,4 @@
 provider "grafana" {
   url  = "https://${module.managed_grafana.workspace_endpoint}"
-  auth = aws_grafana_workspace_api_key.automation_key.key
+  auth = data.aws_secretsmanager_secret_version.grafana_api_key.secret_string
 }

--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -1,1 +1,3 @@
-#### This file can be used to store secrets specific to the member account ####
+resource "aws_secretsmanager_secret" "grafana_api_key" {
+  name = "grafana/api-key"
+}


### PR DESCRIPTION
This pull request:

Part of https://github.com/ministryofjustice/observability-platform/issues/16

- Adds Secrets Manager secret for housing Grafana's API key

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>