### PR TITLE
Delete Quarantined files after 90 days

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
@@ -102,6 +102,8 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])
 
   name       = "ingestion/sftp/${var.name}/${each.key}"

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
@@ -1,3 +1,5 @@
+# tflint-ignore-file: terraform_required_version, terraform_required_providers
+
 data "aws_iam_policy_document" "this" {
   statement {
     sid    = "AllowKMS"
@@ -102,7 +104,6 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
-  # tflint-ignore: terraform_required_version, terraform_required_providers
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
 
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
@@ -102,6 +102,7 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
+  # tflint-ignore: terraform_required_version, terraform_required_providers
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
 
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
@@ -79,6 +79,8 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])
 
   name       = "ingestion/sftp/${var.name}/${each.key}"

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
@@ -1,3 +1,5 @@
+# tflint-ignore-file: terraform_required_version, terraform_required_providers
+
 data "aws_iam_policy_document" "this" {
   statement {
     sid    = "AllowKMS"
@@ -79,7 +81,6 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
-  # tflint-ignore: terraform_required_version, terraform_required_providers
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
 
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
@@ -79,6 +79,7 @@ resource "aws_security_group_rule" "this" {
 }
 
 resource "aws_secretsmanager_secret" "this" {
+  # tflint-ignore: terraform_required_version, terraform_required_providers
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
 
   for_each = toset(["technical-contact", "data-contact", "target-bucket", "slack-channel"])

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -132,6 +132,7 @@ data "aws_iam_policy_document" "bold_egress_bucket_policy" {
   }
 }
 
+#tfsec:ignore:avd-aws-0088 - The bucket policy is attached to the bucket
 module "bold_egress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -133,6 +133,7 @@ data "aws_iam_policy_document" "bold_egress_bucket_policy" {
 }
 
 #tfsec:ignore:avd-aws-0088 - The bucket policy is attached to the bucket
+#tfsec:ignore:avd-aws-0132 - The bucket policy is attached to the bucket
 module "bold_egress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -60,6 +60,17 @@ module "quarantine_bucket" {
       }
     }
   }
+
+  lifecycle_rule = [
+    {
+      id      = "delete-infected-objects-after-90-days"
+      enabled = true
+
+      expiration = {
+        days = 90
+      }
+    }
+  ]
 }
 
 module "definitions_bucket" {

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -1,15 +1,21 @@
 # TODO: look at using https://registry.terraform.io/modules/terraform-aws-modules/secrets-manager/aws/latest
 resource "aws_secretsmanager_secret" "govuk_notify_api_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+
   name       = "ingestion/govuk-notify/api-key"
   kms_key_id = module.govuk_notify_kms.key_arn
 }
 
 resource "aws_secretsmanager_secret" "govuk_notify_templates" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+
   name       = "ingestion/govuk-notify/templates"
   kms_key_id = module.govuk_notify_kms.key_arn
 }
 
 resource "aws_secretsmanager_secret" "slack_token" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+
   name       = "ingestion/slack-token"
   kms_key_id = module.slack_token_kms.key_arn
 }

--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -1,4 +1,6 @@
 resource "aws_security_group" "vpc_endpoints" {
+  #checkov:skip=CKV2_AWS_5
+
   description = "Security Group for controlling all VPC endpoint traffic"
   name        = format("%s-vpc-endpoint-sg", local.application_name)
   vpc_id      = module.vpc.vpc_id

--- a/terraform/environments/analytical-platform-ingestion/sns.tf
+++ b/terraform/environments/analytical-platform-ingestion/sns.tf
@@ -1,4 +1,6 @@
 module "quarantined_topic" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
   source  = "terraform-aws-modules/sns/aws"
   version = "6.0.1"
 
@@ -39,6 +41,7 @@ module "quarantined_topic" {
 }
 
 module "transferred_topic" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/sns/aws"
   version = "6.0.1"
 


### PR DESCRIPTION
Add a lifecycle rule to the `mojap-ingestion-${local.environment}-quarantine` bucket which deletes files 90 days after they were last modified or created. Files should only be created in this context. 