### PR TITLE
Ingestion Transfer Lambda: v0.0.1 -> v0.0.2

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -14,7 +14,7 @@ locals {
 
       /* Image Versions */
       scan_image_version = "0.0.4"
-      transfer_image_version = "0.0.1"
+      transfer_image_version = "0.0.2"
 
       /* Target Buckets */
       target_buckets = ["dev-ingestion-testing"]
@@ -35,7 +35,7 @@ locals {
 
       /* Image Versions */
       scan_image_version = "0.0.4"
-      transfer_image_version = "0.0.1"
+      transfer_image_version = "0.0.2"
 
       /* Target Buckets */
       target_buckets = ["dev-ingestion-testing"]


### PR DESCRIPTION
This is required after a new release to the ingestion-transfer lambda container image. 

New release here:
https://github.com/ministryofjustice/analytical-platform-ingestion-transfer/releases