### PR TITLE
🤐 Add GitHub and Slack secrets

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -11,9 +11,9 @@
       "integrity": "sha256:cca6d0a095f5365ee235302b24c255c7601f2ebfa1fae73c3b42c1840b8389ed"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:0": {
-      "version": "0.0.3",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:ee331ef839de0479888df2049da48aaf980be9887e5ce90937ba5273105b2032",
-      "integrity": "sha256:ee331ef839de0479888df2049da48aaf980be9887e5ce90937ba5273105b2032"
+      "version": "0.0.4",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:37a9344050e0a16eee8db51693ebe26be7023d5babea2d7848720be4ce619617",
+      "integrity": "sha256:37a9344050e0a16eee8db51693ebe26be7023d5babea2d7848720be4ce619617"
     }
   }
 }

--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -5,3 +5,7 @@ resource "aws_secretsmanager_secret" "grafana_api_key" {
 resource "aws_secretsmanager_secret" "github_token" {
   name = "grafana/data-sources/github-token"
 }
+
+resource "aws_secretsmanager_secret" "slack_token" {
+  name = "grafana/notifications/slack-token"
+}

--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -1,3 +1,7 @@
 resource "aws_secretsmanager_secret" "grafana_api_key" {
   name = "grafana/api-key"
 }
+
+resource "aws_secretsmanager_secret" "github_token" {
+  name = "grafana/data-sources/github-token"
+}


### PR DESCRIPTION
This pull request:

- Adds a new secret to consume @moj-observability-platform-bot's GitHub token
- Adds a new secret to consume Observability Platform's Slack token
- Updates `ghcr.io/ministryofjustice/devcontainer-feature/terraform` to `0.0.4`