### PR TITLE
nomis: DSOS-2720: add instance-access-policy tag

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -140,6 +140,7 @@ locals {
       ami                         = "nomis_rhel_7_9_oracledb_11_2"
       backup                      = "false" # disable mod platform backup since we use our own policies
       component                   = "data"
+      instance-access-policy      = "limited"
       server-type                 = "nomis-db"
       os-type                     = "Linux"
       os-major-version            = 7

--- a/terraform/environments/nomis/locals_jumpserver.tf
+++ b/terraform/environments/nomis/locals_jumpserver.tf
@@ -17,11 +17,12 @@ locals {
       vpc_security_group_ids = ["private-jumpserver"]
     })
     tags = {
-      description = "Windows Server 2022 client testing for NOMIS"
-      os-type     = "Windows"
-      component   = "test"
-      server-type = "NomisClient"
-      backup      = "false" # no need to back this up as they are destroyed each night
+      description            = "Windows Server 2022 client testing for NOMIS"
+      instance-access-policy = "full"
+      os-type                = "Windows"
+      component              = "test"
+      server-type            = "NomisClient"
+      backup                 = "false" # no need to back this up as they are destroyed each night
     }
   }
 }

--- a/terraform/environments/nomis/locals_weblogic.tf
+++ b/terraform/environments/nomis/locals_weblogic.tf
@@ -136,12 +136,14 @@ locals {
     }
 
     tags = {
-      ami         = "nomis_rhel_6_10_weblogic_appserver_10_3"
-      backup      = "false" # disable mod platform backup since everything is in code
-      description = "nomis weblogic appserver 10.3"
-      os-type     = "Linux"
-      server-type = "nomis-web"
-      component   = "web"
+      ami                    = "nomis_rhel_6_10_weblogic_appserver_10_3"
+      backup                 = "false" # disable mod platform backup since everything is in code
+      description            = "nomis weblogic appserver 10.3"
+      instance-access-policy = "limited"
+      os-type                = "Linux"
+      server-type            = "nomis-web"
+      component              = "web"
+
     }
   }
 }

--- a/terraform/environments/nomis/locals_xtag.tf
+++ b/terraform/environments/nomis/locals_xtag.tf
@@ -25,10 +25,11 @@ locals {
     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
 
     tags = {
-      description = "nomis XTAG weblogic component"
-      ami         = "nomis_rhel_7_9_weblogic_xtag_10_3"
-      os-type     = "Linux"
-      server-type = "nomis-xtag"
+      description            = "nomis XTAG weblogic component"
+      ami                    = "nomis_rhel_7_9_weblogic_xtag_10_3"
+      instance-access-policy = "limited"
+      os-type                = "Linux"
+      server-type            = "nomis-xtag"
     }
   }
 }


### PR DESCRIPTION
This will restrict access when people use the instance-access role.  Jump server is fully accessible but only SSH/Port forwarding allowed on the other instances 