### PR TITLE
exclude rman backup alarms from the backup database deployment

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -68,6 +68,7 @@ locals {
             "Ec2PreprodDatabasePolicy",
           ])
         })
+        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.database # inc. ec2_instance_cwagent_collectd_oracle_db_backup alarms
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type                = "r6i.xlarge"
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -64,6 +64,7 @@ locals {
             "Ec2ProdDatabasePolicy",
           ])
         })
+        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.database # inc. ec2_instance_cwagent_collectd_oracle_db_backup alarms
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type                = "r6i.xlarge"
           metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
@@ -109,6 +110,7 @@ locals {
             "Ec2ProdDatabasePolicy",
           ])
         })
+        cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.backup_database # EXCLUDES ec2_instance_cwagent_collectd_oracle_db_backup alarms (as this is the backup server)
         instance = merge(local.defaults_database_ec2.instance, {
           instance_type                = "r6i.xlarge"
           disable_api_stop             = true


### PR DESCRIPTION
- remove cloudwatch_metric_alarms from default as it's not applicable anywhere anymore
- declare cloudwatch_metric_alarms in each database server (prod and preprod) where it's needed
- apply special backup_database locals config which doesn't include the rman backup alarms to -pd-csr-db-b in production as this is the backup server where rman backup doesn't run 