### PR TITLE
DSOS-2692: allow tagging on secrets

### DIFF
--- a/terraform/modules/baseline/secretsmanager.tf
+++ b/terraform/modules/baseline/secretsmanager.tf
@@ -42,7 +42,8 @@ locals {
             recovery_window_in_days = sm_value.recovery_window_in_days
           },
           secret_value,
-          secret_value.kms_key_id == null ? { kms_key_id = sm_value.kms_key_id } : {}
+          secret_value.kms_key_id == null ? { kms_key_id = sm_value.kms_key_id } : {},
+          { tags = merge(sm_value.tags, secret_value.tags) }
         )
       }
     ]
@@ -132,7 +133,7 @@ resource "aws_secretsmanager_secret" "this" {
   policy                  = each.value.policy != null ? data.aws_iam_policy_document.secretsmanager_secret_policy[each.value.policy_key].json : null
   recovery_window_in_days = each.value.recovery_window_in_days
 
-  tags = merge(local.tags, {
+  tags = merge(local.tags, each.value.tags, {
     Name = each.key
   })
 }
@@ -144,6 +145,6 @@ resource "aws_secretsmanager_secret_version" "fixed" {
     local.secretsmanager_secrets_file
   )
 
-  secret_id     = aws_secretsmanager_secret.this[each.key]
+  secret_id     = aws_secretsmanager_secret.this[each.key].id
   secret_string = each.value.value
 }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -920,8 +920,10 @@ variable "secretsmanager_secrets" {
         length  = number
         special = optional(bool)
       }))
+      tags  = optional(map(string), {})
       value = optional(string)
     }))
+    tags = optional(map(string), {})
   }))
   default = {}
 }


### PR DESCRIPTION
Allow individual tagging on secrets - for fine-grained iam policy access