### PR TITLE
Lambda CW eventbridge rule and corresponding IAM policies

### DIFF
--- a/terraform/environments/corporate-staff-rostering/.ssh/.gitignore
+++ b/terraform/environments/corporate-staff-rostering/.ssh/.gitignore
@@ -1,1 +1,2 @@
 ec2-user
+*.zip

--- a/terraform/environments/corporate-staff-rostering/lambda.tf
+++ b/terraform/environments/corporate-staff-rostering/lambda.tf
@@ -23,13 +23,6 @@ module "ad-clean-up-lambda" {
   vpc_subnet_ids         = tolist(data.aws_subnets.shared-private.ids)
   vpc_security_group_ids = [module.baseline.security_groups["domain"].id]
 
-  # allowed_triggers = {
-  #   AllowExecutionFromCloudWatch = {
-  #     principal  = ""
-  #     source_arn = ""
-  #   }
-  # }
-
   tags = merge(
     local.tags,
     {

--- a/terraform/environments/corporate-staff-rostering/lambda.tf
+++ b/terraform/environments/corporate-staff-rostering/lambda.tf
@@ -1,3 +1,4 @@
+# START: lambda_ad_object_clean_up
 locals {
   lambda_ad_object_cleanup = {
     function_name = "AD-Object-Clean-Up"
@@ -6,8 +7,6 @@ locals {
 
 module "ad-clean-up-lambda" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-lambda-function" # ref for V3.1
-  count  = local.environment == "test" ? 1 : 0                                             # temporary whilst on-going work
-
 
   application_name = local.lambda_ad_object_cleanup.function_name
   function_name    = local.lambda_ad_object_cleanup.function_name
@@ -24,6 +23,13 @@ module "ad-clean-up-lambda" {
   vpc_subnet_ids         = tolist(data.aws_subnets.shared-private.ids)
   vpc_security_group_ids = [module.baseline.security_groups["domain"].id]
 
+  # allowed_triggers = {
+  #   AllowExecutionFromCloudWatch = {
+  #     principal  = ""
+  #     source_arn = ""
+  #   }
+  # }
+
   tags = merge(
     local.tags,
     {
@@ -37,6 +43,26 @@ data "archive_file" "ad-cleanup-lambda" {
   source_dir  = "lambda/ad-clean-up"
   output_path = "lambda/ad-clean-up/ad-clean-up-lambda-payload-test.zip"
 }
+
+resource "aws_cloudwatch_event_rule" "ec2_state_change_terminated" {
+  name        = "Ec2StateChangedTerminated"
+  description = "Rule to trigger Lambda on EC2 state change"
+  
+  event_pattern = jsonencode({
+    "source": ["aws.ec2"],
+    "detail-type": ["EC2 Instance State-change Notification for EC2 termination event"],
+    "detail": {
+      "state": ["terminated"] 
+    }
+  })
+}
+
+# To be built after first apply
+# resource "aws_cloudwatch_event_target" "lambda_ad_clean_up" {
+#   rule      = aws_cloudwatch_event_rule.ec2_state_change_terminated.name
+#   target_id = "LambdaTarget"
+#   arn       = aws_lambda_function.ad-clean-up-lambda.arn
+# }
 
 # START: lambda_cw_logs_xml_to_json
 locals {

--- a/terraform/environments/corporate-staff-rostering/lambda.tf
+++ b/terraform/environments/corporate-staff-rostering/lambda.tf
@@ -18,7 +18,7 @@ module "ad-clean-up-lambda" {
   runtime          = "python3.8"
 
   create_role = false
-  lambda_role = aws_iam_role.lambda-ad-role[count.index].arn
+  lambda_role = aws_iam_role.lambda-ad-role.arn
 
   vpc_subnet_ids         = tolist(data.aws_subnets.shared-private.ids)
   vpc_security_group_ids = [module.baseline.security_groups["domain"].id]

--- a/terraform/environments/corporate-staff-rostering/lambda/ad-clean-up/lambda_function.py
+++ b/terraform/environments/corporate-staff-rostering/lambda/ad-clean-up/lambda_function.py
@@ -66,10 +66,10 @@ def determine_domain(environment_tag):
         return None
     return domain_info
 
-# function to search active directory if an instance is stopped, final iteration will be state terminated                       
+# function to search active directory if an instance is terminated                       
 def lambda_handler(event, context):
 
-    if event['detail']['state'] == 'stopped': # to be updated to terminated
+    if event['detail']['state'] == 'terminated': # to be updated to terminated
         instance_id = event['detail']['instance-id']
         
         # creates an ec2 connection for terminated instance

--- a/terraform/environments/corporate-staff-rostering/lambda/ad-clean-up/lambda_function.py
+++ b/terraform/environments/corporate-staff-rostering/lambda/ad-clean-up/lambda_function.py
@@ -1,29 +1,32 @@
 import json
-import boto3 
+import boto3
 from ldap3 import Server, Connection, SUBTREE
+
 
 # checks for objects within active directory
 def check_ad_for_object(hostname, domain_fqdn, domain_name, search_base):
 
     # create a secrets manager connection
-    secrets_manager = boto3.client('secretsmanager')
-    
+    secrets_manager = boto3.client("secretsmanager")
+
     # extract the secret value from hmpps-domain-services-test / hmpps-domain-services-prod
     secret_name = f"/microsoft/AD/{domain_fqdn}/shared-passwords"
     response = secrets_manager.get_secret_value(SecretId=secret_name)
-    secret_data = response['SecretString']
+    secret_data = response["SecretString"]
 
     # parse the JSON format secret data
     secret_json = json.loads(secret_data)
-    ad_password = secret_json.get('svc_join_domain')
-    
+    ad_password = secret_json.get("svc_join_domain")
+
     # domain connection details
-    domain_controller = Server(f'{domain_fqdn}:389')
-    ad_username = rf'{domain_name}\aws-lambda'
-    
-    with Connection(Server, user=ad_username, password=ad_password, auto_bind=True) as conn:
+    domain_controller = Server(f"{domain_fqdn}:389")
+    ad_username = rf"{domain_name}\aws-lambda"
+
+    with Connection(
+        Server, user=ad_username, password=ad_password, auto_bind=True
+    ) as conn:
         ad_search = search_base
-        search_filter = f'(sAMAccountName={hostname})'
+        search_filter = f"(sAMAccountName={hostname})"
         # subtree for recursive search through defined OU
         search_result = conn.search(ad_search, search_filter, SUBTREE)
         print(search_result)
@@ -32,75 +35,95 @@ def check_ad_for_object(hostname, domain_fqdn, domain_name, search_base):
             # Get the distinguished name (DN) of the found object
             object_dn = conn.entries[0].entry_dn
             print(object_dn)
-            print(f"The object {object_dn} is present in Active Directory and will be deleted...")
+            print(
+                f"The object {object_dn} is present in Active Directory and will be deleted..."
+            )
             # conn.delete(object_dn) # action removed during testing
-            return 0 # success status
+            return 0  # success status
         else:
-            print(f"The terminated server object {hostname} was not found in Active Directory - no further action taken.")
-            return 1 # object not found status
+            print(
+                f"The terminated server object {hostname} was not found in Active Directory - no further action taken."
+            )
+            return 1  # object not found status
+
 
 # function to iterate through instance tags
 def get_tag_value(tags, key):
     for tag in tags:
-        if tag['Key'] == key:
-            return tag['Value']
+        if tag["Key"] == key:
+            return tag["Value"]
     return None
+
 
 # function to determine test or prod domain values to be used
 def determine_domain(environment_tag):
     domain_info = {}
-    if "development" in environment_tag.split('-') or "test" in environment_tag.split('-'):
-        domain_info['domain_type'] = "dev/test"
-        domain_info['domain_name'] = "azure"
-        domain_info['domain_fqdn'] = "azure.noms.root"
-        domain_info['search_base'] = "ou=Managed-Windows-Servers,ou=Computers,dc=azure,dc=noms,dc=root"
+    if "development" in environment_tag.split("-") or "test" in environment_tag.split(
+        "-"
+    ):
+        domain_info["domain_type"] = "dev/test"
+        domain_info["domain_name"] = "azure"
+        domain_info["domain_fqdn"] = "azure.noms.root"
+        domain_info["search_base"] = (
+            "ou=Managed-Windows-Servers,ou=Computers,dc=azure,dc=noms,dc=root"
+        )
         # domain_info['account'] = "hmpps-domain-services-test"
-    elif "preproduction" in environment_tag.split('-') or "production" in environment_tag.split('-'):
-        domain_info['domain_type'] = "preprod/prod"
-        domain_info['domain_name'] = "hmpp"
-        domain_info['domain_fqdn'] = "azure.hmpp.root"
-        domain_info['search_base'] = "ou=MEMBER_SERVERS,dc=azure,dc=hmpp,dc=root"
+    elif "preproduction" in environment_tag.split(
+        "-"
+    ) or "production" in environment_tag.split("-"):
+        domain_info["domain_type"] = "preprod/prod"
+        domain_info["domain_name"] = "hmpp"
+        domain_info["domain_fqdn"] = "azure.hmpp.root"
+        domain_info["search_base"] = "ou=MEMBER_SERVERS,dc=azure,dc=hmpp,dc=root"
         # domain_info['account'] = "hmpps-domain-services-production"
     else:
         print("Unexpected environment-name tag. Aborting lambda function...")
         return None
     return domain_info
 
-# function to search active directory if an instance is terminated                       
+
+# function to search active directory if an instance is terminated
 def lambda_handler(event, context):
 
-    if event['detail']['state'] == 'terminated': # to be updated to terminated
-        instance_id = event['detail']['instance-id']
-        
+    if event["detail"]["state"] == "terminated":  # to be updated to terminated
+        instance_id = event["detail"]["instance-id"]
+
         # creates an ec2 connection for terminated instance
-        ec2 = boto3.client('ec2')
+        ec2 = boto3.client("ec2")
         response = ec2.describe_instances(InstanceIds=[instance_id])
         # return the tags associated with the terminated instance
-        tags = response['Reservations'][0]['Instances'][0]['Tags']
+        tags = response["Reservations"][0]["Instances"][0]["Tags"]
         # terminated instance server-name value, same as hostname
-        resource_name = 'server-name'
-        
+        resource_name = "server-name"
+
         # obtain the hostame for the terminated server
         hostname = get_tag_value(tags, resource_name)
-        print(f"Server hostname is: {hostname}")        
-        
+        print(f"Server hostname is: {hostname}")
+
         # obtain terminated instance environment-name value
-        resource_environment = 'environment-name'
+        resource_environment = "environment-name"
         environment_tag = get_tag_value(tags, resource_environment)
 
         # determine appropriate domain variables
         domain = determine_domain(environment_tag)
-        print("Domain address: {}".format(domain['domain_type']))
+        print("Domain address: {}".format(domain["domain_type"]))
 
         # pass hostname and domain variables into AD oject deletion function
         if hostname is not None and domain is not None:
-            check_ad_for_object(hostname, domain['domain_fqdn'], domain['domain_name'], domain['search_base'])
+            check_ad_for_object(
+                hostname,
+                domain["domain_fqdn"],
+                domain["domain_name"],
+                domain["search_base"],
+            )
             print(f"The Active Directory object {hostname} has been deleted.")
         else:
-            print(f"The '{resource_name}' tag was not found for the terminated instance.")
-    
+            print(
+                f"The '{resource_name}' tag was not found for the terminated instance."
+            )
+
     # 200 http response lambda run successful
     return {
-        'statusCode': 200,
-        'body': 'Active Directory clean up complete. Computer object {resource_name} has been removed.'
+        "statusCode": 200,
+        "body": "Active Directory clean up complete. Computer object {resource_name} has been removed.",
     }


### PR DESCRIPTION
This PR will add a CW eventbridge rule, lambda target, and lambda IAM policies to allow for invocation by CW event bridge.

Commented resources to be added on a second apply (requires the lambda arn to exist).

Deploying to CSR only for now for end-to-end testing, to then be deployed to Planet FM and domain services accounts.

Python black used to format python code.
