### PR TITLE
ELM Update RDS instance S3 permissions

### DIFF
--- a/terraform/environments/electronic-monitoring-data/server_backups.tf
+++ b/terraform/environments/electronic-monitoring-data/server_backups.tf
@@ -131,8 +131,12 @@ data "aws_iam_policy_document" "rds_data_store_access" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
+      "s3:ListBucket",
     ]
-    resources = ["${aws_s3_bucket.data_store.arn}/*"]
+    resources = [
+        aws_s3_bucket.data_store.arn,
+        "${aws_s3_bucket.data_store.arn}/*",
+    ]
   }
 }
 


### PR DESCRIPTION
The classic tale of Matt vs IAM. The instance needs to be able to list the bucket also in order to do the database restoration.