### PR TITLE
EBS iops and throughput cloudwatch alarms for nomis-test

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -16,6 +16,8 @@ locals {
   # baseline config
   test_config = {
 
+    baseline_cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ebs
+
     baseline_s3_buckets = {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -311,5 +311,97 @@ locals {
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
+    ebs = {
+      volume_disk_iops_reached = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "ebs_volume_disk_iops"
+        period              = "60"
+        namespace           = "AWS/EBS"
+        statistic           = "Maximum"
+        threshold           = "14400"
+        treat_missing_data  = "notBreaching"
+        alarm_description   = "Triggers if Volume disk IOPS limit is greater than or equal to 90%"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        metric_query = {
+          id          = "e3"
+          expression  = "e1+e2"
+          label       = "Total IOPs"
+          return_data = "true"
+        }
+        metric_query = {
+          id          = "e1"
+          expression  = "m1/PERIOD(m1)"
+          label       = "Read IOPs"
+          metric = {
+            metric_name = "VolumeReadOps"
+            namespace   = "AWS/EBS"
+            period      = 60
+            stat        = "Max"
+            dimensions = {
+              VolumeId = "*"
+            }
+          }
+        }
+        metric_query = {
+          id          = "e2"
+          expression  = "m2/PERIOD(m2)"
+          label       = "Write IOPs"
+          metric = {
+            metric_name = "VolumeWriteOps"
+            namespace   = "AWS/EBS"
+            period      = 60
+            stat        = "Max"
+            dimensions = {
+              VolumeId = "*"
+            }
+          }
+        }
+      }
+      volume_disk_throughput_reached = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "ebs_volume_disk_throughput"
+        period              = "60"
+        namespace           = "AWS/EBS"
+        statistic           = "Maximum"
+        threshold           = "900"
+        treat_missing_data  = "notBreaching"
+        alarm_description   = "Triggers if Volume disk throughput limit is greater than or equal to 90%"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        metric_query = {
+          id          = "e1"
+          expression  = "((m1+m2)/1048576)/PERIOD(m1)"
+          label       = "Total Throughput (MiB/s)"
+          return_data = true
+        }
+        metric_query = {
+          id = "m1"
+          metric = {
+            metric_name = "VolumeReadOps"
+            namespace   = "AWS/EBS"
+            period      = 60
+            stat        = "Sum"
+            dimensions = {
+              VolumeId = "*"
+            }
+          }
+        }
+        metric_query = {
+          id = "m2"
+          metric = {
+            metric_name = "VolumeWriteOps"
+            namespace   = "AWS/EBS"
+            period      = 60
+            stat        = "Sum"
+            dimensions = {
+              VolumeId = "*"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Create cloudwatch alarms for EBS volume disk iops limits and EBS throughput limits for nomis-test.