### PR TITLE
Up memory limit to account for filesize

### DIFF
--- a/terraform/environments/data-platform-apps-and-tools/lambda-functions.tf
+++ b/terraform/environments/data-platform-apps-and-tools/lambda-functions.tf
@@ -11,6 +11,7 @@ module "jml_extract_lambda" {
   function_name = "data_platform_jml_extract"
   description   = "Generates a JML report and sends it to JMLv4"
   package_type  = "Image"
+  memory_size   = 512
   image_uri     = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/data-platform-jml-extract-lambda-ecr-repo:1.0.3"
 
   environment_variables = {


### PR DESCRIPTION
Generated dataframes are over the 128MB default memory limit. This bumps us to half a gig.