### PR TITLE
ELM-1498 enable key rotation on KMS key

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
@@ -118,6 +118,7 @@ module "log_bucket" {
 
 resource "aws_kms_key" "this" {
   description             = "${var.supplier} server cloudwatch log encryption key"
+  enable_key_rotation     = true
   key_usage               = "ENCRYPT_DECRYPT"
   deletion_window_in_days = 30
 


### PR DESCRIPTION
As outlined in the [pen test results](https://dsdmoj.atlassian.net/wiki/spaces/EM1/pages/4700111381/Risk+3+-+Lack+of+Customer+Master+Key+Rotation) these keys should have rotation enabled.