### PR TITLE
DSOS-2635: Roll back production domain controller IPs for CSR and Planet

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -24,9 +24,9 @@ locals {
     ])
     domain_controllers = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
-      module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
+      # module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers, # hits rule limit, remove azure DCs first
     ])
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
+    jumpservers = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
   }
 
   security_group_cidrs_preprod_prod = {
@@ -63,7 +63,7 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
       module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
     ])
-    jumpservers        = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
+    jumpservers = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
   }
   security_group_cidrs_by_environment = {
     development   = local.security_group_cidrs_devtest

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -24,7 +24,7 @@ locals {
     ])
     domain_controllers = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
-      # module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers, # hits rule limit, remove azure DCs first
+      module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
     ])
     jumpservers = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
   }
@@ -61,7 +61,7 @@ locals {
     ])
     domain_controllers = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
-      module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
+      # module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers, # hits rule limit, remove azure DCs first
     ])
     jumpservers = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
   }

--- a/terraform/environments/planetfm/locals_security_groups.tf
+++ b/terraform/environments/planetfm/locals_security_groups.tf
@@ -24,7 +24,7 @@ locals {
     ]
     domain_controllers = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
-      module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers,
+      # module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers, # hits rule limit, remove azure DCs first
     ])
     jumpservers = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
     remotedesktop_gateways = flatten([


### PR DESCRIPTION
We've hit the maximum SG Rule limit so will need to remove the Azure IPs before adding the new AWS IPs.  Rolling back