### PR TITLE
Adding cross-account monitoring from planet to csr

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -189,6 +189,5 @@ locals {
   cloudwatch_monitoring_options = {
     enable_cloudwatch_monitoring_account    = false
     enable_cloudwatch_cross_account_sharing = false
-    enable_cloudwatch_dashboard             = false
-  }
+    }
 }

--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -177,4 +177,18 @@ locals {
 
   baseline_sns_topics = {}
 
+  environment_cloudwatch_monitoring_options = {
+    development   = local.development_cloudwatch_monitoring_options
+    test          = local.test_cloudwatch_monitoring_options
+    preproduction = local.preproduction_cloudwatch_monitoring_options
+    production    = local.production_cloudwatch_monitoring_options
+  }
+
+  cloudwatch_local_environment_monitoring_options = local.environment_cloudwatch_monitoring_options[local.environment]
+
+  cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account    = false
+    enable_cloudwatch_cross_account_sharing = false
+    enable_cloudwatch_dashboard             = false
+  }
 }

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -1,6 +1,11 @@
 # csr-development environment settings
 locals {
 
+  # cloudwatch monitoring config
+  development_cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account = false
+  }
+
   # baseline config
   development_config = {
 

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -2,9 +2,7 @@
 locals {
 
   # cloudwatch monitoring config
-  development_cloudwatch_monitoring_options = {
-    enable_cloudwatch_monitoring_account = false
-  }
+  development_cloudwatch_monitoring_options = {}
 
   # baseline config
   development_config = {

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -1,6 +1,11 @@
 # csr-preproduction environment settings
 locals {
 
+  # cloudwatch monitoring config
+  preproduction_cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account = false
+  }
+
   # baseline config
   preproduction_config = {
 

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -2,9 +2,7 @@
 locals {
 
   # cloudwatch monitoring config
-  preproduction_cloudwatch_monitoring_options = {
-    enable_cloudwatch_monitoring_account = false
-  }
+  preproduction_cloudwatch_monitoring_options = {}
 
   # baseline config
   preproduction_config = {

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -4,7 +4,7 @@ locals {
   # cloudwatch monitoring config
   production_cloudwatch_monitoring_options = {
     enable_cloudwatch_monitoring_account = true
-    enable_cloudwatch_dashboard          = true
+    # enable_cloudwatch_dashboard          = true
   }
 
   # baseline config

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -1,6 +1,12 @@
 # csr-production environment settings
 locals {
 
+  # cloudwatch monitoring config
+  production_cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account = true
+    enable_cloudwatch_dashboard          = true
+  }
+
   # baseline config
   production_config = {
 

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -2,9 +2,7 @@
 locals {
 
   # cloudwatch monitoring config
-  test_cloudwatch_monitoring_options = {
-    enable_cloudwatch_monitoring_account = false
-  }
+  test_cloudwatch_monitoring_options = {}
 
   # baseline config
   test_config = {

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -1,6 +1,11 @@
 # nomis-test environment settings
 locals {
 
+  # cloudwatch monitoring config
+  test_cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account = false
+  }
+
   # baseline config
   test_config = {
 

--- a/terraform/environments/corporate-staff-rostering/main.tf
+++ b/terraform/environments/corporate-staff-rostering/main.tf
@@ -143,3 +143,21 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )
 }
+
+module "cross_account_cloudwatch" {
+  source  = "../../modules/cross_account_cloudwatch"
+  environment  = module.environment
+  options = merge(
+    local.cloudwatch_monitoring_options,
+    local.cloudwatch_local_environment_monitoring_options,
+  )
+}
+
+module "cloudwatch" {
+  source  = "../../modules/cloudwatch"
+  environment  = module.environment
+  options = merge(
+    local.cloudwatch_monitoring_options,
+    local.cloudwatch_local_environment_monitoring_options,
+  )
+}

--- a/terraform/environments/corporate-staff-rostering/main.tf
+++ b/terraform/environments/corporate-staff-rostering/main.tf
@@ -152,12 +152,3 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_local_environment_monitoring_options,
   )
 }
-
-module "cloudwatch" {
-  source  = "../../modules/cloudwatch"
-  environment  = module.environment
-  options = merge(
-    local.cloudwatch_monitoring_options,
-    local.cloudwatch_local_environment_monitoring_options,
-  )
-}

--- a/terraform/environments/corporate-staff-rostering/platform_base_variables.tf
+++ b/terraform/environments/corporate-staff-rostering/platform_base_variables.tf
@@ -9,3 +9,4 @@ variable "collaborator_access" {
   default     = "developer"
   description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
 }
+

--- a/terraform/environments/corporate-staff-rostering/platform_base_variables.tf
+++ b/terraform/environments/corporate-staff-rostering/platform_base_variables.tf
@@ -9,4 +9,3 @@ variable "collaborator_access" {
   default     = "developer"
   description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
 }
-

--- a/terraform/environments/corporate-staff-rostering/variables.tf
+++ b/terraform/environments/corporate-staff-rostering/variables.tf
@@ -1,0 +1,9 @@
+# variable "monitoring_account_sink_identifier" {
+#   type    = string
+#   default = "arn:aws:oam:eu-west-2:775245656481:sink/7d4f9ba0-e432-49d1-8f34-1fda2d165bf8"
+# } TODO
+
+variable "monitoring_account_id" {
+  type    = string
+  default = "221841889672" # corporate-staff-rostering-production account
+}

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -81,4 +81,20 @@ locals {
 
   baseline_sns_topics     = {}
   baseline_ssm_parameters = {}
+
+  environment_cloudwatch_monitoring_options = {
+    development   = local.development_cloudwatch_monitoring_options
+    test          = local.test_cloudwatch_monitoring_options
+    preproduction = local.preproduction_cloudwatch_monitoring_options
+    production    = local.production_cloudwatch_monitoring_options
+  }
+
+  cloudwatch_local_environment_monitoring_options = local.environment_cloudwatch_monitoring_options[local.environment]
+
+  cloudwatch_monitoring_options = {
+    enable_cloudwatch_monitoring_account    = false
+    enable_cloudwatch_cross_account_sharing = false
+    # enable_cloudwatch_dashboard             = false
+  }
+
 }

--- a/terraform/environments/planetfm/locals_development.tf
+++ b/terraform/environments/planetfm/locals_development.tf
@@ -1,6 +1,9 @@
 # nomis-development environment settings
 locals {
 
+  # cloudwatch monitoring config
+  development_cloudwatch_monitoring_options = {}
+
   # baseline config
   development_config = {
 

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -1,5 +1,11 @@
 locals {
 
+  # cloudwatch monitoring config
+  production_cloudwatch_monitoring_options = {
+    enable_cloudwatch_cross_account_sharing = true
+    enable_cloudwatch_dashboard             = true
+  }
+
   # baseline config
   preproduction_config = {
     baseline_ec2_instances = {

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -1,5 +1,8 @@
 locals {
 
+  # cloudwatch monitoring config
+  preproduction_cloudwatch_monitoring_options = {}
+
   # baseline config
   preproduction_config = {
     baseline_ec2_instances = {

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -1,11 +1,5 @@
 locals {
 
-  # cloudwatch monitoring config
-  production_cloudwatch_monitoring_options = {
-    enable_cloudwatch_cross_account_sharing = true
-    enable_cloudwatch_dashboard             = true
-  }
-
   # baseline config
   preproduction_config = {
     baseline_ec2_instances = {

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -1,5 +1,11 @@
 locals {
 
+  # cloudwatch monitoring config
+  production_cloudwatch_monitoring_options = {
+    enable_cloudwatch_cross_account_sharing = true
+    # enable_cloudwatch_dashboard             = true
+  }
+
   # baseline config
   production_config = {
 

--- a/terraform/environments/planetfm/locals_test.tf
+++ b/terraform/environments/planetfm/locals_test.tf
@@ -1,5 +1,8 @@
 locals {
 
+  # cloudwatch monitoring config
+  test_cloudwatch_monitoring_options = {}
+
   # baseline config
   test_config = {
 

--- a/terraform/environments/planetfm/main.tf
+++ b/terraform/environments/planetfm/main.tf
@@ -137,3 +137,13 @@ module "baseline" {
   cost_usage_report = lookup(local.baseline_environment_config, "baseline_cost_usage_report", { create = false })
 
 }
+
+module "cross_account_cloudwatch" {
+  source  = "../../modules/cross_account_cloudwatch"
+  environment  = module.environment
+  options = merge(
+    local.cloudwatch_monitoring_options,
+    local.cloudwatch_local_environment_monitoring_options,
+  )
+}
+


### PR DESCRIPTION
Enabling metric sharing from planet fm prod to csr prod.
No preset dashboard built alongside - leaves option for App Support team to build their own, as required.