### PR TITLE
add T2 oracle-sids

### DIFF
--- a/terraform/environments/oasys/locals_secrets.tf
+++ b/terraform/environments/oasys/locals_secrets.tf
@@ -61,4 +61,9 @@ locals {
     }
   }
 
+  secretsmanager_secrets_bo_db = {
+    secrets = {
+      passwords = {}
+    }
+  }
 }

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -52,6 +52,9 @@ locals {
 
       "/oracle/bip/t1" = local.secretsmanager_secrets_bip
       "/oracle/bip/t2" = local.secretsmanager_secrets_bip
+
+      "/oracle/database/T2BOSYS" = local.secretsmanager_secrets_bo_db
+      "/oracle/database/T2BOAUD" = local.secretsmanager_secrets_bo_db
     }
 
     baseline_iam_policies = {
@@ -217,7 +220,7 @@ locals {
           "${local.application_name}-environment" = "t2"
           bip-db-name                             = "T2BIPINF"
           instance-scheduling                     = "skip-scheduling"
-          oracle-sids                             = "T2BIPINF T2MISTRN T2OASREP T2OASYS T2ONRAUD T2ONRBDS T2ONRSYS"
+          oracle-sids                             = "T2BIPINF T2MISTRN T2OASREP T2OASYS T2ONRAUD T2ONRBDS T2ONRSYS T2BOSYS T2BOAUD"
         })
       })
 


### PR DESCRIPTION
- add T2BOSYS and T2BOAUD to `t2-oasys-db-a` for BOE XI 3.1 silent installer testing
  - DB for new install needs to exist IN ADVANCE of filling in the response.ini file for the silent installer
  - @Sandhya1874 creating these new tables so testing doesn't impact anything that already exists
  
This will allow the following items to be completed in the `modernisation-platform-configuration-management` repo
- fill in oracle-tns-names role variables for onr-boe role and test it works
- pull the db-names and passwords etc. into ansible from the AWS Secrets Manager 
- add these secrets to the response file