### PR TITLE
Update autoscaling group to retrieve latest version of launch template

### DIFF
--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -208,7 +208,7 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 
   launch_template {
     id      = aws_launch_template.ec2-launch-template.id
-    version = "$Latest"
+    version = aws_launch_template.ec2-launch-template.latest_version
   }
 
   tag {


### PR DESCRIPTION
From what I could see, setting `$Latest` for the `launch_template {}` in `aws_autoscaling_group.cluster-scaling-group` was not resulting in updates to the launch template in use - the default (`1`) was being used in all cases.

Shifting this to dynamically refer to the latest launch template version appears to work.