### PR TITLE
Dsos 2552 create ebs volume dashboard nomis

### DIFF
--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -4,7 +4,7 @@ resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
   automation_target_parameter_name = "ResourceId"
 
   parameters = {
-    AutomationAssumeRole = "arn:aws:iam::612659970365:role/AWS-SSM-AutomationExecutionRole"
+    AutomationAssumeRole = "arn:aws:iam::612659970365:role/EBSPerformanceMonitoringRole"
     StartTime            = local.ebs_performance_start_time
     EndTime              = local.ebs_performance_end_time
   }
@@ -290,4 +290,34 @@ locals {
     }
   }
 
+}
+
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::374269020027:root"
+            },
+            "Action": "sts:AssumeRole"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::374269020027:role/AWS-SSM-AutomationAdministrationRole"
+            },
+            "Action": "sts:AssumeRole"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ssm.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
 }

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -9,7 +9,7 @@ resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
     EndTime              = local.ebs_performance_end_time
   }
   targets {
-    key = "All Instances"
+    key = "InstanceIds"
     values = ["*"]
   }
 }

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -1,3 +1,23 @@
+resource "aws_ssm_document" "calculate_ebs_performance_metrics" {
+  name          = "AWSSupport-CalculateEBSPerformanceMetrics"
+  document_type = "Automation"
+  content = <<EOF
+{
+  "schemaVersion": "0.3",
+  "description": "Calculates EBS performance metrics.",
+  "parameters": {}
+}
+  EOF
+}
+
+resource "aws_ssm_association" "automation_execution" {
+  name                 = "calculate_ebs_performance_metrics"
+  instance_id_target   = "*"
+  targets              = [{ key = "InstanceIds", values = ["*"] }]
+  schedule_expression  = "rate(12 hour)"
+  document_version     = "$LATEST"
+}
+
 resource "aws_cloudwatch_dashboard" "nomis_cloudwatch_dashboard" {
   dashboard_name = "CloudWatch-Default"
   dashboard_body = jsonencode(local.dashboard_body)

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -1,6 +1,6 @@
 resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
   name                 = "AWSSupport-CalculateEBSPerformanceMetrics"
-  schedule_expression  = "rate(12 hour)"
+  schedule_expression  = "rate(2 hours)"
   automation_target_parameter_name = "ResourceId"
 
   parameters = {

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -1,19 +1,5 @@
-resource "aws_ssm_document" "calculate_ebs_performance_metrics" {
-  name          = "AWSSupport-CalculateEBSPerformanceMetrics"
-  document_type = "Automation"
-  content = <<EOF
-{
-  "schemaVersion": "0.3",
-  "description": "Calculates EBS performance metrics.",
-  "parameters": {
-    "resourceId": "*"
-  }
-}
-  EOF
-}
-
-resource "aws_ssm_association" "automation_execution" {
-  name                 = "calculate_ebs_performance_metrics"
+resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
+  name                 = "AWSSupport-CalculateEBSPerformanceMetrics"
   schedule_expression  = "rate(12 hour)"
   document_version     = "$LATEST"
   parameters = {

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -19,9 +19,9 @@ resource "aws_cloudwatch_dashboard" "nomis_cloudwatch_dashboard" {
 }
 
 locals {
-  sanitized_timestamp = replace(timestamp(), "/[Z]/", "")
-  ebs_performance_start_time = timeadd(local.sanitized_timestamp, "-24h")
-  ebs_performance_end_time = local.sanitized_timestamp
+  start_time = timeadd(timestamp(), "-24h")
+  ebs_performance_start_time = replace(local.start_time, "/[Z]/", "")
+  ebs_performance_end_time = replace(timestamp(), "/[Z]/", "")
   
   cloudwatch_period = 300
   region            = "eu-west-2"

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -3,9 +3,10 @@ resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
   schedule_expression  = "rate(12 hour)"
   document_version     = "$LATEST"
   parameters = {
-    resourceId = "*"
-    startTime  = local.ebs_performance_start_time
-    endTime    = local.ebs_performance_end_time
+    resourceId           = "*"
+    AutomationAssumeRole = "arn:aws:iam::612659970365:role/AWS-SSM-AutomationExecutionRole"
+    startTime            = local.ebs_performance_start_time
+    endTime              = local.ebs_performance_end_time
   }
   targets {
     key = "ResourceId"

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -291,33 +291,3 @@ locals {
   }
 
 }
-
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::374269020027:root"
-            },
-            "Action": "sts:AssumeRole"
-        },
-        {
-            "Sid": "",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::374269020027:role/AWS-SSM-AutomationAdministrationRole"
-            },
-            "Action": "sts:AssumeRole"
-        },
-        {
-            "Sid": "",
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "ssm.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-        }
-    ]
-}

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -1,13 +1,15 @@
 resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
   name                 = "AWSSupport-CalculateEBSPerformanceMetrics"
+  schedule_expression  = "rate(12 hour)"
+  automation_target_parameter_name = "ResourceId"
+
   parameters = {
-    resourceId           = "*"
     AutomationAssumeRole = "arn:aws:iam::612659970365:role/AWS-SSM-AutomationExecutionRole"
     startTime            = local.ebs_performance_start_time
     endTime              = local.ebs_performance_end_time
   }
   targets {
-    key = "ResourceId"
+    key = "All Instances"
     values = ["*"]
   }
 }

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -5,8 +5,8 @@ resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
 
   parameters = {
     AutomationAssumeRole = "arn:aws:iam::612659970365:role/AWS-SSM-AutomationExecutionRole"
-    startTime            = local.ebs_performance_start_time
-    endTime              = local.ebs_performance_end_time
+    StartTime            = local.ebs_performance_start_time
+    EndTime              = local.ebs_performance_end_time
   }
   targets {
     key = "All Instances"

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -5,17 +5,26 @@ resource "aws_ssm_document" "calculate_ebs_performance_metrics" {
 {
   "schemaVersion": "0.3",
   "description": "Calculates EBS performance metrics.",
-  "parameters": {}
+  "parameters": {
+    "resourceId": "*"
+  }
 }
   EOF
 }
 
 resource "aws_ssm_association" "automation_execution" {
   name                 = "calculate_ebs_performance_metrics"
-  instance_id_target   = "*"
-  targets              = [{ key = "InstanceIds", values = ["*"] }]
   schedule_expression  = "rate(12 hour)"
   document_version     = "$LATEST"
+  parameters = {
+    resourceId = "*"
+    startTime  = local.ebs_performance_start_time
+    endTime    = local.ebs_performance_end_time
+  }
+  targets {
+    key = "ResourceId"
+    values = ["*"]
+  }
 }
 
 resource "aws_cloudwatch_dashboard" "nomis_cloudwatch_dashboard" {
@@ -25,6 +34,9 @@ resource "aws_cloudwatch_dashboard" "nomis_cloudwatch_dashboard" {
 
 locals {
 
+  ebs_performance_start_time = formatdate("YYYY-MM-DDTHH:MM:SS", timestamp())
+  ebs_performance_end_time = formatdate("YYYY-MM-DDTHH:MM:SS", timestamp() - 48*60*60)
+  
   cloudwatch_period = 300
   region            = "eu-west-2"
 

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -33,9 +33,9 @@ resource "aws_cloudwatch_dashboard" "nomis_cloudwatch_dashboard" {
 }
 
 locals {
-
-  ebs_performance_start_time = formatdate("YYYY-MM-DDTHH:MM:SS", timestamp())
-  ebs_performance_end_time = formatdate("YYYY-MM-DDTHH:MM:SS", timestamp() - 48*60*60)
+  sanitized_timestamp = replace(timestamp(), "/[Z]/", "")
+  ebs_performance_start_time = timeadd(local.sanitized_timestamp, "-24h")
+  ebs_performance_end_time = local.sanitized_timestamp
   
   cloudwatch_period = 300
   region            = "eu-west-2"

--- a/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
+++ b/terraform/environments/nomis/cloudwatch_dashboard/dashboard.tf
@@ -1,7 +1,5 @@
 resource "aws_ssm_association" "calculate_ebs_performance_metrics" {
   name                 = "AWSSupport-CalculateEBSPerformanceMetrics"
-  schedule_expression  = "rate(12 hour)"
-  document_version     = "$LATEST"
   parameters = {
     resourceId           = "*"
     AutomationAssumeRole = "arn:aws:iam::612659970365:role/AWS-SSM-AutomationExecutionRole"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -4,6 +4,7 @@ locals {
   # baseline presets config
   test_baseline_presets_options = {
     enable_observability_platform_monitoring = true
+    enable_ebs_performance_monitoring = true
     sns_topics = {
       pagerduty_integrations = {
         dso_pagerduty               = "nomis_nonprod_alarms"

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -104,6 +104,7 @@ locals {
       policy_attachments = [
         "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole",
         "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
+        "arn:aws:iam::aws:policy/CloudWatchFullAccess",
       ]
     }
 

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -7,6 +7,7 @@ locals {
     var.options.enable_image_builder ? ["EC2ImageBuilderDistributionCrossAccountRole"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
     var.options.enable_observability_platform_monitoring ? ["observability-platform"] : [],
+    var.options.enable_ebs_performance_monitoring ? ["EBSPerformanceMonitoringRole"] : [],
   ]))
 
   iam_roles = {

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -90,6 +90,22 @@ locals {
       ]
     }
 
+    # allow SSM to call AWS services for EBS Performance Metrics
+    EBSPerformanceMonitoringRole = {
+      assume_role_policy = [{
+        effect = "Allow"
+        actions = ["sts:AssumeRole"]
+        principals = {
+          type = "AWS"
+          identifiers = ["*"]
+        }
+      }]
+      policy_attachments = [
+        "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole",
+        "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
+      ]
+    }
+
     SasTokenRotatorRole = {
       assume_role_policy = [{
         effect  = "Allow"

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -31,6 +31,7 @@ variable "options" {
     enable_ec2_user_keypair                      = optional(bool, false)
     enable_shared_s3                             = optional(bool, false)
     enable_observability_platform_monitoring     = optional(bool, false)
+    enable_ebs_performance_monitoring            = optional(bool, false)
     db_backup_s3                                 = optional(bool, false)
     route53_resolver_rules                       = optional(map(list(string)), {})
     iam_policies_filter                          = optional(list(string), [])


### PR DESCRIPTION
Using the AWSSupport-CalculateEBSPerformanceMetrics automation runbook, separate dashboards are created for EBS volumes to visualise:

- Volume Disk IOPs
- Volume Disk Throughput

IAM role EBSPerformanceMonitoringRole is used to create the EBS cloudwatch dashboards.