### PR TITLE
put stopped instance alarm in it's own block

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_defaults.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_defaults.tf
@@ -3,15 +3,18 @@ locals {
   ec2_cloudwatch_metric_alarms = {
     linux = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
-      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux
     )
     windows = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
-      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
     )
     app = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
       {
         high-memory-usage = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows["high-memory-usage"], {
           threshold           = "75"

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -18,6 +18,7 @@ locals {
           ami_name          = "base_ol_8_5_*"
           availability_zone = null
         })
+        cloudwatch_metric_alarms = {}
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           vpc_security_group_ids = ["database"]
         })

--- a/terraform/environments/planetfm/locals_defaults.tf
+++ b/terraform/environments/planetfm/locals_defaults.tf
@@ -19,7 +19,8 @@ locals {
     }
     cloudwatch_metric_alarms = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
-      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
     )
     route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
   }

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -100,19 +100,6 @@ locals {
         alarm_description   = "Triggers if memory usage is continually high for one hour. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326523370"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
-      instance-or-cloudwatch-agent-stopped = {
-        comparison_operator = "LessThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "CPU_IDLE"
-        period              = "60"
-        namespace           = "CWAgent"
-        statistic           = "SampleCount"
-        threshold           = "0"
-        treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-      }
     }
 
     ec2_cwagent_linux = {
@@ -152,19 +139,7 @@ locals {
         alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 3 hours. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
-      instance-or-cloudwatch-agent-stopped = {
-        comparison_operator = "LessThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "cpu_usage_idle"
-        period              = "60"
-        namespace           = "CWAgent"
-        statistic           = "SampleCount"
-        threshold           = "0"
-        treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-      }
+
     }
 
     ec2_instance_cwagent_collectd_service_status_os = {
@@ -274,6 +249,36 @@ locals {
         threshold           = "129600"
         treat_missing_data  = "breaching"
         alarm_description   = "Triggers if rman_backup metric not collected or not updated for over 36 hours"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
+    ec2_instance_or_cwagent_stopped_linux = {
+      instance-or-cloudwatch-agent-stopped = {
+        comparison_operator = "LessThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "cpu_usage_idle"
+        period              = "60"
+        namespace           = "CWAgent"
+        statistic           = "SampleCount"
+        threshold           = "0"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
+    ec2_instance_or_cwagent_stopped_windows = {
+      instance-or-cloudwatch-agent-stopped = {
+        comparison_operator = "LessThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "CPU_IDLE"
+        period              = "60"
+        namespace           = "CWAgent"
+        statistic           = "SampleCount"
+        threshold           = "0"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }


### PR DESCRIPTION
- moving the 'instance_or_cwagent_stopped' alarm to it's own block to allow this to be more 'opt-in' than it currently is
- added to defaults for CSR and PlanetFM environments as these all require this check
- other environments (pretty much all DSO) can add this themselves as 'opt-in' is far easier than 'opt-out'!