### PR TITLE
add alarms for production lb and training servers in preprod

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -704,6 +704,9 @@ locals {
         }
 
         listeners = {
+          alarm_target_group_names = [
+            "pp-csr-w-12-7781" # this alarm will deliberately fail, will be removed later
+          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -1208,6 +1211,13 @@ locals {
         }
 
         listeners = {
+          # we only want alarms on the training servers in pre-production 
+          alarm_target_group_names = [ 
+            "pp-csr-w-34-7770", 
+            "pp-csr-w-34-7771",
+            "pp-csr-w-34-7780",
+            "pp-csr-w-34-7781",
+          ]
           http = {
             port     = 80
             protocol = "TCP"

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -704,9 +704,7 @@ locals {
         }
 
         listeners = {
-          alarm_target_group_names = [
-            "pp-csr-w-12-7781" # this alarm will deliberately fail, will be removed later
-          ]
+
           http = {
             port     = 80
             protocol = "TCP"
@@ -724,6 +722,7 @@ locals {
             }
           }
           http-7771 = {
+
             port     = 7771
             protocol = "TCP"
             default_action = {
@@ -740,12 +739,14 @@ locals {
             }
           }
           http-7781 = {
+            alarm_target_group_names = [ "pp-csr-w-12-7781" ] # this alarm will deliberately fail, will be removed later
             port     = 7781
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-12-7781"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
         }
       }
@@ -1211,13 +1212,6 @@ locals {
         }
 
         listeners = {
-          # we only want alarms on the training servers in pre-production 
-          alarm_target_group_names = [ 
-            "pp-csr-w-34-7770", 
-            "pp-csr-w-34-7771",
-            "pp-csr-w-34-7780",
-            "pp-csr-w-34-7781",
-          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -1227,36 +1221,44 @@ locals {
             }
           }
           http-7770 = {
+            alarm_target_group_names = [ "pp-csr-w-34-7770" ]
             port     = 7770
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7770"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7771 = {
+            alarm_target_group_names = [ "pp-csr-w-34-7771" ]
             port     = 7771
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7771"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7780 = {
+            alarm_target_group_names = [ "pp-csr-w-34-7780" ]
             port     = 7780
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7780"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7781 = {
+            alarm_target_group_names = [ "pp-csr-w-34-7781" ]
             port     = 7781
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7781"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
         }
       }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -608,6 +608,12 @@ locals {
         }
 
         listeners = {
+          alarm_target_group_names = [
+            "pd-csr-w-12-7770",
+            "pd-csr-w-12-7771",
+            "pd-csr-w-12-7780",
+            "pd-csr-w-12-7781",
+          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -776,6 +782,12 @@ locals {
         }
 
         listeners = {
+          alarm_target_group_names = [
+            "pd-csr-w-34-7770",
+            "pd-csr-w-34-7771",
+            "pd-csr-w-34-7780",
+            "pd-csr-w-34-7781",
+          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -944,6 +956,12 @@ locals {
         }
 
         listeners = {
+          alarm_target_group_names = [
+            "pd-csr-w-56-7770",
+            "pd-csr-w-56-7771",
+            "pd-csr-w-56-7780",
+            "pd-csr-w-56-7781",
+          ]
           http = {
             port     = 80
             protocol = "TCP"

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -608,13 +608,8 @@ locals {
         }
 
         listeners = {
-          alarm_target_group_names = [
-            "pd-csr-w-12-7770",
-            "pd-csr-w-12-7771",
-            "pd-csr-w-12-7780",
-            "pd-csr-w-12-7781",
-          ]
           http = {
+
             port     = 80
             protocol = "TCP"
             default_action = {
@@ -623,36 +618,44 @@ locals {
             }
           }
           http-7770 = {
+            alarm_target_group_names = [ "pd-csr-w-12-7770" ]
             port     = 7770
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7770"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7771 = {
+            alarm_target_group_names = [ "pd-csr-w-12-7771" ]
             port     = 7771
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7771"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7780 = {
+            alarm_target_group_names = [ "pd-csr-w-12-7780" ]
             port     = 7780
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7780"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7781 = {
+            alarm_target_group_names = [ "pd-csr-w-12-7781" ]
             port     = 7781
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7781"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
         }
       }
@@ -782,12 +785,6 @@ locals {
         }
 
         listeners = {
-          alarm_target_group_names = [
-            "pd-csr-w-34-7770",
-            "pd-csr-w-34-7771",
-            "pd-csr-w-34-7780",
-            "pd-csr-w-34-7781",
-          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -797,36 +794,44 @@ locals {
             }
           }
           http-7770 = {
+            alarm_target_group_names = [ "pd-csr-w-34-7770" ]
             port     = 7770
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7770"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7771 = {
+            alarm_target_group_names = [ "pd-csr-w-34-7771" ]
             port     = 7771
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7771"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7780 = {
+            alarm_target_group_names = [ "pd-csr-w-34-7780" ]
             port     = 7780
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7780"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7781 = {
+            alarm_target_group_names = [ "pd-csr-w-34-7781" ]
             port     = 7781
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7781"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
         }
       }
@@ -956,12 +961,6 @@ locals {
         }
 
         listeners = {
-          alarm_target_group_names = [
-            "pd-csr-w-56-7770",
-            "pd-csr-w-56-7771",
-            "pd-csr-w-56-7780",
-            "pd-csr-w-56-7781",
-          ]
           http = {
             port     = 80
             protocol = "TCP"
@@ -971,36 +970,44 @@ locals {
             }
           }
           http-7770 = {
+            alarm_target_group_names = ["pd-csr-w-56-7770"]
             port     = 7770
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7770"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7771 = {
+            alarm_target_group_names = ["pd-csr-w-56-7771"]
             port     = 7771
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7771"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7780 = {
+            alarm_target_group_names = ["pd-csr-w-56-7780"]
             port     = 7780
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7780"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
           http-7781 = {
+            alarm_target_group_names = ["pd-csr-w-56-7781"]
             port     = 7781
             protocol = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7781"
             }
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
           }
         }
       }


### PR DESCRIPTION
- add loadbalancer alarms for csr production servers
- add loadbalancer alarms for csr training servers
- no alarms required for pre-production but included one just to see it fail, will be deleted shortly