### PR TITLE
Nomis: DSOS-2719: warm pool fix

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -156,11 +156,6 @@ locals {
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 2
           max_size         = 2
-
-          warm_pool = {
-            reuse_on_scale_in           = true
-            max_group_prepared_capacity = null
-          }
         })
         autoscaling_schedules = {
           scale_up   = { recurrence = "0 7 * * Mon-Fri" }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -156,6 +156,11 @@ locals {
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 2
           max_size         = 2
+
+          warm_pool = {
+            reuse_on_scale_in           = true
+            max_group_prepared_capacity = null
+          }
         })
         autoscaling_schedules = {
           scale_up   = { recurrence = "0 7 * * Mon-Fri" }

--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -40,7 +40,6 @@ locals {
 
       warm_pool = {
         reuse_on_scale_in           = true
-        max_group_prepared_capacity = 1
       }
     }
 
@@ -61,7 +60,6 @@ locals {
 
       warm_pool = {
         reuse_on_scale_in           = true
-        max_group_prepared_capacity = 1
       }
     }
   }


### PR DESCRIPTION
Better to use the default for this so it matches up with the maximum capacity, e.g. in nomis-preprod where we have max capacity of 2 this isn't really working.