### PR TITLE
ELM Add switches to limit server creation

### DIFF
--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -3,6 +3,8 @@ locals {
   #----------------------------------------------------------------------------
   # CAPITA
   #----------------------------------------------------------------------------
+  switch_on_server_capita = false
+
   capita_ssh_keys = [
     "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBFc140uxPfjq1ilaOxcLYbnyIau2vURzKWFHLsxra+5Vf1nSZypOZ/g9eavBxcf2tkxBjgTx06BeRh3j+QhA8rnV9vKtyh9ZXIe5SNcrGlsGLKMyn+eB05Dt2m58oyMwWA==",
   ]
@@ -46,6 +48,8 @@ locals {
   #----------------------------------------------------------------------------
   # CIVICA
   #----------------------------------------------------------------------------
+  switch_on_server_civica = false
+
   civica_ssh_keys = [
     "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK1ZcqH9f7jMPjoOdwQdykQHnOKpmYVVr5gneYtH0KEdhPUdWDE14sh4aOZPl3rDw8Pu7Kj356KJ0FEmKAl3ByJFn6+oBR9GcTpKVmTXUeYlAqptP5Sszr3Zgh0986v8Gw==",
   ]
@@ -71,6 +75,8 @@ locals {
   #----------------------------------------------------------------------------
   # G4S
   #----------------------------------------------------------------------------
+  switch_on_server_g4s = true
+
   g4s_ssh_keys = [
     "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBK85G9UwgU1KKgsYXfTWDsT4MqGSmjku1XGpH1EqmSuXLk5lmwFsgoLqqsROq2oEw2Yrr3uLyNVY2Dl6Pfm+dkdljfbPtqku+AkRSkhDo4K7bIwhWPh7HImcalxhde6BUA== ecdsa-key-20240208",
   ]

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -1,20 +1,20 @@
 module "capita" {
   source = "./modules/landing_zone/"
-  count  = (local.is-production || local.is-development) && local.switch_on_server_capita ? 1 : 0
+  create_server = local.switch_on_server_capita && (local.is-production || local.is-development) ? 1 : 0
 
   supplier = "capita"
 
   user_accounts = [
     # Developer access.
-    local.sftp_account_dev,
+    # local.sftp_account_dev,
 
     # Test account for supplier.
-    local.sftp_account_capita_test,
+    # local.sftp_account_capita_test,
 
     # Accounts for each system to be migrated.
-    local.sftp_account_capita_alcohol_monitoring,
-    local.sftp_account_capita_blob_storage,
-    local.sftp_account_capita_forms_and_subject_id,
+    # local.sftp_account_capita_alcohol_monitoring,
+    # local.sftp_account_capita_blob_storage,
+    # local.sftp_account_capita_forms_and_subject_id,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store
@@ -27,19 +27,19 @@ module "capita" {
 
 module "civica" {
   source = "./modules/landing_zone/"
-  count  = (local.is-production || local.is-development) && local.switch_on_server_civica ? 1 : 0
+  create_server = local.switch_on_server_civica && (local.is-production || local.is-development) ? 1 : 0
 
   supplier = "civica"
 
   user_accounts = [
     # Developer access.
-    local.sftp_account_dev,
+    # local.sftp_account_dev,
 
     # Test account for supplier.
-    local.sftp_account_civica_test,
+    # local.sftp_account_civica_test,
 
     # Accounts for each system to be migrated.
-    local.sftp_account_civica_orca,
+    # local.sftp_account_civica_orca,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store
@@ -52,7 +52,7 @@ module "civica" {
 
 module "g4s" {
   source = "./modules/landing_zone/"
-  count  = (local.is-production || local.is-development) && local.switch_on_server_g4s ? 1 : 0
+  create_server = local.switch_on_server_g4s && (local.is-production || local.is-development) ? 1 : 0
 
   supplier = "g4s"
 

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -1,6 +1,6 @@
 module "capita" {
   source = "./modules/landing_zone/"
-  create_server = local.switch_on_server_capita && (local.is-production || local.is-development) ? 1 : 0
+  create_server = local.switch_on_server_capita && (local.is-production || local.is-development)
 
   supplier = "capita"
 
@@ -27,7 +27,7 @@ module "capita" {
 
 module "civica" {
   source = "./modules/landing_zone/"
-  create_server = local.switch_on_server_civica && (local.is-production || local.is-development) ? 1 : 0
+  create_server = local.switch_on_server_civica && (local.is-production || local.is-development)
 
   supplier = "civica"
 
@@ -52,7 +52,7 @@ module "civica" {
 
 module "g4s" {
   source = "./modules/landing_zone/"
-  create_server = local.switch_on_server_g4s && (local.is-production || local.is-development) ? 1 : 0
+  create_server = local.switch_on_server_g4s && (local.is-production || local.is-development)
 
   supplier = "g4s"
 

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -1,5 +1,6 @@
 module "capita" {
   source = "./modules/landing_zone/"
+  count  = (local.is-production || local.is-development) && local.switch_on_server_capita ? 1 : 0
 
   supplier = "capita"
 
@@ -26,6 +27,7 @@ module "capita" {
 
 module "civica" {
   source = "./modules/landing_zone/"
+  count  = (local.is-production || local.is-development) && local.switch_on_server_civica ? 1 : 0
 
   supplier = "civica"
 
@@ -50,6 +52,7 @@ module "civica" {
 
 module "g4s" {
   source = "./modules/landing_zone/"
+  count  = (local.is-production || local.is-development) && local.switch_on_server_g4s ? 1 : 0
 
   supplier = "g4s"
 

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/landing_zone_user/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/landing_zone_user/main.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "transfer_assume_role" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_user" "this" {
-  server_id = var.transfer_server.id
+  server_id = coalesce(var.transfer_server.id, "")
   user_name = var.user_name
   role      = aws_iam_role.this_transfer_user.arn
 

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
@@ -168,8 +168,6 @@ resource "aws_kms_key_policy" "this" {
 #------------------------------------------------------------------------------
 
 resource "aws_eip" "this" {
-  count = var.create_server ? 1 : 0
-
   domain = "vpc"
 
   tags = {
@@ -218,6 +216,7 @@ resource "aws_transfer_server" "this" {
   structured_log_destinations = [
     "${aws_cloudwatch_log_group.this.arn}:*"
   ]
+
 }
 
 resource "aws_iam_role" "iam_for_transfer" {

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/main.tf
@@ -168,6 +168,8 @@ resource "aws_kms_key_policy" "this" {
 #------------------------------------------------------------------------------
 
 resource "aws_eip" "this" {
+  count = var.create_server ? 1 : 0
+
   domain = "vpc"
 
   tags = {
@@ -182,6 +184,8 @@ resource "aws_eip" "this" {
 #------------------------------------------------------------------------------
 
 resource "aws_transfer_server" "this" {
+  count = var.create_server ? 1 : 0
+
   protocols              = ["SFTP"]
   identity_provider_type = "SERVICE_MANAGED"
 

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/variables.tf
@@ -2,6 +2,10 @@ variable "account_id" {
   description = "The AWS account id"
 }
 
+variable "create_server" {
+  description = "Bool flag for creating server"
+}
+
 variable "data_store_bucket" {
   description = "The bucket landed data is moved to"
 }


### PR DESCRIPTION
Only if the environment is production or development, and also if the local variable switch_on_server_* is true will the resource be spun up. 

tl;dr servers are spenny.