### PR TITLE
ELM-1393 set unique iam for transfer server logging

### DIFF
--- a/terraform/environments/electronic-monitoring-data/data.tf
+++ b/terraform/environments/electronic-monitoring-data/data.tf
@@ -1,1 +1,12 @@
-#### This file can be used to store data specific to the member account ####
+data "aws_iam_policy_document" "transfer_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/server_access_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_capita.tf
@@ -13,22 +13,9 @@ resource "aws_transfer_user" "capita_transfer_user" {
   home_directory = "/${aws_s3_bucket.capita_landing_bucket.id}/"
 }
 
-data "aws_iam_policy_document" "capita_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "capita_transfer_user_iam_role" {
   name                = "capita-transfer-user-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.capita_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/server_access_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_civica.tf
@@ -13,22 +13,9 @@ resource "aws_transfer_user" "civica_transfer_user" {
   home_directory = "/${aws_s3_bucket.civica_landing_bucket.id}/"
 }
 
-data "aws_iam_policy_document" "civica_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "civica_transfer_user_iam_role" {
   name                = "civica-transfer-user-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.civica_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_g4s.tf
@@ -13,22 +13,9 @@ resource "aws_transfer_user" "g4s_transfer_user" {
   home_directory = "/${aws_s3_bucket.g4s_landing_bucket.id}/"
 }
 
-data "aws_iam_policy_document" "g4s_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "g4s_transfer_user_iam_role" {
   name                = "g4s-transfer-user-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.g4s_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/server_access_test.tf
+++ b/terraform/environments/electronic-monitoring-data/server_access_test.tf
@@ -61,22 +61,9 @@ resource "aws_transfer_user" "test_transfer_user" {
   home_directory = "/${aws_s3_bucket.capita_landing_bucket.id}/"
 }
 
-data "aws_iam_policy_document" "test_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "test_transfer_user_iam_role" {
   name                = "test-transfer-user-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.test_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -33,7 +33,7 @@ resource "aws_transfer_server" "capita" {
 
   security_policy_name = "TransferSecurityPolicy-2023-05"
 
-  pre_authentication_login_banner = "Hello there"
+  pre_authentication_login_banner = "\nHello there\n"
 
   workflow_details {
     on_upload {

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -42,14 +42,20 @@ resource "aws_transfer_server" "capita" {
     }
   }
 
-  logging_role = aws_iam_role.test_transfer_user_iam_role.arn
+  logging_role = aws_iam_role.iam_for_transfer_capita.arn
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.capita.arn}:*"
   ]
 }
 
+resource "aws_iam_role" "iam_for_transfer_capita" {
+  name_prefix         = "iam_for_transfer_capita_"
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
 resource "aws_cloudwatch_log_group" "capita" {
-  name_prefix = "transfer_test_"
+  name_prefix = "transfer_capita_"
 }
 
 #------------------------------------------------------------------------------
@@ -81,22 +87,9 @@ resource "aws_transfer_workflow" "transfer_capita_to_store" {
   }
 }
 
-data "aws_iam_policy_document" "capita_transfer_workflow_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "capita_transfer_workflow_iam_role" {
   name                = "capita-transfer-workflow-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.capita_transfer_workflow_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_capita.tf
@@ -49,7 +49,7 @@ resource "aws_transfer_server" "capita" {
 }
 
 resource "aws_iam_role" "iam_for_transfer_capita" {
-  name_prefix         = "iam_for_transfer_capita_"
+  name_prefix         = "iam-for-transfer-capita-"
   assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -42,14 +42,20 @@ resource "aws_transfer_server" "civica" {
     }
   }
 
-  logging_role = aws_iam_role.test_transfer_user_iam_role.arn
+  logging_role = aws_iam_role.iam_for_transfer_civica.arn
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.civica.arn}:*"
   ]
 }
 
+resource "aws_iam_role" "iam_for_transfer_civica" {
+  name_prefix         = "iam_for_transfer_civica_"
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
+}
+
 resource "aws_cloudwatch_log_group" "civica" {
-  name_prefix = "transfer_test_"
+  name_prefix = "transfer_civica_"
 }
 
 #------------------------------------------------------------------------------
@@ -81,22 +87,9 @@ resource "aws_transfer_workflow" "transfer_civica_to_store" {
   }
 }
 
-data "aws_iam_policy_document" "civica_transfer_workflow_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "civica_transfer_workflow_iam_role" {
   name                = "civica-transfer-workflow-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.civica_transfer_workflow_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -49,7 +49,7 @@ resource "aws_transfer_server" "civica" {
 }
 
 resource "aws_iam_role" "iam_for_transfer_civica" {
-  name_prefix         = "iam_for_transfer_civica_"
+  name_prefix         = "iam-for-transfer-civica-"
   assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }

--- a/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_civica.tf
@@ -33,7 +33,7 @@ resource "aws_transfer_server" "civica" {
 
   security_policy_name = "TransferSecurityPolicy-2023-05"
 
-  pre_authentication_login_banner = "Hello there"
+  pre_authentication_login_banner = "\nHello there\n"
 
   workflow_details {
     on_upload {

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -33,7 +33,7 @@ resource "aws_transfer_server" "g4s" {
 
   security_policy_name = "TransferSecurityPolicy-2023-05"
 
-  pre_authentication_login_banner = "Hello there"
+  pre_authentication_login_banner = "\nHello there\n"
 
   workflow_details {
     on_upload {

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -42,16 +42,21 @@ resource "aws_transfer_server" "g4s" {
     }
   }
 
-  logging_role = aws_iam_role.test_transfer_user_iam_role.arn
+  logging_role = aws_iam_role.iam_for_transfer_g4s.arn
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.g4s.arn}:*"
   ]
 }
 
-resource "aws_cloudwatch_log_group" "g4s" {
-  name_prefix = "transfer_test_"
+resource "aws_iam_role" "iam_for_transfer_g4s" {
+  name_prefix         = "iam_for_transfer_g4s_"
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 
+resource "aws_cloudwatch_log_group" "g4s" {
+  name_prefix = "transfer_g4s_"
+}
 #------------------------------------------------------------------------------
 # AWS transfer workflow
 #
@@ -81,22 +86,9 @@ resource "aws_transfer_workflow" "transfer_g4s_to_store" {
   }
 }
 
-data "aws_iam_policy_document" "g4s_transfer_workflow_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["transfer.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
 resource "aws_iam_role" "g4s_transfer_workflow_iam_role" {
   name                = "g4s-transfer-workflow-iam-role"
-  assume_role_policy  = data.aws_iam_policy_document.g4s_transfer_workflow_assume_role.json
+  assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }
 

--- a/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
+++ b/terraform/environments/electronic-monitoring-data/transfer_server_g4s.tf
@@ -49,7 +49,7 @@ resource "aws_transfer_server" "g4s" {
 }
 
 resource "aws_iam_role" "iam_for_transfer_g4s" {
-  name_prefix         = "iam_for_transfer_g4s_"
+  name_prefix         = "iam-for-transfer-g4s-"
   assume_role_policy  = data.aws_iam_policy_document.transfer_assume_role.json
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
 }


### PR DESCRIPTION
Set to use unique iam role for transfer server logging - noticed it was using the test user iam policy which also gives landing bucket access.