### PR TITLE
ndh: DSOS: remove unused ACM cert

### DIFF
--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -11,7 +11,7 @@ locals {
   baseline_environment_config = local.environment_configs[local.environment]
 
   baseline_presets_options = {
-    enable_application_environment_wildcard_cert = true
+    enable_application_environment_wildcard_cert = false
     enable_backup_plan_daily_and_weekly          = true
     enable_business_unit_kms_cmks                = true
     enable_image_builder                         = true


### PR DESCRIPTION
NDH doesn't need a certificate and it's causing an issue with the terraform. Remove