### PR TITLE
Use `default_tags` in AWS Provider statements

### DIFF
--- a/terraform/environments/example/certificates.tf
+++ b/terraform/environments/example/certificates.tf
@@ -10,9 +10,7 @@ resource "aws_acm_certificate" "example_cert" {
     format("%s.%s-%s.modernisation-platform.service.justice.gov.uk", local.application_name, var.networking[0].business-unit, local.environment),
   ]
 
-  tags = merge(local.tags,
-    { Name = lower(format("%s-%s-certificate", local.application_name, local.environment)) }
-  )
+  tags = { Name = lower(format("%s-%s-certificate", local.application_name, local.environment)) }
 
   lifecycle {
     create_before_destroy = true
@@ -80,12 +78,7 @@ resource "aws_lb" "certificate_example_lb" {
     enabled = true
   }
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.application_name}-external-loadbalancer"
-    }
-  )
+  tags       = { Name = "${local.application_name}-external-loadbalancer" }
   depends_on = [aws_security_group.certificate_example_load_balancer_sg]
 }
 
@@ -93,7 +86,5 @@ resource "aws_security_group" "certificate_example_load_balancer_sg" {
   name        = "certificate-example-lb-sg"
   description = "controls access to load balancer"
   vpc_id      = data.aws_vpc.shared.id
-  tags = merge(local.tags,
-    { Name = lower(format("lb-sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags        = { Name = lower(format("lb-sg-%s-%s-example", local.application_name, local.environment)) }
 }

--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -31,7 +31,7 @@ module "ec2_test_instance" {
   region                   = local.region
   availability_zone        = local.availability_zone_1
   subnet_id                = module.environment.subnet["private"][local.availability_zone_1].id
-  tags                     = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
+  tags                     = merge(local.ec2_test.tags, try(each.value.tags, {}))
   account_ids_lookup       = local.environment_management.account_ids
   cloudwatch_metric_alarms = {}
 }
@@ -41,9 +41,7 @@ resource "aws_security_group" "example_ec2_sg" {
   name        = "example_ec2_sg"
   description = "Controls access to EC2"
   vpc_id      = data.aws_vpc.shared.id
-  tags = merge(local.tags,
-    { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags        = { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
 }
 
 resource "aws_security_group_rule" "ingress_traffic" {
@@ -99,9 +97,7 @@ resource "aws_instance" "develop" {
     volume_size = 20
     encrypted   = true
   }
-  tags = merge(local.tags,
-    { Name = lower(format("ec2-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags       = { Name = lower(format("ec2-%s-%s-example", local.application_name, local.environment)) }
   depends_on = [aws_security_group.example_ec2_sg]
 }
 
@@ -111,12 +107,7 @@ resource "aws_iam_policy" "ec2_common_policy" {
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json
-  tags = merge(
-    local.tags,
-    {
-      Name = "ec2-common-policy"
-    },
-  )
+  tags        = { Name = "ec2-common-policy" }
 }
 
 # combine ec2-common policy documents
@@ -159,12 +150,7 @@ data "aws_iam_policy_document" "ec2_policy" {
 resource "aws_key_pair" "ec2-user" {
   key_name   = "ec2-user"
   public_key = file(".ssh/${terraform.workspace}/ec2-user.pub")
-  tags = merge(
-    local.tags,
-    {
-      Name = "ec2-user"
-    },
-  )
+  tags       = { Name = "ec2-user" }
 }
 
 # Volumes built for use by EC2.
@@ -172,13 +158,7 @@ resource "aws_kms_key" "ec2" {
   description         = "Encryption key for EBS"
   enable_key_rotation = true
   policy              = data.aws_iam_policy_document.ebs-kms.json
-
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.application_name}-ebs-kms"
-    }
-  )
+  tags                = { Name = "${local.application_name}-ebs-kms" }
 }
 
 resource "aws_ebs_volume" "ebs_volume" {
@@ -188,9 +168,7 @@ resource "aws_ebs_volume" "ebs_volume" {
   throughput        = 200
   encrypted         = true
   kms_key_id        = aws_kms_key.ec2.arn
-  tags = {
-    Name = "ebs-data-volume"
-  }
+  tags              = { Name = "ebs-data-volume" }
 
   depends_on = [aws_instance.develop, aws_kms_key.ec2]
 }

--- a/terraform/environments/example/ec2_autoscaling_group.tf
+++ b/terraform/environments/example/ec2_autoscaling_group.tf
@@ -23,7 +23,7 @@ module "ec2_test_autoscaling_group" {
   application_name          = local.application_name
   region                    = local.region
   subnet_ids                = module.environment.subnets["private"].ids
-  tags                      = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
+  tags                      = merge(local.ec2_test.tags, try(each.value.tags, {}))
   account_ids_lookup        = local.environment_management.account_ids
   cloudwatch_metric_alarms  = {}
 }
@@ -48,12 +48,7 @@ resource "aws_iam_policy" "ec2_autoscale_policy" {
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_autoscale_combined.json
-  tags = merge(
-    local.tags,
-    {
-      Name = "ec2-common-policy"
-    },
-  )
+  tags        = { Name = "ec2-common-policy" }
 }
 
 # combine ec2-common policy documents
@@ -79,10 +74,9 @@ resource "aws_security_group" "example_ec2_autoscale_sg" {
   name        = "example_ec2_autoscale_sg"
   description = "Controls access to EC2"
   vpc_id      = data.aws_vpc.shared.id
-  tags = merge(local.tags,
-    { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags        = { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
 }
+
 resource "aws_security_group_rule" "ingress_autoscale_traffic" {
   for_each          = local.application_data.example_ec2_sg_rules
   description       = format("Traffic for %s %d", each.value.protocol, each.value.from_port)
@@ -109,10 +103,5 @@ resource "aws_security_group_rule" "egress_autoscale_traffic" {
 resource "aws_key_pair" "ec2-autoscale-user" {
   key_name   = "ec2-autoscale-user"
   public_key = file(".ssh/${terraform.workspace}/ec2-user.pub")
-  tags = merge(
-    local.tags,
-    {
-      Name = "ec2-autoscale-user"
-    },
-  )
+  tags       = { Name = "ec2-autoscale-user" }
 }

--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -12,12 +12,7 @@
 resource "aws_key_pair" "ec2-user-complete" {
   key_name   = "ec2-user"
   public_key = file(".ssh/${terraform.workspace}/ec2-user.pub")
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.application_name}-ec2-user-complete"
-    },
-  )
+  tags       = { Name = "${local.application_name}-ec2-user-complete" }
 }
 
 # This locals block contains variables required to create ec2 instances using the module.
@@ -199,7 +194,7 @@ module "ec2_complete_instance" {
   business_unit                 = local.comp_business_unit
   environment                   = local.environment
   region                        = local.comp_region
-  tags                          = merge(local.tags, local.ec2_test.tags, try(each.value.tags, {}))
+  tags                          = merge(local.ec2_test.tags, try(each.value.tags, {}))
   account_ids_lookup            = local.environment_management.account_ids
   user_data_raw                 = try(each.value.user_data, "")
   cloudwatch_metric_alarms      = {}
@@ -213,9 +208,7 @@ resource "aws_security_group" "complete_example_ec2_sg" {
   name        = "complete_ec2_sg"
   description = "Ingress and Egress Access Controls for EC2"
   vpc_id      = data.aws_vpc.shared.id
-  tags = merge(local.tags,
-    { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags        = { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
 }
 
 resource "aws_security_group_rule" "complete_ingress_traffic" {
@@ -248,10 +241,5 @@ resource "aws_iam_policy" "ec2_complete_common_policy" {
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json
-  tags = merge(
-    local.tags,
-    {
-      Name = "ec2-common-policy"
-    },
-  )
+  tags        = { Name = "ec2-common-policy" }
 }

--- a/terraform/environments/example/ecs.tf
+++ b/terraform/environments/example/ecs.tf
@@ -17,12 +17,11 @@ module "ecs-cluster" {
   environment = local.environment
   name        = local.ecs_application_name
   namespace   = "platforms"
-
-  tags = local.tags
+  tags        = local.tags
 }
 
 module "service" {
-  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service?ref=v3.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service?ref=v3.0.0"
 
   container_definition_json = templatefile("${path.module}/templates/task_definition.json.tftpl", {})
   ecs_cluster_arn           = module.ecs-cluster.ecs_cluster_arn
@@ -54,8 +53,7 @@ module "service" {
   ]
 
   ignore_changes_task_definition = false
-
-  tags = local.tags
+  tags                           = local.tags
 }
 
 locals {
@@ -213,7 +211,5 @@ resource "aws_security_group" "cluster_ec2" {
       security_groups = lookup(egress.value, "security_groups", null)
     }
   }
-  tags = merge(local.tags,
-    { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags = { Name = lower(format("sg-%s-%s-example", local.application_name, local.environment)) }
 }

--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -8,9 +8,7 @@ resource "aws_security_group" "example_load_balancer_sg" {
   name        = "example-lb-sg"
   description = "controls access to load balancer"
   vpc_id      = data.aws_vpc.shared.id
-  tags = merge(local.tags,
-    { Name = lower(format("lb-sg-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags        = { Name = lower(format("lb-sg-%s-%s-example", local.application_name, local.environment)) }
 
   # Set up the ingress and egress parts of the security group
 }
@@ -55,12 +53,7 @@ resource "aws_lb" "external" {
     enabled = true
   }
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.application_name}-external-loadbalancer"
-    }
-  )
+  tags       = { Name = "${local.application_name}-external-loadbalancer" }
   depends_on = [aws_security_group.example_load_balancer_sg]
 }
 # Create the target group
@@ -85,12 +78,7 @@ resource "aws_lb_target_group" "target_group" {
     timeout             = "5"
   }
 
-  tags = merge(
-    local.tags,
-    {
-      Name = "${local.application_name}-tg-${local.environment}"
-    }
-  )
+  tags = { Name = "${local.application_name}-tg-${local.environment}" }
 }
 
 # Link target group to the EC2 instance on port 80
@@ -253,9 +241,7 @@ module "s3-bucket-lb" { #tfsec:ignore:aws-s3-enable-versioning
     }
   ]
 
-  tags = merge(local.tags,
-    { Name = lower(format("s3-bucket-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags = { Name = lower(format("s3-bucket-%s-%s-example", local.application_name, local.environment)) }
 }
 
 data "aws_iam_policy_document" "bucket_policy_lb" {
@@ -350,8 +336,6 @@ resource "aws_instance" "lb_example_instance" {
     http_endpoint = "enabled"
     http_tokens   = "required"
   }
-  tags = merge(local.tags,
-    { Name = lower(format("ec2-%s-%s-example", local.application_name, local.environment)) }
-  )
+  tags       = { Name = lower(format("ec2-%s-%s-example", local.application_name, local.environment)) }
   depends_on = [aws_security_group.example_load_balancer_sg]
 }

--- a/terraform/environments/example/loadbalancer_module.tf
+++ b/terraform/environments/example/loadbalancer_module.tf
@@ -13,11 +13,11 @@ module "lb_access_logs_enabled" {
   public_subnets             = [data.aws_subnet.data_subnets_a.id, data.aws_subnet.data_subnets_b.id, data.aws_subnet.data_subnets_c.id]
   loadbalancer_ingress_rules = local.loadbalancer_ingress_rules
   loadbalancer_egress_rules  = local.loadbalancer_egress_rules
-  tags                       = local.tags
   account_number             = local.environment_management.account_ids[terraform.workspace]
   region                     = "eu-west-2"
   enable_deletion_protection = false
   idle_timeout               = 60
+  tags                       = {}
 }
 
 # Create the target group

--- a/terraform/environments/example/platform_providers.tf
+++ b/terraform/environments/example/platform_providers.tf
@@ -2,6 +2,7 @@
 provider "aws" {
   alias  = "original-session"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
@@ -10,6 +11,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
@@ -19,6 +21,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to access resources in the core-vpc accounts
@@ -28,6 +31,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
@@ -37,6 +41,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for creating resources in us-east-1, eg ACM resources for CloudFront
@@ -46,6 +51,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for reading resources from root account IdentityStore
@@ -55,4 +61,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
As a possible example for https://github.com/ministryofjustice/modernisation-platform/issues/1519, this PR implements the use of `default_tags` as configured in version 5.0 and above of the Terraform AWS Provider, using the common values in `local.tags`:

```
provider "aws" {
  default_tags { tags = local.tags }
}
```