### PR TITLE
csr: rename application log metric namespace

### DIFF
--- a/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
+++ b/terraform/environments/corporate-staff-rostering/app_log_metrics.tf
@@ -2,7 +2,7 @@
 locals {
   application_log_metric_filters_meta = {
     log_group_name = "cwagent-windows-application-json"
-    namespace      = "ApplicationLogMetrics"
+    namespace      = "ApplicationLog"
   }
   application_log_metric_filters_defaults = {
     log_group_name = local.application_log_metric_filters_meta.log_group_name


### PR DESCRIPTION
This commit removes the word "Metrics" from the namespace name. It was redundant.