### PR TITLE
onr(test): fix reference to ec2 defaults local

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -3,7 +3,7 @@ locals {
   # baseline config
   test_config = {
     baseline_ec2_autoscaling_groups = {
-      test-web-asg = merge(local.defaults_web_ec2.config, {
+      test-web-asg = merge(local.defaults_web_ec2, {
         config = merge(local.defaults_web_ec2.config, {
           availability_zone = "${local.region}a"
         })


### PR DESCRIPTION
`.config` shouldn't be there. It should merge on the parent, in order to include any maps that aren't explicitly declared.