### PR TITLE
Add account for G4S x drive data

### DIFF
--- a/terraform/environments/electronic-monitoring-data/locals.tf
+++ b/terraform/environments/electronic-monitoring-data/locals.tf
@@ -178,6 +178,13 @@ locals {
     cidr_ipv6s = local.g4s_cidr_ipv6s
   }
 
+  sftp_account_g4s_x_drive = {
+    name       = "x_drive"
+    ssh_keys   = local.g4s_ssh_keys
+    cidr_ipv4s = local.g4s_cidr_ipv4s
+    cidr_ipv6s = local.g4s_cidr_ipv6s
+  }
+
   #----------------------------------------------------------------------------
   # DEVELOPERS
   #----------------------------------------------------------------------------

--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -77,6 +77,7 @@ module "g4s" {
     # local.sftp_account_g4s_atv,
     # local.sftp_account_g4s_emsys_mvp,
     # local.sftp_account_g4s_emsys_tpims,
+    local.sftp_account_g4s_x_drive,
   ]
 
   data_store_bucket = aws_s3_bucket.data_store


### PR DESCRIPTION
Create the final transfer family SFTP account needed for transferring G4S data.