### PR TITLE
DSOS-2635: update azure noms root dns forward

### DIFF
--- a/terraform/modules/baseline_presets/route53.tf
+++ b/terraform/modules/baseline_presets/route53.tf
@@ -19,7 +19,7 @@ locals {
     azure-fixngo-devtest-domain = {
       domain_name = "azure.noms.root"
       target_ips = flatten([
-        var.ip_addresses.azure_fixngo_ips.devtest_domain_controllers,
+        var.ip_addresses.azure_fixngo_ips.devtest.domain_controllers,
         var.ip_addresses.mp_ips.ad_fixngo_azure_domain_controllers,
       ])
       rule_type = "FORWARD"

--- a/terraform/modules/baseline_presets/route53.tf
+++ b/terraform/modules/baseline_presets/route53.tf
@@ -18,8 +18,11 @@ locals {
   route53_resolver_rules_all = {
     azure-fixngo-devtest-domain = {
       domain_name = "azure.noms.root"
-      target_ips  = var.ip_addresses.azure_fixngo_ips.devtest.domain_controllers
-      rule_type   = "FORWARD"
+      target_ips = flatten([
+        module.ip_addresses.azure_fixngo_ips.devtest_domain_controllers,
+        module.ip_addresses.mp_ips.ad_fixngo_azure_domain_controllers,
+      ])
+      rule_type = "FORWARD"
     }
     azure-fixngo-production-domain = {
       domain_name = "azure.hmpp.root"

--- a/terraform/modules/baseline_presets/route53.tf
+++ b/terraform/modules/baseline_presets/route53.tf
@@ -19,8 +19,8 @@ locals {
     azure-fixngo-devtest-domain = {
       domain_name = "azure.noms.root"
       target_ips = flatten([
-        module.ip_addresses.azure_fixngo_ips.devtest_domain_controllers,
-        module.ip_addresses.mp_ips.ad_fixngo_azure_domain_controllers,
+        var.ip_addresses.azure_fixngo_ips.devtest_domain_controllers,
+        var.ip_addresses.mp_ips.ad_fixngo_azure_domain_controllers,
       ])
       rule_type = "FORWARD"
     }

--- a/terraform/modules/ip_addresses/modernisation_platform.tf
+++ b/terraform/modules/ip_addresses/modernisation_platform.tf
@@ -10,6 +10,17 @@ locals {
     ad-azure-rdlic = "10.20.108.6"
   }
 
+  mp_ips = {
+    ad_fixngo_hmpp_domain_controllers = [
+      local.mp_ip["ad-hmpp-dc-a"],
+      local.mp_ip["ad-hmpp-dc-b"],
+    ]
+    ad_fixngo_azure_domain_controllers = [
+      local.mp_ip["ad-azure-dc-a"],
+      local.mp_ip["ad-azure-dc-b"],
+    ]
+  }
+
   mp_cidr = {
     # Aggregate ranges
     development_test         = "10.26.0.0/16"

--- a/terraform/modules/ip_addresses/outputs.tf
+++ b/terraform/modules/ip_addresses/outputs.tf
@@ -13,6 +13,11 @@ output "mp_ip" {
   description = "Modernisation Platform ips: map(string)"
 }
 
+output "mp_ips" {
+  value       = local.mp_ips
+  description = "Modernisation Platform ips: map(list(string))"
+}
+
 output "mp_cidr" {
   value       = local.mp_cidr
   description = "Modernisation Platform cidrs: map(string)"


### PR DESCRIPTION
Update resolver rules for azure.noms.root domain.  A couple of azure IPs are gone, replaced with AWS ones.