### PR TITLE
Dsos 2661 cross account alarms

### DIFF
--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -11,6 +11,12 @@ locals {
 
   # baseline config
   test_config = {
+    baseline_cloudwatch_metric_alarms = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+    )
 
     baseline_secretsmanager_secrets = {
       "/oracle/oem"              = local.oem_secretsmanager_secrets

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -11,12 +11,6 @@ locals {
 
   # baseline config
   test_config = {
-    baseline_cloudwatch_metric_alarms = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
-    )
 
     baseline_secretsmanager_secrets = {
       "/oracle/oem"              = local.oem_secretsmanager_secrets

--- a/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
+++ b/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_metric_alarm" "oasys-cpu-util" {
-    alarm_name = "oasys-cpu-util"
+resource "aws_cloudwatch_metric_alarm" "nomis-cpu-util" {
+    alarm_name = "nomis-cpu-util"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     evaluation_periods  = "15"
     datapoints_to_alarm = "15"
@@ -15,6 +15,9 @@ resource "aws_cloudwatch_metric_alarm" "oasys-cpu-util" {
             namespace = "AWS/EC2"
             period = "60"
             stat = "Maximum"
+            dimensions = {
+                InstanceId = "*"
+            }
         }
     }
 }

--- a/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
+++ b/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
@@ -1,0 +1,20 @@
+resource "aws_cloudwatch_metric_alarm" "oasys-cpu-util" {
+    alarm_name = "oasys-cpu-util"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods  = "15"
+    datapoints_to_alarm = "15"
+    threshold           = "95"
+    alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
+
+    metric_query {
+        id = "m1"
+        account_id = "612659970365"
+        return_data = "true"
+        metric {
+            metric_name = "CPUUtilization"
+            namespace = "AWS/EC2"
+            period = "60"
+            stat = "Maximum"
+        }
+    }
+}

--- a/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
+++ b/terraform/environments/hmpps-oem/modules/cloudwatch_dashboard/cross_account_alarms.tf
@@ -1,3 +1,4 @@
+# remove hardcoded values and modularise
 resource "aws_cloudwatch_metric_alarm" "nomis-cpu-util" {
     alarm_name = "nomis-cpu-util"
     comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -16,7 +17,31 @@ resource "aws_cloudwatch_metric_alarm" "nomis-cpu-util" {
             period = "60"
             stat = "Maximum"
             dimensions = {
-                InstanceId = "*"
+                InstanceId = "i-03389635247630d25"
+            }
+        }
+    }
+}
+
+resource "aws_cloudwatch_metric_alarm" "oasys-cpu-util" {
+    alarm_name = "oasys-cpu-util"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods  = "15"
+    datapoints_to_alarm = "15"
+    threshold           = "95"
+    alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 15 minutes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
+
+    metric_query {
+        id = "m1"
+        account_id = "546088120047"
+        return_data = "true"
+        metric {
+            metric_name = "CPUUtilization"
+            namespace = "AWS/EC2"
+            period = "60"
+            stat = "Maximum"
+            dimensions = {
+                InstanceId = "i-0752b4bfbacf4c9e9"
             }
         }
     }


### PR DESCRIPTION
Shows cross-account alarms in hmpps-oem-test from nomis-test and oasys-test.
Hardcoded values will be removed as part of this ticket - https://dsdmoj.atlassian.net/browse/DSOS-2638 