### PR TITLE
create alarms for network lb host health

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -739,14 +739,14 @@ locals {
             }
           }
           http-7781 = {
-            alarm_target_group_names = [ "pp-csr-w-12-7781" ] # this alarm will deliberately fail, will be removed later
-            port     = 7781
-            protocol = "TCP"
+            alarm_target_group_names = ["pp-csr-w-12-7781"] # this alarm will deliberately fail, will be removed later
+            port                     = 7781
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-12-7781"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
         }
       }
@@ -1221,44 +1221,44 @@ locals {
             }
           }
           http-7770 = {
-            alarm_target_group_names = [ "pp-csr-w-34-7770" ]
-            port     = 7770
-            protocol = "TCP"
+            alarm_target_group_names = ["pp-csr-w-34-7770"]
+            port                     = 7770
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7770"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7771 = {
-            alarm_target_group_names = [ "pp-csr-w-34-7771" ]
-            port     = 7771
-            protocol = "TCP"
+            alarm_target_group_names = ["pp-csr-w-34-7771"]
+            port                     = 7771
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7771"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7780 = {
-            alarm_target_group_names = [ "pp-csr-w-34-7780" ]
-            port     = 7780
-            protocol = "TCP"
+            alarm_target_group_names = ["pp-csr-w-34-7780"]
+            port                     = 7780
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7780"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7781 = {
-            alarm_target_group_names = [ "pp-csr-w-34-7781" ]
-            port     = 7781
-            protocol = "TCP"
+            alarm_target_group_names = ["pp-csr-w-34-7781"]
+            port                     = 7781
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7781"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
         }
       }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -618,44 +618,44 @@ locals {
             }
           }
           http-7770 = {
-            alarm_target_group_names = [ "pd-csr-w-12-7770" ]
-            port     = 7770
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-12-7770"]
+            port                     = 7770
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7770"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7771 = {
-            alarm_target_group_names = [ "pd-csr-w-12-7771" ]
-            port     = 7771
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-12-7771"]
+            port                     = 7771
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7771"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7780 = {
-            alarm_target_group_names = [ "pd-csr-w-12-7780" ]
-            port     = 7780
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-12-7780"]
+            port                     = 7780
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7780"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7781 = {
-            alarm_target_group_names = [ "pd-csr-w-12-7781" ]
-            port     = 7781
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-12-7781"]
+            port                     = 7781
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-12-7781"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
         }
       }
@@ -794,44 +794,44 @@ locals {
             }
           }
           http-7770 = {
-            alarm_target_group_names = [ "pd-csr-w-34-7770" ]
-            port     = 7770
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-34-7770"]
+            port                     = 7770
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7770"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7771 = {
-            alarm_target_group_names = [ "pd-csr-w-34-7771" ]
-            port     = 7771
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-34-7771"]
+            port                     = 7771
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7771"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7780 = {
-            alarm_target_group_names = [ "pd-csr-w-34-7780" ]
-            port     = 7780
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-34-7780"]
+            port                     = 7780
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7780"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7781 = {
-            alarm_target_group_names = [ "pd-csr-w-34-7781" ]
-            port     = 7781
-            protocol = "TCP"
+            alarm_target_group_names = ["pd-csr-w-34-7781"]
+            port                     = 7781
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-34-7781"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
         }
       }
@@ -971,43 +971,43 @@ locals {
           }
           http-7770 = {
             alarm_target_group_names = ["pd-csr-w-56-7770"]
-            port     = 7770
-            protocol = "TCP"
+            port                     = 7770
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7770"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7771 = {
             alarm_target_group_names = ["pd-csr-w-56-7771"]
-            port     = 7771
-            protocol = "TCP"
+            port                     = 7771
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7771"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7780 = {
             alarm_target_group_names = ["pd-csr-w-56-7780"]
-            port     = 7780
-            protocol = "TCP"
+            port                     = 7780
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7780"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
           http-7781 = {
             alarm_target_group_names = ["pd-csr-w-56-7781"]
-            port     = 7781
-            protocol = "TCP"
+            port                     = 7781
+            protocol                 = "TCP"
             default_action = {
               type              = "forward"
               target_group_name = "pd-csr-w-56-7781"
             }
-            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].lb
+            cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
           }
         }
       }

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -296,5 +296,19 @@ locals {
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
+    network_lb = {
+      unhealthy-network-load-balancer-host = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "3"
+        datapoints_to_alarm = "3"
+        metric_name         = "UnHealthyHostCount"
+        namespace           = "AWS/NetworkELB"
+        period              = "60"
+        statistic           = "Average"
+        threshold           = "1"
+        alarm_description   = "Triggers if the number of unhealthy network loadbalancer hosts in the target table group is at least one for 3 minutes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4615340278"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
   }
 }


### PR DESCRIPTION
- create a network lb specific alarm as this exists in a different namespace from the application loadbalancer one
- redeploy across csr-prod and csr-preprod for training servers
- one network lb host health alarm WILL fail (on purpose) so will remove this in the next PR after a positive test 