### PR TITLE
invert security group deletion-creation

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/server_security_group/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/server_security_group/main.tf
@@ -8,6 +8,10 @@ resource "aws_security_group" "this" {
   name        = "${var.supplier}-${var.user_name}-inbound-ips"
   description = "Allowed IP addresses for ${var.user_name} on ${var.supplier} server"
   vpc_id      = var.vpc_id
+  
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags = {
     supplier = var.user_name


### PR DESCRIPTION
This change makes it so terraform creates the new resource before deleting the old one. Without
terraform cannot delete the original group as it's associated to a resource.