### PR TITLE
nomis: DSOS-2667: build syscon env part3

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -392,6 +392,39 @@ locals {
           oracle-db-name       = "qa11r"
         })
       })
+
+      dev-nomis-build-a = {
+        cloudwatch_metric_alarms = {}
+        config = merge(module.baseline_presets.ec2_instance.config.default, {
+          ami_name          = "base_rhel_7_9_2024-03-01T00-00-34.773Z"
+          availability_zone = "${local.region}a"
+          instance_profile_policies = concat(local.weblogic_ec2.config.instance_profile_policies, [
+            "Ec2DevWeblogicPolicy",
+            "Ec2Qa11GWeblogicPolicy",
+            "Ec2Qa11RWeblogicPolicy",
+          ])
+        })
+        ebs_volumes = {
+          "/dev/sdb" = { label = "app", size = 100, type = "gp3" } # /u01
+          "/dev/sdc" = { label = "app", size = 100, type = "gp3" } # /u02
+        }
+        instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+          instance_type          = "t3.medium"
+          vpc_security_group_ids = ["private-web"]
+        })
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+            branch = "nomis/DSOS-2667/add-build-server"
+          })
+        })
+        tags = {
+          description = "Syscon build and release server"
+          ami         = "base_rhel_7_9"
+          os-type     = "Linux"
+          component   = "build"
+          server-type = "nomis-build"
+        }
+      }
     }
 
     baseline_lbs = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -154,7 +154,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-2667/add-syscon-users"
+            branch = "main"
           })
         })
         tags = {
@@ -180,7 +180,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-2667/add-syscon-users"
+            branch = "main"
           })
         })
         tags = {
@@ -206,7 +206,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-2667/add-syscon-users"
+            branch = "main"
           })
         })
         tags = {
@@ -233,7 +233,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-2667/add-syscon-users"
+            branch = "main"
           })
         })
         tags = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -318,6 +318,7 @@ locals {
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
         })
+        route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
           args = merge(local.weblogic_ec2.user_data_cloud_init.args, {
             branch = "main"
@@ -343,6 +344,7 @@ locals {
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
         })
+        route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
           args = merge(local.weblogic_ec2.user_data_cloud_init.args, {
             branch = "main"
@@ -368,6 +370,7 @@ locals {
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
         })
+        route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
           args = merge(local.weblogic_ec2.user_data_cloud_init.args, {
             branch = "main"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -414,7 +414,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "nomis/DSOS-2667/add-build-server"
+            branch = "main"
           })
         })
         tags = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -411,6 +411,9 @@ locals {
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
           instance_type          = "t3.medium"
           vpc_security_group_ids = ["private-web"]
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -224,7 +224,8 @@ locals {
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name          = "base_rhel_6_10*"
+          ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
+          #ami_name          = "base_rhel_6_10*"
           availability_zone = null
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -244,7 +244,7 @@ locals {
         }
       }
 
-      dev-jumpserver-a = merge(local.jumpserver_ec2, {
+      dev-nomis-client-a = merge(local.jumpserver_ec2, {
         config = merge(local.jumpserver_ec2.config, {
           user_data_raw = base64encode(templatefile("./templates/jumpserver-user-data.yaml.tftpl", {
             ie_compatibility_mode_site_list = join(",", [
@@ -316,6 +316,9 @@ locals {
         })
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
@@ -342,6 +345,9 @@ locals {
         })
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
@@ -368,6 +374,9 @@ locals {
         })
         instance = merge(local.weblogic_ec2.instance, {
           instance_type = "t2.large"
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -154,7 +154,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
+            branch = "nomis/DSOS-2667/add-syscon-users"
           })
         })
         tags = {
@@ -180,7 +180,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
+            branch = "nomis/DSOS-2667/add-syscon-users"
           })
         })
         tags = {
@@ -206,7 +206,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
+            branch = "nomis/DSOS-2667/add-syscon-users"
           })
         })
         tags = {
@@ -232,7 +232,7 @@ locals {
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "main"
+            branch = "nomis/DSOS-2667/add-syscon-users"
           })
         })
         tags = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -224,8 +224,7 @@ locals {
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         config = merge(module.baseline_presets.ec2_instance.config.default, {
-          ami_name = "nomis_rhel_6_10_weblogic_appserver_10_3_release_2023-03-15T17-18-22.178Z"
-          #ami_name          = "base_rhel_6_10*"
+          ami_name          = "base_rhel_6_10*"
           availability_zone = null
         })
         instance = merge(module.baseline_presets.ec2_instance.instance.default_rhel6, {

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -179,7 +179,7 @@ locals {
         })
       })
 
-      preprod-jumpserver-a = merge(local.jumpserver_ec2, {
+      preprod-nomis-client-a = merge(local.jumpserver_ec2, {
         config = merge(local.jumpserver_ec2.config, {
           user_data_raw = base64encode(templatefile("./templates/jumpserver-user-data.yaml.tftpl", {
             ie_compatibility_mode_site_list = join(",", [

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -208,7 +208,7 @@ locals {
         })
       })
 
-      prod-jumpserver-a = merge(local.jumpserver_ec2, {
+      prod-nomis-client-a = merge(local.jumpserver_ec2, {
         config = merge(local.jumpserver_ec2.config, {
           user_data_raw = base64encode(templatefile("./templates/jumpserver-user-data.yaml.tftpl", {
             ie_compatibility_mode_site_list = join(",", [

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -382,7 +382,7 @@ locals {
         })
       })
 
-      test-jumpserver-a = merge(local.jumpserver_ec2, {
+      test-nomis-client-a = merge(local.jumpserver_ec2, {
         config = merge(local.jumpserver_ec2.config, {
           user_data_raw = base64encode(templatefile("./templates/jumpserver-user-data.yaml.tftpl", {
             ie_compatibility_mode_site_list = join(",", [


### PR DESCRIPTION
Rename jump server hosts to nomis-client
Add route53 records to syscon EC2s
Added syscon build server
Enabled backup for syscon standalone EC2s