### PR TITLE
:wrench: Move Lambda to VPC

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/data.tf
+++ b/terraform/environments/analytical-platform-ingestion/data.tf
@@ -1,1 +1,7 @@
 data "aws_availability_zones" "available" {}
+
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.eu-west-2.s3"
+
+  depends_on = [module.vpc_endpoints]
+}

--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -47,7 +47,7 @@ locals {
       transfer_image_version = "0.0.2"
 
       /* Target Buckets */
-      target_buckets = ["dev-ingestion-testing"]
+      target_buckets = []
 
       /* Transfer Server */
       transfer_server_hostname               = "sftp.ingestion.analytical-platform.service.justice.gov.uk"

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -15,7 +15,7 @@ module "definition_upload_lambda" {
   image_uri     = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-scan:${local.environment_configuration.scan_image_version}"
 
   vpc_subnet_ids         = module.vpc.private_subnets
-  vpc_security_group_ids = [module.vpc.default_security_group_id]
+  vpc_security_group_ids = [module.definition_upload_lambda_security_group.security_group_id]
   attach_network_policy  = true
 
   environment_variables = {
@@ -72,6 +72,10 @@ module "scan_lambda" {
   ephemeral_storage_size = 10240
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-scan:${local.environment_configuration.scan_image_version}"
+
+  vpc_subnet_ids         = module.vpc.private_subnets
+  vpc_security_group_ids = [module.scan_lambda_security_group.security_group_id]
+  attach_network_policy  = true
 
   environment_variables = {
     MODE                         = "scan",
@@ -143,6 +147,10 @@ module "transfer_lambda" {
   ephemeral_storage_size = 10240
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-transfer:${local.environment_configuration.transfer_image_version}"
+
+  vpc_subnet_ids         = module.vpc.private_subnets
+  vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
+  attach_network_policy  = true
 
   environment_variables = {
     PROCESSED_BUCKET_NAME = module.processed_bucket.s3_bucket_id

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -141,7 +141,7 @@ module "transfer_lambda" {
   create_package = false
 
   function_name          = "transfer"
-  description            = "Transfers files from to S3 Buckets"
+  description            = "Transfers files from processed S3 to target S3"
   package_type           = "Image"
   memory_size            = 2048
   ephemeral_storage_size = 10240

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -2,7 +2,7 @@ module "definition_upload_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.2.1"
+  version = "7.2.5"
 
   publish        = true
   create_package = false
@@ -13,6 +13,10 @@ module "definition_upload_lambda" {
   memory_size   = 2048
   timeout       = 900
   image_uri     = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-scan:${local.environment_configuration.scan_image_version}"
+
+  vpc_subnet_ids         = module.vpc.private_subnets
+  vpc_security_group_ids = [module.vpc.default_security_group_id]
+  attach_network_policy  = true
 
   environment_variables = {
     MODE                         = "definition-upload",
@@ -56,7 +60,7 @@ module "scan_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.2.1"
+  version = "7.2.5"
 
   publish        = true
   create_package = false
@@ -127,7 +131,7 @@ module "transfer_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.2.1"
+  version = "7.2.5"
 
   publish        = true
   create_package = false

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -137,7 +137,7 @@ module "transfer_lambda" {
   create_package = false
 
   function_name          = "transfer"
-  description            = ""
+  description            = "Transfers files from to S3 Buckets"
   package_type           = "Image"
   memory_size            = 2048
   ephemeral_storage_size = 10240

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -22,8 +22,9 @@ module "definition_upload_lambda_security_group" {
 
   vpc_id = module.vpc.vpc_id
 
-  egress_cidr_blocks = ["0.0.0.0/0"]
-  egress_rules       = ["all-all"]
+  egress_cidr_blocks     = ["0.0.0.0/0"]
+  egress_rules           = ["all-all"]
+  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
 
   tags = local.tags
 }
@@ -39,8 +40,9 @@ module "transfer_lambda_security_group" {
 
   vpc_id = module.vpc.vpc_id
 
-  egress_cidr_blocks = [module.vpc.vpc_cidr_block]
-  egress_rules       = ["all-all"]
+  egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
+  egress_rules           = ["all-all"]
+  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
 
   tags = local.tags
 }
@@ -56,8 +58,9 @@ module "scan_lambda_security_group" {
 
   vpc_id = module.vpc.vpc_id
 
-  egress_cidr_blocks = [module.vpc.vpc_cidr_block]
-  egress_rules       = ["all-all"]
+  egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
+  egress_rules           = ["all-all"]
+  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -10,3 +10,54 @@ resource "aws_security_group" "transfer_server" {
   name        = "transfer-server"
   vpc_id      = module.vpc.vpc_id
 }
+
+module "definition_upload_lambda_security_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.application_name}-${local.environment}-definition-upload-lambda"
+  description = "Security Group for Definition Upload Lambda"
+
+  vpc_id = module.vpc.vpc_id
+
+  egress_cidr_blocks = ["0.0.0.0/0"]
+  egress_rules       = ["all-all"]
+
+  tags = local.tags
+}
+
+module "transfer_lambda_security_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.application_name}-${local.environment}-definition-upload-lambda"
+  description = "Security Group for Definition Upload Lambda"
+
+  vpc_id = module.vpc.vpc_id
+
+  egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  egress_rules       = ["all-all"]
+
+  tags = local.tags
+}
+
+module "scan_lambda_security_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.application_name}-${local.environment}-definition-upload-lambda"
+  description = "Security Group for Definition Upload Lambda"
+
+  vpc_id = module.vpc.vpc_id
+
+  egress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  egress_rules       = ["all-all"]
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -34,8 +34,8 @@ module "transfer_lambda_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 5.0"
 
-  name        = "${local.application_name}-${local.environment}-definition-upload-lambda"
-  description = "Security Group for Definition Upload Lambda"
+  name        = "${local.application_name}-${local.environment}-transfer-lambda"
+  description = "Security Group for Transfer Lambda"
 
   vpc_id = module.vpc.vpc_id
 
@@ -51,8 +51,8 @@ module "scan_lambda_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 5.0"
 
-  name        = "${local.application_name}-${local.environment}-definition-upload-lambda"
-  description = "Security Group for Definition Upload Lambda"
+  name        = "${local.application_name}-${local.environment}-scan-lambda"
+  description = "Security Group for Scan Lambda"
 
   vpc_id = module.vpc.vpc_id
 

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -24,7 +24,7 @@ module "definition_upload_lambda_security_group" {
 
   egress_cidr_blocks     = ["0.0.0.0/0"]
   egress_rules           = ["all-all"]
-  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
+  egress_prefix_list_ids = [data.aws_prefix_list.s3.id]
 
   tags = local.tags
 }
@@ -42,7 +42,7 @@ module "transfer_lambda_security_group" {
 
   egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
   egress_rules           = ["all-all"]
-  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
+  egress_prefix_list_ids = [data.aws_prefix_list.s3.id]
 
   tags = local.tags
 }
@@ -60,7 +60,7 @@ module "scan_lambda_security_group" {
 
   egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
   egress_rules           = ["all-all"]
-  egress_prefix_list_ids = [data.aws_vpc_endpoint.s3.id]
+  egress_prefix_list_ids = [data.aws_prefix_list.s3.id]
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -40,7 +40,7 @@ module "transfer_lambda_security_group" {
 
   vpc_id = module.vpc.vpc_id
 
-  egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
+  egress_cidr_blocks     = ["0.0.0.0/0"]
   egress_rules           = ["all-all"]
   egress_prefix_list_ids = [data.aws_prefix_list.s3.id]
 
@@ -58,7 +58,7 @@ module "scan_lambda_security_group" {
 
   vpc_id = module.vpc.vpc_id
 
-  egress_cidr_blocks     = [module.vpc.vpc_cidr_block]
+  egress_cidr_blocks     = ["0.0.0.0/0"]
   egress_rules           = ["all-all"]
   egress_prefix_list_ids = [data.aws_prefix_list.s3.id]
 

--- a/terraform/environments/analytical-platform-ingestion/vpc-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/vpc-endpoints.tf
@@ -39,6 +39,15 @@ module "vpc_endpoints" {
         local.tags,
         { Name = format("%s-s3-vpc-endpoint", local.application_name) }
       )
-    }
+    },
+    secretsmanager = {
+      service             = "secretsmanager"
+      service_type        = "Interface"
+      private_dns_enabled = true
+      tags = merge(
+        local.tags,
+        { Name = format("%s-secretsmanager-vpc-endpoint", local.application_name) }
+      )
+    },
   }
 }


### PR DESCRIPTION
This pull request:

- Moves Lambda functions into VPC
- Creates and attaches security groups to Lambda functions
- Allows access to S3 gateway
- Adds a VPC interface for Secrets Manager