### PR TITLE
DSO-2691:  add ec2-user secret to DSO apps

### DIFF
--- a/terraform/environments/corporate-staff-rostering/main.tf
+++ b/terraform/environments/corporate-staff-rostering/main.tf
@@ -122,6 +122,7 @@ module "baseline" {
   )
 
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/hmpps-domain-services/main.tf
+++ b/terraform/environments/hmpps-domain-services/main.tf
@@ -146,6 +146,7 @@ module "baseline" {
   )
 
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -141,6 +141,7 @@ module "baseline" {
   )
 
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/nomis-combined-reporting/main.tf
+++ b/terraform/environments/nomis-combined-reporting/main.tf
@@ -65,6 +65,7 @@ module "baseline" {
     lookup(local.environment_config, "baseline_s3_buckets", {}),
   )
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -147,6 +147,7 @@ module "baseline" {
   )
 
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/oasys-national-reporting/main.tf
+++ b/terraform/environments/oasys-national-reporting/main.tf
@@ -117,6 +117,7 @@ module "baseline" {
   )
 
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -125,6 +125,7 @@ module "baseline" {
     lookup(local.environment_config, "baseline_s3_buckets", {})
   )
   secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
     local.baseline_secretsmanager_secrets,
     lookup(local.environment_config, "baseline_secretsmanager_secrets", {})
   )

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -69,6 +69,8 @@ locals {
     }
   }
 
+  baseline_secretsmanager_secrets = {}
+
   baseline_security_groups = {
     loadbalancer              = local.security_groups.loadbalancer
     web                       = local.security_groups.web

--- a/terraform/environments/planetfm/main.tf
+++ b/terraform/environments/planetfm/main.tf
@@ -116,6 +116,12 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_s3_buckets", {})
   )
 
+  secretsmanager_secrets = merge(
+    module.baseline_presets.secretsmanager_secrets,
+    local.baseline_secretsmanager_secrets,
+    lookup(local.baseline_environment_config, "baseline_secretsmanager_secrets", {})
+  )
+
   security_groups = merge(
     local.baseline_security_groups,
     lookup(local.baseline_environment_config, "baseline_security_groups", {})


### PR DESCRIPTION
Moving ec2-user private key secret into SecretsManager to ensure EC2s can't access it.  Via baseline module.