### PR TITLE
DSOS-2537: remove old hmpps domain cert and enable backup

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -11,7 +11,7 @@ locals {
   baseline_environment_config = local.environment_configs[local.environment]
 
   baseline_presets_options = {
-    enable_application_environment_wildcard_cert = true
+    enable_application_environment_wildcard_cert = false
     enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true

--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -34,7 +34,7 @@ locals {
           user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          vpc_security_group_ids = ["private-dc"]
+          vpc_security_group_ids = ["rds-ec2s"]
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 100 }

--- a/terraform/environments/hmpps-domain-services/locals_rds.tf
+++ b/terraform/environments/hmpps-domain-services/locals_rds.tf
@@ -15,8 +15,9 @@ locals {
       "/dev/sda1" = { type = "gp3", size = 100 }
     }
     tags = {
-      os-type   = "Windows"
-      component = "remotedesktop"
+      os-type     = "Windows"
+      component   = "remotedesktop"
+      backup-plan = "daily-and-weekly"
     }
   }
 


### PR DESCRIPTION
Some tidy up:
- move to new security group on ASG
- remove old default cert
- enable backup on EC2s