### PR TITLE
JML lambda execution role and secrets manager

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/jml_lambda_execution_roles.tf
+++ b/terraform/environments/data-platform-apps-and-tools/jml_lambda_execution_roles.tf
@@ -1,0 +1,54 @@
+# IAM role with a trust policy that allows the Lambda service to assume this role. 
+resource "aws_iam_role" "lambda_execution_role" {
+  name = "lambda_execution_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+#Creates a Lambda function named using the IAM role created earlier. 
+resource "aws_lambda_function" "jml_lambda_execution_function" {
+  function_name = "jml_lambda_execution_function"
+  handler       = "handler"
+  runtime       = "python3.11"
+  filename      = "src/var/task"
+  role          = aws_iam_role.lambda_execution_role.arn
+}
+# Defines an IAM policy named that grants various permissions to interact with CloudWatch Logs.
+resource "aws_iam_policy" "cloudwatch_logs_policy" {
+  name        = "CloudWatchLogsPolicy"
+  description = "Policy to access CloudWatch Logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "cloudwatch:GenerateQuery",
+          "logs:DescribeLogStreams",
+          "logs:DescribeLogGroups",
+          "logs:GetLogEvents",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecrets"
+        ],
+        Effect   = "Allow",
+        Resource = "arn:aws:logs::${local.environment_management.account_ids["data-platform-apps-and-tools-production"]}:log-group:/aws/events/auth0/*",
+      }
+    ]
+  })
+}
+# Attaches the CloudWatch Logs policy to the IAM role created for the Lambda function.
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy_attachment" {
+  policy_arn = aws_iam_policy.cloudwatch_logs_policy.arn
+  role       = aws_iam_role.lambda_execution_role.name
+}

--- a/terraform/environments/data-platform-apps-and-tools/secrets.tf
+++ b/terraform/environments/data-platform-apps-and-tools/secrets.tf
@@ -33,3 +33,15 @@ resource "aws_secretsmanager_secret" "github_app_arc_private_key" {
 
   name = "github/arc/private-key"
 }
+
+# Create a new secret in AWS SecretsManager for Gov.UK Notify API key
+resource "aws_secretsmanager_secret" "govuk_notify_api_key" {
+  count = terraform.workspace == "data-platform-apps-and-tools-production" ? 1 : 0
+
+  name = "gov-uk-notify/production/api-key"
+}
+
+# Email secret for Lambda function
+resource "aws_secretsmanager_secret" "email_secret" {
+  name = "jml/email"
+}


### PR DESCRIPTION
We are working on a JML (Joiners, Movers, and Leavers) project. We have created a lambda function on the data platform, which queries logs from 'data-platform-apps-and-tools-production' and sends emails to specific users using the 'gov-notify' service. We are using these roles and secrets for that lambda function. If needed more information here is the [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=40142613#:~:text=%E2%9A%99%20Automate%20generating%20and%20sending%20JML%20extracts%20monthly%231719)