### PR TITLE
hmpps: DSOS-2542: add AD secret sharing role

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -2,13 +2,20 @@ locals {
   business_unit = var.networking[0].business-unit
   region        = "eu-west-2"
 
+  environment_baseline_presets_options = {
+    development   = local.development_baseline_presets_options
+    test          = local.test_baseline_presets_options
+    preproduction = local.preproduction_baseline_presets_options
+    production    = local.production_baseline_presets_options
+  }
   environment_configs = {
     development   = local.development_config
     test          = local.test_config
     preproduction = local.preproduction_config
     production    = local.production_config
   }
-  baseline_environment_config = local.environment_configs[local.environment]
+  baseline_environment_presets_options = local.environment_baseline_presets_options[local.environment]
+  baseline_environment_config          = local.environment_configs[local.environment]
 
   baseline_presets_options = {
     enable_application_environment_wildcard_cert = false

--- a/terraform/environments/hmpps-oem/locals_development.tf
+++ b/terraform/environments/hmpps-oem/locals_development.tf
@@ -1,6 +1,11 @@
 # nomis-development environment settings
 locals {
 
+  # baseline presets config
+  development_baseline_presets_options = {
+    enable_ec2_delius_dba_secrets_access = true # additional permissions to access delius secrets
+  }
+
   # baseline config
   development_config = {
 

--- a/terraform/environments/hmpps-oem/locals_preproduction.tf
+++ b/terraform/environments/hmpps-oem/locals_preproduction.tf
@@ -1,6 +1,9 @@
 # nomis-preproduction environment settings
 locals {
 
+  # baseline presets config
+  preproduction_baseline_presets_options = {}
+
   # baseline config
   preproduction_config = {
 

--- a/terraform/environments/hmpps-oem/locals_production.tf
+++ b/terraform/environments/hmpps-oem/locals_production.tf
@@ -1,6 +1,9 @@
 # nomis-production environment settings
 locals {
 
+  # baseline presets config
+  production_baseline_presets_options = {}
+
   # baseline config
   production_config = {
 

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -1,6 +1,9 @@
 # nomis-test environment settings
 locals {
 
+  # baseline presets config
+  test_baseline_presets_options = {}
+
   # baseline config
   test_config = {
 

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -27,7 +27,11 @@ module "baseline_presets" {
 
   environment  = module.environment
   ip_addresses = module.ip_addresses
-  options      = local.baseline_presets_options
+
+  options = merge(
+    local.baseline_presets_options,
+    local.baseline_environment_presets_options,
+  )
 }
 
 module "baseline" {

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -5,6 +5,7 @@ locals {
     var.options.enable_hmpps_domain ? ["HmppsDomainSecretsPolicy"] : [],
     var.options.enable_image_builder ? ["ImageBuilderLaunchTemplatePolicy"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
+    var.options.enable_ec2_delius_dba_secrets_access ? ["DeliusDbaSecretsPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
     var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
     var.options.enable_ec2_reduced_ssm_policy ? ["SSMManagedInstanceCoreReducedPolicy"] : [],
@@ -106,6 +107,11 @@ locals {
     OracleEnterpriseManagementSecretsPolicy = {
       description = "For cross account secret access identity policy"
       statements  = local.iam_policy_statements_ec2.OracleEnterpriseManagementSecrets
+    }
+
+    DeliusDbaSecretsPolicy = {
+      description = "Permissions to access Delius DBA secrets in delius-core account"
+      statements  = local.iam_policy_statements_ec2.DeliusDbaSecrets
     }
 
     HmppsDomainSecretsPolicy = {

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -2,6 +2,7 @@ locals {
 
   iam_policies_filter = distinct(flatten([
     var.options.enable_business_unit_kms_cmks ? ["BusinessUnitKmsCmkPolicy"] : [],
+    var.options.enable_hmpps_domain ? ["HmppsDomainSecretsPolicy"] : [],
     var.options.enable_image_builder ? ["ImageBuilderLaunchTemplatePolicy"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
@@ -104,7 +105,12 @@ locals {
 
     OracleEnterpriseManagementSecretsPolicy = {
       description = "For cross account secret access identity policy"
-      statements  = local.iam_policy_statements_ec2.SecretsCrossAccount
+      statements  = local.iam_policy_statements_ec2.OracleEnterpriseManagementSecrets
+    }
+
+    HmppsDomainSecretsPolicy = {
+      description = "Permissions to access secrets in hmpps-domain-services account"
+      statements  = local.iam_policy_statements_ec2.HmppsDomainSecrets
     }
 
     # NOTE, this doesn't include GetSecretValue since the EC2 must assume

--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -202,14 +202,30 @@ locals {
       }
     ]
 
-    SecretsCrossAccount = [
+    OracleEnterpriseManagementSecrets = [
       {
-        sid    = "SecretsCrossAccount"
+        sid    = "OracleEnterpriseManagementSecrets"
         effect = "Allow"
         actions = [
           "secretsmanager:GetSecretValue",
         ]
-        resources = ["*"]
+        resources = [
+          "arn:aws:secretsmanager:*:${var.environment.cross_account_secret_account_ids.hmpps_oem}:secret:/oracle/oem/shared-*",
+          "arn:aws:secretsmanager:*:${var.environment.cross_account_secret_account_ids.hmpps_oem}:secret:/oracle/database/*/shared-*",
+        ]
+      }
+    ]
+
+    HmppsDomainSecrets = [
+      {
+        sid    = "HmppsDomainSecrets"
+        effect = "Allow"
+        actions = [
+          "secretsmanager:GetSecretValue",
+        ]
+        resources = [
+          "arn:aws:secretsmanager:*:${var.environment.cross_account_secret_account_ids.hmpps_domain}:secret:/microsoft/AD/*/shared-*",
+        ]
       }
     ]
 

--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -216,6 +216,19 @@ locals {
       }
     ]
 
+    DeliusDbaSecrets = [
+      {
+        sid    = "OracleEnterpriseManagementSecrets"
+        effect = "Allow"
+        actions = [
+          "secretsmanager:GetSecretValue",
+        ]
+        resources = [
+          "arn:aws:secretsmanager:*:${var.environment.cross_account_secret_account_ids.delius}:secret:*delius-dba*",
+        ]
+      }
+    ]
+
     HmppsDomainSecrets = [
       {
         sid    = "HmppsDomainSecrets"

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -1,11 +1,12 @@
 locals {
 
-  iam_roles_filter = flatten([
+  iam_roles_filter = distinct(flatten([
     var.options.enable_hmpps_domain ? ["EC2HmppsDomainSecretsRole"] : [],
+    var.options.enable_ec2_delius_dba_secrets_access ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
     var.options.enable_image_builder ? ["EC2ImageBuilderDistributionCrossAccountRole"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
     var.options.enable_observability_platform_monitoring ? ["observability-platform"] : [],
-  ])
+  ]))
 
   iam_roles = {
     # prereq: ImageBuilderLaunchTemplatePolicy and BusinessUnitKmsCmkPolicy 
@@ -43,10 +44,11 @@ locals {
           ]
         }]
       }]
-      policy_attachments = [
-        "OracleEnterpriseManagementSecretsPolicy",
+      policy_attachments = flatten([
+        var.options.enable_ec2_oracle_enterprise_managed_server ? ["OracleEnterpriseManagementSecretsPolicy"] : [],
+        var.options.enable_ec2_delius_dba_secrets_access ? ["DeliusDbaSecretsPolicy"] : [],
         "BusinessUnitKmsCmkPolicy",
-      ]
+      ])
     }
 
     # allow EC2 instance profiles ability to assume this role

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -20,6 +20,7 @@ variable "options" {
     enable_application_environment_wildcard_cert = optional(bool, false)
     enable_backup_plan_daily_and_weekly          = optional(bool, false)
     enable_business_unit_kms_cmks                = optional(bool, false)
+    enable_hmpps_domain                          = optional(bool, false)
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)
     enable_ec2_self_provision                    = optional(bool, false)

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -23,6 +23,7 @@ variable "options" {
     enable_hmpps_domain                          = optional(bool, false)
     enable_image_builder                         = optional(bool, false)
     enable_ec2_cloud_watch_agent                 = optional(bool, false)
+    enable_ec2_delius_dba_secrets_access         = optional(bool, false)
     enable_ec2_self_provision                    = optional(bool, false)
     enable_ec2_reduced_ssm_policy                = optional(bool, false)
     enable_ec2_oracle_enterprise_managed_server  = optional(bool, false)

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -64,7 +64,7 @@ output "account_ids" {
 output "cross_account_secret_account_ids" {
   description = "account id lookup for cross-account secrets"
   value = {
-    delius    = var.environment_management.account_ids["delius-core-${var.environment}"]
+    delius    = try(var.environment_management.account_ids["delius-core-${var.environment}"], "delius-core-${var.environment}-not-found")
     hmpps_oem = var.environment_management.account_ids["hmpps-oem-${var.environment}"]
     hmpps_domain = (contains(["development", "test"], var.environment) ?
       var.environment_management.account_ids["hmpps-domain-services-test"] :

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -61,6 +61,17 @@ output "account_ids" {
   value       = nonsensitive(var.environment_management.account_ids)
 }
 
+output "cross_account_secret_account_ids" {
+  description = "account id lookup for cross-account secrets"
+  value = {
+    hmpps_oem = var.environment_management.account_ids["hmpps-oem-${var.environment}"]
+    hmpps_domain = (contains(["development", "test"], var.environment) ?
+      var.environment_management.account_ids["hmpps-domain-services-test"] :
+      var.environment_management.account_ids["hmpps-domain-services-production"]
+    )
+  }
+}
+
 output "account_root_arns" {
   description = "account arn map where the key is the account name and the value is the account id"
   value       = nonsensitive({ for name, id in var.environment_management.account_ids : name => "arn:aws:iam::${id}:root" })

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -64,6 +64,7 @@ output "account_ids" {
 output "cross_account_secret_account_ids" {
   description = "account id lookup for cross-account secrets"
   value = {
+    delius    = var.environment_management.account_ids["delius-core-${var.environment}"]
     hmpps_oem = var.environment_management.account_ids["hmpps-oem-${var.environment}"]
     hmpps_domain = (contains(["development", "test"], var.environment) ?
       var.environment_management.account_ids["hmpps-domain-services-test"] :


### PR DESCRIPTION
Primarily, adding new role to allow sharing of AD secrets. But also tightened up the policies on the existing OEM sharing role as these were too permissive:
- rejig baseline presets in hmpps-oem to align with nomis (allows different settings per environment)
- added delius sharing policy in hmpps-oem-development only (for delius DBAs)
- added option to create new role and policy for sharing AD secrets
Applied in nomis-test and hmpps-oem-test and all works.