### PR TITLE
hmpps-oem: DSOS: update db backup sharing permissions

### DIFF
--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -54,7 +54,8 @@ locals {
       description = "Default EC2 Policy for a DB in this environment"
       statements = flatten([
         local.iam_policy_statements_in_ec2_default,
-        local.iam_policy_statements_ec2.OracleLicenseTracking
+        local.iam_policy_statements_ec2.OracleLicenseTracking,
+        var.options.db_backup_s3 ? local.iam_policy_statements_ec2.S3DbBackupRead : [],
       ])
     }
 

--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -334,6 +334,35 @@ locals {
       },
     ]
 
+    S3DbBackupRead = [
+      {
+        sid    = "S3DbBackupRead"
+        effect = "Allow"
+        actions = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        resources = flatten([
+          var.environment.environment == "production" ? [
+            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*",
+            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*/*",
+            "arn:aws:s3:::prod-${var.environment.application_name}-db-backup-bucket-*",
+            "arn:aws:s3:::prod-${var.environment.application_name}-db-backup-bucket-*/*",
+          ] : [],
+          var.environment.environment == "preproduction" ? [
+            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*",
+            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*/*",
+          ] : [],
+          contains(["development", "test"], var.environment.environment) ? [
+            "arn:aws:s3:::dev-${var.environment.application_name}-db-backup-bucket-*",
+            "arn:aws:s3:::dev-${var.environment.application_name}-db-backup-bucket-*/*",
+            "arn:aws:s3:::devtest-${var.environment.application_name}-db-backup-bucket-*",
+            "arn:aws:s3:::devtest-${var.environment.application_name}-db-backup-bucket-*/*",
+          ] : [],
+        ])
+      }
+    ]
+
   }
 
 }

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -25,7 +25,7 @@ locals {
     } } : {},
 
     # If db_backup_s3 enabled, create db_backups in all environments.
-    # The test and production buckets allow read access from development and preproduction resepctively
+    # Dev and Test can both access each other: Preprod can access prod but not vice-versa
     var.options.db_backup_s3 && var.environment.environment == "production" ? { "prod-${var.environment.application_name}-db-backup-bucket-" = {
       bucket_policy_v2 = [
         local.s3_bucket_policies.PreprodReadOnlyAccessBucketPolicy
@@ -39,12 +39,15 @@ locals {
     } } : {},
     var.options.db_backup_s3 && var.environment.environment == "test" ? { "devtest-${var.environment.application_name}-db-backup-bucket-" = {
       bucket_policy_v2 = [
-        local.s3_bucket_policies.DevelopmentReadOnlyAccessBucketPolicy
+        local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy
       ]
       custom_kms_key = var.environment.kms_keys["general"].arn
       iam_policies   = local.requested_s3_iam_policies
     } } : {},
     var.options.db_backup_s3 && var.environment.environment == "development" ? { "dev-${var.environment.application_name}-db-backup-bucket-" = {
+      bucket_policy_v2 = [
+        local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy
+      ]
       custom_kms_key = var.environment.kms_keys["general"].arn
       iam_policies   = local.requested_s3_iam_policies
     } } : {},


### PR DESCRIPTION
On request from Delius DBAs
Allow dev and test DB EC2 instances to access db backup buckets in dev and test.