### PR TITLE
Update interpolation syntax

### DIFF
--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -310,7 +310,7 @@ locals {
   all_tags = merge(
     local.tags,
     {
-      Name = "${local.application_name}"
+      Name = local.application_name
     }
   )
 }

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -800,7 +800,7 @@ module "s3_artifacts_store" {
 
   # Dynamic, supports multiple notifications blocks
   bucket_notifications = {
-    "lambda_function_arn" = "${module.domain_builder_flyway_Lambda.lambda_function}"
+    "lambda_function_arn" = module.domain_builder_flyway_Lambda.lambda_function
     "events"              = ["s3:ObjectCreated:*"]
     "filter_prefix"       = "build-artifacts/domain-builder/jars/"
     "filter_suffix"       = ".jar"
@@ -1012,7 +1012,7 @@ module "datamart" {
   tags = merge(
     local.all_tags,
     {
-      Name          = "${local.redshift_cluster_name}"
+      Name          = local.redshift_cluster_name
       Resource_Type = "Redshift Cluster"
     }
   )


### PR DESCRIPTION
The TF static analysis job keeps failing in this repo I believe due to the syntax used for some of the digital prison resources. Example error... https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/7828023156/job/21357045898

There seems to be a potential overarching bug that despite the changes being made it the job will scan for issues in other unrelated folders which may need addressing via a separate issue.
