### PR TITLE
DSOS-2736: add dataengineering access to preprod oasys and restrict prod

### DIFF
--- a/terraform/environments/oasys/locals_security_groups.tf
+++ b/terraform/environments/oasys/locals_security_groups.tf
@@ -51,6 +51,7 @@ locals {
       "10.40.40.0/24", # pp oasys
       "10.40.37.0/24", # pp prison nomis
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
+      module.ip_addresses.moj_cidr.aws_data_engineering_stage,
     ])
     oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,
@@ -98,9 +99,7 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.azure_studio_hosting_cidrs.prod,
-      module.ip_addresses.moj_cidr.aws_data_engineering_dev,
       module.ip_addresses.moj_cidr.aws_data_engineering_prod,
-      module.ip_addresses.moj_cidr.aws_data_engineering_stage,
     ])
     oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,


### PR DESCRIPTION
Following conversation from Data Engineering, they just need stage -> preprod and prod -> prod.  Limit access to prevent accidents.