### PR TITLE
⚙️ Update Analytical Platform Ingestion

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
@@ -3,6 +3,6 @@ module "transfer_structured_logs" {
   version = "5.3.1"
 
   name              = "/aws/transfer-structured-logs"
-  kms_key_id        = module.transfer_logs_kms.key_id
+  kms_key_id        = module.transfer_logs_kms.key_arn
   retention_in_days = 400
 }

--- a/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
@@ -1,4 +1,8 @@
-# Deactivated for now
-# resource "aws_cloudwatch_log_group" "transfer_structured_logs" {
-#   name = "/aws/transfer-structured-logs"
-# }
+module "transfer_structured_logs" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "5.3.1"
+
+  name              = "/aws/transfer-structured-logs"
+  kms_key_id        = module.transfer_logs_kms.key_id
+  retention_in_days = 400
+}

--- a/terraform/environments/analytical-platform-ingestion/eips.tf
+++ b/terraform/environments/analytical-platform-ingestion/eips.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "transfer_server" {
-  count = length(data.aws_availability_zones.available.names)
+  count = length(module.vpc.public_subnets)
 
   domain = "vpc"
 

--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -21,6 +21,16 @@ locals {
 
       /* Transfer Server */
       transfer_server_hostname = "sftp.development.ingestion.analytical-platform.service.justice.gov.uk"
+      transfer_server_sftp_users = {
+        "jacobwoffenden" = {
+          ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN+3qaLVtn6Pd+DasWHhIOBoXEEhF9GZAG+DYfJBeySS Ministry of Justice"
+          cidr_blocks = ["90.246.52.170/32"]
+        },
+        "garyhenderson" = {
+          ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID2lrI7AhZ9Sy/JAVDfPPEkCZawuuVJ7MHg6NNAwYImb"
+          cidr_blocks = ["154.47.111.68/32"]
+        }
+      }
     }
     production = {
       /* VPC */
@@ -42,6 +52,16 @@ locals {
 
       /* Transfer Server */
       transfer_server_hostname = "sftp.ingestion.analytical-platform.service.justice.gov.uk"
+      transfer_server_sftp_users = {
+        "jacobwoffenden" = {
+          ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN+3qaLVtn6Pd+DasWHhIOBoXEEhF9GZAG+DYfJBeySS Ministry of Justice"
+          cidr_blocks = ["90.246.52.170/32"]
+        },
+        "garyhenderson" = {
+          ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID2lrI7AhZ9Sy/JAVDfPPEkCZawuuVJ7MHg6NNAwYImb"
+          cidr_blocks = ["154.47.111.68/32"]
+        }
+      }
     }
   }
 }

--- a/terraform/environments/analytical-platform-ingestion/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-policies.tf
@@ -1,0 +1,25 @@
+data "aws_iam_policy_document" "transfer_server" {
+  statement {
+    sid    = "AllowKMS"
+    effect = "Allow"
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+    ]
+    resources = [module.transfer_logs_kms.key_arn]
+  }
+}
+
+module "transfer_server_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.37.1"
+
+  name_prefix = "transfer-server"
+
+  policy = data.aws_iam_policy_document.transfer_server.json
+}

--- a/terraform/environments/analytical-platform-ingestion/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-roles.tf
@@ -1,0 +1,18 @@
+module "transfer_server_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.37.1"
+
+  create_role = true
+
+  role_name_prefix  = "transfer-server"
+  role_requires_mfa = false
+
+  trusted_role_services = ["transfer.amazonaws.com"]
+
+  custom_role_policy_arns = [
+    module.transfer_server_iam_policy.arn,
+    "arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"
+  ]
+}

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -6,6 +6,33 @@ module "transfer_logs_kms" {
   aliases               = ["logs/transfer"]
   description           = "CloudWatch Logs for the Transfer Server"
   enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowCloudWatchLogs"
+      actions = [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "ArnEquals"
+          variable = "kms:EncryptionContext:aws:logs:arn"
+          values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/transfer-structured-logs"]
+        }
+      ]
+    }
+  ]
 
   deletion_window_in_days = 7
 }

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -1,3 +1,15 @@
+module "transfer_logs_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/kms/aws"
+  version = "2.2.1"
+
+  aliases               = ["logs/transfer"]
+  description           = "CloudWatch Logs for the Transfer Server"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+}
+
 module "s3_landing_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/kms/aws"

--- a/terraform/environments/analytical-platform-ingestion/transfer-servers.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-servers.tf
@@ -21,10 +21,8 @@ resource "aws_transfer_server" "this" {
 
   security_policy_name = "TransferSecurityPolicy-2024-01"
 
-  # Logging role is only required when using Managed workflows.
-  # logging_role                = module.transfer_family_service_role.iam_role_arn
-
-  # structured_log_destinations = ["${aws_cloudwatch_log_group.transfer_structured_logs.arn}:*"]
+  logging_role                = module.transfer_server_iam_role.iam_role_arn
+  structured_log_destinations = ["${module.transfer_structured_logs.cloudwatch_log_group_arn}:*"]
 }
 
 resource "aws_transfer_tag" "this" {

--- a/terraform/environments/analytical-platform-ingestion/transfer-user.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-user.tf
@@ -1,18 +1,5 @@
-locals {
-  sftp_users = {
-    "jacobwoffenden" = {
-      ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN+3qaLVtn6Pd+DasWHhIOBoXEEhF9GZAG+DYfJBeySS Ministry of Justice"
-      cidr_blocks = ["90.246.52.170/32", "82.132.238.3/32"]
-    },
-    "garyhenderson" = {
-      ssh_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID2lrI7AhZ9Sy/JAVDfPPEkCZawuuVJ7MHg6NNAwYImb"
-      cidr_blocks = ["154.47.111.68/32"]
-    }
-  }
-}
-
 module "sftp_users" {
-  for_each = local.sftp_users
+  for_each = local.environment_configuration.transfer_server_sftp_users
 
   source = "./modules/transfer-family/user"
 


### PR DESCRIPTION
This pull request:

- Adds KMS key for structured transfer logs
- Adds CloudWatch Log Group for structured logs
- Switches to `module.vpc.public_subnets` for calculating EIP count
- Moves SFTP users into environment configuration
- Adds IAM policy and role for transfer logging
- Enables structured logging on transfer server

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 