### PR TITLE
Update_Lambda_Function_200524_4

### DIFF
--- a/terraform/environments/ppud/lambda.tf
+++ b/terraform/environments/ppud/lambda.tf
@@ -274,6 +274,7 @@ resource "aws_cloudwatch_event_target" "trigger_lambda_terminate_cpu_process_uat
   arn       = aws_lambda_function.terraform_lambda_func_terminate_cpu_process_uat[0].arn
 }
 
+/*
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_process_uat" {
   count         = local.is-preproduction == true ? 1 : 0
   statement_id  = "AllowExecutionFromCloudWatch"
@@ -282,14 +283,15 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.terminate_cpu_process_uat[0].arn
 }
+*/
 
-resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_process_uat_2" {
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_process_uat" {
   count         = local.is-preproduction == true ? 1 : 0
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.terraform_lambda_func_terminate_cpu_process_uat[0].function_name
   principal     = "lambda.alarms.cloudwatch.amazonaws.com"
-  source_arn    = "arn:aws:cloudwatch:eu-west-2:172753231260:alarm:CPU-High-i-0c687c72e4bc46755"
+  source_arn    = "arn:aws:cloudwatch:eu-west-2:172753231260:alarm:*"
 }
 
 # Lambda functions to terminate cpu process


### PR DESCRIPTION
Correction to lambda permission update (can't have duplicate AllowExecutionFromCloudWatch statements). 