### PR TITLE
♻️ Switch Data Platform to Observability Platform Terraform module

### DIFF
--- a/terraform/environments/data-platform/observability-platform.tf
+++ b/terraform/environments/data-platform/observability-platform.tf
@@ -1,18 +1,9 @@
-module "observability_platform_iam_role" {
+module "observability_platform_tenant" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5.0"
 
-  create_role = true
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.0.0"
 
-  role_name         = "observability-platform"
-  role_requires_mfa = false
-
-  trusted_role_arns = [
-    "arn:aws:iam::${local.environment_configuration.observability_platform_account_id}:root"
-  ]
-
-  custom_role_policy_arns = ["arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"]
-
-  tags = local.tags
+  observability_platform_account_id = local.environment_configuration.observability_platform_account_id
+  enable_xray                       = true
 }


### PR DESCRIPTION
This pull request:

- Switches the original Observability Platform role to use the new Terraform module

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>