### PR TITLE
Remove minor version pin from reusable terraform version

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -41,7 +41,7 @@ on:
         type: string
         required: false
         description: "The terraform version to use"
-        default: "~1.6"
+        default: "~1"
       plan_apply_tfargs:
         type: string
         required: false

--- a/.github/workflows/reusable_terraform_plan_apply_test.yml
+++ b/.github/workflows/reusable_terraform_plan_apply_test.yml
@@ -41,7 +41,7 @@ on:
         type: string
         required: false
         description: "The terraform version to use"
-        default: "~1.6"
+        default: "~1"
       plan_apply_tfargs:
         type: string
         required: false


### PR DESCRIPTION
To resolve occasion customer issues with S3 bucket rewind failures, and to ensure that by default we're using the most recent version of terraform, this PR sets the floor to `~1` for terraform.

Customers can still override this as they see fit.