### PR TITLE
🔧  Add Deny Policy for Quarantine S3 bucket

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
     sid    = "DenyAccess"
     effect = "Deny"
     principals {
-      type        = ["*"]
+      type        = "*"
       identifiers = ["*"]
     }
     actions   = ["s3:GetObject", "s3:PutObjectTagging"]

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -24,7 +24,10 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
       type        = "*"
       identifiers = ["*"]
     }
-    actions   = ["s3:GetObject", "s3:PutObjectTagging"]
+    actions = [
+      "s3:GetObject",
+      "s3:PutObjectTagging"
+    ]
     resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine/*"]
     condition {
       test     = "StringEquals"

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -18,14 +18,19 @@ module "landing_bucket" {
 
 data "aws_iam_policy_document" "quarantine_bucket_policy" {
   statement {
-    sid    = "DenyAll"
+    sid    = "DenyAccess"
     effect = "Deny"
-    not_principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/scan"]
+    principals {
+      type        = ["*"]
+      identifiers = ["*"]
     }
-    actions   = ["*"]
-    resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine"]
+    actions   = ["s3:GetObject", "s3:PutObjectTagging"]
+    resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:ExistingObjectTag/scan-result"
+      values   = ["infected"]
+    }
   }
 }
 

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -22,10 +22,10 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
     effect = "Deny"
     not_principals {
       type        = "AWS"
-      identifiers = [module.scan_lambda.lambda_function_arn]
+      identifiers = ["arn:aws:iam::${local.environment}:role/scan"]
     }
     actions   = ["*"]
-    resources = [module.quarantine_bucket.s3_bucket_arn] # will this introduce a cyclic issue?
+    resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine"]
   }
 }
 

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
     effect = "Deny"
     not_principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.environment}:role/scan"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/scan"]
     }
     actions   = ["*"]
     resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine"]

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -3,7 +3,7 @@ module "landing_bucket" {
   version = "4.1.0"
 
   bucket = "mojap-ingestion-${local.environment}-landing"
-  # TODO: Is this needed below?
+
   force_destroy = true
 
   server_side_encryption_configuration = {
@@ -16,13 +16,29 @@ module "landing_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "quarantine_bucket_policy" {
+  statement {
+    sid    = "DenyAll"
+    effect = "Deny"
+    not_principals {
+      type        = "AWS"
+      identifiers = [module.scan_lambda.lambda_function_arn]
+    }
+    actions   = ["*"]
+    resources = [module.quarantine_bucket.s3_bucket_arn] # will this introduce a cyclic issue?
+  }
+}
+
 module "quarantine_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.1.0"
 
   bucket = "mojap-ingestion-${local.environment}-quarantine"
-  # TODO: Is this needed below?
+
   force_destroy = true
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.quarantine_bucket_policy.json
 
   server_side_encryption_configuration = {
     rule = {
@@ -39,7 +55,7 @@ module "definitions_bucket" {
   version = "4.1.0"
 
   bucket = "mojap-ingestion-${local.environment}-definitions"
-  # TODO: Is this needed below?
+
   force_destroy = true
 
   server_side_encryption_configuration = {
@@ -57,7 +73,7 @@ module "processed_bucket" {
   version = "4.1.0"
 
   bucket = "mojap-ingestion-${local.environment}-processed"
-  # TODO: Is this needed below?
+
   force_destroy = true
 
   server_side_encryption_configuration = {


### PR DESCRIPTION
This locks down the quarantine S3 bucket in Analytical Platform Ingestion.