### PR TITLE
DSOS-2749: Add file share for preprod nomis combined reporting

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -29,6 +29,7 @@ locals {
   baseline_cloudwatch_log_groups  = {}
   baseline_ec2_autoscaling_groups = {}
   baseline_ec2_instances          = {}
+  baseline_efs                    = {}
   baseline_iam_policies = {
     SasTokenRotatorPolicy = {
       description = "Allows updating of secrets in SSM"

--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -28,6 +28,39 @@ locals {
       "/oracle/database/PPBIPAUD" = local.database_secretsmanager_secrets
     }
 
+    baseline_efs = {
+      bip = {
+        access_points = {
+          root = {
+            posix_user = {
+              gid = 10003 # binstall
+              uid = 10003 # bobj
+            }
+            root_directory = {
+              path = "/"
+              creation_info = {
+                owner_gid   = 10003 # binstall
+                owner_uid   = 10003 # bobj
+                permissions = "0777"
+              }
+            }
+          }
+        }
+        backup_policy_status = "DISABLED"
+        file_system = {
+          availability_zone_name = "eu-west-2a"
+          lifecycle_policy = {
+            transition_to_ia = "AFTER_30_DAYS"
+          }
+        }
+        mount_targets = [{
+          subnet_name        = "private"
+          availability_zones = ["eu-west-2a"]
+          security_groups    = ["private"]
+        }]
+      }
+    }
+
     baseline_iam_policies = {
       Ec2PPDatabasePolicy = {
         description = "Permissions required for PREPROD Database EC2s"

--- a/terraform/environments/nomis-combined-reporting/main.tf
+++ b/terraform/environments/nomis-combined-reporting/main.tf
@@ -25,6 +25,10 @@ module "baseline" {
     local.baseline_cloudwatch_log_groups,
     lookup(local.environment_config, "baseline_cloudwatch_log_groups", {}),
   )
+  efs = merge(
+    local.baseline_efs,
+    lookup(local.environment_config, "baseline_efs", {})
+  )
   iam_policies = merge(
     module.baseline_presets.iam_policies,
     local.baseline_iam_policies,

--- a/terraform/environments/nomis-combined-reporting/outputs.tf
+++ b/terraform/environments/nomis-combined-reporting/outputs.tf
@@ -1,3 +1,7 @@
+output "efs_dns_names" {
+  description = "EFS DNS names"
+  value       = { for key, value in module.baseline.efs : key => value.file_system.dns_name }
+}
 output "route53_zone_ns_records" {
   description = "NS records of created zones"
   value       = { for key, value in module.baseline.route53_zones : key => value.name_servers }


### PR DESCRIPTION
The BIP application servers require a file share.  Creating EFS for that purpose
