### PR TITLE
Revert "Update hashicorp/cloudinit requirement from ~> 2.2.0 to ~> 2.3.3 in /terraform/environments/hmpps-domain-services"

### DIFF
--- a/terraform/modules/rds_instance/versions.tf
+++ b/terraform/modules/rds_instance/versions.tf
@@ -6,7 +6,7 @@ terraform {
       configuration_aliases = [aws.core-vpc]
     }
     cloudinit = {
-      version = "~> 2.3.3"
+      version = "~> 2.2.0"
       source  = "hashicorp/cloudinit"
     }
 


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform-environments#5021