### PR TITLE
ELM-1499 Add access credentials for G4S to their server

### DIFF
--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -32,7 +32,7 @@ locals {
       "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
     ]
     cidr_ipv4s = [
-      "10.180.2.161",
+      "10.180.2.161/32",
     ]
     cidr_ipv6s = []
   }

--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -26,10 +26,14 @@ locals {
     cidr_ipv6s = []
   }
 
-  sftp_account_g4s = {
-    name = "g4s"
-    ssh_keys   = []
-    cidr_ipv4s = []
+  sftp_account_g4s_test = {
+    name = "g4s_test"
+    ssh_keys   = [
+      "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
+    ]
+    cidr_ipv4s = [
+      "10.180.2.161",
+    ]
     cidr_ipv6s = []
   }
 

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -40,7 +40,7 @@ module "g4s" {
   supplier = "g4s"
 
   user_accounts = [
-    local.sftp_account_g4s,
+    local.sftp_account_g4s_test,
     local.sftp_account_dev,
   ]
 


### PR DESCRIPTION
Adding access for G4S ahead of them testing the connection to the SFTP server for them to deposit data.

This will add a new (well renamed from just `g4s`) user account `g4s_test` to the existing G4S sftp server.