### PR TITLE
DPR2-46: Add reload pipeline and associated glue jobs

### DIFF
--- a/terraform/environments/digital-prison-reporting/data_ingestion_pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/data_ingestion_pipeline.tf
@@ -148,6 +148,7 @@ module "data_ingestion_pipeline" {
               "--dpr.file.transfer.destination.bucket" : module.s3_raw_archive_bucket.bucket_id,
               "--dpr.file.transfer.retention.days" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
+              "--dpr.allowed.s3.file.extensions" : ".parquet",
               "--dpr.config.s3.bucket" : module.s3_glue_job_bucket.bucket_id
             }
           },

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -422,6 +422,7 @@ module "glue_s3_data_deletion_job" {
     "--dpr.config.s3.bucket"                 = module.s3_glue_job_bucket.bucket_id,
 #    "--dpr.config.key"                       = "(Required) config key. Will be specified at point of call in the reload step-functions"
 #    "--dpr.file.deletion.buckets"            = "(Required) comma separated set of s3 buckets from which to delete data from"
+    "--dpr.allowed.s3.file.extensions"       = "*"
     "--dpr.log.level"                        = local.refresh_job_log_level
   }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -318,6 +318,163 @@ resource "aws_glue_trigger" "glue_s3_file_transfer_job_trigger" {
   }
 }
 
+# Glue Job, Switch Prisons Hive Data Location
+module "glue_switch_prisons_hive_data_location_job" {
+  source                        = "./modules/glue_job"
+  create_job                    = local.create_job
+  name                          = "${local.project}-switch-prisons-hive-data-location-${local.env}"
+  short_name                    = "${local.project}-switch-prisons-hive-data-location"
+  command_type                  = "glueetl"
+  description                   = "Switch Prisons Hive tables data location"
+  create_security_configuration = local.create_sec_conf
+  job_language                  = "scala"
+  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-switch-prisons-hive-data-location-${local.env}/"
+  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-switch-prisons-hive-data-location-${local.env}/"
+  # Placeholder Script Location
+  script_location              = local.glue_placeholder_script_location
+  enable_continuous_log_filter = false
+  project_id                   = local.project
+  aws_kms_key                  = local.s3_kms_arn
+
+  execution_class             = "STANDARD"
+  worker_type                 = "G.1X"
+  number_of_workers           = 2
+  max_concurrent              = 64
+  region                      = local.account_region
+  account                     = local.account_id
+  log_group_retention_in_days = 1
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-switch-prisons-hive-data-location-${local.env}"
+      Resource_Type = "Glue Job"
+      Jira          = "DPR2-46"
+    }
+  )
+
+  arguments = {
+    "--extra-jars"                             = local.glue_jobs_latest_jar_location
+    "--class"                                  = "uk.gov.justice.digital.job.SwitchHiveTableJob"
+    "--dpr.aws.region"                         = local.account_region
+#    "--dpr.config.key"                         = "(Required) config key. Will be specified at point of call in the reload step-functions"
+    "--dpr.prisons.data.switch.target.s3.path" = "s3://${module.s3_temp_reload_bucket.bucket_id}"
+    "--dpr.prisons.database"                   = module.glue_prisons_database.db_name
+    "--dpr.contract.registryName"              = module.s3_schema_registry_bucket.bucket_id
+    "--dpr.schema.cache.max.size"              = local.hive_table_creation_job_schema_cache_max_size
+    "--dpr.log.level"                          = local.refresh_job_log_level
+  }
+
+  depends_on = [
+    module.s3_raw_archive_bucket.bucket_id,
+    module.s3_structured_bucket.bucket_id,
+    module.s3_curated_bucket.bucket_id,
+    module.glue_raw_archive_database.db_name,
+    module.glue_structured_zone_database.db_name,
+    module.glue_curated_zone_database.db_name,
+    module.glue_prisons_database.db_name,
+    module.glue_registry_avro.registry_name
+  ]
+}
+
+# Glue Job, S3 Data Deletion Job
+module "glue_s3_data_deletion_job" {
+  source                        = "./modules/glue_job"
+  create_job                    = local.create_job
+  name                          = "${local.project}-s3-data-deletion-job-${local.env}"
+  short_name                    = "${local.project}-s3-data-deletion-job"
+  command_type                  = "glueetl"
+  description                   = "Deletes s3 data belonging to a configured domain from specified bucket"
+  create_security_configuration = local.create_sec_conf
+  job_language                  = "scala"
+  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-s3-data-deletion-${local.env}/"
+  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-s3-data-deletion-${local.env}/"
+  # Placeholder Script Location
+  script_location              = local.glue_placeholder_script_location
+  enable_continuous_log_filter = false
+  project_id                   = local.project
+  aws_kms_key                  = local.s3_kms_arn
+
+  execution_class             = "STANDARD"
+  worker_type                 = "G.1X"
+  number_of_workers           = 2
+  max_concurrent              = 64
+  region                      = local.account_region
+  account                     = local.account_id
+  log_group_retention_in_days = 1
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-s3-data-deletion-${local.env}"
+      Resource_Type = "Glue Job"
+      Jira          = "DPR2-46"
+    }
+  )
+
+  arguments = {
+    "--extra-jars"                           = local.glue_jobs_latest_jar_location
+    "--class"                                = "uk.gov.justice.digital.job.S3DataDeletionJob"
+    "--dpr.aws.region"                       = local.account_region
+    "--dpr.config.s3.bucket"                 = module.s3_glue_job_bucket.bucket_id,
+#    "--dpr.config.key"                       = "(Required) config key. Will be specified at point of call in the reload step-functions"
+#    "--dpr.file.deletion.buckets"            = "(Required) comma separated set of s3 buckets from which to delete data from"
+    "--dpr.log.level"                        = local.refresh_job_log_level
+  }
+
+  depends_on = [
+    module.s3_raw_bucket.bucket_id,
+    module.s3_raw_archive_bucket.bucket_id,
+    module.s3_structured_bucket.bucket_id,
+    module.s3_curated_bucket.bucket_id,
+    module.s3_temp_reload_bucket.bucket_id
+  ]
+}
+
+# Glue Job, Stop Glue Instance Job
+module "glue_stop_glue_instance_job" {
+  source                        = "./modules/glue_job"
+  create_job                    = local.create_job
+  name                          = "${local.project}-stop-glue-instance-job-${local.env}"
+  short_name                    = "${local.project}-stop-glue-instance-job"
+  command_type                  = "glueetl"
+  description                   = "Stops a running Glue job instance"
+  create_security_configuration = local.create_sec_conf
+  job_language                  = "scala"
+  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-stop-glue-instance-${local.env}/"
+  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-stop-glue-instance-${local.env}/"
+  # Placeholder Script Location
+  script_location              = local.glue_placeholder_script_location
+  enable_continuous_log_filter = false
+  project_id                   = local.project
+  aws_kms_key                  = local.s3_kms_arn
+
+  execution_class             = "STANDARD"
+  worker_type                 = "G.1X"
+  number_of_workers           = 2
+  max_concurrent              = 64
+  region                      = local.account_region
+  account                     = local.account_id
+  log_group_retention_in_days = 1
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-stop-glue-instance-${local.env}"
+      Resource_Type = "Glue Job"
+      Jira          = "DPR2-46"
+    }
+  )
+
+  arguments = {
+    "--extra-jars"                           = local.glue_jobs_latest_jar_location
+    "--class"                                = "uk.gov.justice.digital.job.StopGlueInstanceJob"
+    "--dpr.aws.region"                       = local.account_region
+#    "--dpr.stop.glue.instance.job.name"      = "(Required) name of the glue job whose running instance is to be stopped"
+    "--dpr.log.level"                        = local.refresh_job_log_level
+  }
+}
+
 # kinesis Data Stream Ingestor
 module "kinesis_stream_ingestor" {
   source                    = "./modules/kinesis_stream"
@@ -538,6 +695,25 @@ module "s3_curated_bucket" {
     {
       Name          = "${local.project}-curated-zone-${local.env}"
       Resource_Type = "S3 Bucket"
+    }
+  )
+}
+
+# S3 Curated
+module "s3_temp_reload_bucket" {
+  source                    = "./modules/s3_bucket"
+  create_s3                 = local.setup_buckets
+  name                      = "${local.project}-temp-reload-${local.env}"
+  custom_kms_key            = local.s3_kms_arn
+  create_notification_queue = false # For SQS Queue
+  enable_lifecycle          = true
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-temp-reload-${local.env}"
+      Resource_Type = "S3 Bucket",
+      Jira          = "DPR2-46"
     }
   )
 }

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -359,7 +359,7 @@ module "glue_switch_prisons_hive_data_location_job" {
     "--dpr.aws.region"                         = local.account_region
     "--dpr.config.s3.bucket"                   = module.s3_glue_job_bucket.bucket_id,
 #    "--dpr.config.key"                         = "(Required) config key. Will be specified at point of call in the reload step-functions"
-    "--dpr.prisons.data.switch.target.s3.path" = "s3://${module.s3_temp_reload_bucket.bucket_id}"
+#    "--dpr.prisons.data.switch.target.s3.path" = "(Required) s3 path to point the prisons data to"
     "--dpr.prisons.database"                   = module.glue_prisons_database.db_name
     "--dpr.contract.registryName"              = module.s3_schema_registry_bucket.bucket_id
     "--dpr.schema.cache.max.size"              = local.hive_table_creation_job_schema_cache_max_size
@@ -379,74 +379,6 @@ module "glue_switch_prisons_hive_data_location_job" {
   ]
 }
 
-<<<<<<< HEAD
-=======
-# Glue Job, S3 File Archive Job
-module "glue_s3_file_transfer_job" {
-  source                        = "./modules/glue_job"
-  create_job                    = local.create_job
-  name                          = "${local.project}-s3-file-transfer-job-${local.env}"
-  short_name                    = "${local.project}-s3-file-transfer-job"
-  command_type                  = "glueetl"
-  description                   = "Transfers s3 data from one bucket to another"
-  create_security_configuration = local.create_sec_conf
-  job_language                  = "scala"
-  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-s3-file-transfer-${local.env}/"
-  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-s3-file-transfer-${local.env}/"
-  # Placeholder Script Location
-  script_location              = local.glue_placeholder_script_location
-  enable_continuous_log_filter = false
-  project_id                   = local.project
-  aws_kms_key                  = local.s3_kms_arn
-
-  execution_class             = "STANDARD"
-  worker_type                 = "G.1X"
-  number_of_workers           = 2
-  max_concurrent              = 64
-  region                      = local.account_region
-  account                     = local.account_id
-  log_group_retention_in_days = 1
-
-  tags = merge(
-    local.all_tags,
-    {
-      Name          = "${local.project}-s3-file-transfer-${local.env}"
-      Resource_Type = "Glue Job"
-      Jira          = "DPR2-46"
-    }
-  )
-
-  arguments = {
-    "--extra-jars"                            = local.glue_jobs_latest_jar_location
-    "--class"                                 = "uk.gov.justice.digital.job.S3FileTransferJob"
-    "--dpr.aws.region"                        = local.account_region
-    "--dpr.config.s3.bucket"                  = module.s3_glue_job_bucket.bucket_id,
-#    "--dpr.config.key"                        = "(Optional) config key, when provided, the job will only transfer data belonging to config otherwise all data will be transferred"
-    "--dpr.file.transfer.source.bucket"       = module.s3_raw_bucket.bucket_id
-    "--dpr.file.transfer.destination.bucket"  = module.s3_raw_archive_bucket.bucket_id
-    "--dpr.file.transfer.retention.days"      = tostring(local.scheduled_s3_file_transfer_retention_days)
-    "--dpr.file.transfer.delete.copied.files" = true,
-    "--dpr.log.level"                         = local.refresh_job_log_level
-  }
-
-  depends_on = [
-    module.s3_raw_bucket.bucket_id,
-    module.s3_raw_archive_bucket.bucket_id,
-    module.s3_glue_job_bucket
-  ]
-}
-
-resource "aws_glue_trigger" "glue_s3_file_transfer_job_trigger" {
-  name     = "${module.glue_s3_file_transfer_job.name}-trigger"
-  schedule = local.scheduled_s3_file_transfer_schedule
-  type     = "SCHEDULED"
-
-  actions {
-    job_name = module.glue_s3_file_transfer_job.name
-  }
-}
-
->>>>>>> 579405afa (DPR2-46: Add config bucket arg to jobs)
 # Glue Job, S3 Data Deletion Job
 module "glue_s3_data_deletion_job" {
   source                        = "./modules/glue_job"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -298,6 +298,7 @@ module "glue_s3_file_transfer_job" {
     "--dpr.file.transfer.destination.bucket"  = module.s3_raw_archive_bucket.bucket_id
     "--dpr.file.transfer.retention.days"      = tostring(local.scheduled_s3_file_transfer_retention_days)
     "--dpr.file.transfer.delete.copied.files" = true,
+    "--dpr.allowed.s3.file.extensions"        = "*",
     "--dpr.log.level"                         = local.refresh_job_log_level
   }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -83,6 +83,7 @@ module "data_ingestion_pipeline" {
               "--dpr.file.transfer.retention.days" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.allowed.s3.file.extensions" : ".parquet",
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -121,7 +121,6 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.days" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -22,9 +22,9 @@ module "reload_pipeline" {
               "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
             }
           },
-          "Next" : "Copy Data To Temp Reload Bucket"
+          "Next" : "Copy Data to Temp-Reload Bucket"
         },
-        "Copy Data to Temp Reload Bucket" : {
+        "Copy Data to Temp-Reload Bucket" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -58,7 +58,7 @@ module "reload_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}"
+              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
               "--dpr.config.key" : var.domain
             }
           },
@@ -166,7 +166,7 @@ module "reload_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id
+              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -59,7 +59,6 @@ module "reload_pipeline" {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
               "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
-              "--dpr.allowed.s3.file.extensions" : "*",
               "--dpr.config.key" : var.domain
             }
           },
@@ -168,7 +167,6 @@ module "reload_pipeline" {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
               "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.allowed.s3.file.extensions" : "*",
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -46,7 +46,7 @@ module "reload_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_switch_prisons_hive_data_location_job,
             "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : var.s3_temp_reload_bucket_id,
+              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_temp_reload_bucket_id}",
               "--dpr.config.key" : var.domain
             }
           },
@@ -59,6 +59,7 @@ module "reload_pipeline" {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
               "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+              "--dpr.allowed.s3.file.extensions" : "*",
               "--dpr.config.key" : var.domain
             }
           },
@@ -121,6 +122,7 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.days" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
+              "--dpr.allowed.s3.file.extensions" : ".parquet",
               "--dpr.config.key" : var.domain
             }
           },
@@ -153,7 +155,7 @@ module "reload_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_switch_prisons_hive_data_location_job,
             "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : var.s3_curated_bucket_id,
+              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
               "--dpr.config.key" : var.domain
             }
           },
@@ -166,6 +168,7 @@ module "reload_pipeline" {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
               "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+              "--dpr.allowed.s3.file.extensions" : "*",
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -22,9 +22,9 @@ module "reload_pipeline" {
               "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
             }
           },
-          "Next" : "Copy Data To Temp-Reload Bucket"
+          "Next" : "Copy Data To Temp Reload Bucket"
         },
-        "Copy Data to Temp-Reload Bucket" : {
+        "Copy Data to Temp Reload Bucket" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -158,15 +158,15 @@ module "reload_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Empty Temp-Reload Bucket Data"
+          "Next" : "Empty Temp Reload Bucket Data"
         },
-        "Empty Temp-Reload Bucket Data" : {
+        "Empty Temp Reload Bucket Data" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_temp_reload_bucket_id}"
+              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id
               "--dpr.config.key" : var.domain
             }
           },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -1,0 +1,181 @@
+# Reload Pipeline Step Function
+module "reload_pipeline" {
+  source = "../../step_function"
+
+  enable_step_function = var.setup_reload_pipeline
+  step_function_name   = var.reload_pipeline
+  dms_task_time_out    = var.pipeline_dms_task_time_out
+
+  additional_policies = var.pipeline_additional_policies
+
+  definition = jsonencode(
+    {
+      "Comment" : "Reload Pipeline Step Function",
+      "StartAt" : "Stop Glue Streaming Job",
+      "States" : {
+        "Stop Glue Streaming Job" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_stop_glue_instance_job,
+            "Arguments" : {
+              "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
+            }
+          },
+          "Next" : "Copy Data To Temp-Reload Bucket"
+        },
+        "Copy Data to Temp-Reload Bucket" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_file_transfer_job,
+            "Arguments" : {
+              "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
+              "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
+              "--dpr.file.transfer.retention.days" : "0",
+              "--dpr.file.transfer.delete.copied.files" : "false",
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Switch Hive Tables for Prisons to Temp-Reload Bucket"
+        },
+        "Switch Hive Tables for Prisons to Temp-Reload Bucket" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_switch_prisons_hive_data_location_job,
+            "Arguments" : {
+              "--dpr.prisons.data.switch.target.s3.path" : var.s3_temp_reload_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Truncate Data"
+        },
+        "Truncate Data" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_data_deletion_job,
+            "Arguments" : {
+              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}"
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Start DMS Replication Task"
+        },
+        "Start DMS Replication Task" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+          "Parameters" : {
+            "ReplicationTaskArn" : var.dms_replication_task_arn,
+            "StartReplicationTaskType" : "reload-target"
+          },
+          "Next" : "Invoke DMS State Control Lambda"
+        },
+        "Invoke DMS State Control Lambda" : {
+          "Type" : "Task",
+          "TimeoutSeconds" : var.pipeline_dms_task_time_out,
+          "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
+          "Parameters" : {
+            "Payload" : {
+              "token.$" : "$$.Task.Token",
+              "replicationTaskArn" : var.dms_replication_task_arn
+            },
+            "FunctionName" : var.pipeline_notification_lambda_function
+          },
+          "Retry" : [
+            {
+              "ErrorEquals" : [
+                "Lambda.ServiceException",
+                "Lambda.AWSLambdaException",
+                "Lambda.SdkClientException",
+                "Lambda.TooManyRequestsException"
+              ],
+              "IntervalSeconds" : 60,
+              "MaxAttempts" : 2,
+              "BackoffRate" : 2
+            }
+          ],
+          "Next" : "Start Glue Batch Job"
+        },
+        "Start Glue Batch Job" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_reporting_hub_batch_jobname,
+            "Arguments" : {
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Archive Raw Data"
+        },
+        "Archive Raw Data" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_file_transfer_job,
+            "Arguments" : {
+              "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
+              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+              "--dpr.file.transfer.retention.days" : "0",
+              "--dpr.file.transfer.delete.copied.files" : "true",
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Resume DMS Replication Task"
+        },
+        "Resume DMS Replication Task" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+          "Parameters" : {
+            "ReplicationTaskArn" : var.dms_replication_task_arn,
+            "StartReplicationTaskType" : "resume-processing"
+          },
+          "Next" : "Start Glue Streaming Job"
+        },
+        "Start Glue Streaming Job" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun",
+          "Parameters" : {
+            "JobName" : var.glue_reporting_hub_cdc_jobname,
+            "Arguments" : {
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Switch Hive Tables for Prisons to Curated"
+        },
+        "Switch Hive Tables for Prisons to Curated" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_switch_prisons_hive_data_location_job,
+            "Arguments" : {
+              "--dpr.prisons.data.switch.target.s3.path" : var.s3_curated_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Empty Temp-Reload Bucket Data"
+        },
+        "Empty Temp-Reload Bucket Data" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_data_deletion_job,
+            "Arguments" : {
+              "--dpr.file.deletion.buckets" : "${var.s3_temp_reload_bucket_id}"
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "End" : true
+        }
+      }
+    }
+  )
+
+  tags = var.tags
+
+}

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -1,0 +1,115 @@
+variable "setup_reload_pipeline"  {
+  description = "Enable Reload Pipeline, True or False?"
+  type        = bool
+  default     = false
+}
+
+variable "reload_pipeline"  {
+  description = "Name for the Reload Pipeline"
+  type        = string
+  default     = ""  
+}
+
+variable "pipeline_dms_task_time_out"  {
+  description = "DMS Task Timeout"
+  type        = number
+  default     = 36000 # 10 hours
+}
+
+variable "pipeline_additional_policies" {
+  description = "Pipeline Additional policies"
+  type        = list(string)
+  default     = []
+}
+
+variable "glue_stop_glue_instance_job" {
+  description = "Name of job to stop the current running instance of the streaming job"
+  type        = string
+  default     = ""
+}
+
+variable "glue_s3_file_transfer_job" {
+  description = "Name of s3 file transfer job"
+  type        = string
+  default     = ""
+}
+
+variable "glue_switch_prisons_hive_data_location_job" {
+  description = "Name of glue job to switch the prisons hive data location"
+  type        = string
+  default     = ""
+}
+
+variable "glue_s3_data_deletion_job" {
+  description = "Name of glue job which deletes parquet files from s3 bucket(s)"
+  type        = string
+  default     = ""
+}
+
+variable "dms_replication_task_arn" {}
+
+variable "pipeline_notification_lambda_function" {
+  description = "Pipeline Notification Lambda Name"
+  type        = string
+  default     = ""  
+}
+
+variable "glue_reporting_hub_batch_jobname" {
+  description = "Glue Reporting Hub Batch JobName"
+  type        = string
+  default     = ""  
+}
+
+variable "glue_reporting_hub_cdc_jobname" {
+  description = "Glue Reporting Hub CDC JobName"
+  type        = string
+  default     = ""  
+}
+
+variable "s3_glue_bucket_id" {
+  description = "S3, Glue Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_raw_bucket_id" {
+  description = "S3, RAW Bucket ID"
+  type        = string
+  default     = ""  
+}
+
+variable "s3_raw_archive_bucket_id" {
+  description = "S3, RAW Archive Bucket ID"
+  type        = string
+  default     = ""  
+}
+
+variable "s3_structured_bucket_id" {
+  description = "S3, Structured Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_curated_bucket_id" {
+  description = "S3, Curated Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_temp_reload_bucket_id" {
+  description = "S3 Bucket ID for the temporary location to store reload data"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "(Optional) Key-value map of resource tags."
+}
+
+variable "domain" {
+  type        = string
+  default     = ""
+  description = "Domain Name"
+}

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -13,7 +13,7 @@ variable "reload_pipeline"  {
 variable "pipeline_dms_task_time_out"  {
   description = "DMS Task Timeout"
   type        = number
-  default     = 36000 # 10 hours
+  default     = 43200 # 12 hours
 }
 
 variable "pipeline_additional_policies" {

--- a/terraform/environments/digital-prison-reporting/modules/step_function/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/step_function/variables.tf
@@ -21,7 +21,7 @@ variable "step_function_name" {
 
 variable "dms_task_time_out" {
   description = "(Optional) The duration after which the DMS load step is deemed to have failed."
-  default     = 43200 # 12 hours
+  default     = 86400 # 24 hours
   type        = number
 }
 


### PR DESCRIPTION
This PR:
- creates a reload step functions pipeline
- creates a glue job `glue_stop_glue_instance_job` to stop a running instance of the CDC job
- creates a `s3_temp_reload_bucket` for temporarily holding the curated data to avoid downtime during the data reload
- creates a glue job `glue_switch_prisons_hive_data_location_job` which switches the prisons hive table to a s3 location according to the given args
- creates a glue job `glue_s3_data_deletion_job` to delete data from s3 bucket(s)
- defaults the `dms_task_time_out` to 24 hours