### PR TITLE
set alarms for pd-csr-db-a now it's deployed

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_defaults.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_defaults.tf
@@ -31,12 +31,6 @@ locals {
         })
       }
     )
-    # This block can be removed when prod database goes live
-    database_awaiting_deployment = merge(
-      module.baseline_presets.cloudwatch_metric_alarms.ec2,
-      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux
-    )
     web = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -64,8 +64,6 @@ locals {
             "Ec2ProdDatabasePolicy",
           ])
         })
-        # IMPORTANT: remove this line when the DB is live in Production
-        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.database_awaiting_deployment
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type                = "r6i.xlarge"
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token


### PR DESCRIPTION
- set alarms for pd-csr-db-a now that it's been deployed
- this changes some params specifically for databases