### PR TITLE
ndh: DSOS: Resize NDH EC2 size

### DIFF
--- a/terraform/environments/nomis-data-hub/locals_ndh.tf
+++ b/terraform/environments/nomis-data-hub/locals_ndh.tf
@@ -12,6 +12,7 @@ locals {
       ami_name = "nomis_data_hub_rhel_7_9_app_release_2023-05-02T00-00-47.783Z"
     })
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+      instance_type          = "t3.xlarge"
       vpc_security_group_ids = ["ndh_app"]
       tags = {
         backup-plan = "daily-and-weekly"
@@ -32,6 +33,7 @@ locals {
       ami_name = "nomis_data_hub_rhel_7_9_ems_test_2023-04-02T00-00-21.281Z"
     })
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+      instance_type          = "t3.xlarge"
       vpc_security_group_ids = ["ndh_ems"]
       tags = {
         backup-plan = "daily-and-weekly"


### PR DESCRIPTION
Default size is too small, needs 16GB RAM.