### PR TITLE
Dsos 2545/ad lambda secrets

### DIFF
--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
       identifiers = ["lambda.amazonaws.com"]
     }
   }
-}q
+}
 
 resource "aws_iam_role" "lambda-ad-role" {
   count = local.environment == "test" ? 1 : 0 # temporary

--- a/terraform/environments/corporate-staff-rostering/iam.tf
+++ b/terraform/environments/corporate-staff-rostering/iam.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
       identifiers = ["lambda.amazonaws.com"]
     }
   }
-}
+}q
 
 resource "aws_iam_role" "lambda-ad-role" {
   count = local.environment == "test" ? 1 : 0 # temporary
@@ -72,8 +72,20 @@ resource "aws_iam_role_policy_attachment" "lambda-vpc-attachment" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "lambda_secrets_manager" {
   count      = local.environment == "test" ? 1 : 0 # temporary
   role       = aws_iam_role.lambda-ad-role[count.index].name
-  policy_arn = "arn:aws:iam::aws:policy/SecretsManagerRead"
+  policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
 }


### PR DESCRIPTION
Updating a lambda IAM policy to use the correct arn for secret access