### PR TITLE
increase prod DB flash disk sizes

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -86,7 +86,7 @@ locals {
             total_size = 1500
           }
           flash = {
-            total_size = 100
+            total_size = 500
           }
         })
 
@@ -129,7 +129,7 @@ locals {
             total_size = 1500
           }
           flash = {
-            total_size = 100
+            total_size = 500
           }
         })
 


### PR DESCRIPTION
- request from db's to make flash disks on pd-csr-db-a and -b 250G each as they're running out of space
- increase 'flash' size in db code to 500 so it's split