### PR TITLE
don't create oracle backup alarms in prod yet

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_defaults.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_defaults.tf
@@ -7,6 +7,12 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup
     )
+    # This block can be removed when prod database goes live
+    database_awaiting_deployment = merge(
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux
+    )
     windows = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -64,6 +64,8 @@ locals {
             "Ec2ProdDatabasePolicy",
           ])
         })
+        # IMPORTANT: remove this line when the DB is live in Production
+        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.database_awaiting_deployment
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type                = "r6i.xlarge"
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token


### PR DESCRIPTION
- remove the oracle rman backup status alarms till CSR Prod DB has been deployed