### PR TITLE
Dsos 2735 cloudwatch dashboard account names

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -145,5 +145,7 @@ locals {
     enable_cloudwatch_monitoring_account    = false
     enable_cloudwatch_cross_account_sharing = false
     enable_cloudwatch_dashboard             = false
+    monitoring_account_id                   = {}
+    source_account_ids                      = {}
   }
 }

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -5,6 +5,8 @@ locals {
   test_cloudwatch_monitoring_options = {
     enable_cloudwatch_monitoring_account = true
     enable_cloudwatch_dashboard          = true
+    monitoring_account_id                = module.environment.account_ids.hmpps-oem-test
+    source_account_ids                   = [module.environment.account_ids.nomis-test, module.environment.account_ids.oasys-test]
   }
 
   # baseline presets config

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -171,7 +171,7 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_local_environment_monitoring_options,
   )
   monitoring_account_id              = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
-  source_account_ids                 = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
+  source_account_ids                 = local.cloudwatch_local_environment_monitoring_options.source_account_ids
 }
 
 module "cloudwatch" {

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -170,8 +170,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
-  monitoring_account_id              = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
-  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", [])
+  monitoring_account_id = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
+  source_account_ids    = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", [])
 }
 
 module "cloudwatch" {

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -170,8 +170,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
-  monitoring_account_id              = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", {})
-  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", {})
+  monitoring_account_id              = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
+  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", "")
 }
 
 module "cloudwatch" {

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -171,7 +171,7 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_local_environment_monitoring_options,
   )
   monitoring_account_id              = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
-  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", "")
+  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", [])
 }
 
 module "cloudwatch" {

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -170,8 +170,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
-  monitoring_account_id              = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
-  source_account_ids                 = local.cloudwatch_local_environment_monitoring_options.source_account_ids
+  monitoring_account_id              = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", {})
+  source_account_ids                 = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", {})
 }
 
 module "cloudwatch" {

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -170,6 +170,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
+  monitoring_account_id              = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
+  source_account_ids                 = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
 }
 
 module "cloudwatch" {

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -97,5 +97,7 @@ locals {
     enable_cloudwatch_monitoring_account    = false
     enable_cloudwatch_cross_account_sharing = false
     enable_cloudwatch_dashboard             = false
+    monitoring_account_id                   = {}
+    source_account_ids                      = {}
   }
 }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -6,7 +6,7 @@ locals {
     enable_cloudwatch_cross_account_sharing = true
     enable_cloudwatch_dashboard             = true
     monitoring_account_id                   = module.environment.account_ids.hmpps-oem-test
-    source_account_ids                      = module.environment.account_ids.nomis-test
+    source_account_ids                      = [module.environment.account_ids.nomis-test]
   }
 
   # baseline presets config

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -5,6 +5,8 @@ locals {
   test_cloudwatch_monitoring_options = {
     enable_cloudwatch_cross_account_sharing = true
     enable_cloudwatch_dashboard             = true
+    monitoring_account_id                   = module.environment.account_ids.hmpps-oem-test
+    source_account_ids                      = module.environment.account_ids.nomis-test
   }
 
   # baseline presets config

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -175,8 +175,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
-  monitoring_account_id = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
-  source_account_ids    = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
+  monitoring_account_id = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
+  source_account_ids    = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", [])
 }
 
 module "cloudwatch" {

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -175,6 +175,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
+  monitoring_account_id = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
+  source_account_ids    = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
 }
 
 module "cloudwatch" {

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -476,5 +476,7 @@ locals {
     enable_cloudwatch_monitoring_account    = false
     enable_cloudwatch_cross_account_sharing = false
     enable_cloudwatch_dashboard             = false
+    monitoring_account_id                   = {}
+    source_account_ids                      = {}
   }
 }

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -5,6 +5,8 @@ locals {
   test_cloudwatch_monitoring_options = {
     enable_cloudwatch_cross_account_sharing = true
     enable_cloudwatch_dashboard             = true
+    monitoring_account_id                   = module.environment.account_ids.hmpps-oem-test
+    source_account_ids                      = module.environment.account_ids.oasys-test
   }
 
   test_baseline_presets_options = {

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -6,7 +6,7 @@ locals {
     enable_cloudwatch_cross_account_sharing = true
     enable_cloudwatch_dashboard             = true
     monitoring_account_id                   = module.environment.account_ids.hmpps-oem-test
-    source_account_ids                      = module.environment.account_ids.oasys-test
+    source_account_ids                      = [module.environment.account_ids.oasys-test]
   }
 
   test_baseline_presets_options = {

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -151,8 +151,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
-  monitoring_account_id = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
-  source_account_ids    = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
+  monitoring_account_id = lookup(local.cloudwatch_local_environment_monitoring_options, "monitoring_account_id", "")
+  source_account_ids    = lookup(local.cloudwatch_local_environment_monitoring_options, "source_account_ids", [])
 }
 
 module "cloudwatch" {

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -151,6 +151,8 @@ module "cross_account_cloudwatch" {
     local.cloudwatch_monitoring_options,
     local.cloudwatch_local_environment_monitoring_options,
   )
+  monitoring_account_id = local.cloudwatch_local_environment_monitoring_options.monitoring_account_id
+  source_account_ids    = [local.cloudwatch_local_environment_monitoring_options.source_account_ids]
 }
 
 module "cloudwatch" {

--- a/terraform/modules/cross_account_cloudwatch/monitoring_account.tf
+++ b/terraform/modules/cross_account_cloudwatch/monitoring_account.tf
@@ -26,3 +26,7 @@ resource "aws_oam_sink_policy" "monitoring_account_oam_sink_policy" {
     ]
   })
 }
+
+output "sink_arn" {
+  value = var.options.enable_cloudwatch_monitoring_account ? "${aws_oam_sink.monitoring_account_oam_sink[0].arn}" : null
+}

--- a/terraform/modules/cross_account_cloudwatch/outputs.tf
+++ b/terraform/modules/cross_account_cloudwatch/outputs.tf
@@ -1,3 +1,0 @@
-output "monitoring_account_sink_identifier" {
-  value = var.options.enable_cloudwatch_monitoring_account ? "${aws_oam_sink.monitoring_account_oam_sink[0].arn}" : null
-}

--- a/terraform/modules/cross_account_cloudwatch/variables.tf
+++ b/terraform/modules/cross_account_cloudwatch/variables.tf
@@ -6,7 +6,6 @@ variable "environment" {
 
 variable "source_account_ids" {
   type    = list(string)
-  default = ["612659970365", "546088120047"] #nomis-test and oasys-test
 }
 
 variable "options" {
@@ -16,12 +15,12 @@ variable "options" {
     enable_cloudwatch_cross_account_sharing = optional(bool, false)
   })
 }
+
 variable "monitoring_account_sink_identifier" {
   type    = string
-  default = ""
+  default = "arn:aws:oam:eu-west-2:775245656481:sink/7d4f9ba0-e432-49d1-8f34-1fda2d165bf8"
 }
 
 variable "monitoring_account_id" {
   type    = string
-  default = "775245656481" # hmpps-oem-test account
 }


### PR DESCRIPTION
- Removed hardcoded values for hmpps-oem-test, oasys-test and nomis-test account IDs in cross_account_cloudwatch module
- monitoring_account_id and source_account_ids can now be defined in locals_<environment>.tf files
- Output for monitoring_account_sink_identifier to remove hardcoded value
