### PR TITLE
DSOS-2542: enable rds secrets role

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -14,6 +14,7 @@ locals {
     enable_application_environment_wildcard_cert = false
     enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
+    enable_hmpps_domain                          = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -14,6 +14,7 @@ locals {
     enable_application_environment_wildcard_cert = false
     enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
+    enable_hmpps_domain                          = true
     enable_image_builder                         = true
     enable_ec2_cloud_watch_agent                 = true
     enable_ec2_self_provision                    = true

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -36,7 +36,6 @@ locals {
     var.options.enable_shared_s3 ? local.iam_policy_statements_ec2.S3ReadSharedWrite : [],
     var.options.enable_ec2_reduced_ssm_policy ? local.iam_policy_statements_ec2.SSMManagedInstanceCoreReduced : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? local.iam_policy_statements_ec2.OracleEnterpriseManagedServer : [],
-    var.options.enable_hmpps_domain ? local.iam_policy_statements_ec2.HmppsDomainSecrets : [],
     var.options.iam_policy_statements_ec2_default
   ])
 

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -36,6 +36,7 @@ locals {
     var.options.enable_shared_s3 ? local.iam_policy_statements_ec2.S3ReadSharedWrite : [],
     var.options.enable_ec2_reduced_ssm_policy ? local.iam_policy_statements_ec2.SSMManagedInstanceCoreReduced : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? local.iam_policy_statements_ec2.OracleEnterpriseManagedServer : [],
+    var.options.enable_hmpps_domain ? local.iam_policy_statements_ec2.HmppsDomainSecrets : [],
     var.options.iam_policy_statements_ec2_default
   ])
 


### PR DESCRIPTION
Enable role which allows HMPPS secrets access for CSR and PlanetFM