### PR TITLE
Equip Cutover: Upgrade from EQP01 to EQP04

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -68,7 +68,7 @@ resource "aws_lb_target_group" "lb_tg_equip-portal" {
 
   health_check {
     enabled             = true
-    path                = "/"
+    path                = "/nimbus/CtrlWebIsapi.dll"
     interval            = 30
     protocol            = "HTTP"
     port                = 80
@@ -90,7 +90,7 @@ resource "aws_lb_target_group" "lb_tg_portal" {
 
   health_check {
     enabled             = true
-    path                = "/"
+    path                = "/nimbus/CtrlWebIsapi.dll"
     interval            = 30
     protocol            = "HTTP"
     port                = 80
@@ -132,12 +132,12 @@ resource "aws_lb_target_group_attachment" "lb_tga_gateway" {
 
 resource "aws_lb_target_group_attachment" "lb_tga_equip-portal" {
   target_group_arn = aws_lb_target_group.lb_tg_equip-portal.arn
-  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
+  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP04"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_portal" {
   target_group_arn = aws_lb_target_group.lb_tg_portal.arn
-  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP01"].private_ip)
+  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP04"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_analytics" {

--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -132,12 +132,12 @@ resource "aws_lb_target_group_attachment" "lb_tga_gateway" {
 
 resource "aws_lb_target_group_attachment" "lb_tga_equip-portal" {
   target_group_arn = aws_lb_target_group.lb_tg_equip-portal.arn
-  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP04"].private_ip)
+  target_id        = join("", module.win2022_STD_multiple["COR-A-EQP04"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_portal" {
   target_group_arn = aws_lb_target_group.lb_tg_portal.arn
-  target_id        = join("", module.win2012_STD_multiple["COR-A-EQP04"].private_ip)
+  target_id        = join("", module.win2022_STD_multiple["COR-A-EQP04"].private_ip)
 }
 
 resource "aws_lb_target_group_attachment" "lb_tga_analytics" {


### PR DESCRIPTION
This PR updates the target groups for Equip changing it from `COR-A-EQP01 `to `COR-A-EQP04`

I have also updated the health checks as these are currently failing due to the re-direct on the homepage. 