### PR TITLE
🔥 Remove Analytical Platform Compute VPC

### DIFF
--- a/terraform/environments/analytical-platform-compute/data.tf
+++ b/terraform/environments/analytical-platform-compute/data.tf
@@ -1,2 +1,1 @@
-#### This file can be used to store data specific to the member account ####
 data "aws_availability_zones" "available" {}

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -12,6 +12,17 @@ locals {
       /* Observability Platform */
       observability_platform = "development"
     }
+    test = {
+      /* VPC */
+      vpc_cidr                   = "10.0.0.0/16"
+      vpc_private_subnets        = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+      vpc_public_subnets         = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+      vpc_enable_nat_gateway     = true
+      vpc_one_nat_gateway_per_az = true
+
+      /* Observability Platform */
+      observability_platform = "development"
+    }
     production = {
       /* VPC */
       vpc_cidr                   = "10.0.0.0/16"

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -1,0 +1,27 @@
+locals {
+  environment_configuration = local.environment_configurations[local.environment]
+  environment_configurations = {
+    development = {
+      /* VPC */
+      vpc_cidr                   = "10.0.0.0/16"
+      vpc_private_subnets        = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+      vpc_public_subnets         = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+      vpc_enable_nat_gateway     = true
+      vpc_one_nat_gateway_per_az = true
+
+      /* Observability Platform */
+      observability_platform = "development"
+    }
+    production = {
+      /* VPC */
+      vpc_cidr                   = "10.0.0.0/16"
+      vpc_private_subnets        = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+      vpc_public_subnets         = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+      vpc_enable_nat_gateway     = true
+      vpc_one_nat_gateway_per_az = true
+
+      /* Observability Platform */
+      observability_platform = "production"
+    }
+  }
+}

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -1,1 +1,0 @@
-#### This file can be used to store secrets specific to the member account ####

--- a/terraform/environments/analytical-platform-compute/vpc.tf
+++ b/terraform/environments/analytical-platform-compute/vpc.tf
@@ -1,21 +1,21 @@
-module "vpc" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+# module "vpc" {
+#   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+#   source  = "terraform-aws-modules/vpc/aws"
+#   version = "~> 5.0"
 
-  name            = "${local.application_name}-${local.environment}"
-  azs             = local.availability_zones
-  cidr            = local.application_data.accounts[local.environment].vpc_cidr
-  private_subnets = local.private_subnets
+#   name            = "${local.application_name}-${local.environment}"
+#   azs             = local.availability_zones
+#   cidr            = local.application_data.accounts[local.environment].vpc_cidr
+#   private_subnets = local.private_subnets
 
-  # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
-  enable_flow_log                      = true
-  create_flow_log_cloudwatch_log_group = true
-  create_flow_log_cloudwatch_iam_role  = true
-  flow_log_max_aggregation_interval    = 60
+#   # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
+#   enable_flow_log                      = true
+#   create_flow_log_cloudwatch_log_group = true
+#   create_flow_log_cloudwatch_iam_role  = true
+#   flow_log_max_aggregation_interval    = 60
 
-  tags = local.tags
-}
+#   tags = local.tags
+# }
 
 # module "vpc_endpoints" {
 #   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"

--- a/terraform/environments/analytical-platform-compute/vpc.tf
+++ b/terraform/environments/analytical-platform-compute/vpc.tf
@@ -17,56 +17,56 @@ module "vpc" {
   tags = local.tags
 }
 
-module "vpc_endpoints" {
-  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 5.0"
+# module "vpc_endpoints" {
+#   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+#   version = "~> 5.0"
 
-  security_group_ids = [aws_security_group.vpc_endpoints.id]
-  subnet_ids         = module.vpc.private_subnets
-  vpc_id             = module.vpc.vpc_id
+#   security_group_ids = [aws_security_group.vpc_endpoints.id]
+#   subnet_ids         = module.vpc.private_subnets
+#   vpc_id             = module.vpc.vpc_id
 
-  endpoints = {
-    logs = {
-      service      = "logs"
-      service_type = "Interface"
-      tags = merge(
-        local.tags,
-        { Name = format("%s-logs-api-vpc-endpoint", local.application_name) }
-      )
-    },
-    sts = {
-      service      = "sts"
-      service_type = "Interface"
-      tags = merge(
-        local.tags,
-        { Name = format("%s-sts-vpc-endpoint", local.application_name) }
-      )
-    },
-    s3 = {
-      service         = "s3"
-      service_type    = "Gateway"
-      route_table_ids = module.vpc.private_route_table_ids
-      tags = merge(
-        local.tags,
-        { Name = format("%s-s3-vpc-endpoint", local.application_name) }
-      )
-    }
-  }
-}
+#   endpoints = {
+#     logs = {
+#       service      = "logs"
+#       service_type = "Interface"
+#       tags = merge(
+#         local.tags,
+#         { Name = format("%s-logs-api-vpc-endpoint", local.application_name) }
+#       )
+#     },
+#     sts = {
+#       service      = "sts"
+#       service_type = "Interface"
+#       tags = merge(
+#         local.tags,
+#         { Name = format("%s-sts-vpc-endpoint", local.application_name) }
+#       )
+#     },
+#     s3 = {
+#       service         = "s3"
+#       service_type    = "Gateway"
+#       route_table_ids = module.vpc.private_route_table_ids
+#       tags = merge(
+#         local.tags,
+#         { Name = format("%s-s3-vpc-endpoint", local.application_name) }
+#       )
+#     }
+#   }
+# }
 
-resource "aws_security_group" "vpc_endpoints" {
-  description = "Security Group for controlling all VPC endpoint traffic"
-  name        = format("%s-vpc-endpoint-sg", local.application_name)
-  vpc_id      = module.vpc.vpc_id
-  tags        = local.tags
-}
+# resource "aws_security_group" "vpc_endpoints" {
+#   description = "Security Group for controlling all VPC endpoint traffic"
+#   name        = format("%s-vpc-endpoint-sg", local.application_name)
+#   vpc_id      = module.vpc.vpc_id
+#   tags        = local.tags
+# }
 
-resource "aws_security_group_rule" "allow_all_vpc" {
-  cidr_blocks       = [module.vpc.vpc_cidr_block]
-  description       = "Allow all traffic in from VPC CIDR"
-  from_port         = 0
-  protocol          = -1
-  security_group_id = aws_security_group.vpc_endpoints.id
-  to_port           = 65535
-  type              = "ingress"
-}
+# resource "aws_security_group_rule" "allow_all_vpc" {
+#   cidr_blocks       = [module.vpc.vpc_cidr_block]
+#   description       = "Allow all traffic in from VPC CIDR"
+#   from_port         = 0
+#   protocol          = -1
+#   security_group_id = aws_security_group.vpc_endpoints.id
+#   to_port           = 65535
+#   type              = "ingress"
+# }


### PR DESCRIPTION
This pull request:

Part of https://github.com/ministryofjustice/data-platform/issues/3555

- Removes the VPC and VPC endpoints that are provided as part of the isolated networking option, I need to resize the subnets but they are blocked by the existence of VPC endpoints, so instead of doing it bit-by-bit, I'll just blow it all away and start again, which as a lesson learned from Analytical Platform Ingestion

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 