### PR TITLE
DSOS-2797: cloudwatch metric sharing into baseline

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -104,8 +104,24 @@ locals {
   baseline_key_pairs                = {}
   baseline_kms_grants               = {}
   baseline_lbs                      = {}
-  baseline_route53_resolvers        = {}
-  baseline_route53_zones            = {}
+
+  baseline_oam_sinks = {
+    "CloudWatchMetricOamSink" = {
+      source_account_names = [
+        "corporate-staff-rostering-${local.environment}",
+        "hmpps-domain-services-${local.environment}",
+        "nomis-${local.environment}",
+        "nomis-combined-reporting-${local.environment}",
+        "nomis-data-hub-${local.environment}",
+        "oasys-${local.environment}",
+        "oasys-national-reporting-${local.environment}",
+        "planetfm-${local.environment}",
+      ]
+    }
+  }
+
+  baseline_route53_resolvers = {}
+  baseline_route53_zones     = {}
 
   baseline_s3_buckets = {
     s3-bucket = {

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -107,6 +107,7 @@ locals {
 
   baseline_oam_sinks = {
     "CloudWatchMetricOamSink" = {
+      resource_types = ["AWS::CloudWatch::Metric"]
       source_account_names = [
         "corporate-staff-rostering-${local.environment}",
         "hmpps-domain-services-${local.environment}",

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -123,6 +123,11 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_lbs", {})
   )
 
+  oam_sinks = merge(
+    local.baseline_oam_sinks,
+    lookup(local.baseline_environment_config, "baseline_oam_sinks", {})
+  )
+
   route53_resolvers = merge(
     module.baseline_presets.route53_resolvers,
     local.baseline_route53_resolvers,

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -30,7 +30,7 @@ locals {
     enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters   = ["hmpps-oem-${local.environment}"]
-    cloudwatch_metric_oam_links                  = ["hmpps-oem-${local.environment}"]
+    #cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
     }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -30,6 +30,7 @@ locals {
     enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters   = ["hmpps-oem-${local.environment}"]
+    cloudwatch_metric_oam_links                  = ["hmpps-oem-${local.environment}"]
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
     }

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -29,6 +29,7 @@ locals {
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_ec2_user_keypair                      = true
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
+    cloudwatch_metric_oam_links_ssm_parameters   = ["hmpps-oem-${local.environment}"]
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]
     }
@@ -61,6 +62,8 @@ locals {
   baseline_key_pairs                = {}
   baseline_kms_grants               = {}
   baseline_lbs                      = {}
+  baseline_oam_links                = {}
+  baseline_oam_sinks                = {}
   baseline_route53_resolvers        = {}
 
   baseline_route53_zones = {

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -138,6 +138,17 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_lbs", {})
   )
 
+  oam_links = merge(
+    module.baseline_presets.oam_links,
+    local.baseline_oam_links,
+    lookup(local.baseline_environment_config, "baseline_oam_links", {})
+  )
+
+  oam_sinks = merge(
+    local.baseline_oam_sinks,
+    lookup(local.baseline_environment_config, "baseline_oam_sinks", {})
+  )
+
   route53_resolvers = merge(
     module.baseline_presets.route53_resolvers,
     local.baseline_route53_resolvers,

--- a/terraform/modules/baseline/oam.tf
+++ b/terraform/modules/baseline/oam.tf
@@ -40,7 +40,7 @@
 resource "aws_oam_link" "this" {
   for_each = var.oam_links
 
-  label_template  = each.key
+  label_template  = each.value.label_template
   resource_types  = each.value.resource_types
   sink_identifier = aws_ssm_parameter.placeholder[each.value.sink_identifier_ssm_parameter_name].value
 

--- a/terraform/modules/baseline/oam.tf
+++ b/terraform/modules/baseline/oam.tf
@@ -1,0 +1,49 @@
+# OAM = AWS CloudWatch Observability Access Manager
+# Create a link in the account which sends metrics
+# Create a sink in the account which receive metrics
+
+resource "aws_oam_link" "this" {
+  for_each = var.oam_links
+
+  label_template  = each.key
+  resource_types  = each.value.resource_types
+  sink_identifier = aws_ssm_parameter.placeholder[each.value.sink_identifier_ssm_parameter_name].value
+
+  tags = merge(local.tags, {
+    Name = each.key
+  })
+}
+
+resource "aws_oam_sink" "this" {
+  for_each = var.oam_sinks
+
+  name = each.key
+  tags = merge(local.tags, {
+    Name = each.key
+  })
+}
+
+resource "aws_oam_sink_policy" "monitoring_account_oam_sink_policy" {
+  for_each = var.oam_sinks
+
+  sink_identifier = aws_oam_sink.this[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = [for name in each.value.source_account_names : var.environment.account_ids[name]]
+        }
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "oam:ResourceTypes" = each.value.resource_types
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -84,6 +84,16 @@ output "lbs" {
   }
 }
 
+output "oam_links" {
+  description = "map of aws_oam_link resources corresponding to var.oam_links"
+  value       = aws_oam_link.this
+}
+
+output "oam_sinks" {
+  description = "map of aws_oam_sink resources corresponding to var.oam_sinks"
+  value       = aws_oam_sink.this
+}
+
 output "route53_resolvers_security_group" {
   description = "security group used for route53 resolvers"
   value       = length(aws_security_group.route53_resolver) != 0 ? aws_security_group.route53_resolver[0] : null

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -827,6 +827,7 @@ variable "kms_grants" {
 variable "oam_links" {
   description = "map of aws_oam_link resources to create where the map key is the label_template and tag.Name"
   type = map(object({
+    label_template                     = string
     resource_types                     = list(string) # e.g. ["AWS::CloudWatch::Metric"]
     sink_identifier_ssm_parameter_name = string
   }))

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -827,7 +827,7 @@ variable "kms_grants" {
 variable "oam_links" {
   description = "map of aws_oam_link resources to create where the map key is the label_template and tag.Name"
   type = map(object({
-    resource_types                     = optional(list(string), ["AWS::CloudWatch::Metric"])
+    resource_types                     = list(string) # e.g. ["AWS::CloudWatch::Metric"]
     sink_identifier_ssm_parameter_name = string
   }))
   default = {}
@@ -836,7 +836,7 @@ variable "oam_links" {
 variable "oam_sinks" {
   description = "map of aws_oam_sink and ows_oam_sink_policy resources to create where the map key is the sink name"
   type = map(object({
-    resource_types       = optional(list(string), ["AWS::CloudWatch::Metric"])
+    resource_types       = list(string) # e.g. ["AWS::CloudWatch::Metric"]
     source_account_names = list(string)
   }))
   default = {}

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -824,6 +824,24 @@ variable "kms_grants" {
   default = {}
 }
 
+variable "oam_links" {
+  description = "map of aws_oam_link resources to create where the map key is the label_template and tag.Name"
+  type = map(object({
+    resource_types                     = optional(list(string), ["AWS::CloudWatch::Metric"])
+    sink_identifier_ssm_parameter_name = string
+  }))
+  default = {}
+}
+
+variable "oam_sinks" {
+  description = "map of aws_oam_sink and ows_oam_sink_policy resources to create where the map key is the sink name"
+  type = map(object({
+    resource_types       = optional(list(string), ["AWS::CloudWatch::Metric"])
+    source_account_names = list(string)
+  }))
+  default = {}
+}
+
 variable "route53_resolvers" {
   description = "map of resolver endpoints and associated rules to configure, where map keys are the names of the resources.  The application name is automatically added as a prefix to the resource names"
   type = map(object({

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -8,6 +8,7 @@ locals {
     var.options.enable_image_builder ? ["EC2ImageBuilderDistributionCrossAccountRole"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
     var.options.enable_observability_platform_monitoring ? ["observability-platform"] : [],
+    try(length(var.options.cloudwatch_metric_oam_links), 0) != 0 ? ["CloudWatchCrossAccountSharingRole"] : [],
   ]))
 
   iam_roles = {
@@ -73,6 +74,22 @@ locals {
       policy_attachments = [
         "HmppsDomainSecretsPolicy",
         "BusinessUnitKmsCmkPolicy",
+      ]
+    }
+
+    CloudWatchCrossAccountSharingRole = {
+      assume_role_policy = [{
+        effect  = "Allow"
+        actions = ["sts:AssumeRole"]
+        principals = {
+          type        = "AWS"
+          identifiers = var.options.cloudwatch_metric_oam_links
+        }
+      }]
+      policy_attachments = [
+        "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
+        "arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess",
+        "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
       ]
     }
 

--- a/terraform/modules/baseline_presets/oam.tf
+++ b/terraform/modules/baseline_presets/oam.tf
@@ -1,0 +1,11 @@
+# CloudWatch Observability Access Manager
+# The sink ID is stored in an SSM parameter
+
+locals {
+  oam_links = {
+    for oam_link in coalesce(var.options.cloudwatch_metric_oam_links, []) : oam_link => {
+      resource_types                     = ["AWS::CloudWatch::Metric"]
+      sink_identifier_ssm_parameter_name = "/oam/${oam_link}"
+    }
+  }
+}

--- a/terraform/modules/baseline_presets/oam.tf
+++ b/terraform/modules/baseline_presets/oam.tf
@@ -4,6 +4,7 @@
 locals {
   oam_links = {
     for oam_link in coalesce(var.options.cloudwatch_metric_oam_links, []) : oam_link => {
+      label_template                     = var.environment.account_name
       resource_types                     = ["AWS::CloudWatch::Metric"]
       sink_identifier_ssm_parameter_name = "/oam/${oam_link}"
     }

--- a/terraform/modules/baseline_presets/oam.tf
+++ b/terraform/modules/baseline_presets/oam.tf
@@ -1,5 +1,5 @@
 # CloudWatch Observability Access Manager
-# The sink ID is stored in an SSM parameter
+# See baseline module oam.tf for documentation
 
 locals {
   oam_links = {

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -109,6 +109,11 @@ output "kms_grants" {
   }
 }
 
+output "oam_links" {
+  description = "Map of oam_links to create depending on options provided"
+  value       = local.oam_links
+}
+
 output "route53_resolver_rules" {
   description = "Map of route53 resolver rules depending on options provided"
   value       = local.route53_resolver_rules

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -25,7 +25,7 @@ locals {
     } } : {},
 
     # If db_backup_s3 enabled, create db_backups in all environments.
-    # Dev and Test can both access each other: Preprod can access prod but not vice-versa
+    # Dev and Test can both access each other: Preprod can access prod but not vice-versa
     var.options.db_backup_s3 && var.environment.environment == "production" && !var.options.db_backup_more_permissions ? { "prod-${var.environment.application_name}-db-backup-bucket-" = {
       bucket_policy_v2 = [
         local.s3_bucket_policies.PreprodReadOnlyAccessBucketPolicy,

--- a/terraform/modules/baseline_presets/ssm.tf
+++ b/terraform/modules/baseline_presets/ssm.tf
@@ -31,7 +31,7 @@ locals {
     length(local.account_names_for_account_ids_ssm_parameter) != 0 ? ["account"] : [],
     var.options.enable_azure_sas_token ? ["/azure"] : [],
     var.options.enable_ec2_cloud_watch_agent && fileexists(local.cloud_watch_windows_filename) ? ["cloud-watch-config"] : [],
-    try(length(var.options.cloudwatch_metric_oam_links), 0) != 0 ? ["/oam"] : [],
+    try(length(var.options.cloudwatch_metric_oam_links_ssm_parameters), 0) != 0 ? ["/oam"] : [],
   ])
 
   ssm_parameters = {
@@ -57,7 +57,7 @@ locals {
 
     "/oam" = {
       parameters = {
-        for oam_link in coalesce(var.options.cloudwatch_metric_oam_links, []) : oam_link => {
+        for oam_link in coalesce(var.options.cloudwatch_metric_oam_links_ssm_parameters, []) : oam_link => {
           description = "oam sink_identifier to use in aws_oam_link resource"
         }
       }

--- a/terraform/modules/baseline_presets/ssm.tf
+++ b/terraform/modules/baseline_presets/ssm.tf
@@ -31,6 +31,7 @@ locals {
     length(local.account_names_for_account_ids_ssm_parameter) != 0 ? ["account"] : [],
     var.options.enable_azure_sas_token ? ["/azure"] : [],
     var.options.enable_ec2_cloud_watch_agent && fileexists(local.cloud_watch_windows_filename) ? ["cloud-watch-config"] : [],
+    try(length(var.options.cloudwatch_metric_oam_links), 0) != 0 ? ["/oam"] : [],
   ])
 
   ssm_parameters = {
@@ -51,6 +52,14 @@ locals {
     "/azure" = {
       parameters = {
         sas_token = { description = "database backup storage account read-only sas token" }
+      }
+    }
+
+    "/oam" = {
+      parameters = {
+        for oam_link in coalesce(var.options.cloudwatch_metric_oam_links, []) : oam_link => {
+          description = "oam sink_identifier to use in aws_oam_link resource"
+        }
       }
     }
 

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -17,6 +17,7 @@ variable "options" {
     backup_plan_weekly_delete_after              = optional(number, 28)
     cloudwatch_log_groups                        = optional(list(string))
     cloudwatch_metric_alarms_default_actions     = optional(list(string))
+    cloudwatch_metric_oam_links                  = optional(list(string)) # list of account names
     enable_application_environment_wildcard_cert = optional(bool, false)
     enable_azure_sas_token                       = optional(bool, false)
     enable_offloc_sync                           = optional(bool, false)

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -17,7 +17,8 @@ variable "options" {
     backup_plan_weekly_delete_after              = optional(number, 28)
     cloudwatch_log_groups                        = optional(list(string))
     cloudwatch_metric_alarms_default_actions     = optional(list(string))
-    cloudwatch_metric_oam_links                  = optional(list(string)) # list of account names
+    cloudwatch_metric_oam_links_ssm_parameters   = optional(list(string))
+    cloudwatch_metric_oam_links                  = optional(list(string))
     enable_application_environment_wildcard_cert = optional(bool, false)
     enable_azure_sas_token                       = optional(bool, false)
     enable_offloc_sync                           = optional(bool, false)


### PR DESCRIPTION
Add cloudwatch OAM into baseline so can be easily applied across all accounts.