### PR TITLE
LASB-2974 Update MLRA property name to include APP prefix

### DIFF
--- a/terraform/environments/maat/maat-param.tf
+++ b/terraform/environments/maat/maat-param.tf
@@ -57,7 +57,7 @@ resource "aws_ssm_parameter" "maat_app_ccp_client_secret" {
 }
 
 resource "aws_ssm_parameter" "maat_app_google_analytics_tag_id" {
-  name  = "/maat/APP_GOOGLE_ANALYTICS_4_TAG_ID"
+  name  = "/maat/APP_MAAT_GOOGLE_ANALYTICS_4_TAG_ID"
   type  = "SecureString"
   value = "replace in console"
   lifecycle {

--- a/terraform/environments/maat/maat-task-definition.json
+++ b/terraform/environments/maat/maat-task-definition.json
@@ -57,8 +57,8 @@
         "valueFrom": "arn:aws:ssm:${env_account_region}:${env_account_id}:parameter/maat/APP_CCP_CLIENT_SECRET"
       },
       {
-        "name": "APP_GOOGLE_ANALYTICS_4_TAG_ID",
-        "valueFrom": "arn:aws:ssm:${env_account_region}:${env_account_id}:parameter/maat/APP_GOOGLE_ANALYTICS_4_TAG_ID"
+        "name": "APP_MAAT_GOOGLE_ANALYTICS_4_TAG_ID",
+        "valueFrom": "arn:aws:ssm:${env_account_region}:${env_account_id}:parameter/maat/APP_MAAT_GOOGLE_ANALYTICS_4_TAG_ID"
       },
       {
         "name": "APP_CMA_CLIENT_ID",

--- a/terraform/environments/mlra/locals.tf
+++ b/terraform/environments/mlra/locals.tf
@@ -31,7 +31,7 @@ locals {
   }))
 
   maatdb_password_secret_name = "APP_MAATDB_DBPASSWORD_MLA1"
-  ga_4_tag_id_secret_name     = "MLRA_GOOGLE_ANALYTICS_4_TAG_ID"
+  ga_4_tag_id_secret_name     = "APP_MLRA_GOOGLE_ANALYTICS_4_TAG_ID"
   task_definition = templatefile("task_definition.json", {
     app_name                  = local.application_name
     ecr_url                   = "${local.environment_management.account_ids["core-shared-services-production"]}.dkr.ecr.eu-west-2.amazonaws.com/mlra-ecr-repo"

--- a/terraform/environments/mlra/task_definition.json
+++ b/terraform/environments/mlra/task_definition.json
@@ -85,7 +85,7 @@
         "valueFrom": "${db_secret_arn}"
       },
       {
-        "name": "APP_GOOGLE_ANALYTICS_4_TAG_ID",
+        "name": "APP_MLRA_GOOGLE_ANALYTICS_4_TAG_ID",
         "valueFrom": "${google_analytics_4_tag_id}"
       }
     ]


### PR DESCRIPTION
Update MLRA Google Analytics 4 property name to `APP_MLRA_GOOGLE_ANALYTICS_4_TAG_ID` to include `APP` prefix and also confirm to the same pattern as the MAAT application `APP_MAAT_GOOGLE_ANALYTICS_4_TAG_ID`.

Also update the MAAT Google Analytics 4 property name to follow the same structure `APP_MAAT_GOOGLE_ANALYTICS_4_TAG_ID`

This will also address the "Invalid parameters" issue with MLRA

![image](https://github.com/ministryofjustice/modernisation-platform-environments/assets/129768292/eb5b4c36-1231-487a-804f-02da1e047c7d)
