### PR TITLE
Csr/dsos 2565/ssm doc updates

### DIFF
--- a/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
+++ b/terraform/environments/corporate-staff-rostering/ssm-documents/windows-domain-join.yaml
@@ -1,32 +1,12 @@
 ---
 schemaVersion: "2.2"
-description: "SSM Document for joining Windows EC2 instances to the domain. Moving Computers to a different OU must be done manually on the relevant domain controller."
+description: "SSM Document for joining Windows EC2 instances to the hmpp noms domain. Moving Computers to a different OU must be done manually on the relevant domain controller."
 parameters:
-  domain:
-    type: "String"
-    default: "dev"
-    description: "Domain to join, either Dev (default) or Prod"
-    allowedValues:
-      - dev
-      - prod
-  domainJoinUsername:
-    type: "String"
-    description: "Username with domain join permissions"
-  domainJoinPassword:
-    type: "String"
-    description: "Password for domain join user (NOTE: Do not use a password containing quotes)"
   newHostname:
     type: "String"
-    description: "If over-written, the hostname will be changed to this value. If un-changed the existing hostname will be kept. The new hostname must be 15 characters or less"
-    default: "keep-existing"
+    description: "By default uses the Name tag. Otherwise set to keep-existing or the desired hostname 15 chars or less"
+    default: "tag:Name"
     maxChars: 15
-  restart:
-    type: "String"
-    description: "If set to true, the instance will be restarted after joining the domain. If set to false, the instance will not be restarted. Default is true."
-    default: "true"
-    allowedValues:
-      - "true"
-      - "false"
 mainSteps:
   - name: WindowsDomainJoin
     action: aws:runPowerShellScript
@@ -38,112 +18,84 @@ mainSteps:
       runCommand:
         - |
           $ErrorActionPreference = "Stop" # all errors will terminate the script
-
-          $domainJoinUsername = "{{domainJoinUsername}}"
-          $domainJoinPassword = "{{domainJoinPassword}}"
           $newHostname = "{{newHostname}}"
-          $domain = "{{domain}}"
-          $restart = "{{restart}}"
 
-          # Check pre-requisites are installed, exit if not
-          if (-Not (Get-Module -ListAvailable -Name "ActiveDirectory")) {
-            Write-Error "ERROR: ActiveDirectory module not installed"
-            Write-Error "ERROR: Run 'Install-WindowsFeature -Name "RSAT-AD-PowerShell" -IncludeAllSubFeature' via PoweShell as admin to install the ActiveDirectory, then re-run this ssm document"
-            exit 1
-          }
-          # Define environment settings
-          $environments = @{
-            "dev" = @{
-                "domain" = "azure.noms.root";
-                "primarydns" = "10.102.0.196";
-                "serveraddresses" = @("10.102.0.196","10.102.0.200");
-                "suffixsearchlist" = @("azure.noms.root", "noms.root");
-                "domaincontroller" = "MGMCW0002.azure.noms.root";
-                "usernameprefix" = "azure";
-            };
-            "prod" = @{
-                "domain" = "azure.hmpp.root";
-                "primarydns" = "10.40.128.196";
-                "serveraddresses" = @("10.40.128.196","10.40.0.133");
-                "suffixsearchlist" = @("azure.hmpp.root", "hmpp.root");
-                "domaincontroller" = "PCMCW0011.azure.hmpp.root";
-                "usernameprefix" = "hmpp";
-            };
+          # Lookup domain configuration based on environment-name tag
+          $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
+          $instanceId = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/instance-id
+          $tagsRaw = aws ec2 describe-tags --filters "Name=resource-id,Values=$instanceId"
+          $tags = "$tagsRaw" | ConvertFrom-Json
+          $environmentNameTag = ($tags.Tags | Where-Object  {$_.Key -eq "environment-name"}).Value
+          $environment = $environmentNameTag.Split("-")[-1]
+          If ($environment -Eq "development" -Or $environment -Eq "test") {
+            $secretAccountName = "hmpps-domain-services-test"
+            $domainNameFQDN = "azure.noms.root"
+            $domainNameNetbios = "AZURE"
+            $domainJoinUsername = "svc_join_domain"
+          } ElseIf ($environment -Eq "preproduction" -Or $environment -Eq "production") {
+            $secretAccountName = "hmpps-domain-services-production"
+            $domainNameFQDN = "azure.hmpp.root"
+            $domainNameNetbios = "HMPP"
+            $domainJoinUsername = "svc_join_domain"
+          } Else {
+            Write-Error "Unexpected environment_name tag $$environmentNameTag.tags.Value"
+            Exit 1
           }
 
-          # Set up DNS IP addresses and suffixes
-          Write-Host "INFO: Setting DNS Client Server and DNS Client Global Settings for $domain domain"
-
-          # Get the network interface alias
-          $interfaceAlias = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } | Select-Object -ExpandProperty Name
-          Set-DnsClientServerAddress -InterfaceAlias $interfaceAlias -ServerAddresses $environments[$domain]["serveraddresses"]
-
-          # Get existing SuffixSearchList and prepend suffixSearchList
-          $existingSuffixSearchList = (Get-DnsClientGlobalSetting).SuffixSearchList
-          $newSuffixSearchList = $environments[$domain]["suffixsearchlist"] + $existingSuffixSearchList
-          Set-DnsClientGlobalSetting -SuffixSearchList $newSuffixSearchList
-            
-          function Get-HostnameInUse {
-            param (
-              [Parameter(Mandatory=$true)]
-              [string]$hostname,
-              [Parameter(Mandatory=$true)]
-              [System.Management.Automation.PSCredential]$credentials,
-              [Parameter(Mandatory=$true)]
-              [string]$domain
-            )
-
-            $hostnameInUse = Get-ADComputer -Filter 'Name -eq $hostname' -Credential $credentials -Server ($environments[$domain]["domaincontroller"])
-
-            if ($hostnameInUse) {
-              return $true
-            } else {
-              return $false
+          # Check if already domain joined
+          If ((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain) {
+            $existingDomain = (Get-WmiObject -Class Win32_ComputerSystem).Domain
+            if ($existingDomain -Eq $domainNameFQDN) {
+              Write-Output "Joined to domain $domainNameFQDN"
+              Exit 0
+            } Else {
+              Write-Error "Joined to a different domain $existingDomain. Expected $domainNameFQDN"
+              Exit 1
             }
           }
 
-          $secpasswd = ConvertTo-SecureString $domainJoinPassword -AsPlainText -Force
-          $credentials = New-Object System.Management.Automation.PSCredential (($environments[$domain]["usernameprefix"] + "\" + $domainJoinUsername), $secpasswd)
-
-          # splatting Add-Computer parameters to make it easier to read
-          $args = @{
-            DomainName = $environments[$domain]["domain"]
-            Credential = $credentials
-            Verbose = $true
-            Force = $true
+          # Install powershell features if missing
+          if (-Not (Get-Module -ListAvailable -Name "ActiveDirectory")) {
+            Write-Host "INFO: Installing RSAT-AD-PowerShell feature"
+            Install-WindowsFeature -Name "RSAT-AD-PowerShell" -IncludeAllSubFeature
           }
 
-          # adds new name to parameters if supplied & runs the rename step
-          if ($newHostname -eq "keep-existing") {
-            Write-Host "INFO: No new hostname supplied, using existing hostname $env:COMPUTERNAME"
-            $hostname = $env:COMPUTERNAME
-          } elseif ($newHostname -ne $env:COMPUTERNAME) {
+          # Lookup domain join secrets
+          $accountIdsRaw = aws ssm get-parameter --name account_ids --with-decryption --query Parameter.Value --output text
+          $accountIds = "$accountIdsRaw" | ConvertFrom-Json
+          $secretAccountId = $accountIds.$secretAccountName
+          $secretName = "/microsoft/AD/$domainNameFQDN/shared-passwords"
+          $secretArn = "arn:aws:secretsmanager:eu-west-2:${secretAccountId}:secret:${secretName}"
+          $accountId = aws sts get-caller-identity --query Account --output text
+          $roleArn = "arn:aws:iam::${accountId}:role/EC2HmppsDomainSecretsRole"
+          $session = "ssm-windows-domain-join"
+          $credsRaw = aws sts assume-role --role-arn "${roleArn}" --role-session-name "${session}"
+          $creds = "$credsRaw" | ConvertFrom-Json
+          $env:AWS_ACCESS_KEY_ID = $creds.Credentials.AccessKeyId
+          $env:AWS_SECRET_ACCESS_KEY = $creds.Credentials.SecretAccessKey
+          $env:AWS_SESSION_TOKEN = $creds.Credentials.SessionToken
+          $secretValueRaw = aws secretsmanager get-secret-value --secret-id "${secretArn}" --query SecretString --output text
+          $secretValue = "$secretValueRaw" | ConvertFrom-Json
+          $env:AWS_ACCESS_KEY_ID = ""
+          $env:AWS_SECRET_ACCESS_KEY = ""
+          $env:AWS_SESSION_TOKEN = ""
+          $domainJoinPassword = $secretValue.$domainJoinUsername
+          $domainJoinPasswordSecureString = ConvertTo-SecureString $secretValue.$domainJoinUsername -AsPlainText -Force
+          $credentials = New-Object System.Management.Automation.PSCredential ("$domainNameNetbios\$domainJoinUsername", $domainJoinPasswordSecureString)
+
+          #Rename host
+          If ($newHostname -Eq "tag:Name") {
+            $newHostname = ($tags.Tags | Where-Object  {$_.Key -eq "Name"}).Value
+          } ElseIf ($newHostname -Eq "keep-existing") {
+            $newHostname = $env:COMPUTERNAME
+          }
+          If ($newHostname -Ne $env:COMPUTERNAME) {
             Write-Host "INFO: Renaming EC2 instance to $newHostname and then rebooting"
             Rename-Computer -NewName $newHostname -Force
-            exit 3010 # exit code 3010 means reboot required, ssm document will continue after reboot
-          } elseif ($newHostname -eq $env:COMPUTERNAME) {
-            Write-Host "INFO: Hostname has been succesfully changed to $newHostname"
-            $hostname = $newHostname
-          } else {
-            Write-Error "ERROR: Something went wrong with the hostname parameter"
-            exit 1
+            Exit 3010 # Exit code 3010 means reboot required, ssm document will continue after reboot
           }
 
-          # optional restart parameter, mainly for testing, defaults to true
-          if ($restart -eq "true") {
-            Write-Host "WARNING: Instance will restart to complete domain join"
-            $args.Add("Restart", $true)
-          } else {
-            Write-Host "WARNING: Instance will not be restarted but must be restarted manually to complete domain join operation"
-            $args.Add("Restart", $false)
-          }
-
-          if (Get-HostnameInUse -hostname $hostname -credentials $credentials -domain $domain) {
-            Write-Error "ERROR: Hostname $hostname is already in use"
-            exit 1
-          } else {
-            Write-Host "INFO: Hostname $hostname is not already a member of the $domain domain, continuing..."
-            Write-Host "INFO: Running Add-Computer with args" @args
-            Add-Computer @args
-          }
-
+          # Join the domain
+          Write-Host "INFO: Joining $env:COMPUTERNAME to $domainNameFQDN domain and rebooting"
+          Add-Computer -DomainName $domainNameFQDN -Credential $credentials -Verbose -Force
+          Exit 3010 # Exit code 3010 means reboot required, ssm document will continue after reboot

--- a/terraform/environments/planetfm/ec2-common.tf
+++ b/terraform/environments/planetfm/ec2-common.tf
@@ -81,3 +81,17 @@ resource "aws_ssm_document" "network-testing-tools" {
     },
   )
 }
+
+resource "aws_ssm_document" "windows-domain-leave" {
+  name            = "windows-domain-leave"
+  document_type   = "Command"
+  document_format = "YAML"
+  content         = file("./ssm-documents/windows-domain-leave.yaml")
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "network-testing-tools"
+    },
+  )
+}

--- a/terraform/environments/planetfm/ssm-documents/windows-domain-leave.yaml
+++ b/terraform/environments/planetfm/ssm-documents/windows-domain-leave.yaml
@@ -1,14 +1,8 @@
 ---
 schemaVersion: "2.2"
-description: "SSM Document for joining Windows EC2 instances to the hmpp noms domain. Moving Computers to a different OU must be done manually on the relevant domain controller."
-parameters:
-  newHostname:
-    type: "String"
-    description: "By default uses the Name tag. Otherwise set to keep-existing or the desired hostname 15 chars or less"
-    default: "tag:Name"
-    maxChars: 15
+description: "SSM Document for removing Windows EC2 instances from hmpp noms domain."
 mainSteps:
-  - name: WindowsDomainJoin
+  - name: WindowsDomainLeave
     action: aws:runPowerShellScript
     precondition:
       StringEquals:
@@ -18,7 +12,6 @@ mainSteps:
       runCommand:
         - |
           $ErrorActionPreference = "Stop" # all errors will terminate the script
-          $newHostname = "{{newHostname}}"
 
           # Lookup domain configuration based on environment-name tag
           $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
@@ -45,13 +38,13 @@ mainSteps:
           # Check if already domain joined
           If ((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain) {
             $existingDomain = (Get-WmiObject -Class Win32_ComputerSystem).Domain
-            if ($existingDomain -Eq $domainNameFQDN) {
-              Write-Output "Joined to domain $domainNameFQDN"
-              Exit 0
-            } Else {
+            if ($existingDomain -Ne $domainNameFQDN) {
               Write-Error "Joined to a different domain $existingDomain. Expected $domainNameFQDN"
               Exit 1
             }
+          } Else {
+            Write-Output "Unjoined from domain"
+            Exit 0
           }
 
           # Install powershell features if missing
@@ -83,19 +76,7 @@ mainSteps:
           $domainJoinPasswordSecureString = ConvertTo-SecureString $secretValue.$domainJoinUsername -AsPlainText -Force
           $credentials = New-Object System.Management.Automation.PSCredential ("$domainNameNetbios\$domainJoinUsername", $domainJoinPasswordSecureString)
 
-          #Rename host
-          If ($newHostname -Eq "tag:Name") {
-            $newHostname = ($tags.Tags | Where-Object  {$_.Key -eq "Name"}).Value
-          } ElseIf ($newHostname -Eq "keep-existing") {
-            $newHostname = $env:COMPUTERNAME
-          }
-          If ($newHostname -Ne $env:COMPUTERNAME) {
-            Write-Host "INFO: Renaming EC2 instance to $newHostname and then rebooting"
-            Rename-Computer -NewName $newHostname -Force
-            Exit 3010 # Exit code 3010 means reboot required, ssm document will continue after reboot
-          }
-
-          # Join the domain
-          Write-Host "INFO: Joining $env:COMPUTERNAME to $domainNameFQDN domain and rebooting"
-          Add-Computer -DomainName $domainNameFQDN -Credential $credentials -Verbose -Force
+          # Leave the domain
+          Write-Host "INFO: Removing $env:COMPUTERNAME from $domainNameFQDN domain and rebooting"
+          Remove-Computer -Credential $credentials -Verbose -Force
           Exit 3010 # Exit code 3010 means reboot required, ssm document will continue after reboot


### PR DESCRIPTION
Each SSM domain join and domain leave/unjoin script has removed the requirement to type in a domain username and password instead calls upon the hmpps-domain-secrets account and fetched them from there and is able to distinguish between environments

Script was tested through an ec2 windows machine in dev to join AZURE.NOMS.ROOT both in the machine and through ssm