### PR TITLE
🚑 Correct Analytical Platform Compute Production VPC subnetting

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -40,11 +40,11 @@ locals {
     production = {
       /* VPC */
       vpc_cidr                   = "10.201.0.0/16"
-      vpc_public_subnets         = ["10.201.0.0/26", "10.0.0.64/26", "10.0.0.128/26"]
-      vpc_database_subnets       = ["10.201.1.0/26", "10.0.1.64/26", "10.0.1.128/26"]
-      vpc_elasticache_subnets    = ["10.201.2.0/26", "10.0.2.64/26", "10.0.2.128/26"]
-      vpc_intra_subnets          = ["10.201.3.0/26", "10.0.3.64/26", "10.0.3.128/26"]
-      vpc_private_subnets        = ["10.201.128.0/19", "10.0.160.0/19", "10.0.192.0/19"]
+      vpc_public_subnets         = ["10.201.0.0/26", "10.201.0.64/26", "10.201.0.128/26"]
+      vpc_database_subnets       = ["10.201.1.0/26", "10.201.1.64/26", "10.201.1.128/26"]
+      vpc_elasticache_subnets    = ["10.201.2.0/26", "10.201.2.64/26", "10.201.2.128/26"]
+      vpc_intra_subnets          = ["10.201.3.0/26", "10.201.3.64/26", "10.201.3.128/26"]
+      vpc_private_subnets        = ["10.201.128.0/19", "10.201.160.0/19 ", "10.201.192.0/19"]
       vpc_enable_nat_gateway     = true
       vpc_one_nat_gateway_per_az = true
       vpc_single_nat_gateway     = false

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -44,7 +44,7 @@ locals {
       vpc_database_subnets       = ["10.201.1.0/26", "10.201.1.64/26", "10.201.1.128/26"]
       vpc_elasticache_subnets    = ["10.201.2.0/26", "10.201.2.64/26", "10.201.2.128/26"]
       vpc_intra_subnets          = ["10.201.3.0/26", "10.201.3.64/26", "10.201.3.128/26"]
-      vpc_private_subnets        = ["10.201.128.0/19", "10.201.160.0/19 ", "10.201.192.0/19"]
+      vpc_private_subnets        = ["10.201.128.0/19", "10.201.160.0/19", "10.201.192.0/19"]
       vpc_enable_nat_gateway     = true
       vpc_one_nat_gateway_per_az = true
       vpc_single_nat_gateway     = false


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/data-platform/issues/3555
- Corrects Production subnets, I've spent too long looking at these now.

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 