### PR TITLE
ELM-1519 Add accounts for each system to be migrated

### DIFF
--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -75,7 +75,7 @@ locals {
     "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
   ]
   g4s_cidr_ipv4s = [
-    "13.41.117.98/32",
+    "18.135.195.129/32",
   ]
   g4s_cidr_ipv6s = []
   

--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -1,42 +1,157 @@
 #### This file can be used to store locals specific to the member account ####
 locals {
-  sftp_account_capita = {
-    name = "capita"
-    ssh_keys   = [
+  #----------------------------------------------------------------------------
+  # CAPITA
+  #----------------------------------------------------------------------------
+  capita_ssh_keys = [
       "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBFc140uxPfjq1ilaOxcLYbnyIau2vURzKWFHLsxra+5Vf1nSZypOZ/g9eavBxcf2tkxBjgTx06BeRh3j+QhA8rnV9vKtyh9ZXIe5SNcrGlsGLKMyn+eB05Dt2m58oyMwWA==",
     ]
-    cidr_ipv4s = [
-      "82.203.33.112/28",
-      "82.203.33.128/28",
-      "85.115.52.0/24",
-      "85.115.53.0/24",
-      "85.115.54.0/24",
-    ]
-    cidr_ipv6s = []
+  capita_cidr_ipv4s = [
+    "82.203.33.112/28",
+    "82.203.33.128/28",
+    "85.115.52.0/24",
+    "85.115.53.0/24",
+    "85.115.54.0/24",
+  ]
+  capita_cidr_ipv6s = []
+
+  sftp_account_capita_test = {
+    name       = "capita_test"
+    ssh_keys   = local.capita_ssh_keys
+    cidr_ipv4s = local.capita_cidr_ipv4s
+    cidr_ipv6s = local.capita_cidr_ipv6s
+  }
+  
+  sftp_account_capita_alcohol_monitoring = {
+    name       = "alcohol_monitoring"
+    ssh_keys   = local.capita_ssh_keys
+    cidr_ipv4s = local.capita_cidr_ipv4s
+    cidr_ipv6s = local.capita_cidr_ipv6s
   }
 
-  sftp_account_civica = {
-    name = "civica"
-    ssh_keys   = [
-      "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBCJBwZM5nMigS31soM45PITAHCmyhQpdDAkdX1liqnIZSd8A+zn3XQyVRy5E2a39gfsng5hAQetDFJKn+SaayATCQAzN0cJWlcrvtv314UsRV+PxO236sWVf+RwguUDZRQ==",
-    ]
-    cidr_ipv4s = [
-      "20.0.26.153/32",
-    ]
-    cidr_ipv6s = []
+  sftp_account_capita_blob_storage = {
+    name       = "blob_storage"
+    ssh_keys   = local.capita_ssh_keys
+    cidr_ipv4s = local.capita_cidr_ipv4s
+    cidr_ipv6s = local.capita_cidr_ipv6s
   }
 
+  sftp_account_capita_forms_and_subject_id = {
+    name       = "forms_and_subject_id"
+    ssh_keys   = local.capita_ssh_keys
+    cidr_ipv4s = local.capita_cidr_ipv4s
+    cidr_ipv6s = local.capita_cidr_ipv6s
+  }
+
+  #----------------------------------------------------------------------------
+  # CIVICA
+  #----------------------------------------------------------------------------
+  civica_ssh_keys   = [
+    "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBCJBwZM5nMigS31soM45PITAHCmyhQpdDAkdX1liqnIZSd8A+zn3XQyVRy5E2a39gfsng5hAQetDFJKn+SaayATCQAzN0cJWlcrvtv314UsRV+PxO236sWVf+RwguUDZRQ==",
+  ]
+  civica_cidr_ipv4s = [
+    "20.0.26.153/32",
+  ]
+  civica_cidr_ipv6s = []
+
+  sftp_account_civica_test = {
+    name       = "civica_test"
+    ssh_keys   = local.civica_ssh_keys
+    cidr_ipv4s = local.civica_cidr_ipv4s
+    cidr_ipv6s = local.civica_cidr_ipv6s
+  }
+
+  sftp_account_civica_orca = {
+    name       = "orca"
+    ssh_keys   = local.civica_ssh_keys
+    cidr_ipv4s = local.civica_cidr_ipv4s
+    cidr_ipv6s = local.civica_cidr_ipv6s
+  }
+
+  #----------------------------------------------------------------------------
+  # G4S
+  #----------------------------------------------------------------------------
+  g4s_ssh_keys   = [
+    "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
+  ]
+  g4s_cidr_ipv4s = [
+    "13.41.117.98/32",
+  ]
+  g4s_cidr_ipv6s = []
+  
   sftp_account_g4s_test = {
-    name = "g4s_test"
-    ssh_keys   = [
-      "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
-    ]
-    cidr_ipv4s = [
-      "13.41.117.98/32",
-    ]
-    cidr_ipv6s = []
+    name       = "g4s_test"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
   }
 
+  sftp_account_g4s_atrium = {
+    name       = "atrium"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_atv = {
+    name       = "atv"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_emsys_mvp = {
+    name       = "emsys_mvp"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_emsys_tpims = {
+    name       = "emsys_tpims"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_fep = {
+    name       = "fep"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_integrity = {
+    name       = "integrity"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_subject_history = {
+    name       = "subject_history"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_tasking = {
+    name       = "tasking"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  sftp_account_g4s_telephony = {
+    name       = "telephony"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
+  #----------------------------------------------------------------------------
+  # DEVELOPERS
+  #----------------------------------------------------------------------------
   sftp_account_dev = {
     name = "dev"
     ssh_keys   = [
@@ -53,5 +168,4 @@ locals {
     ]
     cidr_ipv6s = []
   }
-
 }

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -4,8 +4,16 @@ module "capita" {
   supplier = "capita"
 
   user_accounts = [
-    local.sftp_account_capita,
+    # Developer access.
     local.sftp_account_dev,
+
+    # Test account for supplier.
+    local.sftp_account_capita_test,
+
+    # Accounts for each system to be migrated.
+    local.sftp_account_capita_alcohol_monitoring,
+    local.sftp_account_capita_blob_storage,
+    local.sftp_account_capita_forms_and_subject_id,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store
@@ -22,8 +30,14 @@ module "civica" {
   supplier = "civica"
 
   user_accounts = [
-    local.sftp_account_civica,
+    # Developer access.
     local.sftp_account_dev,
+
+    # Test account for supplier.
+    local.sftp_account_civica_test,
+
+    # Accounts for each system to be migrated.
+    local.sftp_account_civica_orca,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store
@@ -40,8 +54,22 @@ module "g4s" {
   supplier = "g4s"
 
   user_accounts = [
-    local.sftp_account_g4s_test,
+    # Developer access.
     local.sftp_account_dev,
+
+    # Test account for supplier.
+    local.sftp_account_g4s_test,
+
+    # Accounts for each system to be migrated.
+    local.sftp_account_g4s_atrium,
+    local.sftp_account_g4s_atv,
+    local.sftp_account_g4s_emsys_mvp,
+    local.sftp_account_g4s_emsys_tpims,
+    local.sftp_account_g4s_fep,
+    local.sftp_account_g4s_integrity,
+    local.sftp_account_g4s_subject_history,
+    local.sftp_account_g4s_tasking,
+    local.sftp_account_g4s_telephony,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store


### PR DESCRIPTION
To allow better storage of data migrated to MoJ use usernames of accounts for each system. This means we will have the structure `/supplier/system/upload_date/*`