### PR TITLE
ELM Change checksum lambda to work with large files

### DIFF
--- a/terraform/environments/electronic-monitoring-data/data_store.tf
+++ b/terraform/environments/electronic-monitoring-data/data_store.tf
@@ -89,7 +89,7 @@ resource "aws_s3_bucket_notification" "data_store" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.calculate_checksum_lambda.arn
     events              = [
-      "s3:ObjectCreated:Copy"
+      "s3:ObjectCreated:*"
     ]
   }
 
@@ -98,7 +98,7 @@ resource "aws_s3_bucket_notification" "data_store" {
   # lambda_function {
   #   lambda_function_arn = aws_lambda_function.summarise_zip_lambda.arn
   #   events              = [
-  #     "s3:ObjectCreated:Copy"
+  #     "s3:ObjectCreated:*"
   #   ]
   # }
 


### PR DESCRIPTION
Done two things:

1. updated the lambda python code to read files in chunks so we're not trying to dump a multi GB file into memory and crashing out
2. Updated the s3 event notification to all object types as large files come in via multiPartUpload (and unclear if via `put` or `copy`