### PR TITLE
Planetfm/dsos 2576/call ssm docs with reboots from user data

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -59,6 +59,7 @@ locals {
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
           user_data_raw                 = base64encode(file("./templates/user-data-test.yaml"))
+          instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["SSMPolicy"])
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["rds-ec2s"]

--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -58,7 +58,7 @@ locals {
           ami_name                      = "hmpps_windows_server_2022_release_2023-*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
+          user_data_raw                 = base64encode(file("./templates/user-data-test.yaml"))
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["rds-ec2s"]

--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -58,7 +58,7 @@ locals {
           ami_name                      = "hmpps_windows_server_2022_release_2023-*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/user-data-call-ssm-example.yaml"))
+          user_data_raw                 = base64encode(file("./templates/windows_server_2022-user-data.yaml"))
           instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["SSMPolicy"])
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {

--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -58,7 +58,7 @@ locals {
           ami_name                      = "hmpps_windows_server_2022_release_2023-*"
           availability_zone             = null
           ebs_volumes_copy_all_from_ami = false
-          user_data_raw                 = base64encode(file("./templates/user-data-test.yaml"))
+          user_data_raw                 = base64encode(file("./templates/user-data-call-ssm-example.yaml"))
           instance_profile_policies     = concat(module.baseline_presets.ec2_instance.config.default.instance_profile_policies, ["SSMPolicy"])
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {

--- a/terraform/environments/hmpps-domain-services/templates/user-data-call-ssm-example.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-call-ssm-example.yaml
@@ -14,29 +14,35 @@ tasks:
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
           }
 
+          # Example code for getting EC2 Instance facts
+
           $instanceId = Get-EC2InstanceMetadata -Category InstanceId
 
-          Write-Host "instanceId: $instanceId"
+          Write-Debug "instanceId: $instanceId"
 
+          # Get the EC2 instance details
           $instance = Get-EC2Instance -InstanceId $instanceId | Select-Object -ExpandProperty Instances
 
-          Write-Host "instance: $instance"
-
-          New-Item -Type File -Path "C:\Temp\instanceinfo.txt" -Force 
-
-          $instanceJson = $instance | ConvertTo-Json -Depth 10
-
-          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instanceJson
-
+          # Get the EC2 instance tag value for the tag 'Name'
           $TagName = ( $instance.Tag | Where-Object { $_.Key -eq "Name"} ).Value
 
-          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value "TagName: $TagName"
-      - frequency: always
-        type: powershell
-        runAs: admin
-        content: |-
-          # Are previously available values available?
-          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value "TagName_two: $TagName"
+          Write-Debug "instance: $instance"
+
+          # Write the EC2 instance details to a file as Json
+          New-Item -Type File -Path "C:\Temp\instanceinfo.txt" -Force 
+          $instanceJson = $instance | ConvertTo-Json -Depth 10
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instanceJson
+      
+          # Write the EC2 instance tag value for the tag 'Name' to a file
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value "Tag = Name: $TagName"
+
+          # NOTE: Values from one code block like the one above are NOT available in subsequent blocks
+          # This means that if you wanted to supply a new hostname in an instance tag via terraform you
+          # would need to execute the $instanceId EC2InstanceMetadata and EC2Instance lookups in the block 
+          # where the value is needed
+          #
+          # When calling SSM documents it's likely better if the ssm-document does all the lookups for parameter values
+          # See windows-domain-join.yaml as a good example of this.
       - frequency: once
         type: powershell
         runAs: admin
@@ -46,9 +52,11 @@ tasks:
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
           }
 
+          $logFile = "C:\Temp\user_data_status.txt"
+
           # Create a file to track the status of the user data script
-          if (-Not (Test-Path -Path "C:\Temp\user_data_status.txt")) {
-            New-Item -Type File -Path "C:\Temp\user_data_status.txt" -Force
+          if (-Not (Test-Path -Path $logFile)) {
+            New-Item -Type File -Path $logFile -Force
           }
 
           Function Get-SSMAgentStatus {
@@ -71,20 +79,18 @@ tasks:
 
             $instanceId = Get-EC2InstanceMetadata -Category InstanceId
 
-            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing SSM Document $DocumentName with newHostname $Parameters.newHostname $(Get-Date)"
+            Add-Content -Path $logFile -Value "Executing SSM Document $DocumentName with newHostname $Parameters.newHostname $(Get-Date)"
 
-            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing on instance $instanceId. $(Get-Date)"
+            Add-Content -Path $logFile -Value "Executing on instance $instanceId. $(Get-Date)"
 
             $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $DocumentName -Parameter $Parameters -Force
-            Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
+            Add-Content -Path $logFile -Value "Executed SSM command with Command ID: $($commandId.CommandId) $(Get-Date)"
           }
-
-          $startTime = Get-Date
 
           $ssmDocuments = @(
             [PSCustomObject]@{
               "windows-domain-join" = @{
-                "newHostname" = "rstestssm2"
+                "newHostname" = "tag:Name" # default value when calling windows-domain-join
                 }
             }
           )
@@ -105,18 +111,20 @@ tasks:
           # }            
           #)
 
+          $startTime = Get-Date
+
           # Main loop to wait for SSM Agent to be running & run multiple ssm docs with parameters
           do {
             if (Get-SSMAgentStatus) {
-              Add-Content -Path "C:\Temp\user_data_status.txt" -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
+              Add-Content -Path $logFile -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
 
               foreach ($ssmDocument in $ssmDocuments) {
-                Add-Content -Path "C:\Temp\user_data_status.txt" - Value "SSM Document $ssmDocument run has started. $(Get-Date)"
+                Add-Content -Path $logFile -Value "SSM Document $ssmDocument run has started. $(Get-Date)"
                 Invoke-SSMDocument -SSMDocumentObject $ssmDocument
               }
               break
             } else {
-              Add-Content -Path "C:\Temp\user_data_status.txt" -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
+              Add-Content -Path $logFile -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
               Start-Sleep -Seconds 10
             }
           } while ((Get-Date) -lt $startTime.AddMinutes(10))

--- a/terraform/environments/hmpps-domain-services/templates/user-data-call-ssm-example.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-call-ssm-example.yaml
@@ -47,6 +47,8 @@ tasks:
         type: powershell
         runAs: admin
         content: |-
+          # NOTE: EC2 Instance calling SSM documents MUST have ssm:SendCommand permissions for [*] resources
+
           # Install AWS PowerShell module if not already installed
           if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck

--- a/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
@@ -18,14 +18,25 @@ tasks:
 
           Write-Host "instanceId: $instanceId"
 
-          $instance = (Get-EC2Instance -InstanceId $instanceId).Instance
+          $instance = Get-EC2Instance -InstanceId $instanceId | Select-Object -ExpandProperty Instances
 
           Write-Host "instance: $instance"
 
           New-Item -Type File -Path "C:\Temp\instanceinfo.txt" -Force 
 
-          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instance
+          $instanceJson = $instance | ConvertTo-Json -Depth 10
 
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instanceJson
+
+          $TagName = ( $instance.Tag | Where-Object { $_.Key -eq "Name"} ).Value
+
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value "TagName: $TagName"
+      - frequency: always
+        type: powershell
+        runAs: admin
+        content: |-
+          # Are previously available values available?
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value "TagName_two: $TagName"
       - frequency: once
         type: powershell
         runAs: admin
@@ -60,7 +71,7 @@ tasks:
 
             $instanceId = Get-EC2InstanceMetadata -Category InstanceId
 
-            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing SSM Document $DocumentName with parameters $Parameters. $(Get-Date)"
+            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing SSM Document $DocumentName with newHostname $Parameters.newHostname $(Get-Date)"
 
             Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing on instance $instanceId. $(Get-Date)"
 

--- a/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
@@ -42,7 +42,9 @@ tasks:
 
           $ssmDocuments = @(
             [PSCustomObject]@{
-              "windows-psreadline-fix" = @{}
+              "windows-domain-join" = @{
+                "newHostname" = "rstestssm2"
+                }
             }
           )
 
@@ -77,3 +79,4 @@ tasks:
               Start-Sleep -Seconds 10
             }
           } while ((Get-Date) -lt $startTime.AddMinutes(10))
+

--- a/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
@@ -9,6 +9,25 @@ tasks:
         type: powershell
         runAs: admin
         content: |-
+          # Get EC2 Instance facts
+          if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
+            Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+          }
+
+          $instanceId = Get-EC2InstanceMetadata -Category InstanceId
+
+          Write-Host "instanceId: $instanceId"
+
+          $instance = (Get-EC2Instance -InstanceId $instanceId).Instance
+
+          Write-Host "instance: $instance"
+
+          Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instance
+
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
           # Install AWS PowerShell module if not already installed
           if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck

--- a/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-test.yaml
@@ -22,6 +22,8 @@ tasks:
 
           Write-Host "instance: $instance"
 
+          New-Item -Type File -Path "C:\Temp\instanceinfo.txt" -Force 
+
           Add-Content -Path "C:\Temp\instanceinfo.txt" -Value $instance
 
       - frequency: once
@@ -31,6 +33,11 @@ tasks:
           # Install AWS PowerShell module if not already installed
           if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
             Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+          }
+
+          # Create a file to track the status of the user data script
+          if (-Not (Test-Path -Path "C:\Temp\user_data_status.txt")) {
+            New-Item -Type File -Path "C:\Temp\user_data_status.txt" -Force
           }
 
           Function Get-SSMAgentStatus {
@@ -52,6 +59,10 @@ tasks:
             $Parameters = $SSMDocumentObject.$DocumentName
 
             $instanceId = Get-EC2InstanceMetadata -Category InstanceId
+
+            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing SSM Document $DocumentName with parameters $Parameters. $(Get-Date)"
+
+            Add-Content -Path "C:\Temp\user_data_status.txt" -Value "Executing on instance $instanceId. $(Get-Date)"
 
             $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $DocumentName -Parameter $Parameters -Force
             Write-Host "Executed SSM command with Command ID: $($commandId.CommandId)"
@@ -81,7 +92,7 @@ tasks:
           #     # Param2 = "Value2"
           #   }
           # }            
-          #) 
+          #)
 
           # Main loop to wait for SSM Agent to be running & run multiple ssm docs with parameters
           do {


### PR DESCRIPTION
* add a user-data example that calls the windows-domain-join ssm document
* add a user-data step which always runs and gets the EC2 instance information
  * sadly getting EC2 info from one script step doesn't survive into the next one 