### PR TITLE
create jumpserver asg for nart client software development

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -72,10 +72,11 @@ locals {
   baseline_security_groups = {
     # instance type security groups
     # loadbalancer              = local.security_groups.loadbalancer
-    web    = local.security_groups.web # apply to onr web servers
-    bods   = local.security_groups.bods
-    boe    = local.security_groups.boe
-    onr_db = local.security_groups.onr_db
+    web                = local.security_groups.web # apply to onr web servers
+    bods               = local.security_groups.bods
+    boe                = local.security_groups.boe
+    onr_db             = local.security_groups.onr_db
+    private-jumpserver = local.security_groups.private_jumpserver
 
     # shared security groups
     oasys_db        = local.security_groups.oasys_db        # apply to bods & boe servers

--- a/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
+++ b/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
@@ -1,0 +1,29 @@
+locals {
+  jumpserver_ec2 = {
+    autoscaling_group     = module.baseline_presets.ec2_autoscaling_group.default_with_warm_pool
+    autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
+    # ami has unwanted ephemeral device, don't copy all the ebs_volumes
+    config = merge(module.baseline_presets.ec2_instance.config.default, {
+      ami_name                      = "base_windows_server_2012_r2_release_2024-*"
+      ami_owner                     = "374269020027"
+      availability_zone             = null
+      ebs_volumes_copy_all_from_ami = false
+      user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
+    })
+    ebs_volumes = {
+      "/dev/sda1" = { type = "gp3", size = 100 }
+    }
+    instance = merge(module.baseline_presets.ec2_instance.instance.default, {
+      instance_type          = "t3.large"
+      vpc_security_group_ids = ["private-jumpserver"]
+    })
+    tags = {
+      description            = "Windows Server 2012 R2 client testing for NART"
+      instance-access-policy = "full"
+      os-type                = "Windows"
+      component              = "test"
+      server-type            = "OnrClient"
+      backup                 = "false" # no need to back this up as they are destroyed each night
+    }
+  }
+}

--- a/terraform/environments/oasys-national-reporting/locals_security_groups.tf
+++ b/terraform/environments/oasys-national-reporting/locals_security_groups.tf
@@ -296,5 +296,27 @@ locals {
         }
       }
     }
+    private_jumpserver = {
+      description = "Security group for jumpservers"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -107,6 +107,7 @@ locals {
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
       })
+      test-onr-client-a = local.jumpserver_ec2
     }
     baseline_route53_zones = {
       "test.reporting.oasys.service.justice.gov.uk" = {}


### PR DESCRIPTION
- create locals for jumpserver asg
- add a security-group just for this

We might not end up using/keeping this in this particular environment BUT it's just a dev platform at this point

Should probably have a better description TBH, we're not 'developing' the nart client software. This asg is just a dev instance to automate how the nart client software gets installed on Windows Server 2102 r2 automatically :P 