### PR TITLE
hmpp-oem: DSOS-2671: add tags for OEM monitoring

### DIFF
--- a/terraform/environments/hmpps-oem/locals_preproduction.tf
+++ b/terraform/environments/hmpps-oem/locals_preproduction.tf
@@ -28,9 +28,9 @@ locals {
             branch = "main"
           })
         })
-        # tags = merge(local.oem_ec2_default.tags, {
-        #   oracle-sids = "EMREP PPRCVCAT"
-        # })
+        tags = merge(local.oem_ec2_default.tags, {
+          oracle-sids = "EMREP PPRCVCAT"
+        })
       })
     }
 

--- a/terraform/environments/hmpps-oem/locals_production.tf
+++ b/terraform/environments/hmpps-oem/locals_production.tf
@@ -28,9 +28,9 @@ locals {
             branch = "main"
           })
         })
-        # tags = merge(local.oem_ec2_default.tags, {
-        #   oracle-sids = "EMREP PRCVCAT"
-        # })
+        tags = merge(local.oem_ec2_default.tags, {
+          oracle-sids = "EMREP PRCVCAT"
+        })
       })
     }
 


### PR DESCRIPTION
Add tags used by cloudwatch monitoring for preprod and prod OEM.