### PR TITLE
nomis: disable pagerduty alerts for disconnected Oracle DBs

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -49,7 +49,8 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_connectivity_test,
     )
     db_connected = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_high_priority_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_connected,
+      # DBAs have slack integration via OEM for this so don't include pagerduty integration
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
     )
     db_backup = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -222,7 +222,8 @@ locals {
         statistic           = "Maximum"
         threshold           = "1"
         alarm_description   = "Triggers if an oracle database defined in oracle-sids tag is disconnected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4294246698"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        # Slack integration is via Oracle Enterprise Management rather than cloudwatch
+        # alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
     ec2_instance_cwagent_collectd_oracle_db_backup = {


### PR DESCRIPTION
On DBAs request since there is now OEM pagerduty integration