### PR TITLE
burn down pd-rds-1-b, apply domain join automatically and move fwd

### DIFF
--- a/terraform/environments/hmpps-domain-services/lambda.tf
+++ b/terraform/environments/hmpps-domain-services/lambda.tf
@@ -1,25 +1,25 @@
 locals {
-    lambda_ad_object_cleanup = {
-        function_name = "AD-Object-CleanUp"
-    }
+  lambda_ad_object_cleanup = {
+    function_name = "AD-Object-CleanUp"
+  }
 }
 
 module "ad-clean-up-lambda" {
-  source                 = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function" # ref for V3.1
-  count                  = local.environment == "test" ? 1 : 0 # temporary whilst on-going work
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function" # ref for V3.1
+  count  = local.environment == "test" ? 1 : 0                                             # temporary whilst on-going work
 
 
-  application_name       = local.lambda_ad_object_cleanup.function_name
-  function_name          = local.lambda_ad_object_cleanup.function_name
-  description            = "Lambda to remove corresponding computer object from Active Directory upon server termination"
-  package_type           = "Zip"
-  filename               = data.archive_file.ad-cleanup-lambda.output_path
-  source_code_hash       = data.archive_file.ad-cleanup-lambda.output_base64sha256
-  handler                = "lambda_function.lambda_handler"
-  runtime                = "python3.8"
+  application_name = local.lambda_ad_object_cleanup.function_name
+  function_name    = local.lambda_ad_object_cleanup.function_name
+  description      = "Lambda to remove corresponding computer object from Active Directory upon server termination"
+  package_type     = "Zip"
+  filename         = data.archive_file.ad-cleanup-lambda.output_path
+  source_code_hash = data.archive_file.ad-cleanup-lambda.output_base64sha256
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.8"
 
-  create_role            = false
-  lambda_role            = aws_iam_role.lambda-ad-role[count.index].arn
+  create_role = false
+  lambda_role = aws_iam_role.lambda-ad-role[count.index].arn
 
   vpc_subnet_ids         = tolist(data.aws_subnets.shared-private.ids)
   vpc_security_group_ids = [module.baseline.security_groups["domain"].id]
@@ -33,9 +33,9 @@ module "ad-clean-up-lambda" {
 }
 
 data "archive_file" "ad-cleanup-lambda" {
-  type             = "zip"
-  source_dir       = "lambda/ad-clean-up"
-  output_path      = "lambda/ad-cleanup/ad-cleanup-lambda-payload-test.zip"
+  type        = "zip"
+  source_dir  = "lambda/ad-clean-up"
+  output_path = "lambda/ad-cleanup/ad-cleanup-lambda-payload-test.zip"
 }
 
 data "aws_iam_policy_document" "lambda_assume_role_policy" {

--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -29,7 +29,7 @@ locals {
     enable_shared_s3                             = false # adds permissions to ec2s to interact with devtest or prodpreprod buckets
     db_backup_s3                                 = false # adds db backup buckets
     enable_oracle_secure_web                     = false # allows db to list all buckets
-    cloudwatch_metric_alarms_default_actions = ["hmpps_domain_services_pagerduty"]
+    cloudwatch_metric_alarms_default_actions     = ["hmpps_domain_services_pagerduty"]
     route53_resolver_rules = {
       # outbound-data-and-private-subnets = ["azure-fixngo-domain"]  # already set by nomis account
     }

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -87,7 +87,7 @@ locals {
         config = merge(local.rds_ec2_instance.config, {
           availability_zone         = "eu-west-2a"
           user_data_raw             = base64encode(file("./templates/user-data-domain-join.yaml"))
-          instance_profile_policies = concat(local.rds_ec2_instance.instance_profile_policies, ["SSMPolicy"])
+          instance_profile_policies = concat(local.rds_ec2_instance.config.instance_profile_policies, ["SSMPolicy"])
         })
         instance = merge(local.rds_ec2_instance.instance, {
           instance_type = "t3.large"

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -83,9 +83,11 @@ locals {
           description = "Remote Desktop Gateway for hmpp.noms.root domain"
         })
       })
-      pd-rds-1-b = merge(local.rds_ec2_instance, {
+      pd-rds-1-a = merge(local.rds_ec2_instance, {
         config = merge(local.rds_ec2_instance.config, {
-          availability_zone = "eu-west-2b"
+          availability_zone         = "eu-west-2a"
+          user_data_raw             = base64encode(file("./templates/user-data-domain-join.yaml"))
+          instance_profile_policies = concat(local.rds_ec2_instance.instance_profile_policies, ["SSMPolicy"])
         })
         instance = merge(local.rds_ec2_instance.instance, {
           instance_type = "t3.large"

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -109,7 +109,7 @@ locals {
           })
           pd-rds-1-https = merge(local.rds_target_groups.https, {
             attachments = [
-              { ec2_instance_name = "pd-rds-1-b" },
+              { ec2_instance_name = "pd-rds-1-a" },
             ]
           })
         }

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -1,11 +1,11 @@
 locals {
 
   security_group_cidrs_devtest = {
-    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.devtest
+    azure_vnets        = module.ip_addresses.azure_fixngo_cidrs.devtest
     domain_controllers = module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers
   }
   security_group_cidrs_preprod_prod = {
-    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.prod
+    azure_vnets        = module.ip_addresses.azure_fixngo_cidrs.prod
     domain_controllers = module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers
 
   }

--- a/terraform/environments/hmpps-domain-services/templates/user-data-domain-join.yaml
+++ b/terraform/environments/hmpps-domain-services/templates/user-data-domain-join.yaml
@@ -1,0 +1,95 @@
+# This is an EC2Launch V2 type user-data script
+# https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
+# See C:\ProgramData\Amazon\EC2Launch\log for logs
+version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
+tasks:
+  - task: executeScript
+    inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # NOTE: EC2 Instance calling SSM documents MUST have ssm:SendCommand permissions for [*] resources
+
+          # Install AWS PowerShell module if not already installed
+          if (-Not (Get-Module -ListAvailable -Name "AWSPowerShell")) {
+            Install-Package -Name "AWSPowerShell" -Force -SkipPublisherCheck
+          }
+
+          $logFile = "C:\Temp\user_data_status.txt"
+
+          # Create a file to track the status of the user data script
+          if (-Not (Test-Path -Path $logFile)) {
+            New-Item -Type File -Path $logFile -Force
+          }
+
+          Function Get-SSMAgentStatus {
+            $service = Get-Service -Name "AmazonSSMAgent"
+            if ($service.Status -eq "Running") {
+                return $true
+            } else {
+                Start-Service -Name "AmazonSSMAgent" -Force
+            }
+          }
+
+          Function Invoke-SSMDocument {
+            param(
+              [Parameter(Mandatory = $true)]
+              [PSCustomObject]$SSMDocumentObject
+            )
+
+            $DocumentName = $SSMDocumentObject.PSObject.Properties.Name
+            $Parameters = $SSMDocumentObject.$DocumentName
+
+            $instanceId = Get-EC2InstanceMetadata -Category InstanceId
+
+            Add-Content -Path $logFile -Value "Executing SSM Document $DocumentName with newHostname $Parameters.newHostname $(Get-Date)"
+
+            Add-Content -Path $logFile -Value "Executing on instance $instanceId. $(Get-Date)"
+
+            $commandId = Send-SSMCommand -InstanceId $instanceId -DocumentName $DocumentName -Parameter $Parameters -Force
+            Add-Content -Path $logFile -Value "Executed SSM command with Command ID: $($commandId.CommandId) $(Get-Date)"
+          }
+
+          $ssmDocuments = @(
+            [PSCustomObject]@{
+              "windows-domain-join" = @{
+                "newHostname" = "tag:Name" # default value when calling windows-domain-join
+                }
+            }
+          )
+
+          # EXAMPLE SSMDOCUMENTS list
+          # $ssmDocuments = @(
+          # [PSCustomObject]@{
+          #   "windows-psreadline-fix" = @{}
+          # },
+          # [PSCustomObject]@{
+          #   "another-ssm-doc" = @{
+          #     # Add your parameters here as a hashtable.
+          #     # Quoting depends on the values, special characters etc.
+          #     # Example:
+          #     # Param1 = "Value1"
+          #     # Param2 = "Value2"
+          #   }
+          # }            
+          #)
+
+          $startTime = Get-Date
+
+          # Main loop to wait for SSM Agent to be running & run multiple ssm docs with parameters
+          do {
+            if (Get-SSMAgentStatus) {
+              Add-Content -Path $logFile -Value "SSM Agent is running, executing SSM command. $(Get-Date)"
+
+              foreach ($ssmDocument in $ssmDocuments) {
+                Add-Content -Path $logFile -Value "SSM Document $ssmDocument run has started. $(Get-Date)"
+                Invoke-SSMDocument -SSMDocumentObject $ssmDocument
+              }
+              break
+            } else {
+              Add-Content -Path $logFile -Value "SSM Agent is not running yet. $(Get-Date) Waiting..."
+              Start-Sleep -Seconds 10
+            }
+          } while ((Get-Date) -lt $startTime.AddMinutes(10))
+


### PR DESCRIPTION
- replace pd-rds-1-b with pd-rds-1-a and move it to eu-west-2a

IMPORTANT 
- this instance will run the user-data-domain-join script and add itself to the domain automatically 🥇 
- don't start changing it's config till it's definitely reachable via rdp using it's name, at least 1 reboot happens during this

THEN:
- need to remove pd-rds-1-b from the domain controller when it's been killed
- check nslookup (domain name) and nslookup (ip) to make sure the new one is in the correct place!
- move to GPO_BLOCKED manually and start configuring it again (lovely)