### PR TITLE
Update 100424 5

### DIFF
--- a/terraform/environments/ppud/application_variables.json
+++ b/terraform/environments/ppud/application_variables.json
@@ -5,6 +5,7 @@
       "SES_domain": "internaltest.ppud.justice.gov.uk",
       "WAM_ALB": "WAM-ALB-DEV",
       "patch_group": "dev_win_patch",
+      "test_patch_group": "win_patch_test_group",
       "patch_maintenance_window_name": "dev_patch_maintenance_window",
       "patch_maintenance_schedule_cron": "cron(0 18 ? * 3#3 *)",
       "patch_maintenance_window_duration": 3,

--- a/terraform/environments/ppud/instances.tf
+++ b/terraform/environments/ppud/instances.tf
@@ -165,7 +165,7 @@ resource "aws_instance" "s609693lo6vw110" {
 
   tags = {
     Name        = "s609693lo6vw110"
-    patch_group = "dev_win_test_patch"
+    patch_group = "win_patch_test_group"
     backup      = true
   }
 }

--- a/terraform/environments/ppud/instances.tf
+++ b/terraform/environments/ppud/instances.tf
@@ -165,7 +165,7 @@ resource "aws_instance" "s609693lo6vw110" {
 
   tags = {
     Name        = "s609693lo6vw110"
-    patch_group = "dev_win_patch"
+    patch_group = "dev_win_test_patch"
     backup      = true
   }
 }

--- a/terraform/environments/ppud/win_patchmgmt.tf
+++ b/terraform/environments/ppud/win_patchmgmt.tf
@@ -200,7 +200,7 @@ resource "aws_ssm_document" "perform_healthcheck_s3" {
 
 resource "aws_ssm_patch_group" "win_patch_test_group" {
   baseline_id = aws_ssm_patch_baseline.windows_os_apps_test_baseline.id
-  patch_group = win_patch_test_group
+  patch_group = win_patch_test_group.patch_group
 }
 
 # Create Windows Patch Baseline

--- a/terraform/environments/ppud/win_patchmgmt.tf
+++ b/terraform/environments/ppud/win_patchmgmt.tf
@@ -200,7 +200,7 @@ resource "aws_ssm_document" "perform_healthcheck_s3" {
 
 resource "aws_ssm_patch_group" "win_patch_test_group" {
   baseline_id = aws_ssm_patch_baseline.windows_os_apps_test_baseline.id
-  patch_group = dev_win_test_patch
+  patch_group = win_patch_test_group
 }
 
 # Create Windows Patch Baseline
@@ -264,7 +264,7 @@ resource "aws_ssm_maintenance_window_target" "patch_maintenance_window_test_targ
 
   targets {
     key    = "tag:patch_group"
-    values = [aws_ssm_patch_group.dev_win_test_patch.patch_group]
+    values = [aws_ssm_patch_group.win_patch_test_group.patch_group]
   }
 }
 

--- a/terraform/environments/ppud/win_patchmgmt.tf
+++ b/terraform/environments/ppud/win_patchmgmt.tf
@@ -199,8 +199,10 @@ resource "aws_ssm_document" "perform_healthcheck_s3" {
 # Test Group
 
 resource "aws_ssm_patch_group" "win_patch_test_group" {
+  count       = local.is-development == true ? 1 : 0
   baseline_id = aws_ssm_patch_baseline.windows_os_apps_test_baseline.id
-  patch_group = aws_ssm_patch_group.win_patch_test_group.patch_group
+  patch_group = local.application_data.accounts[local.environment].test_patch_group
+
 }
 
 # Create Windows Patch Baseline

--- a/terraform/environments/ppud/win_patchmgmt.tf
+++ b/terraform/environments/ppud/win_patchmgmt.tf
@@ -200,7 +200,7 @@ resource "aws_ssm_document" "perform_healthcheck_s3" {
 
 resource "aws_ssm_patch_group" "win_patch_test_group" {
   baseline_id = aws_ssm_patch_baseline.windows_os_apps_test_baseline.id
-  patch_group = win_patch_test_group.patch_group
+  patch_group = aws_ssm_patch_group.win_patch_test_group.patch_group
 }
 
 # Create Windows Patch Baseline


### PR DESCRIPTION
Creation of a new test patch group, patch baseline, maintenance window, target and task. This is to aid in the troubleshooting of AWS patch baselines being applied to EC2 instances.