### PR TITLE
📌 DPAT EKS upgrade

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/environment-configuration.tf
+++ b/terraform/environments/data-platform-apps-and-tools/environment-configuration.tf
@@ -17,13 +17,13 @@ locals {
       eks_cluster_name = "apps-tools-${local.environment}"
       eks_versions = {
         cluster                   = "1.28"
-        ami_release               = "1.16.0-d2d9cf87" // [major version].[minor version].[patch version]-[first 8 chars of commit SHA]. Get the SHA from here: https://github.com/bottlerocket-os/bottlerocket/releases
-        addon_coredns             = "v1.10.1-eksbuild.5"
-        addon_kube_proxy          = "v1.28.2-eksbuild.2"
-        addon_vpc_cni             = "v1.15.3-eksbuild.1"
+        ami_release               = "1.17.0-53f322c2" // [major version].[minor version].[patch version]-[first 8 chars of commit SHA]. Get the SHA from here: https://github.com/bottlerocket-os/bottlerocket/releases
+        addon_coredns             = "v1.10.1-eksbuild.6"
+        addon_kube_proxy          = "v1.28.4-eksbuild.4"
+        addon_vpc_cni             = "v1.16.0-eksbuild.1"
         addon_aws_guardduty_agent = "v1.4.0-eksbuild.1"
-        addon_ebs_csi_driver      = "v1.24.1-eksbuild.1"
-        addon_efs_csi_driver      = "v1.7.0-eksbuild.1"
+        addon_ebs_csi_driver      = "v1.26.1-eksbuild.1"
+        addon_efs_csi_driver      = "v1.7.2-eksbuild.1"
       }
       eks_sso_access_role = "modernisation-platform-sandbox"
 

--- a/terraform/environments/data-platform-apps-and-tools/environment-configuration.tf
+++ b/terraform/environments/data-platform-apps-and-tools/environment-configuration.tf
@@ -105,13 +105,13 @@ locals {
       eks_cluster_name = "apps-tools-${local.environment}"
       eks_versions = {
         cluster                   = "1.28"
-        ami_release               = "1.16.0-d2d9cf87" // [major version].[minor version].[patch version]-[first 8 chars of commit SHA]. Get the SHA from here: https://github.com/bottlerocket-os/bottlerocket/releases
-        addon_coredns             = "v1.10.1-eksbuild.5"
-        addon_kube_proxy          = "v1.28.2-eksbuild.2"
-        addon_vpc_cni             = "v1.15.3-eksbuild.1"
-        addon_aws_guardduty_agent = "v1.3.1-eksbuild.1"
-        addon_ebs_csi_driver      = "v1.24.1-eksbuild.1"
-        addon_efs_csi_driver      = "v1.7.0-eksbuild.1"
+        ami_release               = "1.17.0-53f322c2" // [major version].[minor version].[patch version]-[first 8 chars of commit SHA]. Get the SHA from here: https://github.com/bottlerocket-os/bottlerocket/releases
+        addon_coredns             = "v1.10.1-eksbuild.6"
+        addon_kube_proxy          = "v1.28.4-eksbuild.4"
+        addon_vpc_cni             = "v1.16.0-eksbuild.1"
+        addon_aws_guardduty_agent = "v1.4.0-eksbuild.1"
+        addon_ebs_csi_driver      = "v1.26.1-eksbuild.1"
+        addon_efs_csi_driver      = "v1.7.2-eksbuild.1"
       }
       eks_sso_access_role = "modernisation-platform-developer"
 

--- a/terraform/environments/data-platform-apps-and-tools/helm-charts-applications.tf
+++ b/terraform/environments/data-platform-apps-and-tools/helm-charts-applications.tf
@@ -1,0 +1,76 @@
+resource "helm_release" "static_assets" {
+  name      = "static-assets"
+  chart     = "./src/helm/charts/static-assets"
+  namespace = kubernetes_namespace.static_assets.metadata[0].name
+
+  set {
+    name  = "ingress.host"
+    value = local.environment_configuration.static_assets_hostname
+  }
+
+  depends_on = [helm_release.cert_manager_additional]
+}
+
+resource "helm_release" "openmetadata_dependencies" {
+  name       = "openmetadata-dependencies"
+  repository = "https://helm.open-metadata.org"
+  chart      = "openmetadata-dependencies"
+  version    = "1.2.1"
+  namespace  = kubernetes_namespace.openmetadata.metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/openmetadata-dependencies/values.yml.tftpl",
+      {
+        openmetadata_airflow_password                = random_password.openmetadata_airflow.result
+        openmetadata_airflow_eks_role_arn            = module.openmetadata_airflow_iam_role.iam_role_arn
+        openmetadata_airflow_rds_host                = module.openmetadata_airflow_rds.db_instance_address
+        openmetadata_airflow_rds_user                = module.openmetadata_airflow_rds.db_instance_username
+        openmetadata_airflow_rds_db                  = module.openmetadata_airflow_rds.db_instance_name
+        openmetadata_airflow_rds_password_secret     = kubernetes_secret.openmetadata_airflow_rds_credentials.metadata[0].name
+        openmetadata_airflow_rds_password_secret_key = "password"
+        openmetadata_airflow_admin_email             = "${local.environment_configuration.airflow_mail_from_address}@${local.environment_configuration.ses_domain_identity}"
+      }
+    )
+  ]
+  wait    = true
+  timeout = 600
+
+  depends_on = [kubernetes_secret.openmetadata_airflow]
+}
+
+resource "helm_release" "openmetadata" {
+  name       = "openmetadata"
+  repository = "https://helm.open-metadata.org"
+  chart      = "openmetadata"
+  version    = "1.2.1"
+  namespace  = kubernetes_namespace.openmetadata.metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/openmetadata/values.yml.tftpl",
+      {
+        host                                 = "catalogue.${local.environment_configuration.route53_zone}"
+        eks_role_arn                         = module.openmetadata_iam_role.iam_role_arn
+        client_id                            = data.aws_secretsmanager_secret_version.openmetadata_entra_id_client_id.secret_string
+        tenant_id                            = data.aws_secretsmanager_secret_version.openmetadata_entra_id_tenant_id.secret_string
+        jwt_key_id                           = random_uuid.openmetadata_jwt.result
+        openmetadata_airflow_username        = "${local.environment_configuration.airflow_mail_from_address}@${local.environment_configuration.ses_domain_identity}"
+        openmetadata_airflow_password_secret = kubernetes_secret.openmetadata_airflow.metadata[0].name
+        #checkov:skip=CKV_SECRET_6:Reference to Kubernetes secret not a sensitive value
+        openmetadata_airflow_password_secret_key    = "openmetadata-airflow-password"
+        openmetadata_opensearch_host                = resource.aws_opensearch_domain.openmetadata.endpoint
+        openmetadata_opensearch_user                = "openmetadata"
+        openmetadata_opensearch_password_secret     = kubernetes_secret.openmetadata_opensearch_credentials.metadata[0].name
+        openmetadata_opensearch_password_secret_key = "password"
+        openmetadata_rds_host                       = module.openmetadata_rds.db_instance_address
+        openmetadata_rds_user                       = module.openmetadata_rds.db_instance_username
+        openmetadata_rds_dbname                     = module.openmetadata_rds.db_instance_name
+        openmetadata_rds_password_secret            = kubernetes_secret.openmetadata_rds_credentials.metadata[0].name
+        openmetadata_rds_password_secret_key        = "password"
+      }
+    )
+  ]
+  wait    = true
+  timeout = 600
+
+  depends_on = [helm_release.openmetadata_dependencies]
+}

--- a/terraform/environments/data-platform-apps-and-tools/helm-charts-system.tf
+++ b/terraform/environments/data-platform-apps-and-tools/helm-charts-system.tf
@@ -33,7 +33,7 @@ resource "helm_release" "cluster_autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.29.4"
+  version    = "9.34.1"
   namespace  = "kube-system"
 
   values = [
@@ -53,7 +53,7 @@ resource "helm_release" "external_dns" {
   name       = "external-dns"
   repository = "https://kubernetes-sigs.github.io/external-dns"
   chart      = "external-dns"
-  version    = "1.13.1"
+  version    = "1.14.1"
   namespace  = kubernetes_namespace.external_dns.metadata[0].name
   values = [
     templatefile(
@@ -71,7 +71,7 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.13.2"
+  version    = "v1.13.3"
   namespace  = kubernetes_namespace.cert_manager.metadata[0].name
   values = [
     templatefile(
@@ -134,7 +134,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
-  version    = "4.8.3"
+  version    = "4.9.0"
   namespace  = kubernetes_namespace.ingress_nginx.metadata[0].name
   values = [
     templatefile(
@@ -152,14 +152,14 @@ resource "helm_release" "velero" {
   name       = "velero"
   repository = "https://vmware-tanzu.github.io/helm-charts"
   chart      = "velero"
-  version    = "5.1.3"
+  version    = "5.2.0"
   namespace  = kubernetes_namespace.velero_system.metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/velero/values.yml.tftpl",
       {
         eks_role_arn              = module.velero_role.iam_role_arn
-        velero_aws_plugin_version = "v1.8.1"
+        velero_aws_plugin_version = "v1.8.2"
         velero_bucket             = module.velero_s3_bucket.bucket.id
         velero_prefix             = module.eks.cluster_name
         aws_region                = data.aws_region.current.name
@@ -173,7 +173,7 @@ resource "helm_release" "external_secrets" {
   name       = "external-secrets"
   repository = "https://charts.external-secrets.io"
   chart      = "external-secrets"
-  version    = "0.9.8"
+  version    = "0.9.11"
   namespace  = kubernetes_namespace.external_secrets.metadata[0].name
   values = [
     templatefile(
@@ -190,7 +190,7 @@ resource "helm_release" "policy_controller" {
   name       = "policy-controller"
   repository = "https://sigstore.github.io/helm-charts"
   chart      = "policy-controller"
-  version    = "0.6.5"
+  version    = "0.6.7"
   namespace  = kubernetes_namespace.cosign_system.metadata[0].name
   values     = [templatefile("${path.module}/src/helm/policy-controller/values.yml.tftpl", {})]
 
@@ -201,7 +201,7 @@ resource "helm_release" "aws_for_fluent_bit" {
   name       = "aws-for-fluent-bit"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-for-fluent-bit"
-  version    = "0.1.31"
+  version    = "0.1.32"
   namespace  = "kube-system"
   values = [
     templatefile(
@@ -216,75 +216,11 @@ resource "helm_release" "aws_for_fluent_bit" {
   depends_on = [helm_release.gatekeeper]
 }
 
-resource "helm_release" "openmetadata_dependencies" {
-  name       = "openmetadata-dependencies"
-  repository = "https://helm.open-metadata.org"
-  chart      = "openmetadata-dependencies"
-  version    = "1.2.1"
-  namespace  = kubernetes_namespace.openmetadata.metadata[0].name
-  values = [
-    templatefile(
-      "${path.module}/src/helm/openmetadata-dependencies/values.yml.tftpl",
-      {
-        openmetadata_airflow_password                = random_password.openmetadata_airflow.result
-        openmetadata_airflow_eks_role_arn            = module.openmetadata_airflow_iam_role.iam_role_arn
-        openmetadata_airflow_rds_host                = module.openmetadata_airflow_rds.db_instance_address
-        openmetadata_airflow_rds_user                = module.openmetadata_airflow_rds.db_instance_username
-        openmetadata_airflow_rds_db                  = module.openmetadata_airflow_rds.db_instance_name
-        openmetadata_airflow_rds_password_secret     = kubernetes_secret.openmetadata_airflow_rds_credentials.metadata[0].name
-        openmetadata_airflow_rds_password_secret_key = "password"
-        openmetadata_airflow_admin_email             = "${local.environment_configuration.airflow_mail_from_address}@${local.environment_configuration.ses_domain_identity}"
-      }
-    )
-  ]
-  wait    = true
-  timeout = 600
-
-  depends_on = [kubernetes_secret.openmetadata_airflow]
-}
-
-resource "helm_release" "openmetadata" {
-  name       = "openmetadata"
-  repository = "https://helm.open-metadata.org"
-  chart      = "openmetadata"
-  version    = "1.2.1"
-  namespace  = kubernetes_namespace.openmetadata.metadata[0].name
-  values = [
-    templatefile(
-      "${path.module}/src/helm/openmetadata/values.yml.tftpl",
-      {
-        host                                 = "catalogue.${local.environment_configuration.route53_zone}"
-        eks_role_arn                         = module.openmetadata_iam_role.iam_role_arn
-        client_id                            = data.aws_secretsmanager_secret_version.openmetadata_entra_id_client_id.secret_string
-        tenant_id                            = data.aws_secretsmanager_secret_version.openmetadata_entra_id_tenant_id.secret_string
-        jwt_key_id                           = random_uuid.openmetadata_jwt.result
-        openmetadata_airflow_username        = "${local.environment_configuration.airflow_mail_from_address}@${local.environment_configuration.ses_domain_identity}"
-        openmetadata_airflow_password_secret = kubernetes_secret.openmetadata_airflow.metadata[0].name
-        #checkov:skip=CKV_SECRET_6:Reference to Kubernetes secret not a sensitive value
-        openmetadata_airflow_password_secret_key    = "openmetadata-airflow-password"
-        openmetadata_opensearch_host                = resource.aws_opensearch_domain.openmetadata.endpoint
-        openmetadata_opensearch_user                = "openmetadata"
-        openmetadata_opensearch_password_secret     = kubernetes_secret.openmetadata_opensearch_credentials.metadata[0].name
-        openmetadata_opensearch_password_secret_key = "password"
-        openmetadata_rds_host                       = module.openmetadata_rds.db_instance_address
-        openmetadata_rds_user                       = module.openmetadata_rds.db_instance_username
-        openmetadata_rds_dbname                     = module.openmetadata_rds.db_instance_name
-        openmetadata_rds_password_secret            = kubernetes_secret.openmetadata_rds_credentials.metadata[0].name
-        openmetadata_rds_password_secret_key        = "password"
-      }
-    )
-  ]
-  wait    = true
-  timeout = 600
-
-  depends_on = [helm_release.openmetadata_dependencies]
-}
-
 resource "helm_release" "amazon_managed_prometheus_proxy" {
   name       = "prometheus-proxy"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "prometheus"
-  version    = "25.4.0"
+  version    = "25.8.2"
   namespace  = kubernetes_namespace.prometheus.metadata[0].name
   values = [
     templatefile(
@@ -302,17 +238,4 @@ resource "helm_release" "amazon_managed_prometheus_proxy" {
   ]
 
   depends_on = [helm_release.gatekeeper]
-}
-
-resource "helm_release" "static_assets" {
-  name      = "static-assets"
-  chart     = "./src/helm/charts/static-assets"
-  namespace = kubernetes_namespace.static_assets.metadata[0].name
-
-  set {
-    name  = "ingress.host"
-    value = local.environment_configuration.static_assets_hostname
-  }
-
-  depends_on = [helm_release.cert_manager_additional]
 }


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/data-platform/issues/2905
- Upgrades EKS AMI release to `1.17.0-53f322c2`
- Upgrades EKS add-ons
  - coredns
  - kube-proxy
  - vpc-cni
  - ebs-csi
  - efs-csi
- Upgrades system Helm charts
  - cluster-autoscaler
  - external-dns
  - cert-manager
  - ingress-nginx
  - velero
  - external-secrets
  - policy-controller
  - aws-for-fluent-bit
  - prometheus

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>