### PR TITLE
DSOS-2615: give secret access to DCs

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_domain.tf
+++ b/terraform/environments/hmpps-domain-services/locals_domain.tf
@@ -11,7 +11,7 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.planetfm-test}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-test}:role/LambdaFunctionADObjectCleanUp", # testing
       # "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-development}:role/LambdaFunctionADObjectCleanUp", # to be added after hmpps dev apply
-
+      "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-nonlive-role"
     ]
     preproduction = []
     production = [
@@ -21,6 +21,7 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-production}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.planetfm-preproduction}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.planetfm-production}:role/EC2HmppsDomainSecretsRole",
+      "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-live-role",
     ]
   }
 


### PR DESCRIPTION
New roles have been created in core-shared-services-production for domain controllers - grant relevant permissions.