### PR TITLE
Add bedrock provider for cica-data-extraction

### DIFF
--- a/terraform/environments/cica-data-extraction/platform_providers.tf
+++ b/terraform/environments/cica-data-extraction/platform_providers.tf
@@ -48,6 +48,15 @@ provider "aws" {
   }
 }
 
+# Provider for creating resources in eu-central-1, eg Bedrock resources
+provider "aws" {
+  alias  = "eu-central-1"
+  region = "eu-central-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureBedrockEuCentral"
+  }
+}
+
 # Provider for reading resources from root account IdentityStore
 provider "aws" {
   region = "eu-west-2"


### PR DESCRIPTION
This provider will allow the `cica-data-extract` application to make use of AWS Bedrock resources in `eu-central-1`.