### PR TITLE
upgrade Equip SSL policy to support modern TLS versions

### DIFF
--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -150,7 +150,7 @@ resource "aws_lb_listener" "lb_listener_https" {
   load_balancer_arn = aws_lb.citrix_alb.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = data.aws_acm_certificate.equip_cert.arn
 
   default_action {

--- a/terraform/environments/equip/alb.tf
+++ b/terraform/environments/equip/alb.tf
@@ -10,7 +10,7 @@ data "aws_acm_certificate" "equip_cert" {
   most_recent = true
 }
 
-#Load balancer needs to be publically accessible
+#Load balancer needs to be publicly accessible
 #tfsec:ignore:aws-elb-alb-not-public
 resource "aws_lb" "citrix_alb" {
 


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/modernisation-platform-security/issues/4, it was identified that the Equip ALB listener is not using the recommended TLS policy.

This PR amends the `ssl_policy` value, adding compatibility with TLS 1.3 and removing compatibility with some older cipher suites.