### PR TITLE
update dts-legacy .net services elb policy

### DIFF
--- a/terraform/environments/dacp/load_balancer.tf
+++ b/terraform/environments/dacp/load_balancer.tf
@@ -250,7 +250,7 @@ resource "aws_lb_listener" "dacp_lb" {
   load_balancer_arn = aws_lb.dacp_lb.arn
   port              = local.application_data.accounts[local.environment].server_port_2
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol_2
-  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-2016-08"
+  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     type             = "forward"

--- a/terraform/environments/ncas/load_balancer.tf
+++ b/terraform/environments/ncas/load_balancer.tf
@@ -252,7 +252,7 @@ resource "aws_lb_listener" "ncas_lb" {
   load_balancer_arn = aws_lb.ncas_lb.arn
   port              = local.application_data.accounts[local.environment].server_port_2
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol_2
-  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-2016-08"
+  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     type             = "forward"

--- a/terraform/environments/pra-register/load_balancer.tf
+++ b/terraform/environments/pra-register/load_balancer.tf
@@ -251,7 +251,7 @@ resource "aws_lb_listener" "pra_lb" {
   load_balancer_arn = aws_lb.pra_lb.arn
   port              = local.application_data.accounts[local.environment].server_port_2
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol_2
-  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-2016-08"
+  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     type             = "forward"

--- a/terraform/environments/tipstaff/load_balancer.tf
+++ b/terraform/environments/tipstaff/load_balancer.tf
@@ -277,7 +277,7 @@ resource "aws_lb_listener" "tipstaff_lb" {
   load_balancer_arn = aws_lb.tipstaff_lb.arn
   port              = local.application_data.accounts[local.environment].server_port_2
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol_2
-  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-2016-08"
+  ssl_policy        = local.application_data.accounts[local.environment].lb_listener_protocol_2 == "HTTP" ? "" : "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
update LB to recommended tls security policy on DTS Legacy apps (dacp, ncas, pra, tipstaff)