### PR TITLE
change alarms for db instances to cope with refresh duration

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_defaults.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_defaults.tf
@@ -5,7 +5,23 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
+      {
+        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2["cpu-utilization-high"], {
+          evaluation_periods  = "480"
+          datapoints_to_alarm = "480"
+          threshold           = "95"
+          alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
+        })
+      },
+      {
+        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
+          evaluation_periods  = "480"
+          datapoints_to_alarm = "480"
+          threshold           = "40"
+          alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 8 hours allowing for DB refreshes.  See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
+        })
+      }
     )
     # This block can be removed when prod database goes live
     database_awaiting_deployment = merge(


### PR DESCRIPTION
- only applies to pre-prod at the moment 
- will ensure that refresh db activity doesn't trigger an alarm un-necessarily