### PR TITLE
🛂 Add `aws_iam_openid_connect_provider` to plan evaluator

### DIFF
--- a/scripts/terraform-plan-evaluator.sh
+++ b/scripts/terraform-plan-evaluator.sh
@@ -17,7 +17,8 @@ RESOURCES_TO_CHECK_FOR=(
   "aws_nat_gateway"
   "aws_route_table"
   "aws_route_table_association"
-  "aws_route"
+  "aws_route",
+  "aws_iam_openid_connect_provider"
 )
 
 resourcesFound=false


### PR DESCRIPTION
This pull request:

Relates to https://github.com/ministryofjustice/analytical-platform/issues/3555

- Adds `aws_iam_openid_connect_provider` to `scripts/terraform-plan-evaluator.sh`
  - source: https://mojdt.slack.com/archives/C01A7QK5VM1/p1715690493676859?thread_ts=1715600755.670579&cid=C01A7QK5VM1 

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 