### PR TITLE
Issue #5899

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@5581a7d1d42cd24fc0308cdab75be22f2d8c9d11 # v15.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -49,7 +49,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@5581a7d1d42cd24fc0308cdab75be22f2d8c9d11 # v15.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -68,7 +68,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@433c75e44be4eabb0a6ca573951090b9da4901cf # v15.1.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@5581a7d1d42cd24fc0308cdab75be22f2d8c9d11 # v15.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Changes the version used of ministryofjustice/github-actions/terraform-static-analysis to 15.2.0 re Issue 5899.