### PR TITLE
Adds tags for use by flexible schedule github workflow re issue 6709

### DIFF
--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -54,6 +54,8 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "development"
+          startup     = "0 8 * * *"
+          shutdown    = "0 20 * * *" 
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }
@@ -86,6 +88,8 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "development"
+          startup     = "30 8 * * *"
+          shutdown    = "30 20 * * *" 
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }


### PR DESCRIPTION
As per title, this adds two tags to each ec2 being created by one of the example templates for use by the flexible schedule workflow that is being created. 