### PR TITLE
quick pr to turn off alarms on dev-tst asg as not necessary

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -47,7 +47,7 @@ locals {
           instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["CSRWebServerPolicy"])
           user_data_raw                 = base64encode(file("./templates/user-data.yaml"))
         })
-        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.windows
+        cloudwatch_metric_alarms = {}
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["app", "domain", "jumpserver"]
           instance_type          = "t3.medium"


### PR DESCRIPTION
- don't have alarms set on dev-tst asg in corporate-staff-rostering-development as this will send the initial start-up alarm into the slack channel 👎 
- alarms aren't really needed if this is just a testing server in the dev environment