### PR TITLE
add new alarms and instance for testing

### DIFF
--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -110,7 +110,7 @@ locals {
         statistic           = "SampleCount"
         threshold           = "0"
         treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
@@ -162,7 +162,7 @@ locals {
         statistic           = "SampleCount"
         threshold           = "0"
         treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }


### PR DESCRIPTION
- added `instance-or-cloudwatch-agent-stopped` alarm for windows & linux default 
- sits in the CWAgent namespace which uses CPU_USAGE and cpu_usage_idle metrics 
- will trigger if the metric is missing for > 5 minutes or the SampleCount == 0
- this is a proxy for 'instance is stopped' or 'cwagent is stopped'
- added a page in Confluence for this as well

We _can_ chance the evaluation period to < 5 minutes BUT this might create a lot of false positives

As it is, certainly on Windows instances, the alarm WILL trigger on start-up as metrics supplied via the cloudwatch-agent don't immediately appear in the AWS console/cloudwatch.

NOTE: merging this PR will create this new alarm for existing Windows/Linux instances with CWAgent based monitoring enabled but will only trigger when the alarm conditions are met
