### PR TITLE
Get `example` successfully completing terraform runs

### DIFF
--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -103,7 +103,7 @@ resource "aws_instance" "develop" {
 
 # create single managed policy
 resource "random_id" "ec2_common_policy" {
-  byte_length = 1
+  byte_length = 4
 }
 
 resource "aws_iam_policy" "ec2_common_policy" {
@@ -111,7 +111,7 @@ resource "aws_iam_policy" "ec2_common_policy" {
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json
-  tags        = { Name = "ec2-common-policy" }
+  tags        = { Name = "${random_id.ec2_common_policy.dec}-ec2-common-policy" }
 }
 
 # combine ec2-common policy documents

--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -4,7 +4,7 @@
 
 # EC2 Created via module
 module "ec2_test_instance" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v2.4.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=edc55b4005b7039e5b54ad7805e89a473fe3c3dd" #v2.4.1
 
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
@@ -138,6 +138,10 @@ locals {
 
 # custom policy for SSM as managed policy AmazonSSMManagedInstanceCore is too permissive
 data "aws_iam_policy_document" "ec2_policy" {
+  #checkov:skip=CKV_AWS_107
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356
   statement {
     sid    = "CustomEc2Policy"
     effect = "Allow"
@@ -188,6 +192,7 @@ resource "aws_volume_attachment" "mountvolumetoec2" {
 data "aws_iam_policy_document" "ebs-kms" {
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_356
   statement {
     effect    = "Allow"
     actions   = ["kms:*"]

--- a/terraform/environments/example/ec2.tf
+++ b/terraform/environments/example/ec2.tf
@@ -102,8 +102,12 @@ resource "aws_instance" "develop" {
 }
 
 # create single managed policy
+resource "random_id" "ec2_common_policy" {
+  byte_length = 1
+}
+
 resource "aws_iam_policy" "ec2_common_policy" {
-  name        = "ec2-common-policy"
+  name        = "${random_id.ec2_common_policy.dec}-ec2-common-policy"
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json

--- a/terraform/environments/example/ec2_autoscaling_group.tf
+++ b/terraform/environments/example/ec2_autoscaling_group.tf
@@ -1,5 +1,5 @@
 module "ec2_test_autoscaling_group" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v2.5.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=03913ac182decfc8224923520439d53d7c930661" #v2.5.3
 
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
@@ -59,6 +59,10 @@ data "aws_iam_policy_document" "ec2_autoscale_combined" {
 }
 
 data "aws_iam_policy_document" "ec2_autoscale_policy" {
+  #checkov:skip=CKV_AWS_107
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356
   statement {
     sid    = "CustomEc2Policy"
     effect = "Allow"

--- a/terraform/environments/example/ec2_bastion_linux.tf
+++ b/terraform/environments/example/ec2_bastion_linux.tf
@@ -1,6 +1,6 @@
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=95ed3c3f454e2014a62990aacd5d68c64d026f11" #v4.2.1
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -142,7 +142,7 @@ locals {
 
 }
 
-# This item is used to combine emultiple policy documents though for this example only one policy document is created.
+# This item is used to combine multiple policy documents though for this example only one policy document is created.
 data "aws_iam_policy_document" "ec2_complete_common_combined" {
   source_policy_documents = [
     data.aws_iam_policy_document.ec2_complete_policy.json
@@ -151,6 +151,8 @@ data "aws_iam_policy_document" "ec2_complete_common_combined" {
 
 # This policy document is added as an example. Note that the module does not support access via AWS Session Manager.
 data "aws_iam_policy_document" "ec2_complete_policy" {
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356
   statement {
     sid    = "AllowSSMAccess"
     effect = "Allow"

--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -236,8 +236,12 @@ resource "aws_security_group_rule" "complete_egress_traffic" {
 ##### IAM Policies #####
 
 # Creates a single managed policy using the combined policy documents.
+resource "random_id" "ec2_complete_common_policy" {
+  byte_length = 1
+}
+
 resource "aws_iam_policy" "ec2_complete_common_policy" {
-  name        = "ec2-common-policy"
+  name        = "${random_id.ec2_common_policy.dec}-ec2-common-policy"
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json

--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -10,7 +10,7 @@
 # Keypair for ec2-user
 #------------------------------------------------------------------------------
 resource "aws_key_pair" "ec2-user-complete" {
-  key_name   = "ec2-user"
+  key_name   = "ec2-user-complete"
   public_key = file(".ssh/${terraform.workspace}/ec2-user.pub")
   tags       = { Name = "${local.application_name}-ec2-user-complete" }
 }
@@ -27,7 +27,7 @@ locals {
   # This local is used by the module variable "instance".  
   instance_complete = {
     disable_api_termination      = false
-    key_name                     = try(aws_key_pair.ec2-user.key_name)
+    key_name                     = try(aws_key_pair.ec2-user-complete.key_name)
     monitoring                   = false
     metadata_options_http_tokens = "required"
     vpc_security_group_ids       = try([aws_security_group.example_ec2_sg.id])
@@ -237,13 +237,13 @@ resource "aws_security_group_rule" "complete_egress_traffic" {
 
 # Creates a single managed policy using the combined policy documents.
 resource "random_id" "ec2_complete_common_policy" {
-  byte_length = 1
+  byte_length = 4
 }
 
 resource "aws_iam_policy" "ec2_complete_common_policy" {
-  name        = "${random_id.ec2_common_policy.dec}-ec2-common-policy"
+  name        = "${random_id.ec2_complete_common_policy.dec}-ec2-common-policy"
   path        = "/"
   description = "Common policy for all ec2 instances"
   policy      = data.aws_iam_policy_document.ec2_common_combined.json
-  tags        = { Name = "ec2-common-policy" }
+  tags        = { Name = "${random_id.ec2_common_policy.dec}-ec2-common-policy" }
 }

--- a/terraform/environments/example/ecs.tf
+++ b/terraform/environments/example/ecs.tf
@@ -4,13 +4,13 @@
 
 
 module "ecs-cluster" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster?ref=v4.3.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster?ref=b00647922a9204a99b023ac884440162e2b51b66" #v4.3.0
   name        = local.ecs_application_name
   tags = local.tags
 }
 
 module "service" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service?ref=v4.3.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//service?ref=b00647922a9204a99b023ac884440162e2b51b66" #v4.3.0
 
   container_definitions = templatefile("${path.module}/templates/task_definition.json.tftpl", {})
   cluster_arn           = module.ecs-cluster.ecs_cluster_arn
@@ -113,7 +113,7 @@ locals {
 
 # Load balancer build using the module
 module "ecs_lb_access_logs_enabled" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v4.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=6f59e1ce47df66bc63ee9720b7c58993d1ee64ee" #v4.0.0
   providers = {
     # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
     # Need to pass the provider to the S3 bucket module

--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -183,7 +183,7 @@ resource "aws_wafv2_web_acl_association" "web_acl_association_my_lb" {
 ######################### S3 Bucket required for logs  ##########################
 #################################################################################
 module "s3-bucket-lb" { #tfsec:ignore:aws-s3-enable-versioning
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.1.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=568694e50e03630d99cb569eafa06a0b879a1239" #v7.1.0
 
   bucket_prefix      = "s3-bucket-example-lb"
   versioning_enabled = false
@@ -327,6 +327,7 @@ data "aws_elb_service_account" "default_lb" {}
 
 resource "aws_instance" "lb_example_instance" {
   #checkov:skip=CKV2_AWS_41:"IAM role is not implemented for this example EC2. SSH/AWS keys are not used either."
+  #checkov:skip=CKV_AWS_8: "Encryption not required for example instance"
   # Specify the instance type and ami to be used (this is the Amazon free tier option)
   instance_type          = local.application_data.accounts[local.environment].instance_type
   ami                    = local.application_data.accounts[local.environment].ami_image_id

--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -79,6 +79,9 @@ resource "aws_lb_target_group" "target_group" {
   }
 
   tags = { Name = "${local.application_name}-tg-${local.environment}" }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Link target group to the EC2 instance on port 80
@@ -88,7 +91,7 @@ resource "aws_lb_target_group_attachment" "develop" {
   port             = 80
 }
 
-# Load blancer listener
+# Load balancer listener
 resource "aws_lb_listener" "external" {
   load_balancer_arn = aws_lb.external.arn
   port              = local.application_data.accounts[local.environment].server_port

--- a/terraform/environments/example/loadbalancer_module.tf
+++ b/terraform/environments/example/loadbalancer_module.tf
@@ -1,6 +1,6 @@
 # Load balancer build using the module
 module "lb_access_logs_enabled" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=v4.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer?ref=6f59e1ce47df66bc63ee9720b7c58993d1ee64ee" #v4.0.0
   providers = {
     # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
     # Need to pass the provider to the S3 bucket module

--- a/terraform/environments/example/platform_versions.tf
+++ b/terraform/environments/example/platform_versions.tf
@@ -8,6 +8,10 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/example/rds.tf
+++ b/terraform/environments/example/rds.tf
@@ -8,7 +8,13 @@
 # Set these up in there and make sure the local points to that location
 
 
-resource "aws_db_instance" "Example-RDS" { #tfsec:ignore:aws-rds-enable-deletion-protection
+resource "aws_db_instance" "example-rds" {
+  #checkov:skip=CKV_AWS_118: "enhanced monitoring is enabled, but optional"
+  #checkov:skip=CKV_AWS_157: "multi-az enabled, but optional"
+  #checkov:skip=CKV_AWS_133: "backup_retention enabled, can be edited it application_variables.json"
+  #checkov:skip=CKV_AWS_161: "iam auth enabled, but optional"
+  #checkov:skip=CKV_AWS_293: "Deletion protection not required for example"
+  #checkov:skip=CKV_AWS_354: "Performance insights don't need encryption for example"
   engine                     = "mysql"
   engine_version             = "5.7"
   auto_minor_version_upgrade = true
@@ -26,14 +32,10 @@ resource "aws_db_instance" "Example-RDS" { #tfsec:ignore:aws-rds-enable-deletion
   allow_major_version_upgrade = local.application_data.accounts[local.environment].allow_major_version_upgrade
   backup_window               = local.application_data.accounts[local.environment].backup_window
   backup_retention_period     = local.application_data.accounts[local.environment].retention_period
-  #checkov:skip=CKV_AWS_133: "backup_retention enabled, can be edited it application_variables.json"
   iam_database_authentication_enabled = local.application_data.accounts[local.environment].db_iam_database_authentication_enabled
-  #checkov:skip=CKV_AWS_161: "iam auth enabled, but optional" #tfsec:ignore:aws-rds-enable-database-authentication
   multi_az = local.application_data.accounts[local.environment].db_multi_az
-  #checkov:skip=CKV_AWS_157: "multi-az enabled, but optional"
   monitoring_interval = local.application_data.accounts[local.environment].db_monitoring_interval
   monitoring_role_arn = local.application_data.accounts[local.environment].db_monitoring_interval == 0 ? "" : aws_iam_role.rds_enhanced_monitoring[0].arn
-  #checkov:skip=CKV_AWS_118: "enhanced monitoring is enabled, but optional"
   storage_encrypted               = true
   db_subnet_group_name = aws_db_subnet_group.example.name
   vpc_security_group_ids = [aws_security_group.rds-example.id]
@@ -53,6 +55,7 @@ resource "aws_db_subnet_group" "example" {
 }
 
 resource "aws_security_group" "rds-example" {
+  description = "RDS Security Group"
   vpc_id = data.aws_vpc.shared.id
 }
 

--- a/terraform/environments/example/s3.tf
+++ b/terraform/environments/example/s3.tf
@@ -6,7 +6,7 @@
 # S3 Bucket
 #------------------------------------------------------------------------------
 module "s3-bucket" { #tfsec:ignore:aws-s3-enable-versioning
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.1.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=568694e50e03630d99cb569eafa06a0b879a1239" #v7.1.0
 
   bucket_prefix      = "s3-bucket-example"
   versioning_enabled = false


### PR DESCRIPTION
I think there's some value in revisiting / rewriting the code we have in `example` as it's gotten a bit disorganised, and doesn't represent consistent practice that we'd always want customers to crib from.

However, this PR add some randomisation to names where there were previous clashes, updates to the most recent version of the ECS module, gets the RDS instance created, switches out the remote refs for modules to commit values, and puts in place some checkov skips where appropriate.