### PR TITLE
Nomis: DSOS-2792: post migration tidy up

### DIFF
--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -12,6 +12,11 @@ locals {
       weblogic-passwords = { description = "passwords available to weblogic servers" }
     }
   }
+  database_weblogic_secretsmanager_secrets = {
+    secrets = {
+      weblogic-passwords = { description = "passwords available to weblogic servers" }
+    }
+  }
   database_mis_secretsmanager_secrets = {
     secrets = {
       passwords      = { description = "database passwords" }

--- a/terraform/environments/nomis/locals_database.tf
+++ b/terraform/environments/nomis/locals_database.tf
@@ -126,7 +126,6 @@ locals {
 
     instance = merge(module.baseline_presets.ec2_instance.instance.default, {
       instance_type                = "r6i.xlarge"
-      disable_api_termination      = true
       metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
       monitoring                   = true
       vpc_security_group_ids       = ["data-db"]

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -270,6 +270,9 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
+        instance = merge(local.database_ec2.instance, {
+          disable_api_termination = true
+        })
         tags = merge(local.database_ec2.tags, {
           nomis-environment   = "dev"
           description         = "syscon nomis dev and qa databases"
@@ -287,7 +290,8 @@ locals {
           ])
         })
         instance = merge(local.weblogic_ec2.instance, {
-          instance_type = "t2.large"
+          disable_api_termination = true
+          instance_type           = "t2.large"
           tags = {
             backup-plan = "daily-and-weekly"
           }
@@ -316,7 +320,8 @@ locals {
           ])
         })
         instance = merge(local.weblogic_ec2.instance, {
-          instance_type = "t2.large"
+          disable_api_termination = true
+          instance_type           = "t2.large"
           tags = {
             backup-plan = "daily-and-weekly"
           }
@@ -345,7 +350,8 @@ locals {
           ])
         })
         instance = merge(local.weblogic_ec2.instance, {
-          instance_type = "t2.large"
+          disable_api_termination = true
+          instance_type           = "t2.large"
           tags = {
             backup-plan = "daily-and-weekly"
           }
@@ -381,8 +387,9 @@ locals {
           "/dev/sdc" = { label = "app", size = 100, type = "gp3" } # /u02
         }
         instance = merge(module.baseline_presets.ec2_instance.instance.default, {
-          instance_type          = "t3.medium"
-          vpc_security_group_ids = ["private-web"]
+          disable_api_termination = true
+          instance_type           = "t3.medium"
+          vpc_security_group_ids  = ["private-web"]
           tags = {
             backup-plan = "daily-and-weekly"
           }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -214,7 +214,8 @@ locals {
           flash = { total_size = 1000 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.2xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.2xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "preprod"
@@ -243,12 +244,13 @@ locals {
           flash = { total_size = 1000 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.2xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.2xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "preprod"
           description       = "Disaster-Recovery/High-Availability pre-production database for CNOMPP"
-          oracle-sids       = "" # TODO
+          oracle-sids       = "PPCNOMHA"
         })
       })
 
@@ -274,7 +276,8 @@ locals {
           flash = { total_size = 1000 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.2xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.2xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "preprod"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -21,7 +21,7 @@ locals {
   # config for load balancer maintenance rule
   production_lb_maintenance_message = {
     maintenance_title   = "Prison-NOMIS Maintenance Window"
-    maintenance_message = "Prison-NOMIS is currently unavailable due to planned maintenance. Please try again after 00:00"
+    maintenance_message = "Prison-NOMIS is currently unavailable due to planned maintenance. Please try again later"
   }
 
   # baseline config
@@ -118,18 +118,15 @@ locals {
 
     baseline_secretsmanager_secrets = {
       "/oracle/weblogic/prod"     = local.weblogic_secretsmanager_secrets
-      "/oracle/database/PDCNOM"   = local.database_nomis_secretsmanager_secrets
+      "/oracle/database/PCNOM"    = local.database_weblogic_secretsmanager_secrets # weblogic oracle-db-name set to PCNOM
+      # PROD ACTIVE
+      "/oracle/database/PDCNOM"   = local.database_secretsmanager_secrets
       "/oracle/database/PDNDH"    = local.database_secretsmanager_secrets
       "/oracle/database/PDTRDAT"  = local.database_secretsmanager_secrets
       "/oracle/database/PDCNMAUD" = local.database_secretsmanager_secrets
       "/oracle/database/PDMIS"    = local.database_mis_secretsmanager_secrets
-      "/oracle/database/PCNOM"    = local.database_nomis_secretsmanager_secrets
-      "/oracle/database/PCNOMHA"  = local.database_secretsmanager_secrets
-      "/oracle/database/PNDH"     = local.database_secretsmanager_secrets
-      "/oracle/database/PTRDAT"   = local.database_secretsmanager_secrets
-      "/oracle/database/PCNMAUD"  = local.database_secretsmanager_secrets
-      "/oracle/database/PMIS"     = local.database_mis_secretsmanager_secrets
-      "/oracle/database/DRCNOM"   = local.database_nomis_secretsmanager_secrets
+      # PROD STANDBY
+      "/oracle/database/DRCNOM"   = local.database_secretsmanager_secrets
       "/oracle/database/DRNDH"    = local.database_secretsmanager_secrets
       "/oracle/database/DRTRDAT"  = local.database_secretsmanager_secrets
       "/oracle/database/DRCNMAUD" = local.database_secretsmanager_secrets
@@ -442,7 +439,7 @@ locals {
 
           https = merge(local.weblogic_lb_listeners.https, {
             alarm_target_group_names = [
-              # "prod-nomis-web-a-http-7777",
+              # "prod-nomis-web-a-http-7777",
               "prod-nomis-web-b-http-7777",
             ]
             # /home/oracle/admin/scripts/lb_maintenance_mode.sh script on

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -220,7 +220,7 @@ locals {
 
     baseline_ec2_instances = {
       prod-nomis-xtag-a = merge(local.xtag_ec2, {
-        # cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
+        cloudwatch_metric_alarms = local.xtag_cloudwatch_metric_alarms
         config = merge(local.xtag_ec2.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "${local.region}a"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -117,8 +117,8 @@ locals {
     }
 
     baseline_secretsmanager_secrets = {
-      "/oracle/weblogic/prod"     = local.weblogic_secretsmanager_secrets
-      "/oracle/database/PCNOM"    = local.database_weblogic_secretsmanager_secrets # weblogic oracle-db-name set to PCNOM
+      "/oracle/weblogic/prod"  = local.weblogic_secretsmanager_secrets
+      "/oracle/database/PCNOM" = local.database_weblogic_secretsmanager_secrets # weblogic oracle-db-name set to PCNOM
       # PROD ACTIVE
       "/oracle/database/PDCNOM"   = local.database_secretsmanager_secrets
       "/oracle/database/PDNDH"    = local.database_secretsmanager_secrets
@@ -276,11 +276,7 @@ locals {
       prod-nomis-db-1-b = merge(local.database_ec2, {
         cloudwatch_metric_alarms = merge(
           local.database_ec2_cloudwatch_metric_alarms.standard,
-          local.database_ec2_cloudwatch_metric_alarms.db_connected, {
-            high-memory-usage = merge(local.database_ec2_cloudwatch_metric_alarms.standard["high-memory-usage"], {
-              threshold = "99" # Sandhya confirmed this is OK while in DR mode
-            })
-          }
+          local.database_ec2_cloudwatch_metric_alarms.db_connected,
         )
         config = merge(local.database_ec2.config, {
           ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -265,7 +265,8 @@ locals {
           flash = { total_size = 1000, iops = 5000, throughput = 500 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.4xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "prod"
@@ -294,7 +295,8 @@ locals {
           flash = { total_size = 1000, iops = 5000, throughput = 500 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.4xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "prod"
@@ -352,7 +354,8 @@ locals {
           flash = { total_size = 1000, iops = 5000, throughput = 500 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.4xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment = "prod"
@@ -384,7 +387,8 @@ locals {
           flash = { total_size = 1000, iops = 5000, throughput = 500 }
         })
         instance = merge(local.database_ec2.instance, {
-          instance_type = "r6i.4xlarge"
+          disable_api_termination = true
+          instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment  = "prod"

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -415,6 +415,9 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
+        instance = merge(local.database_ec2.instance, {
+          disable_api_termination = true
+        })
         tags = merge(local.database_ec2.tags, {
           nomis-environment   = "t1"
           description         = "T1 NOMIS database"
@@ -444,6 +447,9 @@ locals {
         ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
           data  = { total_size = 700 }
           flash = { total_size = 50 }
+        })
+        instance = merge(local.database_ec2.instance, {
+          disable_api_termination = true
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment   = "t1"
@@ -498,6 +504,9 @@ locals {
           data  = { total_size = 500 }
           flash = { total_size = 50 }
         })
+        instance = merge(local.database_ec2.instance, {
+          disable_api_termination = true
+        })
         tags = merge(local.database_ec2.tags, {
           nomis-environment   = "t2"
           description         = "T2 NOMIS database"
@@ -548,6 +557,9 @@ locals {
         ebs_volume_config = merge(local.database_ec2.ebs_volume_config, {
           data  = { total_size = 2500 }
           flash = { total_size = 500 }
+        })
+        instance = merge(local.database_ec2.instance, {
+          disable_api_termination = true
         })
         tags = merge(local.database_ec2.tags, {
           nomis-environment   = "t3"


### PR DESCRIPTION
Remove unused secrets
Reverted high-memory alarm to default for prod-nomis-db-1-b
Reverted maintenance message to a more generic message