### PR TITLE
ELM-1310 & ELM-1311 Create transfer servers for civica and g4s

### DIFF
--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "log_bucket" {
 # moved to a different bucket once landed.
 #------------------------------------------------------------------------------
 
-resource "random_string" "capita_random_string" {
+resource "random_string" "capita" {
   length  = 10
   lower   = true
   upper   = false
@@ -28,15 +28,15 @@ resource "random_string" "capita_random_string" {
 }
 
 resource "aws_s3_bucket" "capita_landing_bucket" {
-  bucket = "capita-${random_string.capita_random_string.result}"
+  bucket = "capita-${random_string.capita.result}"
 }
 
 resource "aws_s3_bucket_policy" "capita_landing_bucket_policy" {
   bucket = aws_s3_bucket.capita_landing_bucket.id
-  policy = data.aws_iam_policy_document.capita_landing_bucket_policy_document.json
+  policy = data.aws_iam_policy_document.capita_landing_bucket.json
 }
 
-data "aws_iam_policy_document" "capita_landing_bucket_policy_document" {
+data "aws_iam_policy_document" "capita_landing_bucket" {
   statement {
     sid = "EnforceTLSv12orHigher"
     principals {
@@ -57,14 +57,14 @@ data "aws_iam_policy_document" "capita_landing_bucket_policy_document" {
   }
 }
 
-resource "aws_s3_bucket_versioning" "capita_landing_bucket" {
+resource "aws_s3_bucket_versioning" "capita" {
   bucket = aws_s3_bucket.capita_landing_bucket.id
   versioning_configuration {
     status = "Disabled"
   }
 }
 
-resource "aws_s3_bucket_logging" "capita_bucket_logging" {
+resource "aws_s3_bucket_logging" "capita" {
   bucket = aws_s3_bucket.capita_landing_bucket.id
 
   target_bucket = aws_s3_bucket.log_bucket.id
@@ -84,7 +84,7 @@ resource "aws_s3_bucket_logging" "capita_bucket_logging" {
 # moved to a different bucket once landed.
 #------------------------------------------------------------------------------
 
-resource "random_string" "civica_random_string" {
+resource "random_string" "civica" {
   length  = 10
   lower   = true
   upper   = false
@@ -93,15 +93,15 @@ resource "random_string" "civica_random_string" {
 }
 
 resource "aws_s3_bucket" "civica_landing_bucket" {
-  bucket = "civica-${random_string.civica_random_string.result}"
+  bucket = "civica-${random_string.civica.result}"
 }
 
 resource "aws_s3_bucket_policy" "civica_landing_bucket_policy" {
   bucket = aws_s3_bucket.civica_landing_bucket.id
-  policy = data.aws_iam_policy_document.civica_landing_bucket_policy_document.json
+  policy = data.aws_iam_policy_document.civica_landing_bucket.json
 }
 
-data "aws_iam_policy_document" "civica_landing_bucket_policy_document" {
+data "aws_iam_policy_document" "civica_landing_bucket" {
   statement {
     sid = "EnforceTLSv12orHigher"
     principals {
@@ -122,14 +122,14 @@ data "aws_iam_policy_document" "civica_landing_bucket_policy_document" {
   }
 }
 
-resource "aws_s3_bucket_versioning" "civica_landing_bucket" {
+resource "aws_s3_bucket_versioning" "civica" {
   bucket = aws_s3_bucket.civica_landing_bucket.id
   versioning_configuration {
     status = "Disabled"
   }
 }
 
-resource "aws_s3_bucket_logging" "civica_bucket_logging" {
+resource "aws_s3_bucket_logging" "civica" {
   bucket = aws_s3_bucket.civica_landing_bucket.id
 
   target_bucket = aws_s3_bucket.log_bucket.id
@@ -149,7 +149,7 @@ resource "aws_s3_bucket_logging" "civica_bucket_logging" {
 # moved to a different bucket once landed.
 #------------------------------------------------------------------------------
 
-resource "random_string" "g4s_random_string" {
+resource "random_string" "g4s" {
   length  = 10
   lower   = true
   upper   = false
@@ -158,15 +158,15 @@ resource "random_string" "g4s_random_string" {
 }
 
 resource "aws_s3_bucket" "g4s_landing_bucket" {
-  bucket = "g4s-${random_string.g4s_random_string.result}"
+  bucket = "g4s-${random_string.g4s.result}"
 }
 
 resource "aws_s3_bucket_policy" "g4s_landing_bucket_policy" {
   bucket = aws_s3_bucket.g4s_landing_bucket.id
-  policy = data.aws_iam_policy_document.g4s_landing_bucket_policy_document.json
+  policy = data.aws_iam_policy_document.g4s_landing_bucket.json
 }
 
-data "aws_iam_policy_document" "g4s_landing_bucket_policy_document" {
+data "aws_iam_policy_document" "g4s_landing_bucket" {
   statement {
     sid = "EnforceTLSv12orHigher"
     principals {
@@ -187,14 +187,14 @@ data "aws_iam_policy_document" "g4s_landing_bucket_policy_document" {
   }
 }
 
-resource "aws_s3_bucket_versioning" "g4s_landing_bucket" {
+resource "aws_s3_bucket_versioning" "g4s" {
   bucket = aws_s3_bucket.g4s_landing_bucket.id
   versioning_configuration {
     status = "Disabled"
   }
 }
 
-resource "aws_s3_bucket_logging" "g4s_bucket_logging" {
+resource "aws_s3_bucket_logging" "g4s" {
   bucket = aws_s3_bucket.g4s_landing_bucket.id
 
   target_bucket = aws_s3_bucket.log_bucket.id
@@ -215,9 +215,9 @@ resource "aws_s3_bucket" "data_store_bucket" {
   bucket_prefix = "em-data-store-"
 }
 
-# resource "aws_s3_bucket_versioning" "data_store_bucket" {
-#   bucket = aws_s3_bucket.data_store_bucket.id
-#   versioning_configuration {
-#     status = "Enabled"
-#   }
-# }
+resource "aws_s3_bucket_versioning" "data_store" {
+  bucket = aws_s3_bucket.data_store_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/server_access_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_capita.tf
@@ -71,14 +71,14 @@ resource "aws_transfer_ssh_key" "capita_ssh_key" {
 # Set the allowed IP addresses for the supplier.
 #------------------------------------------------------------------------------
 
-resource "aws_security_group" "capita_security_group" {
+resource "aws_security_group" "capita" {
   name        = "capita_inbound_ips"
   description = "Allowed IP addresses from Capita"
   vpc_id      = data.aws_vpc.shared.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "capita_ip_1" {
-  security_group_id = aws_security_group.capita_security_group.id
+  security_group_id = aws_security_group.capita.id
 
   cidr_ipv4   = "82.203.33.112/28"
   ip_protocol = "tcp"
@@ -87,7 +87,7 @@ resource "aws_vpc_security_group_ingress_rule" "capita_ip_1" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "capita_ip_2" {
-  security_group_id = aws_security_group.capita_security_group.id
+  security_group_id = aws_security_group.capita.id
 
   cidr_ipv4   = "82.203.33.128/28"
   ip_protocol = "tcp"
@@ -96,7 +96,7 @@ resource "aws_vpc_security_group_ingress_rule" "capita_ip_2" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "capita_ip_3" {
-  security_group_id = aws_security_group.capita_security_group.id
+  security_group_id = aws_security_group.capita.id
 
   cidr_ipv4   = "85.115.52.0/24"
   ip_protocol = "tcp"
@@ -105,7 +105,7 @@ resource "aws_vpc_security_group_ingress_rule" "capita_ip_3" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "capita_ip_4" {
-  security_group_id = aws_security_group.capita_security_group.id
+  security_group_id = aws_security_group.capita.id
 
   cidr_ipv4   = "85.115.53.0/24"
   ip_protocol = "tcp"
@@ -114,7 +114,7 @@ resource "aws_vpc_security_group_ingress_rule" "capita_ip_4" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "capita_ip_5" {
-  security_group_id = aws_security_group.capita_security_group.id
+  security_group_id = aws_security_group.capita.id
 
   cidr_ipv4   = "85.115.54.0/24"
   ip_protocol = "tcp"

--- a/terraform/environments/electronic-monitoring-data/server_access_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_capita.tf
@@ -6,7 +6,7 @@
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_user" "capita_transfer_user" {
-  server_id = aws_transfer_server.capita_transfer_server.id
+  server_id = aws_transfer_server.capita.id
   user_name = "capita"
   role      = aws_iam_role.capita_transfer_user_iam_role.arn
 
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy" "capita_transfer_user_iam_policy" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_ssh_key" "capita_ssh_key" {
-  server_id = aws_transfer_server.capita_transfer_server.id
+  server_id = aws_transfer_server.capita.id
   user_name = aws_transfer_user.capita_transfer_user.user_name
   body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIhggGYKbOk6BH7fpEs6JGRnMyLRK/9/tAMQOVYOZtehKTRcM5vGsJFRGjjm2wEan3/uYOuto0NoVkbRfIi0AIG6EWrp1gvHNQlUTtxQVp7rFeOnZAjVEE9xVUEgHhMNLw=="
 }

--- a/terraform/environments/electronic-monitoring-data/server_access_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_civica.tf
@@ -6,7 +6,7 @@
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_user" "civica_transfer_user" {
-  server_id = aws_transfer_server.civica_transfer_server.id
+  server_id = aws_transfer_server.civica.id
   user_name = "civica"
   role      = aws_iam_role.civica_transfer_user_iam_role.arn
 
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy" "civica_transfer_user_iam_policy" {
 #------------------------------------------------------------------------------
 
 # resource "aws_transfer_ssh_key" "civica_ssh_key" {
-#   server_id = aws_transfer_server.civica_transfer_server.id
+#   server_id = aws_transfer_server.civica.id
 #   user_name = aws_transfer_user.civica_transfer_user.user_name
 #   body      = ""
 # }

--- a/terraform/environments/electronic-monitoring-data/server_access_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_civica.tf
@@ -1,0 +1,87 @@
+#------------------------------------------------------------------------------
+# AWS transfer user
+#
+# Create supplier user profile that has put access to only their landing zone
+# bucket.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_user" "civica_transfer_user" {
+  server_id = aws_transfer_server.civica_transfer_server.id
+  user_name = "civica"
+  role      = aws_iam_role.civica_transfer_user_iam_role.arn
+
+  home_directory = "/${aws_s3_bucket.civica_landing_bucket.id}/"
+}
+
+data "aws_iam_policy_document" "civica_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "civica_transfer_user_iam_role" {
+  name                = "civica-transfer-user-iam-role"
+  assume_role_policy  = data.aws_iam_policy_document.civica_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
+data "aws_iam_policy_document" "civica_transfer_user_iam_policy_document" {
+  statement {
+    sid       = "AllowListAccesstoCivicaS3"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.civica_landing_bucket.arn]
+  }
+  statement {
+    sid       = "AllowPutAccesstoCivicaS3"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.civica_landing_bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "civica_transfer_user_iam_policy" {
+  name   = "civica-transfer-user-iam-policy"
+  role   = aws_iam_role.civica_transfer_user_iam_role.id
+  policy = data.aws_iam_policy_document.civica_transfer_user_iam_policy_document.json
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer ssh key
+#
+# Set the public ssh key for the supplier user profile to access SFTP server.
+#------------------------------------------------------------------------------
+
+# resource "aws_transfer_ssh_key" "civica_ssh_key" {
+#   server_id = aws_transfer_server.civica_transfer_server.id
+#   user_name = aws_transfer_user.civica_transfer_user.user_name
+#   body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIhggGYKbOk6BH7fpEs6JGRnMyLRK/9/tAMQOVYOZtehKTRcM5vGsJFRGjjm2wEan3/uYOuto0NoVkbRfIi0AIG6EWrp1gvHNQlUTtxQVp7rFeOnZAjVEE9xVUEgHhMNLw=="
+# }
+
+#------------------------------------------------------------------------------
+# AWS security group 
+#
+# Set the allowed IP addresses for the supplier.
+#------------------------------------------------------------------------------
+
+resource "aws_security_group" "civica_security_group" {
+  name        = "civica_inbound_ips"
+  description = "Allowed IP addresses from Civica"
+  vpc_id      = data.aws_vpc.shared.id
+}
+
+# resource "aws_vpc_security_group_ingress_rule" "civica_ip_1" {
+#   security_group_id = aws_security_group.civica_security_group.id
+
+#   cidr_ipv4   = "82.203.33.112/28"
+#   ip_protocol = "tcp"
+#   from_port   = 2222
+#   to_port     = 2222
+# }

--- a/terraform/environments/electronic-monitoring-data/server_access_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_civica.tf
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy" "civica_transfer_user_iam_policy" {
 # resource "aws_transfer_ssh_key" "civica_ssh_key" {
 #   server_id = aws_transfer_server.civica_transfer_server.id
 #   user_name = aws_transfer_user.civica_transfer_user.user_name
-#   body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIhggGYKbOk6BH7fpEs6JGRnMyLRK/9/tAMQOVYOZtehKTRcM5vGsJFRGjjm2wEan3/uYOuto0NoVkbRfIi0AIG6EWrp1gvHNQlUTtxQVp7rFeOnZAjVEE9xVUEgHhMNLw=="
+#   body      = ""
 # }
 
 #------------------------------------------------------------------------------
@@ -80,7 +80,7 @@ resource "aws_security_group" "civica_security_group" {
 # resource "aws_vpc_security_group_ingress_rule" "civica_ip_1" {
 #   security_group_id = aws_security_group.civica_security_group.id
 
-#   cidr_ipv4   = "82.203.33.112/28"
+#   cidr_ipv4   = ""
 #   ip_protocol = "tcp"
 #   from_port   = 2222
 #   to_port     = 2222

--- a/terraform/environments/electronic-monitoring-data/server_access_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_civica.tf
@@ -71,14 +71,14 @@ resource "aws_iam_role_policy" "civica_transfer_user_iam_policy" {
 # Set the allowed IP addresses for the supplier.
 #------------------------------------------------------------------------------
 
-resource "aws_security_group" "civica_security_group" {
+resource "aws_security_group" "civica" {
   name        = "civica_inbound_ips"
   description = "Allowed IP addresses from Civica"
   vpc_id      = data.aws_vpc.shared.id
 }
 
 # resource "aws_vpc_security_group_ingress_rule" "civica_ip_1" {
-#   security_group_id = aws_security_group.civica_security_group.id
+#   security_group_id = aws_security_group.civica.id
 
 #   cidr_ipv4   = ""
 #   ip_protocol = "tcp"

--- a/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
@@ -1,0 +1,87 @@
+#------------------------------------------------------------------------------
+# AWS transfer user
+#
+# Create supplier user profile that has put access to only their landing zone
+# bucket.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_user" "g4s_transfer_user" {
+  server_id = aws_transfer_server.g4s_transfer_server.id
+  user_name = "g4s"
+  role      = aws_iam_role.g4s_transfer_user_iam_role.arn
+
+  home_directory = "/${aws_s3_bucket.g4s_landing_bucket.id}/"
+}
+
+data "aws_iam_policy_document" "g4s_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "g4s_transfer_user_iam_role" {
+  name                = "g4s-transfer-user-iam-role"
+  assume_role_policy  = data.aws_iam_policy_document.g4s_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
+data "aws_iam_policy_document" "g4s_transfer_user_iam_policy_document" {
+  statement {
+    sid       = "AllowListAccesstoG4sS3"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.g4s_landing_bucket.arn]
+  }
+  statement {
+    sid       = "AllowPutAccesstoG4sS3"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.g4s_landing_bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "g4s_transfer_user_iam_policy" {
+  name   = "g4s-transfer-user-iam-policy"
+  role   = aws_iam_role.g4s_transfer_user_iam_role.id
+  policy = data.aws_iam_policy_document.g4s_transfer_user_iam_policy_document.json
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer ssh key
+#
+# Set the public ssh key for the supplier user profile to access SFTP server.
+#------------------------------------------------------------------------------
+
+# resource "aws_transfer_ssh_key" "g4s_ssh_key" {
+#   server_id = aws_transfer_server.g4s_transfer_server.id
+#   user_name = aws_transfer_user.g4s_transfer_user.user_name
+#   body      = ""
+# }
+
+#------------------------------------------------------------------------------
+# AWS security group 
+#
+# Set the allowed IP addresses for the supplier.
+#------------------------------------------------------------------------------
+
+resource "aws_security_group" "g4s_security_group" {
+  name        = "g4s_inbound_ips"
+  description = "Allowed IP addresses from g4s"
+  vpc_id      = data.aws_vpc.shared.id
+}
+
+# resource "aws_vpc_security_group_ingress_rule" "g4s_ip_1" {
+#   security_group_id = aws_security_group.g4s_security_group.id
+
+#   cidr_ipv4   = ""
+#   ip_protocol = "tcp"
+#   from_port   = 2222
+#   to_port     = 2222
+# }

--- a/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
@@ -71,14 +71,14 @@ resource "aws_iam_role_policy" "g4s_transfer_user_iam_policy" {
 # Set the allowed IP addresses for the supplier.
 #------------------------------------------------------------------------------
 
-resource "aws_security_group" "g4s_security_group" {
+resource "aws_security_group" "g4s" {
   name        = "g4s_inbound_ips"
   description = "Allowed IP addresses from g4s"
   vpc_id      = data.aws_vpc.shared.id
 }
 
 # resource "aws_vpc_security_group_ingress_rule" "g4s_ip_1" {
-#   security_group_id = aws_security_group.g4s_security_group.id
+#   security_group_id = aws_security_group.g4s.id
 
 #   cidr_ipv4   = ""
 #   ip_protocol = "tcp"

--- a/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
@@ -6,7 +6,7 @@
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_user" "g4s_transfer_user" {
-  server_id = aws_transfer_server.g4s_transfer_server.id
+  server_id = aws_transfer_server.g4s.id
   user_name = "g4s"
   role      = aws_iam_role.g4s_transfer_user_iam_role.arn
 
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy" "g4s_transfer_user_iam_policy" {
 #------------------------------------------------------------------------------
 
 # resource "aws_transfer_ssh_key" "g4s_ssh_key" {
-#   server_id = aws_transfer_server.g4s_transfer_server.id
+#   server_id = aws_transfer_server.g4s.id
 #   user_name = aws_transfer_user.g4s_transfer_user.user_name
 #   body      = ""
 # }

--- a/terraform/environments/electronic-monitoring-data/server_access_test.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_test.tf
@@ -5,13 +5,13 @@
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_ssh_key" "test_ssh_key_mp" {
-  server_id = aws_transfer_server.capita_transfer_server.id
+  server_id = aws_transfer_server.capita.id
   user_name = aws_transfer_user.test_transfer_user.user_name
   body      = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBA3BsCFaNiGxbmJffRi9q/W3aLmZWgqE6QkeFJD5O6F4nDdjsV1R0ZMUvTSoi3tKqoAE+1RYYj2Ra/F1buHov9e+sFPrlMl0wql6uMsBA1ndiIiKuq+NLY1NOxEvqm2J9Q=="
 }
 
 resource "aws_transfer_ssh_key" "test_ssh_key_mh" {
-  server_id = aws_transfer_server.capita_transfer_server.id
+  server_id = aws_transfer_server.capita.id
   user_name = aws_transfer_user.test_transfer_user.user_name
   body      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQClyRRkvW162H2NQm5IlavjE4zBhnzGJ/V+raqe7ynPumIgKhmNto8GD6iKlWkzLGxfwXQhONM/9J8+u9tqncw5FzEWEYdX/FEJF5VwLYma/OtMUio3vtwsc9zbae4EyTvROvbJSMgL07ZicUjQ9pS4+pst2KVjDtgCXD8l7A66wOkmht2Cb2Ebfk+wk965uN5wE5vHDQBx6QQ4z9UiGEp34n/g2O9gUGUJcFdYCEHVl1MY+dicCJwsRzEC1a0s/LzCtiCo66yWW8VEpMpDJNCAJccxadwWBI1d+8R94LTUakxkYhAVCpzs+A/qjaAUKsT/1KQm0+3gJIfLqmWYUumB4VgP2+cYiFbdxWQt2lLAUYZmsTwR5EktCftA5OGcwKO11sKnouj+IYiN9wfRl8kQEs+KZDDSjXKAdsWvRwhRMbBZdLqIzO2InyLCQaujZqMupMh5KkmrhL9eYFn0qtWSG274vnmUacvaIl1e8EmIb9j5ksyVXysPlIVxbNks51E= matt.heery@MJ004484"
 }
@@ -54,7 +54,7 @@ resource "aws_vpc_security_group_ingress_rule" "test_petty_france_ip" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_user" "test_transfer_user" {
-  server_id = aws_transfer_server.capita_transfer_server.id
+  server_id = aws_transfer_server.capita.id
   user_name = "test"
   role      = aws_iam_role.test_transfer_user_iam_role.arn
 

--- a/terraform/environments/electronic-monitoring-data/server_access_test.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_test.tf
@@ -22,14 +22,14 @@ resource "aws_transfer_ssh_key" "test_ssh_key_mh" {
 # Set the allowed IP addresses for the supplier.
 #------------------------------------------------------------------------------
 
-resource "aws_security_group" "test_security_group" {
+resource "aws_security_group" "test" {
   name        = "test_inbound_ips"
   description = "Allowed IP addresses for testing"
   vpc_id      = data.aws_vpc.shared.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "test_fynhy_ip" {
-  security_group_id = aws_security_group.test_security_group.id
+  security_group_id = aws_security_group.test.id
 
   cidr_ipv4   = "46.69.144.146/32"
   ip_protocol = "tcp"
@@ -38,7 +38,7 @@ resource "aws_vpc_security_group_ingress_rule" "test_fynhy_ip" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "test_petty_france_ip" {
-  security_group_id = aws_security_group.test_security_group.id
+  security_group_id = aws_security_group.test.id
 
   cidr_ipv4   = "81.134.202.29/32"
   ip_protocol = "tcp"

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -44,11 +44,11 @@ resource "aws_transfer_server" "capita_transfer_server" {
 
   logging_role = aws_iam_role.test_transfer_user_iam_role.arn
   structured_log_destinations = [
-    "${aws_cloudwatch_log_group.transfer.arn}:*"
+    "${aws_cloudwatch_log_group.capita.arn}:*"
   ]
 }
 
-resource "aws_cloudwatch_log_group" "transfer" {
+resource "aws_cloudwatch_log_group" "capita" {
   name_prefix = "transfer_test_"
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -24,8 +24,8 @@ resource "aws_transfer_server" "capita" {
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
     address_allocation_ids = [aws_eip.capita.id]
     security_group_ids     = [
-      aws_security_group.capita_security_group.id,
-      aws_security_group.test_security_group.id
+      aws_security_group.capita.id,
+      aws_security_group.test.id
     ]
   }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -14,7 +14,7 @@ resource "aws_eip" "capita" {
 # Configure SFTP server for supplier that only allows supplier specified IPs.
 #------------------------------------------------------------------------------
 
-resource "aws_transfer_server" "capita_transfer_server" {
+resource "aws_transfer_server" "capita" {
   protocols              = ["SFTP"]
   identity_provider_type = "SERVICE_MANAGED"
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -4,7 +4,7 @@
 # Assign unique IP for each supplier to connect to.
 #------------------------------------------------------------------------------
 
-resource "aws_eip" "capita_eip" {
+resource "aws_eip" "capita" {
   domain = "vpc"
 }
 
@@ -22,7 +22,7 @@ resource "aws_transfer_server" "capita_transfer_server" {
   endpoint_details {
     vpc_id                 = data.aws_vpc.shared.id
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
-    address_allocation_ids = [aws_eip.capita_eip.id]
+    address_allocation_ids = [aws_eip.capita.id]
     security_group_ids     = [
       aws_security_group.capita_security_group.id,
       aws_security_group.test_security_group.id

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -24,8 +24,8 @@ resource "aws_transfer_server" "civica" {
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
     address_allocation_ids = [aws_eip.civica.id]
     security_group_ids     = [
-      aws_security_group.civica_security_group.id,
-      aws_security_group.test_security_group.id
+      aws_security_group.civica.id,
+      aws_security_group.test.id
     ]
   }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -14,7 +14,7 @@ resource "aws_eip" "civica" {
 # Configure SFTP server for supplier that only allows supplier specified IPs.
 #------------------------------------------------------------------------------
 
-resource "aws_transfer_server" "civica_transfer_server" {
+resource "aws_transfer_server" "civica" {
   protocols              = ["SFTP"]
   identity_provider_type = "SERVICE_MANAGED"
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -4,7 +4,7 @@
 # Assign unique IP for each supplier to connect to.
 #------------------------------------------------------------------------------
 
-resource "aws_eip" "civica_eip" {
+resource "aws_eip" "civica" {
   domain = "vpc"
 }
 
@@ -22,7 +22,7 @@ resource "aws_transfer_server" "civica_transfer_server" {
   endpoint_details {
     vpc_id                 = data.aws_vpc.shared.id
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
-    address_allocation_ids = [aws_eip.civica_eip.id]
+    address_allocation_ids = [aws_eip.civica.id]
     security_group_ids     = [
       aws_security_group.civica_security_group.id,
       aws_security_group.test_security_group.id

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -44,11 +44,11 @@ resource "aws_transfer_server" "civica_transfer_server" {
 
   logging_role = aws_iam_role.test_transfer_user_iam_role.arn
   structured_log_destinations = [
-    "${aws_cloudwatch_log_group.transfer.arn}:*"
+    "${aws_cloudwatch_log_group.civica.arn}:*"
   ]
 }
 
-resource "aws_cloudwatch_log_group" "transfer" {
+resource "aws_cloudwatch_log_group" "civica" {
   name_prefix = "transfer_test_"
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -1,0 +1,161 @@
+#------------------------------------------------------------------------------
+# AWS elastic IP
+#
+# Assign unique IP for each supplier to connect to.
+#------------------------------------------------------------------------------
+
+resource "aws_eip" "civica_eip" {
+  domain = "vpc"
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer server 
+#
+# Configure SFTP server for supplier that only allows supplier specified IPs.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_server" "civica_transfer_server" {
+  protocols              = ["SFTP"]
+  identity_provider_type = "SERVICE_MANAGED"
+
+  endpoint_type = "VPC"
+  endpoint_details {
+    vpc_id                 = data.aws_vpc.shared.id
+    subnet_ids             = [data.aws_subnet.public_subnets_b.id]
+    address_allocation_ids = [aws_eip.civica_eip.id]
+    security_group_ids     = [
+      aws_security_group.civica_security_group.id,
+      aws_security_group.test_security_group.id
+    ]
+  }
+
+  domain = "S3"
+
+  security_policy_name = "TransferSecurityPolicy-2023-05"
+
+  pre_authentication_login_banner = "Hello there"
+
+  workflow_details {
+    on_upload {
+      workflow_id    = aws_transfer_workflow.transfer_civica_to_store.id
+      execution_role = aws_iam_role.civica_transfer_workflow_iam_role.arn
+    }
+  }
+
+  logging_role = aws_iam_role.test_transfer_user_iam_role.arn
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.transfer.arn}:*"
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "transfer" {
+  name_prefix = "transfer_test_"
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer workflow
+#
+# For files that arrive in the landing bucket:
+# 1. copy the file to the internal data store bucket
+# 2. delete the file from the landing bucket
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_workflow" "transfer_civica_to_store" {
+  steps {
+    copy_step_details {
+      source_file_location = "$${original.file}"
+      destination_file_location {
+        s3_file_location {
+          bucket = aws_s3_bucket.data_store_bucket.bucket
+          key    = "civica/"
+        }
+      }
+    }
+    type = "COPY"
+  }
+  steps {
+    delete_step_details {
+      source_file_location = "$${original.file}"
+    }
+    type = "DELETE"
+  }
+}
+
+data "aws_iam_policy_document" "civica_transfer_workflow_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "civica_transfer_workflow_iam_role" {
+  name                = "civica-transfer-workflow-iam-role"
+  assume_role_policy  = data.aws_iam_policy_document.civica_transfer_workflow_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
+data "aws_iam_policy_document" "civica_transfer_workflow_iam_policy_document" {
+  statement {
+    sid    = "AllowCopyReadSource"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.civica_landing_bucket.arn}/*"]
+  }
+  statement {
+    sid    = "AllowCopyWriteDestination"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.data_store_bucket.arn}/*"]
+  }
+  statement {
+    sid    = "AllowCopyList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      aws_s3_bucket.civica_landing_bucket.arn,
+      aws_s3_bucket.data_store_bucket.arn
+    ]
+  }
+  statement {
+    sid    = "AllowTag"
+    effect = "Allow"
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      "${aws_s3_bucket.data_store_bucket.arn}/*",
+      "${aws_s3_bucket.civica_landing_bucket.arn}/*",
+    ]
+    # condition {}
+  }
+  statement {
+    sid    = "AllowDeleteSource"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ]
+    resources = ["${aws_s3_bucket.civica_landing_bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "civica_transfer_workflow_iam_policy" {
+  name   = "civica-transfer-workflow-iam-policy"
+  role   = aws_iam_role.civica_transfer_workflow_iam_role.id
+  policy = data.aws_iam_policy_document.civica_transfer_workflow_iam_policy_document.json
+}

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -1,0 +1,161 @@
+#------------------------------------------------------------------------------
+# AWS elastic IP
+#
+# Assign unique IP for each supplier to connect to.
+#------------------------------------------------------------------------------
+
+resource "aws_eip" "g4s_eip" {
+  domain = "vpc"
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer server 
+#
+# Configure SFTP server for supplier that only allows supplier specified IPs.
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_server" "g4s_transfer_server" {
+  protocols              = ["SFTP"]
+  identity_provider_type = "SERVICE_MANAGED"
+
+  endpoint_type = "VPC"
+  endpoint_details {
+    vpc_id                 = data.aws_vpc.shared.id
+    subnet_ids             = [data.aws_subnet.public_subnets_b.id]
+    address_allocation_ids = [aws_eip.g4s_eip.id]
+    security_group_ids     = [
+      aws_security_group.g4s_security_group.id,
+      aws_security_group.test_security_group.id
+    ]
+  }
+
+  domain = "S3"
+
+  security_policy_name = "TransferSecurityPolicy-2023-05"
+
+  pre_authentication_login_banner = "Hello there"
+
+  workflow_details {
+    on_upload {
+      workflow_id    = aws_transfer_workflow.transfer_g4s_to_store.id
+      execution_role = aws_iam_role.g4s_transfer_workflow_iam_role.arn
+    }
+  }
+
+  logging_role = aws_iam_role.test_transfer_user_iam_role.arn
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.transfer.arn}:*"
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "transfer" {
+  name_prefix = "transfer_test_"
+}
+
+#------------------------------------------------------------------------------
+# AWS transfer workflow
+#
+# For files that arrive in the landing bucket:
+# 1. copy the file to the internal data store bucket
+# 2. delete the file from the landing bucket
+#------------------------------------------------------------------------------
+
+resource "aws_transfer_workflow" "transfer_g4s_to_store" {
+  steps {
+    copy_step_details {
+      source_file_location = "$${original.file}"
+      destination_file_location {
+        s3_file_location {
+          bucket = aws_s3_bucket.data_store_bucket.bucket
+          key    = "g4s/"
+        }
+      }
+    }
+    type = "COPY"
+  }
+  steps {
+    delete_step_details {
+      source_file_location = "$${original.file}"
+    }
+    type = "DELETE"
+  }
+}
+
+data "aws_iam_policy_document" "g4s_transfer_workflow_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "g4s_transfer_workflow_iam_role" {
+  name                = "g4s-transfer-workflow-iam-role"
+  assume_role_policy  = data.aws_iam_policy_document.g4s_transfer_workflow_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
+data "aws_iam_policy_document" "g4s_transfer_workflow_iam_policy_document" {
+  statement {
+    sid    = "AllowCopyReadSource"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.g4s_landing_bucket.arn}/*"]
+  }
+  statement {
+    sid    = "AllowCopyWriteDestination"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+    resources = ["${aws_s3_bucket.data_store_bucket.arn}/*"]
+  }
+  statement {
+    sid    = "AllowCopyList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      aws_s3_bucket.g4s_landing_bucket.arn,
+      aws_s3_bucket.data_store_bucket.arn
+    ]
+  }
+  statement {
+    sid    = "AllowTag"
+    effect = "Allow"
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      "${aws_s3_bucket.data_store_bucket.arn}/*",
+      "${aws_s3_bucket.g4s_landing_bucket.arn}/*",
+    ]
+    # condition {}
+  }
+  statement {
+    sid    = "AllowDeleteSource"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ]
+    resources = ["${aws_s3_bucket.g4s_landing_bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "g4s_transfer_workflow_iam_policy" {
+  name   = "g4s-transfer-workflow-iam-policy"
+  role   = aws_iam_role.g4s_transfer_workflow_iam_role.id
+  policy = data.aws_iam_policy_document.g4s_transfer_workflow_iam_policy_document.json
+}

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -44,11 +44,11 @@ resource "aws_transfer_server" "g4s_transfer_server" {
 
   logging_role = aws_iam_role.test_transfer_user_iam_role.arn
   structured_log_destinations = [
-    "${aws_cloudwatch_log_group.transfer.arn}:*"
+    "${aws_cloudwatch_log_group.g4s.arn}:*"
   ]
 }
 
-resource "aws_cloudwatch_log_group" "transfer" {
+resource "aws_cloudwatch_log_group" "g4s" {
   name_prefix = "transfer_test_"
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -4,7 +4,7 @@
 # Assign unique IP for each supplier to connect to.
 #------------------------------------------------------------------------------
 
-resource "aws_eip" "g4s_eip" {
+resource "aws_eip" "g4s" {
   domain = "vpc"
 }
 
@@ -22,7 +22,7 @@ resource "aws_transfer_server" "g4s_transfer_server" {
   endpoint_details {
     vpc_id                 = data.aws_vpc.shared.id
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
-    address_allocation_ids = [aws_eip.g4s_eip.id]
+    address_allocation_ids = [aws_eip.g4s.id]
     security_group_ids     = [
       aws_security_group.g4s_security_group.id,
       aws_security_group.test_security_group.id

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -14,7 +14,7 @@ resource "aws_eip" "g4s" {
 # Configure SFTP server for supplier that only allows supplier specified IPs.
 #------------------------------------------------------------------------------
 
-resource "aws_transfer_server" "g4s_transfer_server" {
+resource "aws_transfer_server" "g4s" {
   protocols              = ["SFTP"]
   identity_provider_type = "SERVICE_MANAGED"
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -24,8 +24,8 @@ resource "aws_transfer_server" "g4s" {
     subnet_ids             = [data.aws_subnet.public_subnets_b.id]
     address_allocation_ids = [aws_eip.g4s.id]
     security_group_ids     = [
-      aws_security_group.g4s_security_group.id,
-      aws_security_group.test_security_group.id
+      aws_security_group.g4s.id,
+      aws_security_group.test.id
     ]
   }
 


### PR DESCRIPTION
Done a few things here, if the files changed tab is a lot, maybe page through the individual commits as they were atomic.

So I've done:
* add transfer server and user account for civica (left access details blank for now)
* add transfer server and user account for G4S (left access details blank for now)
* moved the transfer user terraform code to `server_access_<supplier>.tf` 
* renamed a load of the resources to have simpler names (as I realise now how verbose I was being)

Done a local `terraform plan` and everything looks happy, will get an MP team review and do the deployment after it's had an EM review.