### PR TITLE
ELM-1470 add checksum rule to landing bucket

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
@@ -34,6 +34,12 @@ resource "aws_s3_bucket" "landing_bucket" {
   }
 }
 
+resource "aws_s3_object" "this" {
+  bucket             = aws_s3_bucket.landing_bucket.id
+  key                = "someobject"
+  checksum_algorithm = "SHA256"
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "landing_bucket" {
   bucket = aws_s3_bucket.landing_bucket.id
 

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
@@ -38,6 +38,7 @@ resource "aws_s3_object" "this" {
   bucket             = aws_s3_bucket.landing_bucket.id
   key                = "someobject"
   checksum_algorithm = "SHA256"
+  source = "*"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "landing_bucket" {


### PR DESCRIPTION
Need to generate a SHA256 checksum of every object sent over.

terraform docs aren't entirely clear on how to implement this so anticipating more commits