### PR TITLE
Comments out macie temporarily due to dependencies with bucket names.

### DIFF
--- a/terraform/environments/example/macie.tf
+++ b/terraform/environments/example/macie.tf
@@ -1,24 +1,24 @@
-# Create macie account
+# # Create macie account
 
-resource "aws_macie2_account" "example" {
-  finding_publishing_frequency = "ONE_HOUR"
-  status                       = "ENABLED"
-}
+# resource "aws_macie2_account" "example" {
+#   finding_publishing_frequency = "ONE_HOUR"
+#   status                       = "ENABLED"
+# }
 
-# Now create a job
+# # Now create a job
 
-resource "aws_macie2_classification_job" "example" {
-  job_type = "ONE_TIME"
-  name     = "<an appropriate job name>"
-  s3_job_definition {
-    bucket_definitions {
-      account_id = local.environment_management.account_ids[terraform.workspace]
-      buckets = [
-        data.aws_s3_bucket.bucket1.id,
-        data.aws_s3_bucket.bucket2.id,
-        data.aws_s3_bucket.bucket3.id,
-      ]
-    }
-  }
-  depends_on = [aws_macie2_account.example]
-}
+# resource "aws_macie2_classification_job" "example" {
+#   job_type = "ONE_TIME"
+#   name     = "<an appropriate job name>"
+#   s3_job_definition {
+#     bucket_definitions {
+#       account_id = local.environment_management.account_ids[terraform.workspace]
+#       buckets = [
+#         data.aws_s3_bucket.bucket1.id,
+#         data.aws_s3_bucket.bucket2.id,
+#         data.aws_s3_bucket.bucket3.id,
+#       ]
+#     }
+#   }
+#   depends_on = [aws_macie2_account.example]
+# }


### PR DESCRIPTION
Comments out macie code temporarily as the data items have physical resource names which will change when recreated.