### PR TITLE
DSOS-2560: new version of ASG module fixing target group healthcheck

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_rds.tf
+++ b/terraform/environments/hmpps-domain-services/locals_rds.tf
@@ -74,6 +74,7 @@ locals {
         matcher             = "200-399"
         path                = "/"
         port                = 80
+        protocol            = "HTTP"
         timeout             = 5
         unhealthy_threshold = 2
       }

--- a/terraform/environments/nomis-combined-reporting/locals_tomcat_admin.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_tomcat_admin.tf
@@ -9,7 +9,6 @@ locals {
   tomcat_admin_target_group_http_7777 = {
     port                 = 7777
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -18,6 +17,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 7777
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 5
     }
@@ -30,7 +30,6 @@ locals {
   tomcat_admin_target_group_http_7010 = {
     port                 = 7010
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -39,6 +38,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 7010
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 5
     }
@@ -51,7 +51,6 @@ locals {
   tomcat_admin_target_group_http_8443 = {
     port                 = 8443
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -60,6 +59,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 8443
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 5
     }
@@ -72,7 +72,6 @@ locals {
   tomcat_admin_target_group_http_8005 = {
     port                 = 8005
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -81,6 +80,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 8005
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 5
     }

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -10,7 +10,6 @@ locals {
   weblogic_target_group_http_7001 = {
     port                 = 7001
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -19,6 +18,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 7001
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 2
     }
@@ -31,7 +31,6 @@ locals {
   weblogic_target_group_http_7777 = {
     port                 = 7777
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -40,6 +39,7 @@ locals {
       matcher             = "200-399"
       path                = "/keepalive.htm"
       port                = 7777
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 2
     }

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -100,7 +100,6 @@ locals {
   target_group_http_8080 = {
     port                 = 8080
     protocol             = "HTTP"
-    target_type          = "instance"
     deregistration_delay = 30
     health_check = {
       enabled             = true
@@ -109,6 +108,7 @@ locals {
       matcher             = "200-399"
       path                = "/"
       port                = 8080
+      protocol            = "HTTP"
       timeout             = 5
       unhealthy_threshold = 5
     }

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -15,7 +15,7 @@ module "ec2_autoscaling_group" {
 
   for_each = var.ec2_autoscaling_groups
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.5.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=06257a83fff9b14bf3609f78d1dcc785cd5f0578"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -248,7 +248,6 @@ variable "ec2_autoscaling_groups" {
     lb_target_groups = optional(map(object({
       port                 = optional(number)
       protocol             = optional(string)
-      target_type          = string
       deregistration_delay = optional(number)
       health_check = optional(object({
         enabled             = optional(bool)


### PR DESCRIPTION
Current version of ASG module doesn't allow HTTPS protocol on healthcheck.
Also removing unused variable and explicitly putting protocol in healthcheck to reduce cut-and-paste issues.