### PR TITLE
Amends MACIE s3 bucket name references and adds missing job_status flag.

### DIFF
--- a/terraform/environments/example/data.tf
+++ b/terraform/environments/example/data.tf
@@ -1,14 +1,14 @@
 #### This file can be used to store data specific to the member account ####
 
 # For macie code
-# data "aws_s3_bucket" "bucket1" {
-#   bucket = "bastion-example-example-development-jxaebg"
-# }
+data "aws_s3_bucket" "bucket1" {
+  bucket = module.bastion_linux.bastion_s3_bucket.bucket.id
+}
 
-# data "aws_s3_bucket" "bucket2" {
-#   bucket = "config-20220505080423816000000003"
-# }
+data "aws_s3_bucket" "bucket2" {
+  bucket = "config-20220505080423816000000003"
+}
 
-# data "aws_s3_bucket" "bucket3" {
-#   bucket = "s3-bucket-example20240430100555519600000006"
-# }
+data "aws_s3_bucket" "bucket3" {
+  bucket = module.s3-bucket.bucket.id
+}

--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -54,8 +54,8 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "development"
-          startup     = "0 8 * * *"
-          shutdown    = "0 20 * * *" 
+          flexi-startup     = "8am"
+          flexi-shutdown    = "6pm" 
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }
@@ -88,8 +88,8 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "development"
-          startup     = "30 8 * * *"
-          shutdown    = "30 20 * * *" 
+          flexi-startup     = "9am"
+          flexi-shutdown    = "7pm" 
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }

--- a/terraform/environments/example/macie.tf
+++ b/terraform/environments/example/macie.tf
@@ -20,6 +20,6 @@ resource "aws_macie2_classification_job" "example" {
       ]
     }
   }
-  job_status = "USER_PAUSED"
+  job_status = "RUNNING"
   depends_on = [aws_macie2_account.example]
 }

--- a/terraform/environments/example/macie.tf
+++ b/terraform/environments/example/macie.tf
@@ -20,6 +20,6 @@ resource "aws_macie2_classification_job" "example" {
       ]
     }
   }
-  job_status = "CANCELLED"
+  job_status = "USER_PAUSED"
   depends_on = [aws_macie2_account.example]
 }

--- a/terraform/environments/example/macie.tf
+++ b/terraform/environments/example/macie.tf
@@ -1,24 +1,25 @@
-# # Create macie account
+# Create macie account
 
-# resource "aws_macie2_account" "example" {
-#   finding_publishing_frequency = "ONE_HOUR"
-#   status                       = "ENABLED"
-# }
+resource "aws_macie2_account" "example" {
+  finding_publishing_frequency = "ONE_HOUR"
+  status                       = "ENABLED"
+}
 
-# # Now create a job
+# Now create a job
 
-# resource "aws_macie2_classification_job" "example" {
-#   job_type = "ONE_TIME"
-#   name     = "<an appropriate job name>"
-#   s3_job_definition {
-#     bucket_definitions {
-#       account_id = local.environment_management.account_ids[terraform.workspace]
-#       buckets = [
-#         data.aws_s3_bucket.bucket1.id,
-#         data.aws_s3_bucket.bucket2.id,
-#         data.aws_s3_bucket.bucket3.id,
-#       ]
-#     }
-#   }
-#   depends_on = [aws_macie2_account.example]
-# }
+resource "aws_macie2_classification_job" "example" {
+  job_type = "ONE_TIME"
+  name     = "<an appropriate job name>"
+  s3_job_definition {
+    bucket_definitions {
+      account_id = local.environment_management.account_ids[terraform.workspace]
+      buckets = [
+        data.aws_s3_bucket.bucket1.id,
+        data.aws_s3_bucket.bucket2.id,
+        data.aws_s3_bucket.bucket3.id,
+      ]
+    }
+  }
+  job_status = "CANCELLED"
+  depends_on = [aws_macie2_account.example]
+}


### PR DESCRIPTION
This fixes two issues identified when rebuilding example:
- job_status is a required parameter that is incorrectly stated as optional in the documentation. See bug https://github.com/hashicorp/terraform-provider-aws/issues/20726.
- Amends two of the data items that reference s3 bucket names to use terraform logical names.

Note that that the apply error for an existing ec2 security group occurs which relates to a fixed bug which likely was amended prior to this rebuild. This will require fixing in a separate ticket.

Error: [WARN] A duplicate Security Group rule was found on (sg-02e8df8703e730ebf). This may be
│ a side effect of a now-fixed Terraform issue causing two security groups with
│ identical attributes but different source_security_group_ids to overwrite each
│ other in the state. See https://github.com/hashicorp/terraform/pull/[23](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/9221292004/job/25370071413#step:10:24)76 for more
│ information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: 10.26.16.0/21, TCP, from port: 443, to port: 443, ALLOW" already exists
│ 	status code: 400, request id: 44ceb994-2906-4788-be0b-dddd164cd8aa
│ 
│   with aws_security_group_rule.ingress_traffic["TCP_443"],
│   on ec2.tf line 47, in resource "aws_security_group_rule" "ingress_traffic":
│   47: resource "aws_security_group_rule" "ingress_traffic" {