### PR TITLE
Update 100424 2

### DIFF
--- a/terraform/environments/ppud/instances.tf
+++ b/terraform/environments/ppud/instances.tf
@@ -165,7 +165,7 @@ resource "aws_instance" "s609693lo6vw110" {
 
   tags = {
     Name        = "s609693lo6vw110"
-    patch_group = "dev_win_test_patch"
+    patch_group = "win_patch_test_group"
     backup      = true
   }
 }

--- a/terraform/environments/ppud/instances.tf
+++ b/terraform/environments/ppud/instances.tf
@@ -165,7 +165,7 @@ resource "aws_instance" "s609693lo6vw110" {
 
   tags = {
     Name        = "s609693lo6vw110"
-    patch_group = "dev_win_patch"
+    patch_group = "dev_win_test_patch"
     backup      = true
   }
 }

--- a/terraform/environments/ppud/win_patchmgmt.tf
+++ b/terraform/environments/ppud/win_patchmgmt.tf
@@ -200,7 +200,7 @@ resource "aws_ssm_document" "perform_healthcheck_s3" {
 
 resource "aws_ssm_patch_group" "win_patch_test_group" {
   baseline_id = aws_ssm_patch_baseline.windows_os_apps_test_baseline.id
-  patch_group = dev_win_test_patch
+  patch_group = win_patch_test_group
 }
 
 # Create Windows Patch Baseline
@@ -264,7 +264,7 @@ resource "aws_ssm_maintenance_window_target" "patch_maintenance_window_test_targ
 
   targets {
     key    = "tag:patch_group"
-    values = [aws_ssm_patch_group.dev_win_test_patch.patch_group]
+    values = [aws_ssm_patch_group.win_patch_test_group.patch_group]
   }
 }
 


### PR DESCRIPTION
Creation of a new test patch group, patch baseline, maintenance window, target and task. This is to aid in the troubleshooting of AWS patch baselines being applied to EC2 instances.