### PR TITLE
📟 Observability Platform PagerDuty alerting

### DIFF
--- a/terraform/environments/observability-platform/environment-configurations.tf
+++ b/terraform/environments/observability-platform/environment-configurations.tf
@@ -6,6 +6,7 @@ locals {
         "observability-platform" = {
           identity_centre_team = "observability-platform"
           slack_channels       = ["observability-platform-development-alerts"]
+          pagerduty_services   = ["observability-platform"]
           aws_accounts = {
             "observability-platform-development" = {
               cloudwatch_enabled      = true

--- a/terraform/environments/observability-platform/locals.tf
+++ b/terraform/environments/observability-platform/locals.tf
@@ -10,9 +10,14 @@ locals {
     [for channel in lookup(tenant, "slack_channels", []) : channel]
   ]))
 
-  all_aws_accounts = flatten([
+  all_pagerduty_services = distinct(flatten([
+    for tenant in local.environment_configuration.tenant_configuration :
+    [for service in lookup(tenant, "pagerduty_services", []) : service]
+  ]))
+
+  all_aws_accounts = distinct(flatten([
     for tenant_name, tenant_config in local.environment_configuration.tenant_configuration : [
       for account_name, _ in lookup(tenant_config, "aws_accounts", {}) : account_name
     ]
-  ])
+  ]))
 }

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -75,7 +75,22 @@ resource "grafana_notification_policy" "root" {
     }
   }
 
-  depends_on = [module.contact_point_slack]
+  dynamic "policy" {
+    for_each = toset(local.all_pagerduty_services)
+    content {
+      matcher {
+        label = "pagerduty-integration"
+        match = "="
+        value = policy.value
+      }
+      contact_point = "${policy.value}-pagerduty"
+    }
+  }
+
+  depends_on = [
+    module.contact_point_slack,
+    module.contact_point_pagerduty
+  ]
 }
 
 /* Prometheus Source */

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -46,6 +46,15 @@ module "contact_point_slack" {
   channel = each.value
 }
 
+/* PagerDuty Contact Points */
+module "contact_point_pagerduty" {
+  for_each = toset(local.all_pagerduty_services)
+
+  source = "./modules/grafana/contact-point/pagerduty"
+
+  service = each.value
+}
+
 /* Notification Policy */
 resource "grafana_notification_policy" "root" {
   contact_point   = "grafana-default-sns"

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/main.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/main.tf
@@ -1,0 +1,11 @@
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  secret_id = "grafana/notifications/pagerduty-integration-keys"
+}
+
+resource "grafana_contact_point" "this" {
+  name = "${var.service}-pagerduty"
+
+  pagerduty {
+    integration_key = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)[var.service]
+  }
+}

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/providers.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/variables.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/variables.tf
@@ -1,0 +1,3 @@
+variable "service" {
+  type = string
+}

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/slack/main.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/slack/main.tf
@@ -1,4 +1,4 @@
-data "aws_secretsmanager_secret_version" "github_token" {
+data "aws_secretsmanager_secret_version" "slack_token" {
   secret_id = "grafana/notifications/slack-token"
 }
 
@@ -7,6 +7,6 @@ resource "grafana_contact_point" "this" {
 
   slack {
     recipient = var.channel
-    token     = data.aws_secretsmanager_secret_version.github_token.secret_string
+    token     = data.aws_secretsmanager_secret_version.slack_token.secret_string
   }
 }


### PR DESCRIPTION
This pull request:

- Introduces `pagerduty_services` to `tenant_configuration`
- Creates a Grafana contact point
- Mutates the root notification policy to create labels for routing to PagerDuty

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 