### PR TITLE
DPR2-720 switch from sid to service name

### DIFF
--- a/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
+++ b/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
@@ -1,7 +1,7 @@
 locals {
   nomis_host              = jsondecode(data.aws_secretsmanager_secret_version.nomis.secret_string)["endpoint"]
   nomis_service_name      = jsondecode(data.aws_secretsmanager_secret_version.nomis.secret_string)["db_name"]
-  connection_string_nomis = "oracle://jdbc:oracle:thin:$${${aws_secretsmanager_secret.nomis_athena_federated.name}}@//${local.nomis_host}:1521/${local.nomis_service_name}"
+  connection_string_nomis = "oracle://jdbc:oracle:thin:$${${aws_secretsmanager_secret.nomis.name}}@//${local.nomis_host}:1521/${local.nomis_service_name}"
 }
 
 module "athena_federated_query_connector_oracle" {
@@ -10,7 +10,7 @@ module "athena_federated_query_connector_oracle" {
   connector_jar_bucket_key              = "third-party/athena-connectors/athena-oracle-2022.47.1.jar"
   connector_jar_bucket_name             = module.s3_artifacts_store.bucket_id
   spill_bucket_name                     = module.s3_working_bucket.bucket_id
-  nomis_credentials_secret_arn          = aws_secretsmanager_secret.nomis_athena_federated.arn
+  credentials_secret_arns                = [aws_secretsmanager_secret.nomis.arn]
   project_prefix                        = local.project
   account_id                            = local.account_id
   region                                = local.account_region

--- a/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
+++ b/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
@@ -1,7 +1,7 @@
 locals {
   nomis_host              = jsondecode(data.aws_secretsmanager_secret_version.nomis.secret_string)["endpoint"]
-  nomis_sid               = try(jsondecode(data.aws_secretsmanager_secret_version.nomis_athena_federated.secret_string)["sid"], "")
-  connection_string_nomis = "oracle://jdbc:oracle:thin:$${${aws_secretsmanager_secret.nomis_athena_federated.name}}@${local.nomis_host}:1521:${local.nomis_sid}"
+  nomis_service_name      = jsondecode(data.aws_secretsmanager_secret_version.nomis.secret_string)["db_name"]
+  connection_string_nomis = "oracle://jdbc:oracle:thin:$${${aws_secretsmanager_secret.nomis_athena_federated.name}}@//${local.nomis_host}:1521/${local.nomis_service_name}"
 }
 
 module "athena_federated_query_connector_oracle" {

--- a/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
+++ b/terraform/environments/digital-prison-reporting/athena_federated_queries.tf
@@ -10,7 +10,7 @@ module "athena_federated_query_connector_oracle" {
   connector_jar_bucket_key              = "third-party/athena-connectors/athena-oracle-2022.47.1.jar"
   connector_jar_bucket_name             = module.s3_artifacts_store.bucket_id
   spill_bucket_name                     = module.s3_working_bucket.bucket_id
-  credentials_secret_arns                = [aws_secretsmanager_secret.nomis.arn]
+  credentials_secret_arns               = [aws_secretsmanager_secret.nomis.arn]
   project_prefix                        = local.project
   account_id                            = local.account_id
   region                                = local.account_region

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -16,19 +16,6 @@ data "aws_secretsmanager_secret_version" "nomis" {
   depends_on = [aws_secretsmanager_secret.nomis]
 }
 
-# Nomis Source Secrets in format required by Athena Federated Query
-data "aws_secretsmanager_secret" "nomis_athena_federated" {
-  name = aws_secretsmanager_secret.nomis_athena_federated.id
-
-  depends_on = [aws_secretsmanager_secret_version.nomis_athena_federated]
-}
-
-data "aws_secretsmanager_secret_version" "nomis_athena_federated" {
-  secret_id = data.aws_secretsmanager_secret.nomis_athena_federated.id
-
-  depends_on = [aws_secretsmanager_secret.nomis_athena_federated]
-}
-
 # Source DataMart Secrets
 data "aws_secretsmanager_secret" "datamart" {
   name = aws_secretsmanager_secret.redshift.id

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -314,7 +314,6 @@ locals {
   nomis_secrets_placeholder_athena_federated = {
     username = "placeholder"
     password = "placeholder"
-    sid      = "placeholder"
   }
 
   # DPS Secrets PlaceHolder

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -305,15 +305,11 @@ locals {
   nomis_secrets_placeholder = {
     db_name  = "nomis"
     password = "placeholder"
+    # We need to duplicate the username with 'user' and 'username' keys
     user     = "placeholder"
+    username = "placeholder"
     endpoint = "0.0.0.0" # In dev this is always manually set to the static_private_ip of the ec2_kinesis_agent acting as a tunnel to NOMIS
     port     = "1521"
-  }
-
-  # Nomis Secrets PlaceHolder in Athena Federated Query format
-  nomis_secrets_placeholder_athena_federated = {
-    username = "placeholder"
-    password = "placeholder"
   }
 
   # DPS Secrets PlaceHolder

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -953,7 +953,7 @@ module "ec2_kinesis_agent" {
   aws_region                  = local.account_region
   ec2_terminate_behavior      = "terminate"
   associate_public_ip_address = false
-  static_private_ip           = "10.26.24.202" # Used for Dev as a Secondary IP
+  static_private_ip           = "10.26.24.201" # Used for Dev as a Secondary IP
   ebs_optimized               = true
   monitoring                  = true
   ebs_size                    = 20

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -953,7 +953,7 @@ module "ec2_kinesis_agent" {
   aws_region                  = local.account_region
   ec2_terminate_behavior      = "terminate"
   associate_public_ip_address = false
-  static_private_ip           = "10.26.24.201" # Used for Dev as a Secondary IP
+  static_private_ip           = "10.26.24.202" # Used for Dev as a Secondary IP
   ebs_optimized               = true
   monitoring                  = true
   ebs_size                    = 20

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/iam.tf
@@ -89,9 +89,7 @@ resource "aws_iam_policy" "athena_federated_query_connector_policy" {
         "Action" : [
           "secretsmanager:GetSecretValue"
         ],
-        "Resource" : [
-          var.nomis_credentials_secret_arn
-        ],
+        "Resource" : var.credentials_secret_arns,
         "Effect" : "Allow"
       },
       {

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/variables.tf
@@ -44,9 +44,9 @@ variable "spill_bucket_prefix" {
   description = "The key prefix in the spill S3 bucket to use for writing data that spills from the Connector Lambda's memory"
 }
 
-variable "nomis_credentials_secret_arn" {
-  type        = string
-  description = "The ARN of the Secret Manager secret containing NOMIS credentials"
+variable "credentials_secret_arns" {
+  type        = list(string)
+  description = "The ARNs of the Secret Manager secrets containing the database credentials in the connection strings so the lambda can access them"
 }
 
 variable "connection_strings" {

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -14,32 +14,10 @@ resource "aws_secretsmanager_secret" "nomis" {
   )
 }
 
-# Nomis Source Secrets in format required by Athena Federated Query
-resource "aws_secretsmanager_secret" "nomis_athena_federated" {
-  name = "external/${local.project}-nomis-secrets-athena-federated-query"
-
-  tags = merge(
-    local.all_tags,
-    {
-      Name          = "external/${local.project}-nomis-source-secrets-athena-federated-query"
-      Resource_Type = "Secrets"
-    }
-  )
-}
-
 # PlaceHolder Secrets
 resource "aws_secretsmanager_secret_version" "nomis" {
   secret_id     = aws_secretsmanager_secret.nomis.id
   secret_string = jsonencode(local.nomis_secrets_placeholder)
-
-  lifecycle {
-    ignore_changes = [secret_string, ]
-  }
-}
-
-resource "aws_secretsmanager_secret_version" "nomis_athena_federated" {
-  secret_id     = aws_secretsmanager_secret.nomis_athena_federated.id
-  secret_string = jsonencode(local.nomis_secrets_placeholder_athena_federated)
 
   lifecycle {
     ignore_changes = [secret_string, ]


### PR DESCRIPTION
- Switch from using SID to using service name in NOMIS connection string for Athena federated queries
- Simplify secrets by using a single pre-existing secret rather than a second secret
- Allow oracle connector module to be given access to multiple secrets when using multiple connection strings