### PR TITLE
add boe instance

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -50,24 +50,21 @@ locals {
           "/dev/sds"  = { type = "gp3", size = 100 }
         })
       })
-      #   test-db = merge(local.defaults_onr_db_ec2 ,{
-      #     config = merge(local.defaults_onr_db_ec2.config, {
-      #       ami_name          = "hmpps_ol_8_5_oracledb_19c_release_2024-*"
-      #       availability_zone = "${local.region}a"
-      #     })
-      #     instance = merge(local.defaults_onr_db_ec2.instance, {
-      #       instance_type                = "r6i.xlarge"
-      #       metadata_options_http_tokens = "optional"
-      #     })
-      #     user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-      #     secretsmanager_secrets = module.baseline_presets.ec2_instance.secretsmanager_secrets.oracle_19c
-      #     tags = merge(local.defaults_onr_db_ec2.tags, {
-      #       ami         = "base_ol_8_5"
-      #       server-type = "onr-db-test"
-      #       oracle-sids = "T3ONRAUD T3ONRBDS T3ONRSYS"
-      #       description = "ONR db for BOE Enterprise XI INSTALLATION TESTING ONLY"
-      #     })
-      #   })
+      t2-onr-boe-1-a = merge(local.defaults_boe_ec2, {
+        config = merge(local.defaults_boe_ec2.config, {
+          instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+          availability_zone = "${local.region}a"
+        })
+        instance = merge(local.defaults_boe_ec2.instance, {
+          instance_type = "m4.xlarge"
+        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+        tags = merge(local.defaults_boe_ec2.tags, {
+          oasys-national-reporting-environment = "t2"
+        })
+      })
     }
     baseline_ec2_autoscaling_groups = {
       test-web-asg = merge(local.defaults_web_ec2, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -50,21 +50,21 @@ locals {
           "/dev/sds"  = { type = "gp3", size = 100 }
         })
       })
-      t2-onr-boe-1-a = merge(local.defaults_boe_ec2, {
-        config = merge(local.defaults_boe_ec2.config, {
-          instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-          availability_zone = "${local.region}a"
-        })
-        instance = merge(local.defaults_boe_ec2.instance, {
-          instance_type = "m4.xlarge"
-        })
-        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
-        tags = merge(local.defaults_boe_ec2.tags, {
-          oasys-national-reporting-environment = "t2"
-        })
-      })
+      # t2-onr-boe-1-a = merge(local.defaults_boe_ec2, {
+      #   config = merge(local.defaults_boe_ec2.config, {
+      #     instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #     availability_zone = "${local.region}a"
+      #   })
+      #   instance = merge(local.defaults_boe_ec2.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+      #   tags = merge(local.defaults_boe_ec2.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #   })
+      # })
     }
     baseline_ec2_autoscaling_groups = {
       test-web-asg = merge(local.defaults_web_ec2, {
@@ -87,29 +87,31 @@ locals {
         })
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
       })
-      # test-boe-asg = merge(local.defaults_boe_ec2, {
-      #   config = merge(local.defaults_boe_ec2.config, {
-      #     instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #     availability_zone = "${local.region}a"
-      #   })
-      #   instance = merge(local.defaults_boe_ec2.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
-      #     args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
-      #       branch = "onr/DSOS-2682/onr-boe-install"
-      #     })
-      #   })
-      #   autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
-      #     desired_capacity = 0
-      #   })
-      #   autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
-      #   tags = merge(local.defaults_boe_ec2.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #   })
-      # })
+      # TODO: this is just for testing, remove when not needed
+      t2-test-boe-asg = merge(local.defaults_boe_ec2, {
+        config = merge(local.defaults_boe_ec2.config, {
+          instance_profile_policies = setunion(local.defaults_boe_ec2.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+          availability_zone = "${local.region}a"
+        })
+        instance = merge(local.defaults_boe_ec2.instance, {
+          instance_type = "m4.xlarge"
+        })
+        user_data_cloud_init = module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible
+        # user_data_cloud_init = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible, {
+        #   args = merge(module.baseline_presets.ec2_instance.user_data_cloud_init.ssm_agent_and_ansible.args, {
+        #     branch = "onr/DSOS-2682/onr-boe-install"
+        #   })
+        # })
+        autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default, {
+          desired_capacity = 0
+        })
+        autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
+        tags = merge(local.defaults_boe_ec2.tags, {
+          oasys-national-reporting-environment = "t2"
+        })
+      })
       test-bods-asg = merge(local.defaults_bods_ec2, {
         config = merge(local.defaults_bods_ec2.config, {
           availability_zone = "${local.region}a"


### PR DESCRIPTION
- add t2 onr boe instance not as an asg, but commented out for now
- re-enable an onr boe asg instance with revised name for making sure all the ansible runs okay!

Basically want to test all the ansible first before I finally switch to a non-asg instance