### PR TITLE
move disable_api_termination and other commands

### DIFF
--- a/terraform/environments/planetfm/locals_defaults.tf
+++ b/terraform/environments/planetfm/locals_defaults.tf
@@ -6,9 +6,6 @@ locals {
       ebs_volumes_copy_all_from_ami = false
     })
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-      disable_api_termination = true
-      disable_api_stop        = true
-      monitoring              = true
       tags = {
         backup-plan         = "daily-and-weekly"
         instance-scheduling = "skip-scheduling"

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -11,6 +11,10 @@ locals {
         })
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type = "r6i.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -36,6 +40,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.large"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -54,6 +62,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.large"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -73,6 +85,10 @@ locals {
         })
         instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.large"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -91,6 +107,10 @@ locals {
         })
         instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.large"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -12,6 +12,10 @@ locals {
         })
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type = "r6i.4xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -35,6 +39,10 @@ locals {
         })
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type = "r6i.4xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -60,6 +68,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -84,6 +96,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -108,6 +124,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -132,6 +152,10 @@ locals {
         })
         instance = merge(local.defaults_app_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -158,6 +182,10 @@ locals {
         })
         instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -182,6 +210,10 @@ locals {
         })
         instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.xlarge"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -206,6 +238,10 @@ locals {
         })
         instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.large"
+          # set these to false and apply before instance can be deleted
+          disable_api_termination = true 
+          disable_api_stop        = true
+          monitoring              = true
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume


### PR DESCRIPTION
- make it more obvious what to do if you need to delete an instance
- had issues where this was set in the defaults and got into a tf state problem trying to delete un-deletable instances