### PR TITLE
ELM-1312 Add AWS transfer workflow

### DIFF
--- a/terraform/environments/electronic-monitoring-data/server_access_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_capita.tf
@@ -1,0 +1,68 @@
+#------------------------------------------------------------------------------
+# AWS transfer ssh key
+#
+# Set the public ssh key for the supplier user profile to access SFTP server.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_ssh_key" "capita_ssh_key" {
+  server_id = aws_transfer_server.capita_transfer_server.id
+  user_name = aws_transfer_user.capita_transfer_user.user_name
+  body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIhggGYKbOk6BH7fpEs6JGRnMyLRK/9/tAMQOVYOZtehKTRcM5vGsJFRGjjm2wEan3/uYOuto0NoVkbRfIi0AIG6EWrp1gvHNQlUTtxQVp7rFeOnZAjVEE9xVUEgHhMNLw=="
+}
+
+#------------------------------------------------------------------------------
+# AWS security group 
+#
+# Set the allowed IP addresses for the supplier.
+#------------------------------------------------------------------------------
+
+resource "aws_security_group" "capita_security_group" {
+  name        = "capita_inbound_ips"
+  description = "Allowed IP addresses from Capita"
+  vpc_id      = data.aws_vpc.shared.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "capita_ip_1" {
+  security_group_id = aws_security_group.capita_security_group.id
+
+  cidr_ipv4   = "82.203.33.112/28"
+  ip_protocol = "tcp"
+  from_port   = 2222
+  to_port     = 2222
+}
+
+resource "aws_vpc_security_group_ingress_rule" "capita_ip_2" {
+  security_group_id = aws_security_group.capita_security_group.id
+
+  cidr_ipv4   = "82.203.33.128/28"
+  ip_protocol = "tcp"
+  from_port   = 2222
+  to_port     = 2222
+}
+
+resource "aws_vpc_security_group_ingress_rule" "capita_ip_3" {
+  security_group_id = aws_security_group.capita_security_group.id
+
+  cidr_ipv4   = "85.115.52.0/24"
+  ip_protocol = "tcp"
+  from_port   = 2222
+  to_port     = 2222
+}
+
+resource "aws_vpc_security_group_ingress_rule" "capita_ip_4" {
+  security_group_id = aws_security_group.capita_security_group.id
+
+  cidr_ipv4   = "85.115.53.0/24"
+  ip_protocol = "tcp"
+  from_port   = 2222
+  to_port     = 2222
+}
+
+resource "aws_vpc_security_group_ingress_rule" "capita_ip_5" {
+  security_group_id = aws_security_group.capita_security_group.id
+
+  cidr_ipv4   = "85.115.54.0/24"
+  ip_protocol = "tcp"
+  from_port   = 2222
+  to_port     = 2222
+}

--- a/terraform/environments/electronic-monitoring-data/server_access_test.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_test.tf
@@ -1,3 +1,27 @@
+#------------------------------------------------------------------------------
+# AWS transfer ssh key
+#
+# Set the public ssh key for the test user profile to access SFTP server.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_ssh_key" "test_ssh_key_mp" {
+  server_id = aws_transfer_server.capita_transfer_server.id
+  user_name = aws_transfer_user.test_transfer_user.user_name
+  body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBA3BsCFaNiGxbmJffRi9q/W3aLmZWgqE6QkeFJD5O6F4nDdjsV1R0ZMUvTSoi3tKqoAE+1RYYj2Ra/F1buHov9e+sFPrlMl0wql6uMsBA1ndiIiKuq+NLY1NOxEvqm2J9Q=="
+}
+
+resource "aws_transfer_ssh_key" "test_ssh_key_mh" {
+  server_id = aws_transfer_server.capita_transfer_server.id
+  user_name = aws_transfer_user.test_transfer_user.user_name
+  body      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQClyRRkvW162H2NQm5IlavjE4zBhnzGJ/V+raqe7ynPumIgKhmNto8GD6iKlWkzLGxfwXQhONM/9J8+u9tqncw5FzEWEYdX/FEJF5VwLYma/OtMUio3vtwsc9zbae4EyTvROvbJSMgL07ZicUjQ9pS4+pst2KVjDtgCXD8l7A66wOkmht2Cb2Ebfk+wk965uN5wE5vHDQBx6QQ4z9UiGEp34n/g2O9gUGUJcFdYCEHVl1MY+dicCJwsRzEC1a0s/LzCtiCo66yWW8VEpMpDJNCAJccxadwWBI1d+8R94LTUakxkYhAVCpzs+A/qjaAUKsT/1KQm0+3gJIfLqmWYUumB4VgP2+cYiFbdxWQt2lLAUYZmsTwR5EktCftA5OGcwKO11sKnouj+IYiN9wfRl8kQEs+KZDDSjXKAdsWvRwhRMbBZdLqIzO2InyLCQaujZqMupMh5KkmrhL9eYFn0qtWSG274vnmUacvaIl1e8EmIb9j5ksyVXysPlIVxbNks51E= matt.heery@MJ004484"
+}
+
+#------------------------------------------------------------------------------
+# AWS security group 
+#
+# Set the allowed IP addresses for the supplier.
+#------------------------------------------------------------------------------
+
 resource "aws_security_group" "test_security_group" {
   name        = "test_inbound_ips"
   description = "Allowed IP addresses for testing"
@@ -12,6 +36,7 @@ resource "aws_vpc_security_group_ingress_rule" "test_fynhy_ip" {
   from_port   = 2222
   to_port     = 2222
 }
+
 resource "aws_vpc_security_group_ingress_rule" "test_petty_france_ip" {
   security_group_id = aws_security_group.test_security_group.id
 
@@ -20,7 +45,6 @@ resource "aws_vpc_security_group_ingress_rule" "test_petty_france_ip" {
   from_port   = 2222
   to_port     = 2222
 }
-
 
 #------------------------------------------------------------------------------
 # AWS transfer user
@@ -75,28 +99,4 @@ resource "aws_iam_role_policy" "test_transfer_user_iam_policy" {
   name   = "test-transfer-user-iam-policy"
   role   = aws_iam_role.test_transfer_user_iam_role.id
   policy = data.aws_iam_policy_document.test_transfer_user_iam_policy_document.json
-}
-
-#------------------------------------------------------------------------------
-# AWS transfer ssh key
-#
-# Set the public ssh key for the test user profile to access SFTP server.
-#------------------------------------------------------------------------------
-
-# resource "aws_transfer_ssh_key" "test_ssh_key_mp_ssh_rsa" {
-#   server_id = aws_transfer_server.capita_transfer_server.id
-#   user_name = aws_transfer_user.test_transfer_user.user_name
-#   body      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqXTKqBVVBQX5lvCdCdws4t7lCVaniv3FGCaJQOKMYAzBzwcVD9MKz0RzH7FMMA/iBayw/+13Mb79paBkJdT8T/Wg9lER/YE/lPKZcyT2IJ6myW5kDShQAY9lQliRoJ4oVx9x95hGx48eE9jWsCtwEaQT7pH2aK5l2THqfFCDQEMmT84CaSmJzuxsaYxuohlVcMqnGdU/oq+E76gLm3Z0gvh3NwFHd0RTIzqlVgwEUbTcHqZBON5229VypuvqfIcD9WIPEMnza/rA/6FX5luniqh+h/PCF7HH3Qiveui3PZV64fQtqd2pVnK8llW7CLjXKC1/TkWx1QkWyGzGYBZUXEctNbOBMixFcVbj49CucWMztPC88gZl2bHlJPqdBLMt6sakigCLWJLIvB/oeXGhzCN7XkfKWXDTu4mHuQ+UHPbXzsPvPRxidfxxRVk758M+GB15nQq2Fm3lRtYgZ2mnjQT7dwhhCaiqJiy0qs5kQ4Hs9Jnex6afoPQlqrhamtu8= matthew.price@L1057"
-# }
-
-resource "aws_transfer_ssh_key" "test_ssh_key_mp" {
-  server_id = aws_transfer_server.capita_transfer_server.id
-  user_name = aws_transfer_user.test_transfer_user.user_name
-  body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBA3BsCFaNiGxbmJffRi9q/W3aLmZWgqE6QkeFJD5O6F4nDdjsV1R0ZMUvTSoi3tKqoAE+1RYYj2Ra/F1buHov9e+sFPrlMl0wql6uMsBA1ndiIiKuq+NLY1NOxEvqm2J9Q=="
-}
-
-resource "aws_transfer_ssh_key" "test_ssh_key_mh" {
-  server_id = aws_transfer_server.capita_transfer_server.id
-  user_name = aws_transfer_user.test_transfer_user.user_name
-  body      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQClyRRkvW162H2NQm5IlavjE4zBhnzGJ/V+raqe7ynPumIgKhmNto8GD6iKlWkzLGxfwXQhONM/9J8+u9tqncw5FzEWEYdX/FEJF5VwLYma/OtMUio3vtwsc9zbae4EyTvROvbJSMgL07ZicUjQ9pS4+pst2KVjDtgCXD8l7A66wOkmht2Cb2Ebfk+wk965uN5wE5vHDQBx6QQ4z9UiGEp34n/g2O9gUGUJcFdYCEHVl1MY+dicCJwsRzEC1a0s/LzCtiCo66yWW8VEpMpDJNCAJccxadwWBI1d+8R94LTUakxkYhAVCpzs+A/qjaAUKsT/1KQm0+3gJIfLqmWYUumB4VgP2+cYiFbdxWQt2lLAUYZmsTwR5EktCftA5OGcwKO11sKnouj+IYiN9wfRl8kQEs+KZDDSjXKAdsWvRwhRMbBZdLqIzO2InyLCQaujZqMupMh5KkmrhL9eYFn0qtWSG274vnmUacvaIl1e8EmIb9j5ksyVXysPlIVxbNks51E= matt.heery@MJ004484"
 }

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -224,7 +224,7 @@ resource "aws_iam_role" "capita_transfer_workflow_iam_role" {
 
 data "aws_iam_policy_document" "capita_transfer_workflow_iam_policy_document" {
   statement {
-    sid       = "AllowSourceCopyRead"
+    sid       = "AllowCopyReadSource"
     effect    = "Allow"
     actions   = [
       "s3:GetObject",
@@ -233,7 +233,7 @@ data "aws_iam_policy_document" "capita_transfer_workflow_iam_policy_document" {
     resources = ["${aws_s3_bucket.capita_landing_bucket.arn}/*"]
   }
   statement {
-    sid       = "AllowDestinationCopyWrite"
+    sid       = "AllowCopyWriteDestination"
     effect    = "Allow"
     actions   = [
       "s3:PutObject",
@@ -253,23 +253,26 @@ data "aws_iam_policy_document" "capita_transfer_workflow_iam_policy_document" {
     ]
   }
   statement {
-    sid       = "AllowDestinationTag"
+    sid       = "AllowTag"
     effect    = "Allow"
     actions   = [
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
     ]
-    resources = ["${aws_s3_bucket.data_store_bucket.arn}/*"]
+    resources = [
+      "${aws_s3_bucket.data_store_bucket.arn}/*",
+      "${aws_s3_bucket.capita_landing_bucket.arn}/*",
+    ]
     # condition {}
   }
   statement {
-    sid       = "AllowSourceDelete"
+    sid       = "AllowDeleteSource"
     effect    = "Allow"
     actions   = [
       "s3:DeleteObject",
       "s3:DeleteObjectVersion"
     ]
-    resources = [aws_s3_bucket.capita_landing_bucket.arn]
+    resources = ["${aws_s3_bucket.capita_landing_bucket.arn}/*"]
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -9,68 +9,10 @@ resource "aws_eip" "capita_eip" {
 }
 
 #------------------------------------------------------------------------------
-# AWS security group 
-#
-# Set the allowed IP addresses for the supplier.
-#------------------------------------------------------------------------------
-
-resource "aws_security_group" "capita_security_group" {
-  name        = "capita_inbound_ips"
-  description = "Allowed IP addresses from Capita"
-  vpc_id      = data.aws_vpc.shared.id
-}
-
-resource "aws_vpc_security_group_ingress_rule" "capita_ip_1" {
-  security_group_id = aws_security_group.capita_security_group.id
-
-  cidr_ipv4   = "82.203.33.112/28"
-  ip_protocol = "tcp"
-  from_port   = 2222
-  to_port     = 2222
-}
-
-resource "aws_vpc_security_group_ingress_rule" "capita_ip_2" {
-  security_group_id = aws_security_group.capita_security_group.id
-
-  cidr_ipv4   = "82.203.33.128/28"
-  ip_protocol = "tcp"
-  from_port   = 2222
-  to_port     = 2222
-}
-
-resource "aws_vpc_security_group_ingress_rule" "capita_ip_3" {
-  security_group_id = aws_security_group.capita_security_group.id
-
-  cidr_ipv4   = "85.115.52.0/24"
-  ip_protocol = "tcp"
-  from_port   = 2222
-  to_port     = 2222
-}
-
-resource "aws_vpc_security_group_ingress_rule" "capita_ip_4" {
-  security_group_id = aws_security_group.capita_security_group.id
-
-  cidr_ipv4   = "85.115.53.0/24"
-  ip_protocol = "tcp"
-  from_port   = 2222
-  to_port     = 2222
-}
-
-resource "aws_vpc_security_group_ingress_rule" "capita_ip_5" {
-  security_group_id = aws_security_group.capita_security_group.id
-
-  cidr_ipv4   = "85.115.54.0/24"
-  ip_protocol = "tcp"
-  from_port   = 2222
-  to_port     = 2222
-}
-
-#------------------------------------------------------------------------------
 # AWS transfer server 
 #
 # Configure SFTP server for supplier that only allows supplier specified IPs.
 #------------------------------------------------------------------------------
-
 
 resource "aws_transfer_server" "capita_transfer_server" {
   protocols              = ["SFTP"]
@@ -160,18 +102,6 @@ resource "aws_iam_role_policy" "capita_transfer_user_iam_policy" {
   name   = "capita-transfer-user-iam-policy"
   role   = aws_iam_role.capita_transfer_user_iam_role.id
   policy = data.aws_iam_policy_document.capita_transfer_user_iam_policy_document.json
-}
-
-#------------------------------------------------------------------------------
-# AWS transfer ssh key
-#
-# Set the public ssh key for the supplier user profile to access SFTP server.
-#------------------------------------------------------------------------------
-
-resource "aws_transfer_ssh_key" "capita_ssh_key_ecdsa_sha2_nistp384" {
-  server_id = aws_transfer_server.capita_transfer_server.id
-  user_name = aws_transfer_user.capita_transfer_user.user_name
-  body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIhggGYKbOk6BH7fpEs6JGRnMyLRK/9/tAMQOVYOZtehKTRcM5vGsJFRGjjm2wEan3/uYOuto0NoVkbRfIi0AIG6EWrp1gvHNQlUTtxQVp7rFeOnZAjVEE9xVUEgHhMNLw=="
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -183,18 +183,18 @@ resource "aws_transfer_ssh_key" "capita_ssh_key_ecdsa_sha2_nistp384" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_workflow" "transfer_capita_to_store" {
-  # steps {
-  #   copy_step_details {
-  #     source_file_location = "$${original.file}"
-  #     destination_file_location {
-  #       s3_file_location {
-  #         bucket = aws_s3_bucket.data_store_bucket.bucket
-  #         key = "capita/"
-  #       }  
-  #     }
-  #   }
-  #   type = "COPY"
-  # }
+  steps {
+    copy_step_details {
+      source_file_location = "$${original.file}"
+      destination_file_location {
+        s3_file_location {
+          bucket = aws_s3_bucket.data_store_bucket.bucket
+          key = "capita/"
+        }  
+      }
+    }
+    type = "COPY"
+  }
   steps {
     delete_step_details {
       source_file_location = "$${original.file}"

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -183,20 +183,25 @@ resource "aws_transfer_ssh_key" "capita_ssh_key_ecdsa_sha2_nistp384" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_workflow" "transfer_capita_to_store" {
+  # steps {
+  #   copy_step_details {
+  #     source_file_location = "$${original.file}"
+  #     destination_file_location {
+  #       s3_file_location {
+  #         bucket = aws_s3_bucket.data_store_bucket.bucket
+  #         key = "capita/"
+  #       }  
+  #     }
+  #   }
+  #   type = "COPY"
+  # }
   steps {
-    copy_step_details {
+    delete_step_details {
       source_file_location = "$${original.file}"
-      destination_file_location {
-        s3_file_location {
-          bucket = aws_s3_bucket.data_store_bucket.bucket
-          key = "capita/"
-        }  
-      }
     }
-    type = "COPY"
+    type = "DELETE"
   }
 }
-
 
 data "aws_iam_policy_document" "capita_transfer_workflow_assume_role" {
   statement {

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -219,15 +219,51 @@ resource "aws_iam_role" "capita_transfer_workflow_iam_role" {
 
 data "aws_iam_policy_document" "capita_transfer_workflow_iam_policy_document" {
   statement {
-    sid       = "AllowDataStoreWrite"
+    sid       = "AllowSourceCopyRead"
     effect    = "Allow"
-    actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.data_store_bucket.arn}/capita/*"]
+    actions   = [
+      "s3:GetObject",
+      "s3:GetObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.capita_landing_bucket.arn}/*"]
   }
   statement {
-    sid       = "AllowCapitaLandingZoneRead"
+    sid       = "AllowDestinationCopyWrite"
     effect    = "Allow"
-    actions   = ["s3:GetObject"]
+    actions   = [
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.data_store_bucket.arn}/*"]
+  }
+  statement {
+    sid       = "AllowCopyList"
+    effect    = "Allow"
+    actions   = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      aws_s3_bucket.capita_landing_bucket.arn,
+      aws_s3_bucket.data_store_bucket.arn
+    ]
+  }
+  statement {
+    sid       = "AllowDestinationTag"
+    effect    = "Allow"
+    actions   = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = ["${aws_s3_bucket.data_store_bucket.arn}/*"]
+    # condition {}
+  }
+  statement {
+    sid       = "AllowSourceDelete"
+    effect    = "Allow"
+    actions   = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ]
     resources = [aws_s3_bucket.capita_landing_bucket.arn]
   }
 }


### PR DESCRIPTION
Finishes off implementing the AWS transfer workflow for 
1. copy file once it's put into landing bucket to the data store bucket (in a directory named `capita` in this instance
2. delete the original file in the landing bucket once the above has finished

Tested using the test user account and all works as expected.

I've left permissions for the transfer workflow to also allow adding tags to the files also, but couldn't think of appropriate tags atm.

Also done some reorganisation of the files to pull the access permissions into their own file so they're easier to find and review.