### PR TITLE
check for vpc endpoint or transfer server resources

### DIFF
--- a/scripts/terraform-plan-evaluator.sh
+++ b/scripts/terraform-plan-evaluator.sh
@@ -5,6 +5,9 @@ TERRAFORM_PLAN="${1}"
 RESOURCES_TO_CHECK_FOR=(
   "aws_vpc"
   "aws_eks_cluster"
+  "aws_transfer_server"
+  "aws_vpc_endpoint"
+  ""
 )
 
 resourcesFound=false

--- a/scripts/terraform-plan-evaluator.sh
+++ b/scripts/terraform-plan-evaluator.sh
@@ -7,7 +7,6 @@ RESOURCES_TO_CHECK_FOR=(
   "aws_eks_cluster"
   "aws_transfer_server"
   "aws_vpc_endpoint"
-  ""
 )
 
 resourcesFound=false


### PR DESCRIPTION
This relates to https://github.com/ministryofjustice/modernisation-platform/pull/5975 which is granting the `member-access`role the ability to create and delete ec2 vpc endpoints as listed as min pre reqs in creation of aws transfer servers [here](https://docs.aws.amazon.com/transfer/latest/userguide/getting-started.html)

This PR should ensure that the MP team must review any vpc endpoint related resources being managed by members.

I've added a check for both `"aws_transfer_server` and  `"aws_vpc_endpoint"` as in the case of the aws transfer server it is creating a vpc endpoint by proxy as part of that resource. This makes me wonder whether any other resources in aws create vpc endpoints when they are created and do we need to add more to this list?