### PR TITLE
Create VPC and endpoints for isolated sagemaker VPC

### DIFF
--- a/terraform/environments/electronic-monitoring-data/application_variables.json
+++ b/terraform/environments/electronic-monitoring-data/application_variables.json
@@ -10,7 +10,7 @@
       "example_var": "preproduction-data"
     },
     "production": {
-      "example_var": "production-data"
+      "vpc_cidr": "10.0.0.0/16"
     }
   }
 }

--- a/terraform/environments/electronic-monitoring-data/application_variables.json
+++ b/terraform/environments/electronic-monitoring-data/application_variables.json
@@ -1,7 +1,7 @@
 {
   "accounts": {
     "development": {
-      "example_var": "dev-data"
+      "vpc_cidr": "10.0.0.0/16"
     },
     "test": {
       "example_var": "test-data"

--- a/terraform/environments/electronic-monitoring-data/data.tf
+++ b/terraform/environments/electronic-monitoring-data/data.tf
@@ -1,1 +1,2 @@
 #### This file can be used to store data specific to the member account ####
+data "aws_availability_zones" "available" {}

--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -1,1 +1,5 @@
 #### This file can be used to store locals specific to the member account ####
+locals {
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets    = cidrsubnets(local.application_data.accounts[local.environment].vpc_cidr, 4, 4, 4)
+}

--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# S3 bucket for bucket action logs
+#S3 bucket for bucket action logs
 #------------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "log_bucket" {
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_logging" "capita_bucket_logging" {
 
   target_object_key_format {
     partitioned_prefix {
-        partition_date_source = "EventTime"
+      partition_date_source = "EventTime"
     }
   }
 }

--- a/terraform/environments/electronic-monitoring-data/vpc.tf
+++ b/terraform/environments/electronic-monitoring-data/vpc.tf
@@ -1,0 +1,72 @@
+module "vpc" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name            = "${local.application_name}-${local.environment}"
+  azs             = local.availability_zones
+  cidr            = local.application_data.accounts[local.environment].vpc_cidr
+  private_subnets = local.private_subnets
+
+  # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+  flow_log_max_aggregation_interval    = 60
+
+  tags = local.tags
+}
+
+module "endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 5.0"
+
+  security_group_ids = []
+  vpc_id             = module.vpc.vpc_id
+
+  endpoints = {
+    sagemaker-api = {
+      security_group_ids = [aws_security_group.vpc-endpoints.id]
+      service            = "sagemaker.api"
+      service_type       = "Interface"
+      subnet_ids         = module.vpc.private_subnets
+      tags               = { Name = format("%s-sagemaker-api-vpc-endpoint", local.application_name) }
+    },
+    sagemaker-runtime = {
+      security_group_ids = [aws_security_group.vpc-endpoints.id]
+      service            = "sagemaker.runtime"
+      service_type       = "Interface"
+      subnet_ids         = module.vpc.private_subnets
+      tags               = { Name = format("%s-sagemaker-runtime-vpc-endpoint", local.application_name) }
+    },
+    sagemaker-catalog = {
+      security_group_ids = [aws_security_group.vpc-endpoints.id]
+      service            = "servicecatalog"
+      service_type       = "Interface"
+      subnet_ids         = module.vpc.private_subnets
+      tags               = { Name = format("%s-servicecatalog-vpc-endpoint", local.application_name) }
+    },
+    s3 = {
+      service         = "s3"
+      service_type    = "Gateway"
+      route_table_ids = module.vpc.private_route_table_ids
+      tags            = { Name = format("%s-s3-vpc-endpoint", local.application_name) }
+    }
+  }
+}
+
+resource "aws_security_group" "vpc-endpoints" {
+  description = "Security Group for controlling all VPC endpoint traffic"
+  name        = format("%s-vpc-endpoint-sg", local.application_name)
+  vpc_id      = module.vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "allow-vpc-in" {
+  cidr_blocks       = [module.vpc.vpc_cidr_block]
+  description       = "Allow all traffic in from VPC CIDR"
+  from_port         = 0
+  protocol          = -1
+  security_group_id = aws_security_group.vpc-endpoints.id
+  to_port           = 65535
+  type              = "ingress"
+}

--- a/terraform/environments/electronic-monitoring-data/vpc.tf
+++ b/terraform/environments/electronic-monitoring-data/vpc.tf
@@ -30,41 +30,59 @@ module "endpoints" {
       service            = "logs"
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
-      tags               = { Name = format("%s-logs-api-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-logs-api-vpc-endpoint", local.application_name) }
+      )
     },
     sagemaker-api = {
       security_group_ids = [aws_security_group.vpc-endpoints.id]
       service            = "sagemaker.api"
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
-      tags               = { Name = format("%s-sagemaker-api-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-sagemaker-api-vpc-endpoint", local.application_name) }
+      )
     },
     sagemaker-runtime = {
       security_group_ids = [aws_security_group.vpc-endpoints.id]
       service            = "sagemaker.runtime"
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
-      tags               = { Name = format("%s-sagemaker-runtime-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-sagemaker-runtime-vpc-endpoint", local.application_name) }
+      )
     },
     sagemaker-catalog = {
       security_group_ids = [aws_security_group.vpc-endpoints.id]
       service            = "servicecatalog"
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
-      tags               = { Name = format("%s-servicecatalog-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-servicecatalog-vpc-endpoint", local.application_name) }
+      )
     },
     sts = {
       security_group_ids = [aws_security_group.vpc-endpoints.id]
       service            = "sts"
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
-      tags               = { Name = format("%s-sts-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-sts-vpc-endpoint", local.application_name) }
+      )
     },
     s3 = {
       service         = "s3"
       service_type    = "Gateway"
       route_table_ids = module.vpc.private_route_table_ids
-      tags            = { Name = format("%s-s3-vpc-endpoint", local.application_name) }
+      tags = merge(
+        local.tags,
+        { Name = format("%s-s3-vpc-endpoint", local.application_name) }
+      )
     }
   }
 }
@@ -73,6 +91,7 @@ resource "aws_security_group" "vpc-endpoints" {
   description = "Security Group for controlling all VPC endpoint traffic"
   name        = format("%s-vpc-endpoint-sg", local.application_name)
   vpc_id      = module.vpc.vpc_id
+  tags        = local.tags
 }
 
 resource "aws_security_group_rule" "allow-vpc-in" {

--- a/terraform/environments/electronic-monitoring-data/vpc.tf
+++ b/terraform/environments/electronic-monitoring-data/vpc.tf
@@ -25,6 +25,13 @@ module "endpoints" {
   vpc_id             = module.vpc.vpc_id
 
   endpoints = {
+    logs = {
+      security_group_ids = [aws_security_group.vpc-endpoints.id]
+      service            = "logs"
+      service_type       = "Interface"
+      subnet_ids         = module.vpc.private_subnets
+      tags               = { Name = format("%s-logs-api-vpc-endpoint", local.application_name) }
+    },
     sagemaker-api = {
       security_group_ids = [aws_security_group.vpc-endpoints.id]
       service            = "sagemaker.api"
@@ -45,6 +52,13 @@ module "endpoints" {
       service_type       = "Interface"
       subnet_ids         = module.vpc.private_subnets
       tags               = { Name = format("%s-servicecatalog-vpc-endpoint", local.application_name) }
+    },
+    sts = {
+      security_group_ids = [aws_security_group.vpc-endpoints.id]
+      service            = "sts"
+      service_type       = "Interface"
+      subnet_ids         = module.vpc.private_subnets
+      tags               = { Name = format("%s-sts-vpc-endpoint", local.application_name) }
     },
     s3 = {
       service         = "s3"


### PR DESCRIPTION
As noted in https://github.com/ministryofjustice/modernisation-platform/issues/5878, shared infrastructure isn't appropriate for the `electronic-data-monitoring` AWS SageMaker implementation.

This PR creates the following:
* A VPC with three subnets
* VPC endpoints for SageMaker as detailed [here]([create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) (AWS PrivateLink) to allow Studio Classic to access the following services with the corresponding service names)
* Simple security group allowing all traffic inside VPC to endpoints that can be improved at a later time