### PR TITLE
EM: New DMS job for RDS database to Parquet file

### DIFF
--- a/terraform/environments/electronic-monitoring-data/dms_data.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_data.tf
@@ -31,12 +31,26 @@ data "aws_iam_policy_document" "dms_target_ep_s3_bucket" {
   }
 }
 
-# data "aws_iam_policy_document" "dms_policies" {
-#   statement {
-#     effect    = "Allow"
-#     actions   = ["dms:CreateReplicationSubnetGroup"]
-#     resources = ["*"]
-#   }
-# }
 
-# ---------------------------------------------------------
+
+data "aws_iam_policy_document" "dms_target_ep_s3_bucket_parquet" {
+  statement {
+    sid = "EnforceTLSv12orHigher"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.dms_target_ep_s3_bucket_parquet.arn,
+      "${aws_s3_bucket.dms_target_ep_s3_bucket_parquet.arn}/*"
+    ]
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = [1.2]
+    }
+  }
+}
+

--- a/terraform/environments/electronic-monitoring-data/dms_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_iam.tf
@@ -138,7 +138,7 @@ resource "aws_iam_policy" "dms_ep_s3_role_parquet_bucket" {
 }
 
 resource "aws_iam_policy" "dms_ep_s3_role_parquet_files" {
-  name = "get-dms-parquet-buckets"
+  name = "get-dms-parquet-files"
   policy = data.aws_iam_policy_document.dms_ep_s3_role_parquet_files.json
 }
 

--- a/terraform/environments/electronic-monitoring-data/dms_main.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_main.tf
@@ -43,7 +43,7 @@ module "dms_parquet_task" {
 
   # DMS Target Endpoint Inputs
   target_s3_bucket_name      = aws_s3_bucket.dms_target_ep_s3_bucket_parquet.id
-  ep_service_access_role_arn = aws_iam_role.dms_endpoint_role.arn
+  ep_service_access_role_arn = aws_iam_role.dms_endpoint_role_parquet.arn
 
   # DMS Migration Task Inputs
   dms_replication_instance_arn    = aws_dms_replication_instance.dms_replication_instance.replication_instance_arn

--- a/terraform/environments/electronic-monitoring-data/dms_main.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_main.tf
@@ -47,7 +47,14 @@ module "dms_parquet_task" {
 
   # DMS Migration Task Inputs
   dms_replication_instance_arn    = aws_dms_replication_instance.dms_replication_instance.replication_instance_arn
-  rep_task_settings_filepath      = trimspace(file("${path.module}/dms_replication_task_settings.json"))
+  rep_task_settings_filepath = merge(
+    trimspace(file("${path.module}/dms_replication_task_settings.json")),
+    {
+      "ValidationSettings": {
+        "EnableValidation": true
+      }
+    }
+  )
   rep_task_table_mapping_filepath = trimspace(file("${path.module}/dms_rep_task_table_mappings.json"))
 
   file_target_type = "parquet"

--- a/terraform/environments/electronic-monitoring-data/dms_main.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_main.tf
@@ -21,5 +21,36 @@ module "dms_task" {
   rep_task_settings_filepath      = trimspace(file("${path.module}/dms_replication_task_settings.json"))
   rep_task_table_mapping_filepath = trimspace(file("${path.module}/dms_rep_task_table_mappings.json"))
 
+  file_target_type = "csv"
+
+  local_tags = local.tags
+}
+
+
+module "dms_parquet_task" {
+  source = "./modules/dms"
+
+  for_each = toset(var.database_list)
+
+  database_name = each.key
+
+  # DMS Source Endpoint Inputs
+  rds_db_security_group_id = aws_security_group.db.id
+  rds_db_server_name       = split(":", aws_db_instance.database_2022.endpoint)[0]
+  rds_db_instance_port     = aws_db_instance.database_2022.port
+  rds_db_username          = aws_db_instance.database_2022.username
+  rds_db_instance_pasword  = aws_db_instance.database_2022.password
+
+  # DMS Target Endpoint Inputs
+  target_s3_bucket_name      = aws_s3_bucket.dms_target_ep_s3_bucket_parquet.id
+  ep_service_access_role_arn = aws_iam_role.dms_endpoint_role.arn
+
+  # DMS Migration Task Inputs
+  dms_replication_instance_arn    = aws_dms_replication_instance.dms_replication_instance.replication_instance_arn
+  rep_task_settings_filepath      = trimspace(file("${path.module}/dms_replication_task_settings.json"))
+  rep_task_table_mapping_filepath = trimspace(file("${path.module}/dms_rep_task_table_mappings.json"))
+
+  file_target_type = "parquet"
+
   local_tags = local.tags
 }

--- a/terraform/environments/electronic-monitoring-data/dms_main.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_main.tf
@@ -1,3 +1,6 @@
+locals {
+  rep_task_settings = jsondecode(file("${path.module}/dms_replication_task_settings.json"))
+}
 module "dms_task" {
   source = "./modules/dms"
 
@@ -48,7 +51,7 @@ module "dms_parquet_task" {
   # DMS Migration Task Inputs
   dms_replication_instance_arn    = aws_dms_replication_instance.dms_replication_instance.replication_instance_arn
   rep_task_settings_filepath = merge(
-    trimspace(file("${path.module}/dms_replication_task_settings.json")),
+    local.rep_task_settings,
     {
       "ValidationSettings": {
         "EnableValidation": true

--- a/terraform/environments/electronic-monitoring-data/dms_main.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_main.tf
@@ -1,6 +1,16 @@
 locals {
   rep_task_settings = jsondecode(file("${path.module}/dms_replication_task_settings.json"))
+  rep_task_settings_with_validation = merge(
+    local.rep_task_settings,
+    {
+      "ValidationSettings": {
+        "EnableValidation": true
+      }
+    }
+  )
+  rep_task_settings_filepath = jsonencode(local.rep_task_settings_with_validation)
 }
+
 module "dms_task" {
   source = "./modules/dms"
 
@@ -50,14 +60,7 @@ module "dms_parquet_task" {
 
   # DMS Migration Task Inputs
   dms_replication_instance_arn    = aws_dms_replication_instance.dms_replication_instance.replication_instance_arn
-  rep_task_settings_filepath = merge(
-    local.rep_task_settings,
-    {
-      "ValidationSettings": {
-        "EnableValidation": true
-      }
-    }
-  )
+  rep_task_settings_filepath = local.rep_task_settings_filepath
   rep_task_table_mapping_filepath = trimspace(file("${path.module}/dms_rep_task_table_mappings.json"))
 
   file_target_type = "parquet"

--- a/terraform/environments/electronic-monitoring-data/dms_s3_target_ep.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_s3_target_ep.tf
@@ -31,3 +31,38 @@ resource "aws_s3_bucket_policy" "dms_target_ep_s3_bucket" {
   bucket = aws_s3_bucket.dms_target_ep_s3_bucket.id
   policy = data.aws_iam_policy_document.dms_target_ep_s3_bucket.json
 }
+
+
+resource "aws_s3_bucket" "dms_target_ep_s3_bucket_parquet" {
+  bucket_prefix = "dms-rds-to-parquet-"
+
+  tags = merge(
+    local.tags,
+    {
+      Resource_Type = "DMS Target Endpoint S3 Bucket",
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "dms_target_ep_s3_bucket_parquet" {
+  bucket                  = aws_s3_bucket.dms_target_ep_s3_bucket_parquet.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "dms_target_ep_s3_bucket_parquet" {
+  bucket = aws_s3_bucket.dms_target_ep_s3_bucket_parquet.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "dms_target_ep_s3_bucket_parquet" {
+  bucket = aws_s3_bucket.dms_target_ep_s3_bucket_parquet.id
+  policy = data.aws_iam_policy_document.dms_target_ep_s3_bucket_parquet.json
+}

--- a/terraform/environments/electronic-monitoring-data/modules/dms/db_migration_task.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/db_migration_task.tf
@@ -3,7 +3,7 @@ resource "aws_dms_replication_task" "dms_db_migration_task" {
   # cdc_start_time            = "1993-05-21T05:50:00Z"
   migration_type            = "full-load"
   replication_instance_arn  = var.dms_replication_instance_arn
-  replication_task_id       = "${replace(var.database_name, "_", "-")}-db-migration-task-tf"
+  replication_task_id       = "${replace(var.database_name, "_", "-")}-db-migration-task-${var.file_target_type}"
   replication_task_settings = var.rep_task_settings_filepath
   source_endpoint_arn       = aws_dms_endpoint.dms_rds_source.endpoint_arn
   table_mappings            = var.rep_task_table_mapping_filepath

--- a/terraform/environments/electronic-monitoring-data/modules/dms/db_migration_task.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/db_migration_task.tf
@@ -7,7 +7,7 @@ resource "aws_dms_replication_task" "dms_db_migration_task" {
   replication_task_settings = var.rep_task_settings_filepath
   source_endpoint_arn       = aws_dms_endpoint.dms_rds_source.endpoint_arn
   table_mappings            = var.rep_task_table_mapping_filepath
-  target_endpoint_arn       = aws_dms_s3_endpoint.dms_s3_parquet_target.endpoint_arn
+  target_endpoint_arn       = aws_dms_s3_endpoint.dms_s3_target.endpoint_arn
 
   tags = merge(
     var.local_tags,

--- a/terraform/environments/electronic-monitoring-data/modules/dms/endpoints_rds_s3.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/endpoints_rds_s3.tf
@@ -25,10 +25,10 @@ resource "aws_dms_endpoint" "dms_rds_source" {
 # ==========================================================================
 
 # Create DMS Endpoint to S3 Target
-resource "aws_dms_s3_endpoint" "dms_s3_parquet_target" {
+resource "aws_dms_s3_endpoint" "dms_s3_target" {
 
   # Minimal Config:
-  endpoint_id             = "s3-${replace(var.database_name, "_", "-")}-tf"
+  endpoint_id             = "s3-${replace(var.database_name, "_", "-")}-${var.file_target_type}"
   endpoint_type           = "target"
   bucket_name             = var.target_s3_bucket_name
   service_access_role_arn = var.ep_service_access_role_arn
@@ -44,11 +44,11 @@ resource "aws_dms_s3_endpoint" "dms_s3_parquet_target" {
   # cdc_min_file_size                           = 32000
   # cdc_path                                    = "cdc/path"
   # compression_type                            = "NONE"
-  csv_delimiter     = ","
-  csv_no_sup_value  = "false"
-  csv_null_value    = "null"
-  csv_row_delimiter = "\\n"
-  data_format       = "csv"
+  csv_delimiter     = var.file_target_type == "csv" ? "," : null
+  csv_no_sup_value  = var.file_target_type == "csv" ? "false" : null
+  csv_null_value    = var.file_target_type == "csv" ? "null" : null
+  csv_row_delimiter = var.file_target_type == "csv" ? "\\n": null
+  data_format       = var.file_target_type
   data_page_size    = 68000000
   # date_partition_delimiter                    = "UNDERSCORE"
   # date_partition_enabled                      = false
@@ -63,9 +63,9 @@ resource "aws_dms_s3_endpoint" "dms_s3_parquet_target" {
   # glue_catalog_generation                     = true
   # ignore_header_rows                          = 1
   # include_op_for_full_load                    = true
-  max_file_size = 64000
+  max_file_size = 1024000
   # parquet_timestamp_in_millisecond            = false
-  # parquet_version = "parquet-2-0"
+  parquet_version = var.file_target_type =="parquet" ? "parquet-2-0" : null
   # preserve_transactions                       = false
   # rfc_4180                                    = false
   # row_group_length                            = 11000

--- a/terraform/environments/electronic-monitoring-data/modules/dms/endpoints_rds_s3.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/endpoints_rds_s3.tf
@@ -3,7 +3,7 @@ resource "aws_dms_endpoint" "dms_rds_source" {
 
   #   certificate_arn             = ""
   database_name = var.database_name
-  endpoint_id   = "rds-mssql-${replace(var.database_name, "_", "-")}-tf"
+  endpoint_id   = "rds-mssql-${replace(var.database_name, "_", "-")}-${var.file_target_type}"
   endpoint_type = "source"
   engine_name   = "sqlserver"
   #   extra_connection_attributes = ""

--- a/terraform/environments/electronic-monitoring-data/modules/dms/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/variables.tf
@@ -62,3 +62,10 @@ variable "dms_replication_instance_arn" {
   description = "Assign the Replication Instance-ARN to be used"
   type        = string
 }
+
+# ---------------------------------------------------------
+
+variable "file_target_type" {
+  description = "Type of the file output"
+  type = string
+}


### PR DESCRIPTION
Creating a new dms job (and tweaking the old one) to reflect the potential new pipeline replacement of "register-my-data" that can use parquet files
