### PR TITLE
Remove EC2 instance that is not required

### DIFF
--- a/terraform/environments/equip/main.tf
+++ b/terraform/environments/equip/main.tf
@@ -698,50 +698,6 @@ locals {
         Role = "Nimbus Application Services" }
       )
     }
-    COR-A-EQP06 = {
-      instance_type          = "t3a.xlarge"
-      subnet_id              = data.aws_subnet.private_subnets_c.id
-      vpc_security_group_ids = [aws_security_group.aws_equip_security_group.id, aws_security_group.all_internal_groups.id]
-      root_block_device = [
-        {
-          encrypted   = true
-          volume_type = "gp3"
-          volume_size = 90
-          kms_key_id  = aws_kms_key.this.arn
-          tags = merge(local.tags,
-            { Name = "${local.name}-COR-A-EQP06-root-block" }
-          )
-        }
-      ]
-      ebs_block_device = [
-        {
-          device_name = "/dev/sdf"
-          volume_type = "gp3"
-          volume_size = 500
-          encrypted   = true
-          kms_key_id  = aws_kms_key.this.arn
-          tags = merge(local.tags,
-            { Name = "${local.name}-COR-A-EQP06-ebs-block-1" }
-          )
-        }
-      ]
-      ebs_block_device = [
-        {
-          device_name = "/dev/sdg"
-          volume_type = "gp3"
-          volume_size = 500
-          encrypted   = true
-          kms_key_id  = aws_kms_key.this.arn
-          tags = merge(local.tags,
-            { Name = "${local.name}-COR-A-EQP06-ebs-block-2" }
-          )
-        }
-      ]
-      tags = merge(local.tags,
-        { Name = "${local.name}-COR-A-EQP06"
-        Role = "Nimbus Application Services" }
-      )
-    }
   }
 }
 

--- a/terraform/environments/equip/main.tf
+++ b/terraform/environments/equip/main.tf
@@ -709,7 +709,7 @@ module "win2022_STD_multiple" {
   for_each = local.win2022_STD_instances
 
   name                   = "${local.name}-${each.key}"
-  ami                    = data.aws_ami.windows_2022_std_ami.image_id
+  ami                    = "ami-088bb7db420bf535c"
   instance_type          = each.value.instance_type
   vpc_security_group_ids = each.value.vpc_security_group_ids
   subnet_id              = each.value.subnet_id


### PR DESCRIPTION
after a meeting with the equip team it was decided that EQ06 is not required and can be removed this pr removed this ec2 instance