### PR TITLE
onr: change secret name from t1 to test

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -4,7 +4,7 @@ locals {
   test_config = {
 
     baseline_secretsmanager_secrets = {
-      "/ec2/onr-web/t1" = local.web_secretsmanager_secrets
+      "/ec2/onr-web/test" = local.web_secretsmanager_secrets
 
       "/oracle/database/T3ONRAU"  = local.database_secretsmanager_secrets
       "/oracle/database/T3ONRBDS" = local.database_secretsmanager_secrets


### PR DESCRIPTION
It allows the Ansible to source the name from the default environment tags, which use "test" by default.