### PR TITLE
PlanetFM AppServers are session hosts - add required security groups

### DIFF
--- a/terraform/environments/planetfm/locals_defaults.tf
+++ b/terraform/environments/planetfm/locals_defaults.tf
@@ -35,7 +35,7 @@ locals {
 
   defaults_app_ec2 = merge(local.defaults_ec2, {
     instance = merge(local.defaults_ec2.instance, {
-      vpc_security_group_ids = ["domain", "app", "jumpserver"]
+      vpc_security_group_ids = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
     })
     tags = merge(local.defaults_ec2.tags, {
       component = "app"


### PR DESCRIPTION
We need SessionHost security group on AppServers as well as WebServers