### PR TITLE
Patching refactor to remove accountIds and set schedules

### DIFF
--- a/terraform/environments/hmpps-domain-services/patch.tf
+++ b/terraform/environments/hmpps-domain-services/patch.tf
@@ -11,9 +11,7 @@ module "development" {
   }
   instance_roles = [
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-development}:role/ec2-instance-role-dev-win-2022",
-    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-development}:role/ec2-instance-role-dev-rhel85",
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-win-2022",
-    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-rhel85",
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-preproduction}:role/ec2-instance-role-pp-rdgw-1-a",
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-preproduction}:role/ec2-instance-role-pp-rds-1-a",
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-production}:role/ec2-instance-role-pd-rdgw-1-a",
@@ -35,7 +33,6 @@ module "test" {
   }
   instance_roles = [
     "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-win-2022",
-    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-rhel85",
   ]
 }
 

--- a/terraform/environments/hmpps-domain-services/patch.tf
+++ b/terraform/environments/hmpps-domain-services/patch.tf
@@ -3,9 +3,9 @@ module "development" {
   source              = "../../modules/patch_manager"
   application         = "hmpps-domain-services"
   environment         = "development"
-  predefined_baseline = "AWS-RedHatDefaultPatchBaseline"
-  operating_system    = "REDHAT_ENTERPRISE_LINUX"
-  schedule            = "cron(15 23 ? * * *)" # 11.15pm today
+  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+  operating_system    = "WINDOWS"
+  schedule            = "cron(0 21 ? * TUE#2 *)" # 2nd Tues @ 9pm
   target_tag = {
     "environment-name" = "hmpps-domain-services-development"
   }
@@ -16,10 +16,36 @@ module "test" {
   source              = "../../modules/patch_manager"
   application         = "hmpps-domain-services"
   environment         = "test"
-  predefined_baseline = "AWS-RedHatDefaultPatchBaseline"
-  operating_system    = "REDHAT_ENTERPRISE_LINUX"
-  schedule            = "cron(15 23 ? * * *)" # 11.15pm today
+  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+  operating_system    = "WINDOWS"
+  schedule            = "cron(0 21 ? * WED#2* *)" # 2nd Weds @ 9pm
   target_tag = {
     "environment-name" = "hmpps-domain-services-test"
+  }
+}
+
+module "preproduction" {
+  count               = local.is-preproduction == true ? 1 : 0
+  source              = "../../modules/patch_manager"
+  application         = "hmpps-domain-services"
+  environment         = "preproduction"
+  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+  operating_system    = "WINDOWS"
+  schedule            = "cron(0 21 ? * WED#3 *)" # 3rd Weds @ 9pm
+  target_tag = {
+    "environment-name" = "hmpps-domain-services-preproduction"
+  }
+}
+
+module "production" {
+  count               = local.is-production == true ? 1 : 0
+  source              = "../../modules/patch_manager"
+  application         = "hmpps-domain-services"
+  environment         = "production"
+  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+  operating_system    = "WINDOWS"
+  schedule            = "cron(0 21 ? * THU#3 *)" # 3rd Thurs @ 9pm
+  target_tag = {
+    "environment-name" = "hmpps-domain-services-production"
   }
 }

--- a/terraform/environments/hmpps-domain-services/patch.tf
+++ b/terraform/environments/hmpps-domain-services/patch.tf
@@ -9,6 +9,17 @@ module "development" {
   target_tag = {
     "environment-name" = "hmpps-domain-services-development"
   }
+  instance_roles = [
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-development}:role/ec2-instance-role-dev-win-2022",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-development}:role/ec2-instance-role-dev-rhel85",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-win-2022",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-rhel85",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-preproduction}:role/ec2-instance-role-pp-rdgw-1-a",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-preproduction}:role/ec2-instance-role-pp-rds-1-a",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-production}:role/ec2-instance-role-pd-rdgw-1-a",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-production}:role/ec2-instance-role-pd-rdgw-1-b",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-production}:role/ec2-instance-role-pd-rds-1-a"
+  ]
 }
 
 module "test" {
@@ -22,30 +33,34 @@ module "test" {
   target_tag = {
     "environment-name" = "hmpps-domain-services-test"
   }
+  instance_roles = [
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-win-2022",
+    "arn:aws:iam::${module.environment.account_ids.hmpps-domain-services-test}:role/ec2-instance-role-test-rhel85",
+  ]
 }
 
-module "preproduction" {
-  count               = local.is-preproduction == true ? 1 : 0
-  source              = "../../modules/patch_manager"
-  application         = "hmpps-domain-services"
-  environment         = "preproduction"
-  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
-  operating_system    = "WINDOWS"
-  schedule            = "cron(0 21 ? * WED#3 *)" # 3rd Weds @ 9pm
-  target_tag = {
-    "environment-name" = "hmpps-domain-services-preproduction"
-  }
-}
-
-module "production" {
-  count               = local.is-production == true ? 1 : 0
-  source              = "../../modules/patch_manager"
-  application         = "hmpps-domain-services"
-  environment         = "production"
-  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
-  operating_system    = "WINDOWS"
-  schedule            = "cron(0 21 ? * THU#3 *)" # 3rd Thurs @ 9pm
-  target_tag = {
-    "environment-name" = "hmpps-domain-services-production"
-  }
-}
+#module "preproduction" {
+#  count               = local.is-preproduction == true ? 1 : 0
+#  source              = "../../modules/patch_manager"
+#  application         = "hmpps-domain-services"
+#  environment         = "preproduction"
+#  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+#  operating_system    = "WINDOWS"
+#  schedule            = "cron(0 21 ? * WED#3 *)" # 3rd Weds @ 9pm
+#  target_tag = {
+#    "environment-name" = "hmpps-domain-services-preproduction"
+#  }
+#}
+#
+#module "production" {
+#  count               = local.is-production == true ? 1 : 0
+#  source              = "../../modules/patch_manager"
+#  application         = "hmpps-domain-services"
+#  environment         = "production"
+#  predefined_baseline = "AWS-WindowsPredefinedPatchBaseline-OS-Applications"
+#  operating_system    = "WINDOWS"
+#  schedule            = "cron(0 21 ? * THU#3 *)" # 3rd Thurs @ 9pm
+#  target_tag = {
+#    "environment-name" = "hmpps-domain-services-production"
+#  }
+#}

--- a/terraform/modules/patch_manager/ExtractAndUploadPatches.yaml
+++ b/terraform/modules/patch_manager/ExtractAndUploadPatches.yaml
@@ -19,7 +19,7 @@ mainSteps:
           $PatchResultsTemp = "$WorkingDir\patchresults.txt"
           $PatchesYaml="$WorkingDir\${OS}Patches.yaml"
           $SSMLogsPath = "C:\ProgramData\Amazon\SSM\InstanceData\${InstanceId}\document\orchestration"
-          $PatchesBucket = "s3://hmpps-domain-services-development-patch-logs"
+          $PatchesBucket = "s3://hmpps-domain-services-development-windows-patch-logs"
 
           New-Item -ItemType Directory -Force -Path $WorkingDir > $null
 
@@ -73,7 +73,7 @@ mainSteps:
           OS=$(hostnamectl | grep "Operating System:"|cut -d':' -f2- |tr -dc '[:alnum:]' )
           PatchStatesYAMLPath="/tmp/$OS.yaml"
           PatchStatesJSONPath="/var/log/amazon/ssm/patch-configuration/patch-states-configuration.json"
-          PatchBucket="s3://hmpps-domain-services-development-redhat-enterprise-linux"
+          PatchBucket="s3://hmpps-domain-services-development-redhat-patches"
 
           # Install jq if not available
           rpm -qa | grep -qw jq || sudo yum install -y  jq

--- a/terraform/modules/patch_manager/ExtractAndUploadPatches.yaml
+++ b/terraform/modules/patch_manager/ExtractAndUploadPatches.yaml
@@ -19,7 +19,7 @@ mainSteps:
           $PatchResultsTemp = "$WorkingDir\patchresults.txt"
           $PatchesYaml="$WorkingDir\${OS}Patches.yaml"
           $SSMLogsPath = "C:\ProgramData\Amazon\SSM\InstanceData\${InstanceId}\document\orchestration"
-          $PatchesBucket = "s3://hmpps-domain-services-development-windows-patch-logs"
+          $PatchesBucket = "s3://hmpps-domain-services-development-windows-patches"
 
           New-Item -ItemType Directory -Force -Path $WorkingDir > $null
 

--- a/terraform/modules/patch_manager/README.md
+++ b/terraform/modules/patch_manager/README.md
@@ -3,6 +3,8 @@
 - Use this module to set up a patch schedule for instances.
 - Register instances to patch by giving the `target_tag` map the tag name and value of the instance that requires patching.
 - Successful patches will be picked up from the development environment and referenced by the other environments
+- Pass in a list of `instance_roles` belonging to all instances that need to pull patches from the development environment. 
+- Other environments can still provide an `instance_role` to allow instances to send ssm logs to s3 during patching.
 - Instances that require patching require the `PatchBucketAccessPolicy` added to their role. This role also needs to be trusted by the bucket in the module.
 
 ```hcl
@@ -18,6 +20,10 @@ module "development" {
   target_tag              =  {
     "environment-name" = "hmpps-domain-services-development"
   }
+   instance_roles = [
+    "arn:aws:iam::xxxxxxxxxxxx:role/ec2-instance-role-1",
+    "arn:aws:iam::xxxxxxxxxxxx:role/ec2-instance-role-2"  
+  ] 
  }
 
 # Other environments will reference the list of patches from development
@@ -31,5 +37,8 @@ module "test" {
   target_tag              =  {
     "environment-name" = "hmpps-domain-services-test"
   }
+  instance_roles = [
+    "arn:aws:iam::xxxxxxxxxxxx:role/ec2-instance-role-1"
+   ]
  }
 ```

--- a/terraform/modules/patch_manager/patch-manager.tf
+++ b/terraform/modules/patch_manager/patch-manager.tf
@@ -56,7 +56,7 @@ resource "aws_ssm_maintenance_window_task" "this" {
       comment              = "Patch Baseline Install"
       document_version     = "$LATEST"
       timeout_seconds      = 3600
-      output_s3_bucket     = aws_s3_bucket.this.id
+      output_s3_bucket     = aws_s3_bucket.patch_logs.id
       output_s3_key_prefix = "patch-logs"
       cloudwatch_config {
         cloudwatch_log_group_name = aws_cloudwatch_log_group.this.name
@@ -86,7 +86,7 @@ resource "aws_ssm_maintenance_window_task" "this" {
         for_each = var.environment != "development" && var.operating_system == "WINDOWS" ? [1] : []
         content {
           name   = "InstallOverrideList"
-          values = ["s3://${var.application}-development-${local.os}/WindowsServer2022DatacenterPatches.yaml"]
+          values = ["s3://${var.application}-development-${local.os}-patches/WindowsServer2022DatacenterPatches.yaml"]
         }
       }
 
@@ -94,7 +94,7 @@ resource "aws_ssm_maintenance_window_task" "this" {
         for_each = var.environment != "development" && var.operating_system == "REDHAT_ENTERPRISE_LINUX" ? [1] : []
         content {
           name   = "InstallOverrideList"
-          values = ["s3://${var.application}-development-${local.os}/RedHatEnterpriseLinux89OotpaPatches.yaml"]
+          values = ["s3://${var.application}-development-${local.os}-patches/RedHatEnterpriseLinux89OotpaPatches.yaml"]
         }
       }
     }

--- a/terraform/modules/patch_manager/s3.tf
+++ b/terraform/modules/patch_manager/s3.tf
@@ -1,14 +1,17 @@
-resource "aws_s3_bucket" "this" {
-  bucket        = "${var.application}-${var.environment}-${local.os}"
+resource "aws_s3_bucket" "cross_account_patches" {
+  count         = var.environment == "development" ? 1 : 0
+  bucket        = "${var.application}-${var.environment}-${local.os}-patches"
   force_destroy = true
 }
-
-resource "aws_s3_bucket_policy" "this" {
-  bucket = aws_s3_bucket.this.id
-  policy = data.aws_iam_policy_document.bucket_policy_patch_access.json
+resource "aws_s3_bucket_policy" "cross_account_patches" {
+  count  = var.environment == "development" ? 1 : 0
+  bucket = aws_s3_bucket.cross_account_patches[0].id
+  policy = data.aws_iam_policy_document.cross_account_patches[0].json
 }
 
-data "aws_iam_policy_document" "bucket_policy_patch_access" {
+data "aws_iam_policy_document" "cross_account_patches" {
+  count = var.environment == "development" ? 1 : 0
+
   statement {
     sid    = "AllowCrossAccountAccessToPatchesAndSSMLogging"
     effect = "Allow"
@@ -20,23 +23,46 @@ data "aws_iam_policy_document" "bucket_policy_patch_access" {
     ]
 
     resources = [
-      aws_s3_bucket.this.arn,
-      "${aws_s3_bucket.this.arn}/*",
+      aws_s3_bucket.cross_account_patches[0].arn,
+      "${aws_s3_bucket.cross_account_patches[0].arn}/*",
     ]
 
     principals {
-      identifiers = [
-        "arn:aws:iam::139351334100:role/ec2-instance-role-dev-win-2022",
-        "arn:aws:iam::139351334100:role/ec2-instance-role-dev-rhel85",
-        "arn:aws:iam::161282055413:role/ec2-instance-role-test-win-2022",
-        "arn:aws:iam::161282055413:role/ec2-instance-role-test-rhel85",
-        "arn:aws:iam::228371063224:role/ec2-instance-role-pp-rdgw-1-a",
-        "arn:aws:iam::228371063224:role/ec2-instance-role-pp-rds-1-a",
-        "arn:aws:iam::905761223702:role/ec2-instance-role-pd-rdgw-1-a",
-        "arn:aws:iam::905761223702:role/ec2-instance-role-pd-rdgw-1-b",
-        "arn:aws:iam::905761223702:role/ec2-instance-role-pd-rds-1-a"
-      ]
-      type = "AWS"
+      identifiers = tolist(var.instance_roles)
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "patch_logs" {
+  bucket        = "${var.application}-${var.environment}-${local.os}-patch-logs"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_policy" "patch_logs" {
+  bucket = aws_s3_bucket.patch_logs.id
+  policy = data.aws_iam_policy_document.patch_logs.json
+}
+
+data "aws_iam_policy_document" "patch_logs" {
+  statement {
+    sid    = "PatchManagerLogs"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetEncryptionConfiguration",
+    ]
+
+    resources = [
+      aws_s3_bucket.patch_logs.arn,
+      "${aws_s3_bucket.patch_logs.arn}/*",
+    ]
+
+    principals {
+      identifiers = tolist(var.instance_roles)
+      type        = "AWS"
     }
   }
 }

--- a/terraform/modules/patch_manager/variables.tf
+++ b/terraform/modules/patch_manager/variables.tf
@@ -40,6 +40,10 @@ variable "target_tag" {
   type        = map(any)
 }
 
+variable "instance_roles" {
+  type = list(string)
+}
+
 locals {
-  os = replace(lower(var.operating_system), "_", "-")
+  os = replace(replace(lower(var.operating_system), "_", "-"), "redhat-enterprise-linux", "redhat")
 }


### PR DESCRIPTION
- Remove hard coded account Ids and updated the module to accept a list of instance roles instead.
- Set  windows patch schedules for test and dev environments
- Split bucket so only dev gets a cross account bucket whereas all environments get a patch logging bucket

