### PR TITLE
DSOS-2635: update azure noms root dc ips

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -22,7 +22,10 @@ locals {
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       module.ip_addresses.azure_fixngo_cidrs.devtest_core,
     ])
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
+    ])
     jumpservers        = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
   }
 
@@ -56,7 +59,10 @@ locals {
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       module.ip_addresses.azure_fixngo_cidrs.prod_core,
     ])
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
+    ])
     jumpservers        = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
   }
   security_group_cidrs_by_environment = {

--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -1,16 +1,22 @@
 locals {
 
   security_group_cidrs_devtest = {
-    azure_vnets        = module.ip_addresses.azure_fixngo_cidrs.devtest
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers
+    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.devtest
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
+    ])
     rd_session_hosts = flatten([
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       module.ip_addresses.azure_fixngo_cidrs.devtest,
     ])
   }
   security_group_cidrs_preprod_prod = {
-    azure_vnets        = module.ip_addresses.azure_fixngo_cidrs.prod
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers
+    azure_vnets = module.ip_addresses.azure_fixngo_cidrs.prod
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
+    ])
     rd_session_hosts = flatten([
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       module.ip_addresses.azure_fixngo_cidrs.prod,

--- a/terraform/environments/planetfm/locals_security_groups.tf
+++ b/terraform/environments/planetfm/locals_security_groups.tf
@@ -5,8 +5,11 @@ locals {
     enduserclient = [
       "10.0.0.0/8"
     ]
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
+    ])
+    jumpservers = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
     remotedesktop_gateways = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers,
       module.ip_addresses.mp_cidr[module.environment.vpc_name]
@@ -19,8 +22,11 @@ locals {
     enduserclient = [
       "10.0.0.0/8"
     ]
-    domain_controllers = module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
+    domain_controllers = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
+      module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
+    ])
+    jumpservers = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
     remotedesktop_gateways = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
       module.ip_addresses.mp_cidr[module.environment.vpc_name]

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -9,16 +9,12 @@ locals {
 
     # DevTest Domain Controllers
     MGMCW0002    = "10.102.0.196"
-    tc_mgt_dc_01 = "10.102.0.199"
-    tc_mgt_dc_02 = "10.102.0.200"
   }
 
   azure_fixngo_ips = {
     devtest = {
       domain_controllers = [
         local.azure_fixngo_ip.MGMCW0002,
-        local.azure_fixngo_ip.tc_mgt_dc_01,
-        local.azure_fixngo_ip.tc_mgt_dc_02,
       ]
     }
     prod = {
@@ -54,8 +50,6 @@ locals {
     noms_prod_domain_controller_pcmcw1012 = "10.40.64.133/32"
 
     noms_devtest_domain_controller_MGMCW0002    = "10.102.0.196/32"
-    noms_devtest_domain_controller_tc_mgt_dc_01 = "10.102.0.199/32"
-    noms_devtest_domain_controller_tc_mgt_dc_02 = "10.102.0.200/32"
   }
 
   noms_live_subnet = {
@@ -169,8 +163,6 @@ locals {
 
     devtest_domain_controllers = [
       local.azure_fixngo_cidr.noms_devtest_domain_controller_MGMCW0002,
-      local.azure_fixngo_cidr.noms_devtest_domain_controller_tc_mgt_dc_01,
-      local.azure_fixngo_cidr.noms_devtest_domain_controller_tc_mgt_dc_02,
     ]
 
     devtest_jumpservers = [


### PR DESCRIPTION
Replace Azure DCs with AWS ones.  