### PR TITLE
DSOS-2779: allow ssm parameter value to be looked up from s3 bucket name

### DIFF
--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1099,7 +1099,8 @@ variable "ssm_parameters" {
         length  = number
         special = optional(bool)
       }))
-      value = optional(string)
+      value                = optional(string)
+      value_s3_bucket_name = optional(string) # lookup from module.s3_bucket
     }))
   }))
   default = {}

--- a/terraform/modules/lb_listener/main.tf
+++ b/terraform/modules/lb_listener/main.tf
@@ -1,5 +1,6 @@
 resource "aws_lb_listener" "this" {
-  #checkov:skip=CKV_AWS_2:skip "Ensure ALB protocol is HTTPS"
+  #checkov:skip=CKV_AWS_2:skip "Ensure ALB protocol is HTTPS" - CSR is http
+  #checkov:skip=CKV_AWS_103: "Ensure that load balancer is using at least TLS 1.2" - nice idea but not possible with nomis
   #Allow http listener to be configured, e.g. for auto redirection to https
 
   load_balancer_arn = local.aws_lb.arn


### PR DESCRIPTION
Suppose might be useful elsewhere so adding this feature into baseline, but primarily this is for offloc implementation