### PR TITLE
🚚  Update Ingestion Lambda image versions

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -13,9 +13,9 @@ locals {
       observability_platform = "development"
 
       /* Image Versions */
-      scan_image_version     = "0.0.4"
-      transfer_image_version = "0.0.4"
-      notify_image_version   = "0.0.8"
+      scan_image_version     = "0.0.5"
+      transfer_image_version = "0.0.5"
+      notify_image_version   = "0.0.9"
 
       /* Target Buckets */
       target_buckets = ["mojap-land-dev"]
@@ -44,9 +44,9 @@ locals {
       observability_platform = "production"
 
       /* Image Versions */
-      scan_image_version     = "0.0.4"
-      transfer_image_version = "0.0.4"
-      notify_image_version   = "0.0.8"
+      scan_image_version     = "0.0.5"
+      transfer_image_version = "0.0.5"
+      notify_image_version   = "0.0.9"
 
       /* Target Buckets */
       target_buckets = ["mojap-land"]


### PR DESCRIPTION
Update the transfer, scan and notify lamdba image versions for the ingestion environments. These comprise mainly of Dependabot updates and one change to the logic of the transfer image.