### PR TITLE
DSOS-2700: add missing nomis syscon DNS records

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -407,6 +407,7 @@ locals {
             backup-plan = "daily-and-weekly"
           }
         })
+        route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
             branch = "main"


### PR DESCRIPTION
Forgot the DNS entries for the syscon build server