### PR TITLE
Updated SSL policy used in listeners to use secure TLS protocols

### DIFF
--- a/terraform/environments/cooker/main.tf
+++ b/terraform/environments/cooker/main.tf
@@ -447,7 +447,7 @@ resource "aws_lb_listener" "external" {
   load_balancer_arn = aws_lb.external.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate.external.arn
 
   default_action {
@@ -587,7 +587,7 @@ resource "aws_lb_listener" "inner" {
   load_balancer_arn = aws_lb.inner.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate.inner.arn
 
   default_action {

--- a/terraform/environments/example/loadbalancer.tf
+++ b/terraform/environments/example/loadbalancer.tf
@@ -97,7 +97,7 @@ resource "aws_lb_listener" "external" {
   port              = local.application_data.accounts[local.environment].server_port
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol
   #checkov:skip=CKV_AWS_2: "protocol for lb set in application_variables"
-  ssl_policy = local.application_data.accounts[local.environment].lb_listener_protocol == "HTTP" ? "" : "ELBSecurityPolicy-2016-08"
+  ssl_policy = local.application_data.accounts[local.environment].lb_listener_protocol == "HTTP" ? "" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
   #checkov:skip=CKV_AWS_103: "ssl_policy for lb set in application_variables"
 
   default_action {

--- a/terraform/environments/sprinkler/main.tf
+++ b/terraform/environments/sprinkler/main.tf
@@ -476,7 +476,7 @@ resource "aws_lb_listener" "external" {
   load_balancer_arn = aws_lb.external.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate.external.arn
 
   default_action {
@@ -633,7 +633,7 @@ resource "aws_lb_listener" "inner" {
   load_balancer_arn = aws_lb.inner.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate.inner.arn
 
   default_action {


### PR DESCRIPTION
I noted that a number of MP-provided environments in this repository are not using secure TLS policies. This PR updates the configuration to use secure listeners. From some investigation, it appears that when a policy is not specified in Terraform, it defaults to using `ELBSecurityPolicy-2016-08` as discussed [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies).