### PR TITLE
DSOS-2560: add eu-west-2c to LB config 

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -40,7 +40,7 @@ locals {
           "/dev/sda1" = { type = "gp3", size = 128 }
         }
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 2
+          desired_capacity = 0
           max_size         = 2
         })
         tags = {

--- a/terraform/environments/hmpps-domain-services/locals_rds.tf
+++ b/terraform/environments/hmpps-domain-services/locals_rds.tf
@@ -30,10 +30,6 @@ locals {
       internal_lb                      = false
       load_balancer_type               = "application"
       security_groups                  = ["public-lb"]
-      subnets = [
-        module.environment.subnet["public"]["eu-west-2a"].id,
-        module.environment.subnet["public"]["eu-west-2b"].id,
-      ]
     }
   }
 

--- a/terraform/environments/hmpps-domain-services/locals_rds.tf
+++ b/terraform/environments/hmpps-domain-services/locals_rds.tf
@@ -30,6 +30,7 @@ locals {
       internal_lb                      = false
       load_balancer_type               = "application"
       security_groups                  = ["public-lb"]
+      subnets                          = module.environment.subnets["public"].ids
     }
   }
 


### PR DESCRIPTION
Since some ASG instances are created in 2c region.