### PR TITLE
create a web asg and an ec2 boe instance instead

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_development.tf
+++ b/terraform/environments/oasys-national-reporting/locals_development.tf
@@ -13,15 +13,21 @@ locals {
     #       instance_type = "t3.large"
     #     })
     #   })
-    #   dev-boe-a = merge(local.defaults_boe_ec2, 
-    #   {
-    #     config = merge(local.defaults_boe_ec2.config, {
-    #       availability_zone = "${local.region}a"        
-    #     })
-    #     instance = merge(local.defaults_boe_ec2.instance, {
-    #       instance_type = "t3.large"
-    #     })
-    #   })
+    # NOTE: Sadly rhel 6 ami's do not support ASGs due to ELB networking constraints
+      dev-boe-a = merge(local.defaults_boe_ec2, 
+      {
+        config = merge(local.defaults_boe_ec2.config, {
+          availability_zone = "${local.region}a"        
+        })
+        instance = merge(local.defaults_boe_ec2.instance, {
+          instance_type = "t3.large"
+        })
+        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+            branch = "main"
+          })
+        })    
+      })
     #   dev-bods-a = merge(local.defaults_bods_ec2,
     #   {
     #     config = merge(local.defaults_bods_ec2.config, {
@@ -34,11 +40,11 @@ locals {
     # }
 
     baseline_ec2_autoscaling_groups = {
-      dev-boe-asg = merge(local.defaults_boe_ec2.config, {
-        config = merge(local.defaults_boe_ec2.config, {
+      dev-web-asg = merge(local.defaults_web_ec2.config, {
+        config = merge(local.defaults_web_ec2.config, {
           availability_zone = "${local.region}a"
         })
-        instance = merge(local.defaults_boe_ec2.instance, {
+        instance = merge(local.defaults_web_ec2.instance, {
           instance_type = "t3.large"
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {


### PR DESCRIPTION
- rhel 6 doesn't support use as an asg ami
- create a rhel 6 stand-alone instance instead
- create a web asg for testing as well