### PR TITLE
Deactivate the landing zones for capita and civica

### DIFF
--- a/terraform/environments/electronic-monitoring-data/main.tf
+++ b/terraform/environments/electronic-monitoring-data/main.tf
@@ -1,57 +1,57 @@
-module "capita" {
-  source = "./modules/landing_zone/"
+#module "capita" {
+#  source = "./modules/landing_zone/"
+#
+#  supplier = "capita"
+#
+#  user_accounts = [
+#    # Developer access.
+#    # local.sftp_account_dev,
+#
+#    # Accounts for each system to be migrated.
+#    # local.sftp_account_capita_specials_mailbox,
+#    # local.sftp_account_capita_alcohol_monitoring,
+#    # local.sftp_account_capita_blob_storage,
+#    # local.sftp_account_capita_forms_and_subject_id,
+#
+#    # Test account for supplier.
+#    # local.sftp_account_capita_test,
+#  ]
+#
+#  data_store_bucket = aws_s3_bucket.data_store
+#
+#  account_id = data.aws_caller_identity.current.account_id
+#
+#  vpc_id     = data.aws_vpc.shared.id
+#  subnet_ids = [data.aws_subnet.public_subnets_b.id]
+#
+#  local_tags = local.tags
+#}
 
-  supplier = "capita"
-
-  user_accounts = [
-    # Developer access.
-    # local.sftp_account_dev,
-
-    # Accounts for each system to be migrated.
-    local.sftp_account_capita_specials_mailbox,
-    local.sftp_account_capita_alcohol_monitoring,
-    local.sftp_account_capita_blob_storage,
-    local.sftp_account_capita_forms_and_subject_id,
-
-    # Test account for supplier.
-    local.sftp_account_capita_test,
-  ]
-
-  data_store_bucket = aws_s3_bucket.data_store
-
-  account_id = data.aws_caller_identity.current.account_id
-
-  vpc_id     = data.aws_vpc.shared.id
-  subnet_ids = [data.aws_subnet.public_subnets_b.id]
-
-  local_tags = local.tags
-}
-
-module "civica" {
-  source = "./modules/landing_zone/"
-
-  supplier = "civica"
-
-  user_accounts = [
-    # Developer access.
-    local.sftp_account_dev,
-
-    # Test account for supplier.
-    local.sftp_account_civica_test,
-
-    # Accounts for each system to be migrated.
-    local.sftp_account_civica_orca,
-  ]
-
-  data_store_bucket = aws_s3_bucket.data_store
-
-  account_id = data.aws_caller_identity.current.account_id
-
-  vpc_id     = data.aws_vpc.shared.id
-  subnet_ids = [data.aws_subnet.public_subnets_b.id]
-
-  local_tags = local.tags
-}
+#module "civica" {
+#  source = "./modules/landing_zone/"
+#
+#  supplier = "civica"
+#
+#  user_accounts = [
+#    # Developer access.
+#    # local.sftp_account_dev,
+#
+#    # Test account for supplier.
+#    # local.sftp_account_civica_test,
+#
+#    # Accounts for each system to be migrated.
+#    # local.sftp_account_civica_orca,
+#  ]
+#
+#  data_store_bucket = aws_s3_bucket.data_store
+#
+#  account_id = data.aws_caller_identity.current.account_id
+#
+#  vpc_id     = data.aws_vpc.shared.id
+#  subnet_ids = [data.aws_subnet.public_subnets_b.id]
+#
+#  local_tags = local.tags
+#}
 
 module "g4s" {
   source = "./modules/landing_zone/"


### PR DESCRIPTION
Now that data migration has been completed for these suppliers the servers can be removed (saving $$$). 

There is likely to be an additional transfer in a few months time so not removing the code yet.