### PR TITLE
🔐 Add PagerDuty integration key secret

### DIFF
--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -9,3 +9,7 @@ resource "aws_secretsmanager_secret" "github_token" {
 resource "aws_secretsmanager_secret" "slack_token" {
   name = "grafana/notifications/slack-token"
 }
+
+resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  name = "grafana/notifications/pagerduty-integration-keys"
+}


### PR DESCRIPTION
This pull request:

- Adds a secret we can populate for PagerDuty integration keys

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 