### PR TITLE
ELM-1496 Add TLS to data store and log buckets

### DIFF
--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -42,6 +42,32 @@ resource "aws_s3_bucket_versioning" "data_store" {
   }
 }
 
+resource "aws_s3_bucket_policy" "data_store" {
+  bucket = aws_s3_bucket.data_store.id
+  policy = data.aws_iam_policy_document.data_store.json
+}
+
+data "aws_iam_policy_document" "data_store" {
+  statement {
+    sid = "EnforceTLSv12orHigher"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.data_store.arn,
+      "${aws_s3_bucket.data_store.arn}/*"
+    ]
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = [1.2]
+    }
+  }
+}
+
 resource "aws_s3_bucket_logging" "data_store" {
   bucket = aws_s3_bucket.data_store.id
 


### PR DESCRIPTION
See [here](https://dsdmoj.atlassian.net/wiki/spaces/EM1/pages/4700111402/Risk+4+-+S3+Bucket+Configuration+Weaknesses) for details on the missing bucket configs.

In this PR TLS is added to the additional buckets.