### PR TITLE
👀 Deploy Observability Platform module into Obersvability Platform

### DIFF
--- a/terraform/environments/observability-platform/observability-platform.tf
+++ b/terraform/environments/observability-platform/observability-platform.tf
@@ -1,4 +1,6 @@
 module "observability_platform_tenant" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
   source  = "ministryofjustice/observability-platform-tenant/aws"
   version = "1.0.0"
 

--- a/terraform/environments/observability-platform/observability-platform.tf
+++ b/terraform/environments/observability-platform/observability-platform.tf
@@ -1,0 +1,9 @@
+module "observability_platform_tenant" {
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.0.0"
+
+  observability_platform_account_id = data.aws_caller_identity.current.account_id
+  enable_xray                       = true
+
+  tags = local.tags
+}


### PR DESCRIPTION
This pull request:

- Deployes the module `ministryofjustice/observability-platform-tenant`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>