### PR TITLE
csr: escape parentheses in metric filter regex via hex codes

### DIFF
--- a/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
+++ b/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
@@ -26,7 +26,7 @@ locals {
     iwfm-enterprise-server-terminated = merge(local.application_log_metric_filters_defaults, {
       # `\x28` and `\x29` denote `(` and `)` respectively.
       # this is because AWS do not allow parentheses in the filter pattern.
-      pattern = "{ $.Event.RenderingInfo.Message = %^iWFM Enterprise Server \x28PID \\d+\x29 terminated\\.% }"
+      pattern = "{ $.Event.RenderingInfo.Message = %^iWFM Enterprise Server \\x28PID \\d+\\x29 terminated\\.% }"
 
       metric_transformation = merge(local.application_log_metric_filters_defaults.metric_transformation, {
         name = "iWFMEnterpriseServerTerminated"
@@ -42,7 +42,7 @@ locals {
     invision-http-server-terminated = merge(local.application_log_metric_filters_defaults, {
       # `\x28` and `\x29` denote `(` and `)` respectively.
       # this is because AWS do not allow parentheses in the filter pattern.
-      pattern = "{ $.Event.RenderingInfo.Message = %^InVision HTTP Server \x28PID \\d+\x29 terminated\\.% }"
+      pattern = "{ $.Event.RenderingInfo.Message = %^InVision HTTP Server \\x28PID \\d+\\x29 terminated\\.% }"
 
       metric_transformation = merge(local.application_log_metric_filters_defaults.metric_transformation, {
         name = "InVisionHTTPServerTerminated"

--- a/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
+++ b/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
@@ -24,7 +24,9 @@ locals {
       })
     })
     iwfm-enterprise-server-terminated = merge(local.application_log_metric_filters_defaults, {
-      pattern = "{ $.Event.RenderingInfo.Message = %^iWFM Enterprise Server \\(PID \\d+\\) terminated\\.% }"
+      # `\x28` and `\x29` denote `(` and `)` respectively.
+      # this is because AWS do not allow parentheses in the filter pattern.
+      pattern = "{ $.Event.RenderingInfo.Message = %^iWFM Enterprise Server \x28PID \\d+\x29 terminated\\.% }"
 
       metric_transformation = merge(local.application_log_metric_filters_defaults.metric_transformation, {
         name = "iWFMEnterpriseServerTerminated"
@@ -38,7 +40,9 @@ locals {
       })
     })
     invision-http-server-terminated = merge(local.application_log_metric_filters_defaults, {
-      pattern = "{ $.Event.RenderingInfo.Message = %^InVision HTTP Server \\(PID \\d+\\) terminated\\.% }"
+      # `\x28` and `\x29` denote `(` and `)` respectively.
+      # this is because AWS do not allow parentheses in the filter pattern.
+      pattern = "{ $.Event.RenderingInfo.Message = %^InVision HTTP Server \x28PID \\d+\x29 terminated\\.% }"
 
       metric_transformation = merge(local.application_log_metric_filters_defaults.metric_transformation, {
         name = "InVisionHTTPServerTerminated"


### PR DESCRIPTION
When applying this Terraform, the AWS API was returning `InvalidParameterException: Invalid character(s) in term`.

After trying to backslash escape the parentheses, it still wasn't having it.

Upon reviewing the AWS docs for filter patterns, it explicitly suggests using ASCII hexadecimal codes to specify the disallowed character[^1][^2].

`\x28` and `\x29` denote `(` and `)` respectively.

[^1]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html

[^2]: https://web.archive.org/web/20240221165209/https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html