### PR TITLE
Glue open ports for RDS security group EM

### DIFF
--- a/terraform/environments/electronic-monitoring-data/server_backups.tf
+++ b/terraform/environments/electronic-monitoring-data/server_backups.tf
@@ -111,6 +111,26 @@ resource "aws_vpc_security_group_ingress_rule" "db_ipv4_lb" {
   cidr_ipv4 = "209.35.83.77/32"
 }
 
+resource "aws_vpc_security_group_ingress_rule" "db_glue_access" {
+
+  security_group_id = aws_security_group.db.id
+  description       = "glue"
+  ip_protocol       = "tcp"
+  from_port         = 0
+  to_port           = 65535
+  referenced_security_group_id = aws_security_group.db.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "db_glue_access" {
+
+  security_group_id = aws_security_group.db.id
+  description       = "glue"
+  ip_protocol       = "tcp"
+  from_port         = 0
+  to_port           = 65535
+  referenced_security_group_id = aws_security_group.db.id
+}
+
 # resource "aws_vpc_security_group_ingress_rule" "db_ipv4_mk" {
 #   count = local.is-development ? 1 : 0
 #


### PR DESCRIPTION
open all ingress and egress ports for the rds database so we can run a glue crawler