### PR TITLE
Onr/dsos 2682/add test db instance

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -84,4 +84,5 @@ locals {
 
   baseline_sns_topics     = {}
   baseline_ssm_parameters = {}
+  baseline_secretsmanager_secrets = {}
 }

--- a/terraform/environments/oasys-national-reporting/locals_defaults.tf
+++ b/terraform/environments/oasys-national-reporting/locals_defaults.tf
@@ -109,16 +109,23 @@ locals {
     })
     # FIXME: ebs_volumes list is NOT YET CORRECT and will need to change
     ebs_volumes = {
-      "/dev/sdb" = { label = "app" }   # /u01
-      "/dev/sdc" = { label = "app" }   # /u02
-      "/dev/sde" = { label = "data" }  # DATA01
-      "/dev/sdf" = { label = "data" }  # DATA02
-      "/dev/sdg" = { label = "data" }  # DATA03
-      "/dev/sdh" = { label = "data" }  # DATA04
-      "/dev/sdi" = { label = "data" }  # DATA05
-      "/dev/sdj" = { label = "flash" } # FLASH01
-      "/dev/sdk" = { label = "flash" } # FLASH02
-      "/dev/sds" = { label = "swap" }
+      "/dev/sda1" = { label = "root", size = 30 }  # root volume
+      "/dev/sdb" = { label = "app", size = 128 }   # /u01
+      "/dev/sdc" = { label = "app", size = 128 }   # /u02
+      "/dev/sde" = { label = "data", size = 1023 }  # DATA01
+      # "/dev/sdf" = { label = "data", size = 1023 }  # DATA02
+      # "/dev/sdg" = { label = "data", size = 1023 }  # DATA03
+      # "/dev/sdh" = { label = "data", size = 1023 }  # DATA04
+      # "/dev/sdi" = { label = "data", size = 1023 }  # DATA05
+      # "/dev/sdj" = { label = "data", size = 1023 } # DATA06
+      "/dev/sdk" = { label = "flash", size = 1023 } # FLASH01
+      # "/dev/sdl" = { label = "flash", size = 1023 } # FLASH02
+      # "/dev/sdm" = { label = "flash", size = 1023 } # FLASH03
+      # "/dev/sdn" = { label = "flash", size = 1023 } # FLASH04
+      # "/dev/sdo" = { label = "flash", size = 1023 } # FLASH05
+      # "/dev/sdp" = { label = "flash", size = 1023 } # FLASH06
+      # "/dev/sdq" = { label = "flash", size = 1023 } # FLASH07
+      "/dev/sds" = { label = "swap", size = 128 }
     }
     ebs_volume_config = {
       data = {
@@ -132,7 +139,7 @@ locals {
     }
     # cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.onr_db off for now
     tags = {
-      os-type   = "Windows"
+      os-type   = "Linux"
       component = "onr_db"
     }
     route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external

--- a/terraform/environments/oasys-national-reporting/locals_defaults.tf
+++ b/terraform/environments/oasys-national-reporting/locals_defaults.tf
@@ -19,6 +19,12 @@ locals {
     )
   }
 
+  database_secretsmanager_secrets = {
+    secrets = {
+      passwords = { description = "database passwords" }
+    }
+  }
+
   defaults_ec2 = {
     config = merge(module.baseline_presets.ec2_instance.config.default, {
       ami_owner                     = "self"

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,6 +2,13 @@ locals {
 
   # baseline config
   test_config = {
+
+    baseline_secretsmanager_secrets = {
+      "/oracle/database/T3ONRAU" = local.database_secretsmanager_secrets
+      "/oracle/database/T3ONRBDS" = local.database_secretsmanager_secrets
+      "/oracle/database/T3ONRSYS" = local.database_secretsmanager_secrets
+    }
+
     # baseline_ec2_instances = {
     #   test-db = merge(local.defaults_onr_db_ec2 ,{
     #     config = merge(local.defaults_onr_db_ec2.config, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,6 +2,26 @@ locals {
 
   # baseline config
   test_config = {
+    # baseline_ec2_instances = {
+    #   test-db = merge(local.defaults_onr_db_ec2 ,{
+    #     config = merge(local.defaults_onr_db_ec2.config, {
+    #       ami_name          = "hmpps_ol_8_5_oracledb_19c_release_2024-*"
+    #       availability_zone = "${local.region}a"
+    #     })
+    #     instance = merge(local.defaults_onr_db_ec2.instance, {
+    #       instance_type                = "r6i.xlarge"
+    #       metadata_options_http_tokens = "optional"
+    #     })
+    #     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+    #     secretsmanager_secrets = module.baseline_presets.ec2_instance.secretsmanager_secrets.oracle_19c
+    #     tags = merge(local.defaults_onr_db_ec2.tags, {
+    #       ami         = "base_ol_8_5"
+    #       server-type = "onr-db-test"
+    #       oracle-sids = "T3ONRAUD T3ONRBDS T3ONRSYS"
+    #       description = "ONR db for BOE Enterprise XI INSTALLATION TESTING ONLY"
+    #     })
+    #   })
+    # }
     baseline_ec2_autoscaling_groups = {
       test-web-asg = merge(local.defaults_web_ec2, {
         config = merge(local.defaults_web_ec2.config, {

--- a/terraform/environments/oasys-national-reporting/main.tf
+++ b/terraform/environments/oasys-national-reporting/main.tf
@@ -116,6 +116,11 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_s3_buckets", {})
   )
 
+  secretsmanager_secrets = merge(
+    local.baseline_secretsmanager_secrets,
+    lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
+  )
+
   security_groups = merge(
     local.baseline_security_groups,
     lookup(local.baseline_environment_config, "baseline_security_groups", {})


### PR DESCRIPTION
- db instance in oasys-national-reporting-test is commented out for now
  - pending additions to config management repo
  - note, not all disks exist/are required for testing
- adds secrets for testing ONR db install/config automation
- changes some defaults