### PR TITLE
Update_Lambda_Function_210524

### DIFF
--- a/terraform/environments/ppud/lambda.tf
+++ b/terraform/environments/ppud/lambda.tf
@@ -253,38 +253,6 @@ data "archive_file" "zip_the_terminate_cpu_process_code_dev" {
 # Lambda Function to Terminate MS Word Processes - UAT
 ######################################################
 
-# Eventbridge rules to terminate cpu process
-
-resource "aws_cloudwatch_event_rule" "terminate_cpu_process_uat" {
-  count         = local.is-preproduction == true ? 1 : 0
-  name          = "terminate_cpu_process_uat"
-  description   = "Terminates a CPU process uat"
-  event_pattern = <<EOF
-{
-  "source": ["aws.ec2"],
-  "detail-type": ["EC2 Instance High CPU Utilisation"]
-  }
-EOF
-}
-
-resource "aws_cloudwatch_event_target" "trigger_lambda_terminate_cpu_process_uat" {
-  count     = local.is-preproduction == true ? 1 : 0
-  rule      = aws_cloudwatch_event_rule.terminate_cpu_process_uat[0].name
-  target_id = "terminate_cpu_process_uat"
-  arn       = aws_lambda_function.terraform_lambda_func_terminate_cpu_process_uat[0].arn
-}
-
-/*
-resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_process_uat" {
-  count         = local.is-preproduction == true ? 1 : 0
-  statement_id  = "AllowExecutionFromCloudWatch"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.terraform_lambda_func_terminate_cpu_process_uat[0].function_name
-  principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.terminate_cpu_process_uat[0].arn
-}
-*/
-
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_process_uat" {
   count         = local.is-preproduction == true ? 1 : 0
   statement_id  = "AllowExecutionFromCloudWatch"
@@ -293,8 +261,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_
   principal     = "lambda.alarms.cloudwatch.amazonaws.com"
   source_arn    = "arn:aws:cloudwatch:eu-west-2:172753231260:alarm:*"
 }
-
-# Lambda functions to terminate cpu process
 
 resource "aws_lambda_function" "terraform_lambda_func_terminate_cpu_process_uat" {
   count         = local.is-preproduction == true ? 1 : 0

--- a/terraform/environments/ppud/terminate_cpu_process/terminate_cpu_process_dev.py
+++ b/terraform/environments/ppud/terminate_cpu_process/terminate_cpu_process_dev.py
@@ -8,7 +8,7 @@ def lambda_handler(event, context):
     ssm = boto3.client("ssm")
     InstanceId = "i-0b5c31ecda24ebc04"
 
-    response = ssm.send_command(InstanceIds=[InstanceId],DocumentName="AWS-RunPowerShellScript", Parameters={"commands": ['& "C:\\Scripts\\Terminate_Word.ps1"']})
+    response = ssm.send_command(InstanceIds=[InstanceId],DocumentName="AWS-RunPowerShellScript", Parameters={"commands": ['& "C:\\Scripts\\DEV_Terminate_Word.ps1"']})
     command_id = response["Command"]["CommandId"]
     time.sleep(3)
 

--- a/terraform/environments/ppud/terminate_cpu_process/terminate_cpu_process_uat.py
+++ b/terraform/environments/ppud/terminate_cpu_process/terminate_cpu_process_uat.py
@@ -8,7 +8,7 @@ def lambda_handler(event, context):
     ssm = boto3.client("ssm")
     InstanceId = "i-0c687c72e4bc46755"
 
-    response = ssm.send_command(InstanceIds=[InstanceId],DocumentName="AWS-RunPowerShellScript", Parameters={"commands": ['& "C:\\Scripts\\Terminate_Word.ps1"']})
+    response = ssm.send_command(InstanceIds=[InstanceId],DocumentName="AWS-RunPowerShellScript", Parameters={"commands": ['& "C:\\Scripts\\UAT_Terminate_Word.ps1"']})
     command_id = response["Command"]["CommandId"]
     time.sleep(3)
 


### PR DESCRIPTION
Updated the python script paths and removed the UAT eventbridge rule. To test calling the lambda function directly from cloudwatch alarms.