### PR TITLE
📌 Upgrade Analytical Platform Compute EKS to 1.30

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -37,7 +37,7 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
-      eks_cluster_version = "1.29"
+      eks_cluster_version = "1.30"
       eks_node_version    = "1.20.0-fcf71a47"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -41,7 +41,7 @@ locals {
       eks_node_version    = "1.20.0-fcf71a47"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
-        kube_proxy             = "v1.29.3-eksbuild.2"
+        kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.2-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
@@ -72,11 +72,11 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.29"
+      eks_cluster_version = "1.30"
       eks_node_version    = "1.20.0-fcf71a47"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
-        kube_proxy             = "v1.29.3-eksbuild.2"
+        kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.2-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
@@ -107,11 +107,11 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.29"
+      eks_cluster_version = "1.30"
       eks_node_version    = "1.20.0-fcf71a47"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
-        kube_proxy             = "v1.29.3-eksbuild.2"
+        kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.2-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"


### PR DESCRIPTION
This pull request:

- Upgrades EKS to 1.30
  - https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-eks-distro-kubernetes-version-1-30/
  - https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/

Notes:

- `apply` fails because no version is returned from AWS API when requesting versions for `aws-guardduty-agent` for EKS `1.30`, I have raised this with enterprise support. It doesn't affect clusters upgrading, but **would** affect new clusters

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 