### PR TITLE
change datapoints to alarm to 15 for free-disk-space-low

### DIFF
--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -117,8 +117,8 @@ locals {
       }
       high-memory-usage = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "60"
-        datapoints_to_alarm = "60"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
         metric_name         = "mem_used_percent"
         namespace           = "CWAgent"
         period              = "60"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -105,8 +105,8 @@ locals {
     ec2_cwagent_linux = {
       free-disk-space-low = {
         comparison_operator = "GreaterThanOrEqualToThreshold"
-        evaluation_periods  = "60"
-        datapoints_to_alarm = "60"
+        evaluation_periods  = "15"
+        datapoints_to_alarm = "15"
         metric_name         = "disk_used_percent"
         namespace           = "CWAgent"
         period              = "60"


### PR DESCRIPTION
Changed duration till alarm triggers from 1 hour to 15 minutes so alarms trigger faster when disk and memory threshold  is reached.