### PR TITLE
DPR2-46: Recreate Hive tables during the reload

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -22,6 +22,18 @@ module "reload_pipeline" {
               "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
             }
           },
+          "Next" : "Create Hive Tables"
+        },
+        "Create Hive Tables" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_hive_table_creation_jobname,
+            "Arguments" : {
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
           "Next" : "Prepare Temp Reload Bucket Data"
         },
         "Prepare Temp Reload Bucket Data" : {

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -22,9 +22,9 @@ module "reload_pipeline" {
               "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
             }
           },
-          "Next" : "Create Hive Tables"
+          "Next" : "Update Hive Tables"
         },
-        "Create Hive Tables" : {
+        "Update Hive Tables" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -34,6 +34,12 @@ variable "glue_s3_file_transfer_job" {
   default     = ""
 }
 
+variable "glue_hive_table_creation_jobname" {
+  description = "Glue Hive Table Creation JobName"
+  type        = string
+  default     = ""
+}
+
 variable "glue_switch_prisons_hive_data_location_job" {
   description = "Name of glue job to switch the prisons hive data location"
   type        = string


### PR DESCRIPTION
This PR recreates the Hive tables during the reload pipeline.
This addresses the scenario where a new table is onboarded to a domain that is already in use.