### PR TITLE
check instance type and size changes, check jumpserver ami changes

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_defaults.tf
+++ b/terraform/environments/oasys-national-reporting/locals_defaults.tf
@@ -117,49 +117,49 @@ locals {
     }
   })
 
-  defaults_onr_db_ec2 = merge(local.defaults_ec2, {
-    config = merge(local.defaults_ec2.config, {
-      ami_name = "base_rhel_7_9_*"
-    })
-    instance = merge(local.defaults_ec2.instance, {
-      disable_api_stop       = false
-      vpc_security_group_ids = ["onr_db", "oasys_db_onr_db"]
-    })
-    # FIXME: ebs_volumes list is NOT YET CORRECT and will need to change
-    ebs_volumes = {
-      "/dev/sda1" = { label = "root", size = 30 }   # root volume
-      "/dev/sdb"  = { label = "app", size = 128 }   # /u01
-      "/dev/sdc"  = { label = "app", size = 128 }   # /u02
-      "/dev/sde"  = { label = "data", size = 1023 } # DATA01
-      # "/dev/sdf" = { label = "data", size = 1023 }  # DATA02
-      # "/dev/sdg" = { label = "data", size = 1023 }  # DATA03
-      # "/dev/sdh" = { label = "data", size = 1023 }  # DATA04
-      # "/dev/sdi" = { label = "data", size = 1023 }  # DATA05
-      # "/dev/sdj" = { label = "data", size = 1023 } # DATA06
-      "/dev/sdk" = { label = "flash", size = 1023 } # FLASH01
-      # "/dev/sdl" = { label = "flash", size = 1023 } # FLASH02
-      # "/dev/sdm" = { label = "flash", size = 1023 } # FLASH03
-      # "/dev/sdn" = { label = "flash", size = 1023 } # FLASH04
-      # "/dev/sdo" = { label = "flash", size = 1023 } # FLASH05
-      # "/dev/sdp" = { label = "flash", size = 1023 } # FLASH06
-      # "/dev/sdq" = { label = "flash", size = 1023 } # FLASH07
-      "/dev/sds" = { label = "swap", size = 128 }
-    }
-    ebs_volume_config = {
-      data = {
-        iops       = 5000 # confirmed, by looking at Azure
-        throughput = 200
-      }
-      flash = {
-        iops       = 5000 # confirmed, by looking at Azure
-        throughput = 200
-      }
-    }
-    # cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.onr_db off for now
-    tags = {
-      os-type   = "Linux"
-      component = "onr_db"
-    }
-    route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
-  })
+  # defaults_onr_db_ec2 = merge(local.defaults_ec2, {
+  #   config = merge(local.defaults_ec2.config, {
+  #     ami_name = "base_rhel_7_9_*"
+  #   })
+  #   instance = merge(local.defaults_ec2.instance, {
+  #     disable_api_stop       = false
+  #     vpc_security_group_ids = ["onr_db", "oasys_db_onr_db"]
+  #   })
+  #   # FIXME: ebs_volumes list is NOT YET CORRECT and will need to change
+  #   ebs_volumes = {
+  #     "/dev/sda1" = { label = "root", size = 30 }   # root volume
+  #     "/dev/sdb"  = { label = "app", size = 128 }   # /u01
+  #     "/dev/sdc"  = { label = "app", size = 128 }   # /u02
+  #     "/dev/sde"  = { label = "data", size = 1023 } # DATA01
+  #     # "/dev/sdf" = { label = "data", size = 1023 }  # DATA02
+  #     # "/dev/sdg" = { label = "data", size = 1023 }  # DATA03
+  #     # "/dev/sdh" = { label = "data", size = 1023 }  # DATA04
+  #     # "/dev/sdi" = { label = "data", size = 1023 }  # DATA05
+  #     # "/dev/sdj" = { label = "data", size = 1023 } # DATA06
+  #     "/dev/sdk" = { label = "flash", size = 1023 } # FLASH01
+  #     # "/dev/sdl" = { label = "flash", size = 1023 } # FLASH02
+  #     # "/dev/sdm" = { label = "flash", size = 1023 } # FLASH03
+  #     # "/dev/sdn" = { label = "flash", size = 1023 } # FLASH04
+  #     # "/dev/sdo" = { label = "flash", size = 1023 } # FLASH05
+  #     # "/dev/sdp" = { label = "flash", size = 1023 } # FLASH06
+  #     # "/dev/sdq" = { label = "flash", size = 1023 } # FLASH07
+  #     "/dev/sds" = { label = "swap", size = 128 }
+  #   }
+  #   ebs_volume_config = {
+  #     data = {
+  #       iops       = 5000 # confirmed, by looking at Azure
+  #       throughput = 200
+  #     }
+  #     flash = {
+  #       iops       = 5000 # confirmed, by looking at Azure
+  #       throughput = 200
+  #     }
+  #   }
+  #   # cloudwatch_metric_alarms = local.ec2_cloudwatch_metric_alarms.onr_db off for now
+  #   tags = {
+  #     os-type   = "Linux"
+  #     component = "onr_db"
+  #   }
+  #   route53_records = module.baseline_presets.ec2_instance.route53_records.internal_and_external
+  # })
 }

--- a/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
+++ b/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
@@ -4,11 +4,11 @@ locals {
     autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
     # ami has unwanted ephemeral device, don't copy all the ebs_volumes
     config = merge(module.baseline_presets.ec2_instance.config.default, {
-      ami_name                      = "base_windows_server_2012_r2_release_2024-05-15*"
+      ami_name                      = "base_windows_server_2012_r2_release_2024-*"
       ami_owner                     = "374269020027"
       availability_zone             = null
       ebs_volumes_copy_all_from_ami = false
-      # user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
+      user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
     })
     ebs_volumes = {
       "/dev/sda1" = { type = "gp3", size = 200 }
@@ -23,7 +23,7 @@ locals {
       os-type                = "Windows"
       component              = "test"
       server-type            = "OnrClient"
-      backup                 = "false" # no need to back this up as they are destroyed each night
+      backup                 = "false" # no need to backup as these shouldn't contain persistent data
     }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
+++ b/terraform/environments/oasys-national-reporting/locals_jumpserver.tf
@@ -4,17 +4,17 @@ locals {
     autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
     # ami has unwanted ephemeral device, don't copy all the ebs_volumes
     config = merge(module.baseline_presets.ec2_instance.config.default, {
-      ami_name                      = "base_windows_server_2012_r2_release_2024-*"
+      ami_name                      = "base_windows_server_2012_r2_release_2024-05-15*"
       ami_owner                     = "374269020027"
       availability_zone             = null
       ebs_volumes_copy_all_from_ami = false
-      user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
+      # user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
     })
     ebs_volumes = {
       "/dev/sda1" = { type = "gp3", size = 200 }
     }
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-      instance_type          = "t3.large"
+      instance_type          = "m4.large"
       vpc_security_group_ids = ["private-jumpserver"]
     })
     tags = {

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -5,9 +5,9 @@ locals {
     
     # Instance Type Defaults for preproduction
     # instance_type_defaults = {
-    #   web = "m4.xlarge" # 4 vCPUs, 16GB RAM x 2 instances
+    #   web = "m6i.xlarge" # 4 vCPUs, 16GB RAM x 2 instances
     #   boe = "m4.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
-    #   bods = "r4.2xlarge" # 8 vCPUs, 61GB RAM x 1 instance
+    #   bods = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 1 instance, reduced RAM as Azure usage doesn't warrant higher RAM
     # }
     baseline_route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {}

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -2,6 +2,13 @@ locals {
 
   # baseline config
   preproduction_config = {
+    
+    # Instance Type Defaults for preproduction
+    # instance_type_defaults = {
+    #   web = "m4.xlarge" # 4 vCPUs, 16GB RAM x 2 instances
+    #   boe = "m4.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
+    #   bods = "r4.2xlarge" # 8 vCPUs, 61GB RAM x 1 instance
+    # }
     baseline_route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {}
     }

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -2,6 +2,13 @@ locals {
 
   # baseline config
   production_config = {
+    
+    # Instance Type Defaults for production
+    # instance_type_defaults = {
+    #   web = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
+    #   boe = "m4.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
+    #   bods = "r4.2xlarge" # 8 vCPUs, 61GB RAM x 2 instance
+    # }
     baseline_route53_zones = {
       "reporting.oasys.service.justice.gov.uk" = {
         ns_records = [

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -7,7 +7,7 @@ locals {
     # instance_type_defaults = {
     #   web = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
     #   boe = "m4.2xlarge" # 8 vCPUs, 32GB RAM x 2 instances
-    #   bods = "r4.2xlarge" # 8 vCPUs, 61GB RAM x 2 instance
+    #   bods = "r4.2xlarge" # 8 vCPUs, 61GB RAM x 2 instance, NOT CONFIRMED as pre-prod usage may not warrant this high spec
     # }
     baseline_route53_zones = {
       "reporting.oasys.service.justice.gov.uk" = {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -72,29 +72,29 @@ locals {
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
       })
-      test-boe-asg = merge(local.defaults_boe_ec2, {
-        config = merge(local.defaults_boe_ec2.config, {
-          instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-          availability_zone = "${local.region}a"
-        })
-        instance = merge(local.defaults_boe_ec2.instance, {
-          instance_type = "m4.xlarge"
-        })
-        # user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-        #   args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-        #     branch = "onr/DSOS-2682/onr-boe-install"
-        #   })
-        # })
-        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-          desired_capacity = 0
-        })
-        autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
-        tags = merge(local.defaults_boe_ec2.tags, {
-          oasys-national-reporting-environment = "t2"
-        })
-      })
+      # test-boe-asg = merge(local.defaults_boe_ec2, {
+      #   config = merge(local.defaults_boe_ec2.config, {
+      #     instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #     availability_zone = "${local.region}a"
+      #   })
+      #   instance = merge(local.defaults_boe_ec2.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+      #     args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+      #       branch = "onr/DSOS-2682/onr-boe-install"
+      #     })
+      #   })
+      #   autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+      #     desired_capacity = 0
+      #   })
+      #   autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
+      #   tags = merge(local.defaults_boe_ec2.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #   })
+      # })
       test-bods-asg = merge(local.defaults_bods_ec2, {
         config = merge(local.defaults_bods_ec2.config, {
           availability_zone = "${local.region}a"

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -60,7 +60,7 @@ locals {
           availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_web_ec2.instance, {
-          instance_type = "t3.large"
+          instance_type = "m4.large"
         })
         user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
           args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
@@ -80,13 +80,13 @@ locals {
           availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_boe_ec2.instance, {
-          instance_type = "t2.large"
+          instance_type = "m4.xlarge"
         })
-        user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-          args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-            branch = "onr/DSOS-2682/onr-boe-install"
-          })
-        })
+        # user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+        #   args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+        #     branch = "onr/DSOS-2682/onr-boe-install"
+        #   })
+        # })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0
         })
@@ -100,7 +100,7 @@ locals {
           availability_zone = "${local.region}a"
         })
         instance = merge(local.defaults_bods_ec2.instance, {
-          instance_type = "t3.large"
+          instance_type = "m4.xlarge"
         })
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
           desired_capacity = 0


### PR DESCRIPTION
- revised instance size/types work with underlying OS ✅ 
- add instance types/sizes for preproduction and production as comments for later
- delete test-boe-asg ahead of turning this into a non-asg instance
- comment out onr_db default as we don't seem to need this here

@keirwilliams I have not changed the development environment instance type/sizes 👍 