### PR TITLE
DSOS-2797: cloudwatch dashboards into baseline

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -28,9 +28,15 @@ locals {
     enable_ec2_self_provision                    = true
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_ec2_user_keypair                      = true
-    cloudwatch_dashboards                        = ["CloudWatch-Default"]
-    cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
-    cloudwatch_metric_oam_links_ssm_parameters   = ["hmpps-oem-${local.environment}"]
+    cloudwatch_dashboard_default_widget_groups = [
+      "lb_with_acm",
+      "ec2_linux_only",
+      "ec2_service_status",
+      "ec2_textfile_monitoring",
+      "ec2_oracle_db_with_backup",
+    ]
+    cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
+    cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
     #cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
     route53_resolver_rules = {
       outbound-data-and-private-subnets = ["azure-fixngo-domain"]

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -30,10 +30,10 @@ locals {
     enable_ec2_user_keypair                      = true
     cloudwatch_dashboard_default_widget_groups = [
       "lb_with_acm",
-      "ec2_linux_only",
-      "ec2_service_status",
-      "ec2_textfile_monitoring",
-      "ec2_oracle_db_with_backup",
+      #"ec2_linux_only",
+      #"ec2_service_status",
+      #"ec2_textfile_monitoring",
+      #"ec2_oracle_db_with_backup",
     ]
     cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -30,10 +30,10 @@ locals {
     enable_ec2_user_keypair                      = true
     cloudwatch_dashboard_default_widget_groups = [
       "lb_with_acm",
-      #"ec2_linux_only",
-      #"ec2_service_status",
-      #"ec2_textfile_monitoring",
-      #"ec2_oracle_db_with_backup",
+      "ec2_linux_only",
+      "ec2_service_status",
+      "ec2_textfile_monitoring",
+      "ec2_oracle_db_with_backup",
     ]
     cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -28,6 +28,7 @@ locals {
     enable_ec2_self_provision                    = true
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_ec2_user_keypair                      = true
+    cloudwatch_dashboards                        = ["CloudWatch-Default"]
     cloudwatch_metric_alarms_default_actions     = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters   = ["hmpps-oem-${local.environment}"]
     #cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -29,11 +29,11 @@ locals {
     enable_ec2_oracle_enterprise_managed_server  = true
     enable_ec2_user_keypair                      = true
     cloudwatch_dashboard_default_widget_groups = [
-      "lb_with_acm",
-      "ec2_linux_only",
-      "ec2_service_status",
-      "ec2_textfile_monitoring",
-      "ec2_oracle_db_with_backup",
+      "lb_expression",
+      "ec2_linux_only_expression",
+      "ec2_service_status_expression",
+      "ec2_textfile_monitoring_expression",
+      "ec2_oracle_db_with_backup_expression",
     ]
     cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
     cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -158,8 +158,8 @@ locals {
     }
 
     baseline_secretsmanager_secrets = {
-      "/oracle/database/LSCNOM"   = local.database_secretsmanager_secrets
-      "/oracle/database/LSMIS"    = local.database_mis_secretsmanager_secrets
+      "/oracle/database/LSCNOM" = local.database_secretsmanager_secrets
+      "/oracle/database/LSMIS"  = local.database_mis_secretsmanager_secrets
 
       "/oracle/weblogic/preprod"  = local.weblogic_secretsmanager_secrets
       "/oracle/database/PPCNOM"   = local.database_nomis_secretsmanager_secrets

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -67,6 +67,8 @@ module "baseline" {
   #   lookup(local.baseline_environment_config, "baseline_bastion_linux", {})
   # )
 
+  cloudwatch_dashboards = module.baseline_presets.cloudwatch_dashboards
+
   cloudwatch_metric_alarms = merge(
     local.baseline_cloudwatch_metric_alarms,
     lookup(local.baseline_environment_config, "baseline_cloudwatch_metric_alarms", {})

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -191,12 +191,3 @@ module "baseline" {
     lookup(local.baseline_environment_config, "baseline_ssm_parameters", {}),
   )
 }
-
-module "cloudwatch" {
-  source      = "../../modules/cloudwatch"
-  environment = module.environment
-  options = merge(
-    local.cloudwatch_monitoring_options,
-    local.cloudwatch_local_environment_monitoring_options,
-  )
-}

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -3,11 +3,11 @@ locals {
   # add header widget and calculate x, y positions
   cloudwatch_dashboards = {
     for key, value in var.cloudwatch_dashboards : key => {
-      periodOverride = value.periodOverride
-      start          = value.start
-      widgets = flatten([value.widgets, [
-        for widget_group in value.widget_groups : [
-          widget_group.header_markdown == null ? [] : [{
+      periodOverride = lookup(value, "periodOverride", null)
+      start          = lookup(value, "start", null)
+      widgets = flatten([lookup(value, "widgets", []), [
+        for widget_group in lookup(value, "widget_groups", []) : [
+          lookup(widget_group, "header_markdown", null) == null ? [] : [{
             type   = "text"
             width  = 24
             height = 1
@@ -19,7 +19,7 @@ locals {
             }
           }],
           [
-            for i in range(length(widget_group.widgets)) : merge(coalesce(widget_group.widgets[i], {}), {
+            for i in range(length(widget_group.widgets)) : merge(widget_group.widgets[i], {
               width  = widget_group.width
               height = widget_group.height
               x      = i * widget_group.width % 24

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -25,6 +25,13 @@ locals {
   )
 }
 
+resource "aws_cloudwatch_dashboard" "this" {
+  for_each = var.cloudwatch_dashboards
+
+  dashboard_name = each.key
+  dashboard_body = jsonencode(each.value)
+}
+
 resource "aws_cloudwatch_log_group" "this" {
   for_each = var.cloudwatch_log_groups
 

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -23,13 +23,9 @@ output "bastion_linux" {
   value       = length(module.bastion_linux) == 1 ? module.bastion_linux[0] : null
 }
 
-output "cloudwatch_dashboards_debug" {
-  value = local.cloudwatch_dashboards
-}
-
 output "cloudwatch_dashboards" {
-  description = "map of aws_cloudwatch_dashboards resources"
-  value       = aws_cloudwatch_dashboard.this
+  description = "map of cloudwatch_dashboard modules corresponding to var.cloudwatch_dashboards"
+  value       = module.cloudwatch_dashboard
 }
 
 output "cloudwatch_log_groups" {

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -23,6 +23,15 @@ output "bastion_linux" {
   value       = length(module.bastion_linux) == 1 ? module.bastion_linux[0] : null
 }
 
+output "cloudwatch_dashboards_debug" {
+  value = local.cloudwatch_dashboards
+}
+
+output "cloudwatch_dashboards" {
+  description = "map of aws_cloudwatch_dashboards resources"
+  value       = aws_cloudwatch_dashboard.this
+}
+
 output "cloudwatch_log_groups" {
   description = "map of aws_cloudwatch_log_group resources"
   value       = aws_cloudwatch_log_group.this

--- a/terraform/modules/baseline/secretsmanager.tf
+++ b/terraform/modules/baseline/secretsmanager.tf
@@ -9,7 +9,7 @@ locals {
 
   # Policies can be defined at top-level, e.g. same for all secrets,
   # or specific to an individual secret. This code pulls out all these
-  # policies into a single map.
+  # policies into a single map.
   secretsmanager_secret_policies_top_level_list = [
     for sm_key, sm_value in var.secretsmanager_secrets : {
       key   = sm_key

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -79,10 +79,21 @@ variable "bastion_linux" {
   default = null
 }
 
+# see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
 variable "cloudwatch_dashboards" {
-  description = "map of cloudwatch dashboards where key is the dashboard name and value is the dashboard in hcl format for jsonencode()"
-  type        = map(any) # see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
-  default     = {}
+  description = "map of cloudwatch dashboards where key is the dashboard name. Use widget_groups if you want baseline to work out x,y,width,height"
+  type = map(object({
+    periodOverride = optional(string)
+    start          = optional(string)
+    widgets        = optional(list(any), []) # use if you want to set x,y,width,height yourself
+    widget_groups = optional(list(object({   # automate x,y,width,height values
+      header_markdown = optional(string)     # include a header text widget if set
+      width           = number               # width of each widget, must be divisor of 24
+      height          = number               # height of each widget
+      widgets         = list(any)            # no need to set x,y,width,height
+    })), [])
+  }))
+  default = {}
 }
 
 variable "cloudwatch_log_groups" {

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -79,6 +79,12 @@ variable "bastion_linux" {
   default = null
 }
 
+variable "cloudwatch_dashboards" {
+  description = "map of cloudwatch dashboards where key is the dashboard name and value is the dashboard in hcl format for jsonencode()"
+  type        = map(any) # see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
+  default     = {}
+}
+
 variable "cloudwatch_log_groups" {
   description = "set of cloudwatch log groups to create where the key is the name of the group"
   type = map(object({

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -80,19 +80,21 @@ variable "bastion_linux" {
 }
 
 # see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
+# cannot define a type without fully defining the entire cloudwatch dashboard json structure
 variable "cloudwatch_dashboards" {
+  # tflint-ignore: terraform_typed_variables
   description = "map of cloudwatch dashboards where key is the dashboard name. Use widget_groups if you want baseline to work out x,y,width,height"
-  type = map(object({
-    periodOverride = optional(string)
-    start          = optional(string)
-    widgets        = optional(list(any), []) # use if you want to set x,y,width,height yourself
-    widget_groups = optional(list(object({   # automate x,y,width,height values
-      header_markdown = optional(string)     # include a header text widget if set
-      width           = number               # width of each widget, must be divisor of 24
-      height          = number               # height of each widget
-      widgets         = list(any)            # no need to set x,y,width,height
-    })), [])
-  }))
+  #type = map(object({
+  #  periodOverride = optional(string)
+  #  start          = optional(string)
+  #  widgets        = optional(list(any), []) # use if you want to set x,y,width,height yourself
+  #  widget_groups = optional(list(object({   # automate x,y,width,height values
+  #    header_markdown = optional(string)     # include a header text widget if set
+  #    width           = number               # width of each widget, must be divisor of 24
+  #    height          = number               # height of each widget
+  #    widgets         = list(any)            # no need to set x,y,width,height
+  #  })), [])
+  #}))
   default = {}
 }
 

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -5,7 +5,6 @@ locals {
   ])
 
   cloudwatch_dashboard_widgets = {
-
     acm = {
       cert-expires-soon = {
         type = "metric"
@@ -797,7 +796,7 @@ locals {
       widgets = [
         local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
         null,
-        null
+        null,
       ]
     }
     ec2_oracle_db_with_backup = {
@@ -856,7 +855,7 @@ locals {
     "CloudWatch-Default" = {
       periodOverride = "auto"
       start          = "-PT3H"
-      widgets_groups = [
+      widget_groups = [
         for group in coalesce(var.options.cloudwatch_dashboard_default_widget_groups, []) :
         local.cloudwatch_dashboard_widget_groups[group]
       ]

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -1,0 +1,262 @@
+locals {
+
+  cloudwatch_dashboard_widgets = {
+
+    EC2CPUUtil = {
+      type   = "metric"
+      x      = 0
+      y      = 1
+      width  = 7
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Top 5 instances by highest CPU Utilization %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 5", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EC2MemoryUtil = {
+      type   = "metric"
+      x      = 7
+      y      = 1
+      width  = 6
+      height = 8
+      properties = {
+        view    = "bar"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EC2 Memory Utilization %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(mem_used_percent) FROM SCHEMA(CWAgent, InstanceId,name,server_type) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+        ]
+      }
+    }
+
+    EC2DiskUsed = {
+      type   = "metric"
+      x      = 13
+      y      = 1
+      width  = 6
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EC2 Disk Used %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(disk_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerTargetResponseTime = {
+      type   = "metric"
+      x      = 0
+      y      = 10
+      width  = 7
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = true
+        region  = "eu-west-2"
+        title   = "LoadBalancer Target Response Time"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(TargetResponseTime) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer,TargetGroup) GROUP BY TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerRequestCount = {
+      type   = "metric"
+      x      = 7
+      y      = 10
+      width  = 6
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = true
+        region  = "eu-west-2"
+        title   = "LoadBalancer Request Count"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT COUNT(RequestCount) FROM \"AWS/ApplicationELB\" GROUP BY LoadBalancer ORDER BY COUNT() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerHTTP5XXsCount = {
+      type   = "metric"
+      x      = 13
+      y      = 10
+      width  = 6
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = true
+        region  = "eu-west-2"
+        title   = "LoadBalancer HTTP 5XXs Count"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT COUNT(HTTPCode_ELB_5XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", AvailabilityZone,LoadBalancer,TargetGroup) GROUP BY LoadBalancer ORDER BY COUNT() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EBSVolumeDiskIOPS = {
+      type   = "metric"
+      x      = 0
+      y      = 19
+      width  = 12
+      height = 6
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EBS Volumes Total IOPs"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "m1/PERIOD(m1)", "label" : "Read IOPs", "id" : "e1" }],
+          [{ "expression" : "m2/PERIOD(m2)", "label" : "Write IOPs", "id" : "e2" }],
+          [{ "expression" : "e1+e2", "label" : "Total IOPs", "id" : "e3" }],
+          ["AWS/EBS", "VolumeReadOps", "VolumeId", "*", { "id" : "m1", "visible" : false }],
+          ["AWS/EBS", "VolumeWriteOps", "VolumeId", "*", { "id" : "m2", "visible" : false }]
+        ]
+      }
+    }
+
+    EBSVolumeDiskThroughput = {
+      type   = "metric"
+      x      = 0
+      y      = 25
+      width  = 12
+      height = 6
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EBS Volumes Throughput"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT SUM(VolumeWriteBytes)\nFROM SCHEMA(\"AWS/EBS\", VolumeId)\nGROUP BY VolumeId\nORDER BY SUM() DESC\nLIMIT 10", "label" : "VolumeWriteBytes", "id" : "m3", "stat" : "Sum", "visible" : false }],
+          [{ "expression" : "SELECT SUM(VolumeReadBytes) FROM SCHEMA(\"AWS/EBS\", VolumeId) GROUP BY VolumeId ORDER BY SUM() DESC LIMIT 10", "label" : "VolumeReadBytes", "id" : "m4", "stat" : "Sum", "visible" : false }],
+          [{ "expression" : "(m4/(1024*1024))/PERIOD(m4)", "label" : "MB Read Per Second", "id" : "e4" }],
+          [{ "expression" : "(m3/(1024*1024))/PERIOD(m3)", "label" : "MB Write Per Second", "id" : "e5" }],
+          [{ "expression" : "e4+e5", "label" : "Total Consumed MB/s", "id" : "e6" }]
+        ]
+      }
+    }
+
+    AllEBSVolumeStats = {
+      type   = "explorer"
+      x      = 0
+      y      = 31
+      width  = 24
+      height = 15
+      properties = {
+        region = "eu-west-2"
+        title  = "All EBS Volume Stats"
+        stat   = "Sum"
+        widgetOptions = {
+          view          = "timeSeries"
+          stacked       = false
+          rowsPerPage   = 50
+          widgetsPerRow = 2
+        }
+        labels = [
+          { key : "application", value : "${var.environment.application_name}" }
+        ]
+        metrics = [
+          {
+            "metricName" : "VolumeReadBytes",
+            "resourceType" : "AWS::EC2::Volume",
+            "stat" : "Sum"
+          },
+          {
+            "metricName" : "VolumeWriteBytes",
+            "resourceType" : "AWS::EC2::Volume",
+            "stat" : "Sum"
+          },
+          {
+            "metricName" : "VolumeIdleTime",
+            "resourceType" : "AWS::EC2::Volume",
+            "stat" : "Average"
+          },
+          {
+            "metricName" : "VolumeReadOps",
+            "resourceType" : "AWS::EC2::Volume",
+            "stat" : "Sum"
+          },
+          {
+            "metricName" : "VolumeWriteOps",
+            "resourceType" : "AWS::EC2::Volume",
+            "stat" : "Sum"
+          }
+        ]
+      }
+    }
+
+    LBGraphedMetricsHeading = {
+      type   = "text"
+      x      = 0
+      y      = 9
+      width  = 24
+      height = 1
+      properties = {
+        markdown   = "## LoadBalancer Graphed Metrics"
+        background = "solid"
+      }
+    }
+
+    EC2GraphedMetricsHeading = {
+      type   = "text"
+      x      = 0
+      y      = 0
+      width  = 24
+      height = 1
+      properties = {
+        markdown   = "## EC2 Graphed Metrics"
+        background = "solid"
+      }
+    }
+
+    EBSGraphedMetricsHeading = {
+      type   = "text"
+      x      = 0
+      y      = 18
+      width  = 24
+      height = 1
+      properties = {
+        markdown   = "## EBS Volume Graphed Metrics"
+        background = "solid"
+      }
+    }
+
+  }
+
+  cloudwatch_dashboards = {
+    "CloudWatch-Default" = {
+      widgets = [
+        local.cloudwatch_dashboard_widgets.EC2CPUUtil,
+        local.cloudwatch_dashboard_widgets.EC2MemoryUtil,
+        local.cloudwatch_dashboard_widgets.EC2DiskUsed,
+        local.cloudwatch_dashboard_widgets.LoadBalancerTargetResponseTime,
+        local.cloudwatch_dashboard_widgets.LoadBalancerRequestCount,
+        local.cloudwatch_dashboard_widgets.LoadBalancerHTTP5XXsCount,
+        local.cloudwatch_dashboard_widgets.EBSVolumeDiskIOPS,
+        local.cloudwatch_dashboard_widgets.EBSVolumeDiskThroughput,
+        local.cloudwatch_dashboard_widgets.AllEBSVolumeStats,
+        local.cloudwatch_dashboard_widgets.LBGraphedMetricsHeading,
+        local.cloudwatch_dashboard_widgets.EC2GraphedMetricsHeading,
+        local.cloudwatch_dashboard_widgets.EBSGraphedMetricsHeading,
+      ]
+    }
+  }
+}

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -835,9 +835,9 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-connection-errors,
-        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
+        #local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
-        local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
+        #local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
       ]
     }
     network_lb = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -32,12 +32,12 @@ locals {
         annotations = {
           horizontal = [
             {
-              visible = true,
+              visible = true
               color   = "#9467bd"
               label   = "Alarm threshold"
               value   = 95
-              fill    = above
-              yAxis   = right
+              fill    = "above"
+              yAxis   = "right"
             }
           ]
         }
@@ -274,7 +274,7 @@ locals {
   cloudwatch_dashboards = {
     "CloudWatch-Default" = {
       periodOverride = "auto"
-      start          = "-PT6H"
+      start          = "-PT3H"
       widgets = [
         local.cloudwatch_dashboard_widgets.EC2CPUUtil,
         local.cloudwatch_dashboard_widgets.EC2MemoryUtil,

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -24,13 +24,23 @@ locals {
         view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
-        title   = "Top 5 instances by highest CPU Utilization %"
+        title   = "Top instances by highest CPU Utilization %"
         stat    = "Maximum"
         metrics = [
-          ["AWS/EC2", "CPUUtilization", "InstanceId", "*", { "id" : "m1", "visible" : false }],
-
-          #[{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 5", "label" : "", "id" : "q1" }]
+          [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 20", "label" : "", "id" : "q1" }]
         ]
+        annotations = {
+          horizontal = [
+            {
+              visible = true,
+              color   = "#9467bd"
+              label   = "Alarm threshold"
+              value   = 95
+              fill    = above
+              yAxis   = right
+            }
+          ]
+        }
       }
     }
 
@@ -41,13 +51,13 @@ locals {
       width  = 6
       height = 8
       properties = {
-        view    = "bar"
+        view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
         title   = "EC2 Memory Utilization %"
         stat    = "Maximum"
         metrics = [
-          [{ "expression" : "SELECT MAX(mem_used_percent) FROM SCHEMA(CWAgent, InstanceId,name,server_type) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+          [{ "expression" : "SELECT MAX(mem_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
         ]
       }
     }
@@ -66,6 +76,24 @@ locals {
         stat    = "Maximum"
         metrics = [
           [{ "expression" : "SELECT MAX(disk_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EC2CPUIOWait = {
+      type   = "metric"
+      x      = 13
+      y      = 1
+      width  = 6
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EC2 Disk Used %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(cpu_usage_iowait) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
         ]
       }
     }
@@ -246,6 +274,7 @@ locals {
   cloudwatch_dashboards = {
     "CloudWatch-Default" = {
       periodOverride = "auto"
+      start          = "-PT6H"
       widgets = [
         local.cloudwatch_dashboard_widgets.EC2CPUUtil,
         local.cloudwatch_dashboard_widgets.EC2MemoryUtil,

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -17,15 +17,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MIN(DaysToExpiry) FROM SCHEMA(\"AWS/CertificateManager\", CertificateArn) GROUP BY CertificateArn  ORDER BY MIN() ASC", "id" : "q1", "label" : "" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.acm.cert-expires-soon.threshold
-                fill  = "below"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.acm.cert-expires-soon.threshold
+          #    fill  = "below"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -48,15 +46,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2.cpu-utilization-high.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2.cpu-utilization-high.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -76,15 +72,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(StatusCheckFailed_Instance)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -104,15 +98,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(StatusCheckFailed_System)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 20", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -135,15 +127,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MIN(DISK_FREE) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MIN() ASC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_cwagent_windows.free-disk-space-low.threshold
-                fill  = "below"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_cwagent_windows.free-disk-space-low.threshold
+          #    fill  = "below"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -163,15 +153,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(Memory % Committed Bytes In Use) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_cwagent_windows.high-memory-usage.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_cwagent_windows.high-memory-usage.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -194,15 +182,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(disk_used_percent) FROM SCHEMA(CWAgent, InstanceId, device, fstype, name, path, server_type) GROUP BY InstanceId, path ORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.free-disk-space-low.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.free-disk-space-low.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -222,15 +208,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(mem_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.high-memory-usage.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.high-memory-usage.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -250,15 +234,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(cpu_usage_iowait) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.cpu-iowait-high.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_cwagent_linux.cpu-iowait-high.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -281,15 +263,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_service_status_os_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -311,15 +291,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_service_status_app_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -341,15 +319,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_connectivity_test_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -371,15 +347,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -399,15 +373,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_seconds) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring.textfile-monitoring-metric-not-updated.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring.textfile-monitoring-metric-not-updated.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -430,15 +402,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_oracle_db_connected_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -460,15 +430,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_rman_backup_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = 1
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = 1
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -488,15 +456,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_rman_backup_seconds) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -640,13 +606,11 @@ locals {
             [{ "expression" : "SELECT MAX(UnHealthyHostCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
           #annotations = {
-          #  horizontal = [
-          #    {
-          #      label = "Alarm Threshold"
-          #      value = local.cloudwatch_metric_alarms.lb.unhealthy-load-balancer-host.threshold
-          #      fill  = "above"
-          #    }
-          #  ]
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.lb.unhealthy-load-balancer-host.threshold
+          #    fill  = "above"
+          #  }]
           #}
           yAxis = {
             left = {
@@ -689,15 +653,13 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(UnHealthyHostCount) FROM SCHEMA(\"AWS/NetworkELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.network_lb.unhealthy-network-load-balancer-host.threshold
-                fill  = "above"
-              }
-            ]
-          }
+          #annotations = {
+          #  horizontal = [{
+          #    label = "Alarm Threshold"
+          #    value = local.cloudwatch_metric_alarms.network_lb.unhealthy-network-load-balancer-host.threshold
+          #    fill  = "above"
+          #  }]
+          #}
           yAxis = {
             left = {
               showUnits = false,
@@ -837,7 +799,7 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-connection-errors,
         local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
-        #local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
+        local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
       ]
     }
     network_lb = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -514,7 +514,7 @@ locals {
           view    = "timeSeries"
           stacked = false
           region  = "eu-west-2"
-          title   = "ALB load-balancer-request"
+          title   = "ALB load-balancer-requests"
           stat    = "Sum"
           metrics = [
             [{ "expression" : "SELECT SUM(RequestCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }],
@@ -648,12 +648,12 @@ locals {
               }
             ]
           }
-          yAxis = {
-            left = {
-              showUnits = false,
-              label     = "host count"
-            }
-          }
+          #yAxis = {
+          #  left = {
+          #    showUnits = false,
+          #    label     = "host count"
+          #  }
+          #}
         }
       }
       load-balancer-target-response-time = {
@@ -835,7 +835,7 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-connection-errors,
-        #local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
+        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
         #local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
       ]

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -2,10 +2,148 @@ locals {
 
   cloudwatch_dashboard_widgets = {
 
-    EC2GraphedMetricsHeading = {
+    LoadBalancerGraphedMetricsHeading = {
       type   = "text"
       x      = 0
       y      = 0
+      width  = 24
+      height = 1
+      properties = {
+        markdown   = "## LoadBalancer Graphed Metrics"
+        background = "solid"
+      }
+    }
+
+    LoadBalancerRequestCount = {
+      type   = "metric"
+      x      = 0
+      y      = 1
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Sum LoadBalancer Requests"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT SUM(RequestCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerHTTP4XXsCount = {
+      type   = "metric"
+      x      = 8
+      y      = 1
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Sum LoadBalancer HTTP 4XXs"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT SUM(HTTPCode_ELB_4XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerHTTP5XXsCount = {
+      type   = "metric"
+      x      = 16
+      y      = 1
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Sum LoadBalancer HTTP 5XXs"
+        stat    = "Sum"
+        metrics = [
+          [{ "expression" : "SELECT SUM(HTTPCode_ELB_5XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerUnhealthyTargets = {
+      type   = "metric"
+      x      = 0
+      y      = 9
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Max LoadBalancer Unhealthy Targets"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(UnHealthyHostCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerAverageTargetResponseTime = {
+      type   = "metric"
+      x      = 8
+      y      = 9
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Average LoadBalancer Target Response Time"
+        stat    = "Average"
+        metrics = [
+          [{ "expression" : "SELECT AVG(TargetResponseTime) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    LoadBalancerMaximumTargetResponseTime = {
+      type   = "metric"
+      x      = 16
+      y      = 9
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Max LoadBalancer Target Response Time"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(TargetResponseTime) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    ACMCertificateDaysToExpiry = {
+      type   = "metric"
+      x      = 0
+      y      = 17
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Min ACM Certificate Days To Expiry"
+        stat    = "Minimum"
+        metrics = [
+          [{ "expression" : "SELECT MIN(DaysToExpiry) FROM SCHEMA(\"AWS/CertificateManager\", CertificateArn) GROUP BY CertificateArn ORDER BY MIN() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EC2GraphedMetricsHeading = {
+      type   = "text"
+      x      = 0
+      y      = 25
       width  = 24
       height = 1
       properties = {
@@ -14,47 +152,108 @@ locals {
       }
     }
 
-    EC2CPUUtil = {
+    EC2CPUUtilization = {
       type   = "metric"
       x      = 0
-      y      = 1
-      width  = 7
+      y      = 26
+      width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
-        title   = "Top instances by highest CPU Utilization %"
+        title   = "Max EC2 CPU Utilization %"
         stat    = "Maximum"
         metrics = [
-          [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 20", "label" : "", "id" : "q1" }]
+          [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
         ]
-        annotations = {
-          horizontal = [
-            {
-              visible = true
-              color   = "#9467bd"
-              label   = "Alarm threshold"
-              value   = 95
-              fill    = "above"
-              yAxis   = "right"
-            }
-          ]
-        }
       }
     }
 
-    EC2MemoryUtil = {
+    EC2InstanceStatus = {
       type   = "metric"
-      x      = 7
-      y      = 1
-      width  = 6
+      x      = 8
+      y      = 26
+      width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
-        title   = "EC2 Memory Utilization %"
+        title   = "EC2 Instance Status"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(StatusCheckFailed_Instance)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EC2SystemStatus = {
+      type   = "metric"
+      x      = 16
+      y      = 26
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "EC2 System Status"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(StatusCheckFailed_Instance)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 20", "label" : "", "id" : "q1" }],
+          [{ "expression" : "SELECT MAX(StatusCheckFailed_System)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 20", "label" : "", "id" : "q1" }]
+        ]
+      }
+    }
+
+    EC2WindowsMemoryUtilization = {
+      type   = "metric"
+      x      = 0
+      y      = 34
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Max EC2 Windows Memory Utilization %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(Memory % Committed Bytes In Use) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+        ]
+      }
+    }
+
+    EC2WindowsDiskFree = {
+      type   = "metric"
+      x      = 8
+      y      = 34
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Min EC2 Windows Disk Free %"
+        stat    = "Minimum"
+        metrics = [
+          [{ "expression" : "SELECT MIN(DISK_FREE) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MIN() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+        ]
+      }
+    }
+
+    EC2LinuxMemoryUtilization = {
+      type   = "metric"
+      x      = 0
+      y      = 42
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Max EC2 Linux Memory Utilization %"
         stat    = "Maximum"
         metrics = [
           [{ "expression" : "SELECT MAX(mem_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
@@ -62,17 +261,17 @@ locals {
       }
     }
 
-    EC2DiskUsed = {
+    EC2LinuxDiskUsed = {
       type   = "metric"
-      x      = 13
-      y      = 1
-      width  = 6
+      x      = 8
+      y      = 42
+      width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
-        title   = "EC2 Disk Used %"
+        title   = "Max EC2 Linux Disk Used %"
         stat    = "Maximum"
         metrics = [
           [{ "expression" : "SELECT MAX(disk_used_percent) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
@@ -80,17 +279,17 @@ locals {
       }
     }
 
-    EC2CPUIOWait = {
+    EC2LinuxCPUIOWait = {
       type   = "metric"
-      x      = 13
-      y      = 1
-      width  = 6
+      x      = 16
+      y      = 42
+      width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
         region  = "eu-west-2"
-        title   = "EC2 Disk Used %"
+        title   = "Max EC2 Linux CPU Usage IOWait %"
         stat    = "Maximum"
         metrics = [
           [{ "expression" : "SELECT MAX(cpu_usage_iowait) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
@@ -98,66 +297,24 @@ locals {
       }
     }
 
-    LoadBalancerTargetResponseTime = {
-      type   = "metric"
+    EBSGraphedMetricsHeading = {
+      type   = "text"
       x      = 0
-      y      = 10
-      width  = 7
-      height = 8
+      y      = 43
+      width  = 24
+      height = 1
       properties = {
-        view    = "timeSeries"
-        stacked = true
-        region  = "eu-west-2"
-        title   = "LoadBalancer Target Response Time"
-        stat    = "Maximum"
-        metrics = [
-          [{ "expression" : "SELECT MAX(TargetResponseTime) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer,TargetGroup) GROUP BY TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }]
-        ]
-      }
-    }
-
-    LoadBalancerRequestCount = {
-      type   = "metric"
-      x      = 7
-      y      = 10
-      width  = 6
-      height = 8
-      properties = {
-        view    = "timeSeries"
-        stacked = true
-        region  = "eu-west-2"
-        title   = "LoadBalancer Request Count"
-        stat    = "Sum"
-        metrics = [
-          [{ "expression" : "SELECT COUNT(RequestCount) FROM \"AWS/ApplicationELB\" GROUP BY LoadBalancer ORDER BY COUNT() DESC", "label" : "", "id" : "q1" }]
-        ]
-      }
-    }
-
-    LoadBalancerHTTP5XXsCount = {
-      type   = "metric"
-      x      = 13
-      y      = 10
-      width  = 6
-      height = 8
-      properties = {
-        view    = "timeSeries"
-        stacked = true
-        region  = "eu-west-2"
-        title   = "LoadBalancer HTTP 5XXs Count"
-        stat    = "Sum"
-        metrics = [
-          [{ "expression" : "SELECT COUNT(HTTPCode_ELB_5XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", AvailabilityZone,LoadBalancer,TargetGroup) GROUP BY LoadBalancer ORDER BY COUNT() DESC", "label" : "", "id" : "q1" }]
-        ]
+        markdown   = "## EBS Volume Graphed Metrics"
+        background = "solid"
       }
     }
 
     EBSVolumeDiskIOPS = {
       type   = "metric"
       x      = 0
-      y      = 19
-      width  = 12
-      height = 6
+      y      = 44
+      width  = 8
+      height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
@@ -168,18 +325,18 @@ locals {
           [{ "expression" : "m1/PERIOD(m1)", "label" : "Read IOPs", "id" : "e1" }],
           [{ "expression" : "m2/PERIOD(m2)", "label" : "Write IOPs", "id" : "e2" }],
           [{ "expression" : "e1+e2", "label" : "Total IOPs", "id" : "e3" }],
-          ["AWS/EBS", "VolumeReadOps", "VolumeId", "*", { "id" : "m1", "visible" : false }],
-          ["AWS/EBS", "VolumeWriteOps", "VolumeId", "*", { "id" : "m2", "visible" : false }]
+          ["AWS/EBS", "VolumeReadOps", "*", { "id" : "m1", "visible" : false }],
+          ["AWS/EBS", "VolumeWriteOps", "*", { "id" : "m2", "visible" : false }]
         ]
       }
     }
 
     EBSVolumeDiskThroughput = {
       type   = "metric"
-      x      = 0
-      y      = 25
-      width  = 12
-      height = 6
+      x      = 8
+      y      = 44
+      width  = 8
+      height = 8
       properties = {
         view    = "timeSeries"
         stacked = false
@@ -195,99 +352,35 @@ locals {
         ]
       }
     }
-
-    AllEBSVolumeStats = {
-      type   = "explorer"
-      x      = 0
-      y      = 31
-      width  = 24
-      height = 15
-      properties = {
-        region = "eu-west-2"
-        title  = "All EBS Volume Stats"
-        stat   = "Sum"
-        widgetOptions = {
-          view          = "timeSeries"
-          stacked       = false
-          rowsPerPage   = 50
-          widgetsPerRow = 2
-        }
-        labels = [
-          { key : "application", value : "${var.environment.application_name}" }
-        ]
-        metrics = [
-          {
-            "metricName" : "VolumeReadBytes",
-            "resourceType" : "AWS::EC2::Volume",
-            "stat" : "Sum"
-          },
-          {
-            "metricName" : "VolumeWriteBytes",
-            "resourceType" : "AWS::EC2::Volume",
-            "stat" : "Sum"
-          },
-          {
-            "metricName" : "VolumeIdleTime",
-            "resourceType" : "AWS::EC2::Volume",
-            "stat" : "Average"
-          },
-          {
-            "metricName" : "VolumeReadOps",
-            "resourceType" : "AWS::EC2::Volume",
-            "stat" : "Sum"
-          },
-          {
-            "metricName" : "VolumeWriteOps",
-            "resourceType" : "AWS::EC2::Volume",
-            "stat" : "Sum"
-          }
-        ]
-      }
-    }
-
-    LBGraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 9
-      width  = 24
-      height = 1
-      properties = {
-        markdown   = "## LoadBalancer Graphed Metrics"
-        background = "solid"
-      }
-    }
-
-    EBSGraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 18
-      width  = 24
-      height = 1
-      properties = {
-        markdown   = "## EBS Volume Graphed Metrics"
-        background = "solid"
-      }
-    }
-
   }
+
 
   cloudwatch_dashboards = {
     "CloudWatch-Default" = {
       periodOverride = "auto"
       start          = "-PT3H"
       widgets = [
-        local.cloudwatch_dashboard_widgets.EC2CPUUtil,
-        local.cloudwatch_dashboard_widgets.EC2MemoryUtil,
-        local.cloudwatch_dashboard_widgets.EC2DiskUsed,
-        local.cloudwatch_dashboard_widgets.LoadBalancerTargetResponseTime,
+        local.cloudwatch_dashboard_widgets.LoadBalancerGraphedMetricsHeading,
         local.cloudwatch_dashboard_widgets.LoadBalancerRequestCount,
+        local.cloudwatch_dashboard_widgets.LoadBalancerHTTP4XXsCount,
         local.cloudwatch_dashboard_widgets.LoadBalancerHTTP5XXsCount,
+        local.cloudwatch_dashboard_widgets.LoadBalancerUnhealthyTargets,
+        local.cloudwatch_dashboard_widgets.LoadBalancerAverageTargetResponseTime,
+        local.cloudwatch_dashboard_widgets.LoadBalancerMaximumTargetResponseTime,
+        local.cloudwatch_dashboard_widgets.ACMCertificateDaysToExpiry,
+        local.cloudwatch_dashboard_widgets.EC2GraphedMetricsHeading,
+        local.cloudwatch_dashboard_widgets.EC2CPUUtilization,
+        local.cloudwatch_dashboard_widgets.EC2InstanceStatus,
+        local.cloudwatch_dashboard_widgets.EC2SystemStatus,
+
+        local.cloudwatch_dashboard_widgets.EC2WindowsMemoryUtilization,
+        local.cloudwatch_dashboard_widgets.EC2WindowsDiskFree,
+        local.cloudwatch_dashboard_widgets.EC2LinuxMemoryUtilization,
+        local.cloudwatch_dashboard_widgets.EC2LinuxDiskUsed,
+        local.cloudwatch_dashboard_widgets.EC2LinuxCPUIOWait,
+        local.cloudwatch_dashboard_widgets.EBSGraphedMetricsHeading,
         local.cloudwatch_dashboard_widgets.EBSVolumeDiskIOPS,
         local.cloudwatch_dashboard_widgets.EBSVolumeDiskThroughput,
-        local.cloudwatch_dashboard_widgets.AllEBSVolumeStats,
-        local.cloudwatch_dashboard_widgets.LBGraphedMetricsHeading,
-        local.cloudwatch_dashboard_widgets.EC2GraphedMetricsHeading,
-        local.cloudwatch_dashboard_widgets.EBSGraphedMetricsHeading,
       ]
     }
   }

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -4,7 +4,7 @@ locals {
 
     LoadBalancerGraphedMetricsHeading = {
       type = "text"
-      #x      = 0
+      x      = 0
       #y      = 0
       width  = 24
       height = 1
@@ -16,7 +16,7 @@ locals {
 
     LoadBalancerRequestCount = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 1
       width  = 8
       height = 8
@@ -34,7 +34,7 @@ locals {
 
     LoadBalancerHTTP4XXsCount = {
       type = "metric"
-      #x      = 8
+      x      = 8
       #y      = 1
       width  = 8
       height = 8
@@ -52,7 +52,7 @@ locals {
 
     LoadBalancerHTTP5XXsCount = {
       type = "metric"
-      #x      = 16
+      x      = 16
       #y      = 1
       width  = 8
       height = 8
@@ -70,7 +70,7 @@ locals {
 
     LoadBalancerUnhealthyTargets = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 9
       width  = 8
       height = 8
@@ -88,7 +88,7 @@ locals {
 
     LoadBalancerAverageTargetResponseTime = {
       type = "metric"
-      #x      = 8
+      x      = 8
       #y      = 9
       width  = 8
       height = 8
@@ -106,7 +106,7 @@ locals {
 
     LoadBalancerMaximumTargetResponseTime = {
       type = "metric"
-      #x      = 16
+      x      = 16
       #y      = 9
       width  = 8
       height = 8
@@ -124,7 +124,7 @@ locals {
 
     ACMCertificateDaysToExpiry = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 17
       width  = 8
       height = 8
@@ -142,7 +142,7 @@ locals {
 
     EC2GraphedMetricsHeading = {
       type = "text"
-      #x      = 0
+      x      = 0
       #y      = 25
       width  = 24
       height = 1
@@ -154,7 +154,7 @@ locals {
 
     EC2CPUUtilization = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 26
       width  = 8
       height = 8
@@ -172,7 +172,7 @@ locals {
 
     EC2InstanceStatus = {
       type = "metric"
-      #x      = 8
+      x      = 8
       #y      = 26
       width  = 8
       height = 8
@@ -190,7 +190,7 @@ locals {
 
     EC2SystemStatus = {
       type = "metric"
-      #x      = 16
+      x      = 16
       #y      = 26
       width  = 8
       height = 8
@@ -207,45 +207,9 @@ locals {
       }
     }
 
-    EC2WindowsMemoryUtilization = {
-      type = "metric"
-      #x      = 0
-      #y      = 34
-      width  = 8
-      height = 8
-      properties = {
-        view    = "timeSeries"
-        stacked = false
-        region  = "eu-west-2"
-        title   = "Max EC2 Windows Memory Utilization %"
-        stat    = "Maximum"
-        metrics = [
-          [{ "expression" : "SELECT MAX(Memory % Committed Bytes In Use) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
-        ]
-      }
-    }
-
-    EC2WindowsDiskFree = {
-      type = "metric"
-      #x      = 8
-      #y      = 34
-      width  = 8
-      height = 8
-      properties = {
-        view    = "timeSeries"
-        stacked = false
-        region  = "eu-west-2"
-        title   = "Min EC2 Windows Disk Free %"
-        stat    = "Minimum"
-        metrics = [
-          [{ "expression" : "SELECT MIN(DISK_FREE) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MIN() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
-        ]
-      }
-    }
-
     EC2LinuxMemoryUtilization = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 42
       width  = 8
       height = 8
@@ -263,7 +227,7 @@ locals {
 
     EC2LinuxDiskUsed = {
       type = "metric"
-      #x      = 8
+      x      = 8
       #y      = 42
       width  = 8
       height = 8
@@ -281,7 +245,7 @@ locals {
 
     EC2LinuxCPUIOWait = {
       type = "metric"
-      #x      = 16
+      x      = 16
       #y      = 42
       width  = 8
       height = 8
@@ -297,9 +261,46 @@ locals {
       }
     }
 
+    EC2WindowsMemoryUtilization = {
+      type = "metric"
+      x      = 0
+      #y      = 34
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Max EC2 Windows Memory Utilization %"
+        stat    = "Maximum"
+        metrics = [
+          [{ "expression" : "SELECT MAX(Memory % Committed Bytes In Use) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+        ]
+      }
+    }
+
+    EC2WindowsDiskFree = {
+      type = "metric"
+      x      = 8
+      #y      = 34
+      width  = 8
+      height = 8
+      properties = {
+        view    = "timeSeries"
+        stacked = false
+        region  = "eu-west-2"
+        title   = "Min EC2 Windows Disk Free %"
+        stat    = "Minimum"
+        metrics = [
+          [{ "expression" : "SELECT MIN(DISK_FREE) FROM SCHEMA(CWAgent, InstanceId) GROUP BY InstanceId ORDER BY MIN() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }]
+        ]
+      }
+    }
+
+
     EBSGraphedMetricsHeading = {
       type = "text"
-      #x      = 0
+      x      = 0
       #y      = 43
       width  = 24
       height = 1
@@ -311,7 +312,7 @@ locals {
 
     EBSVolumeDiskIOPS = {
       type = "metric"
-      #x      = 0
+      x      = 0
       #y      = 44
       width  = 8
       height = 8
@@ -333,7 +334,7 @@ locals {
 
     EBSVolumeDiskThroughput = {
       type = "metric"
-      #x      = 8
+      x      = 8
       #y      = 44
       width  = 8
       height = 8

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -82,7 +82,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -108,7 +108,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -273,7 +273,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -301,7 +301,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -329,7 +329,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -357,7 +357,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -412,7 +412,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -440,7 +440,7 @@ locals {
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error code"
+              label     = "exitcode"
             }
           }
         }
@@ -484,7 +484,6 @@ locals {
           stat    = "Sum"
           metrics = [
             [{ "expression" : "SELECT SUM(RequestCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }],
-            [{ "expression" : "SELECT SUM(RequestCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
           ]
           yAxis = {
             left = {
@@ -504,7 +503,6 @@ locals {
           stat    = "Sum"
           metrics = [
             [{ "expression" : "SELECT SUM(HTTPCode_ELB_4XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }],
-            [{ "expression" : "SELECT SUM(HTTPCode_Target_4XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
           ]
           yAxis = {
             left = {
@@ -524,6 +522,62 @@ locals {
           stat    = "Sum"
           metrics = [
             [{ "expression" : "SELECT SUM(HTTPCode_ELB_5XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }],
+          ]
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "error count"
+            }
+          }
+        }
+      }
+      load-balancer-target-group-requests = {
+        type = "metric"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "ALB load-balancer-requests"
+          stat    = "Sum"
+          metrics = [
+            [{ "expression" : "SELECT SUM(RequestCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
+          ]
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "request count"
+            }
+          }
+        }
+      }
+      load-balancer-target-group-http-4XXs = {
+        type = "metric"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "ALB load-balancer-http-4XXs"
+          stat    = "Sum"
+          metrics = [
+            [{ "expression" : "SELECT SUM(HTTPCode_Target_4XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
+          ]
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "error count"
+            }
+          }
+        }
+      }
+      load-balancer-target-group-http-5XXs = {
+        type = "metric"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "ALB load-balancer-http-5XXs"
+          stat    = "Sum"
+          metrics = [
             [{ "expression" : "SELECT SUM(HTTPCode_Target_5XX_Count) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
           ]
           yAxis = {
@@ -572,24 +626,21 @@ locals {
           }
         }
       }
-      load-balancer-connection-errors = {
+      load-balancer-target-connection-errors = {
         type = "metric"
         properties = {
           view    = "timeSeries"
           stacked = false
           region  = "eu-west-2"
-          title   = "ALB load-balancer-connection-errors"
+          title   = "ALB load-balancer-target-connection-errors"
           stat    = "Sum"
           metrics = [
             [{ "expression" : "SELECT SUM(TargetConnectionErrorCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q1" }],
-            [{ "expression" : "SELECT SUM(RejectedConnectionCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q2" }],
-            [{ "expression" : "SELECT SUM(TargetTLSNegotiationErrorCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q3" }],
-            [{ "expression" : "SELECT SUM(ClientTLSNegotiationErrorCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer) GROUP BY LoadBalancer ORDER BY SUM() DESC", "label" : "", "id" : "q4" }],
           ]
           yAxis = {
             left = {
               showUnits = false,
-              label     = "error count"
+              label     = "connection errors"
             }
           }
         }
@@ -778,9 +829,12 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-requests,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-4XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-5XXs,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-requests,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-4XXs,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-5XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-connection-errors,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-connection-errors,
         local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
         null,
@@ -794,9 +848,12 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-requests,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-4XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-5XXs,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-requests,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-4XXs,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-5XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-connection-errors,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-connection-errors,
         local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
         local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -3,9 +3,9 @@ locals {
   cloudwatch_dashboard_widgets = {
 
     LoadBalancerGraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 0
+      type = "text"
+      #x      = 0
+      #y      = 0
       width  = 24
       height = 1
       properties = {
@@ -15,14 +15,14 @@ locals {
     }
 
     LoadBalancerRequestCount = {
-      type   = "metric"
-      x      = 0
-      y      = 1
+      type = "metric"
+      #x      = 0
+      #y      = 1
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "Sum LoadBalancer Requests"
         stat    = "Sum"
@@ -33,14 +33,14 @@ locals {
     }
 
     LoadBalancerHTTP4XXsCount = {
-      type   = "metric"
-      x      = 8
-      y      = 1
+      type = "metric"
+      #x      = 8
+      #y      = 1
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "Sum LoadBalancer HTTP 4XXs"
         stat    = "Sum"
@@ -51,14 +51,14 @@ locals {
     }
 
     LoadBalancerHTTP5XXsCount = {
-      type   = "metric"
-      x      = 16
-      y      = 1
+      type = "metric"
+      #x      = 16
+      #y      = 1
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "Sum LoadBalancer HTTP 5XXs"
         stat    = "Sum"
@@ -69,14 +69,14 @@ locals {
     }
 
     LoadBalancerUnhealthyTargets = {
-      type   = "metric"
-      x      = 0
-      y      = 9
+      type = "metric"
+      #x      = 0
+      #y      = 9
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "Max LoadBalancer Unhealthy Targets"
         stat    = "Maximum"
@@ -87,9 +87,9 @@ locals {
     }
 
     LoadBalancerAverageTargetResponseTime = {
-      type   = "metric"
-      x      = 8
-      y      = 9
+      type = "metric"
+      #x      = 8
+      #y      = 9
       width  = 8
       height = 8
       properties = {
@@ -105,9 +105,9 @@ locals {
     }
 
     LoadBalancerMaximumTargetResponseTime = {
-      type   = "metric"
-      x      = 16
-      y      = 9
+      type = "metric"
+      #x      = 16
+      #y      = 9
       width  = 8
       height = 8
       properties = {
@@ -123,9 +123,9 @@ locals {
     }
 
     ACMCertificateDaysToExpiry = {
-      type   = "metric"
-      x      = 0
-      y      = 17
+      type = "metric"
+      #x      = 0
+      #y      = 17
       width  = 8
       height = 8
       properties = {
@@ -141,9 +141,9 @@ locals {
     }
 
     EC2GraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 25
+      type = "text"
+      #x      = 0
+      #y      = 25
       width  = 24
       height = 1
       properties = {
@@ -153,9 +153,9 @@ locals {
     }
 
     EC2CPUUtilization = {
-      type   = "metric"
-      x      = 0
-      y      = 26
+      type = "metric"
+      #x      = 0
+      #y      = 26
       width  = 8
       height = 8
       properties = {
@@ -171,14 +171,14 @@ locals {
     }
 
     EC2InstanceStatus = {
-      type   = "metric"
-      x      = 8
-      y      = 26
+      type = "metric"
+      #x      = 8
+      #y      = 26
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "EC2 Instance Status"
         stat    = "Maximum"
@@ -189,14 +189,14 @@ locals {
     }
 
     EC2SystemStatus = {
-      type   = "metric"
-      x      = 16
-      y      = 26
+      type = "metric"
+      #x      = 16
+      #y      = 26
       width  = 8
       height = 8
       properties = {
         view    = "timeSeries"
-        stacked = false
+        stacked = true
         region  = "eu-west-2"
         title   = "EC2 System Status"
         stat    = "Maximum"
@@ -208,9 +208,9 @@ locals {
     }
 
     EC2WindowsMemoryUtilization = {
-      type   = "metric"
-      x      = 0
-      y      = 34
+      type = "metric"
+      #x      = 0
+      #y      = 34
       width  = 8
       height = 8
       properties = {
@@ -226,9 +226,9 @@ locals {
     }
 
     EC2WindowsDiskFree = {
-      type   = "metric"
-      x      = 8
-      y      = 34
+      type = "metric"
+      #x      = 8
+      #y      = 34
       width  = 8
       height = 8
       properties = {
@@ -244,9 +244,9 @@ locals {
     }
 
     EC2LinuxMemoryUtilization = {
-      type   = "metric"
-      x      = 0
-      y      = 42
+      type = "metric"
+      #x      = 0
+      #y      = 42
       width  = 8
       height = 8
       properties = {
@@ -262,9 +262,9 @@ locals {
     }
 
     EC2LinuxDiskUsed = {
-      type   = "metric"
-      x      = 8
-      y      = 42
+      type = "metric"
+      #x      = 8
+      #y      = 42
       width  = 8
       height = 8
       properties = {
@@ -280,9 +280,9 @@ locals {
     }
 
     EC2LinuxCPUIOWait = {
-      type   = "metric"
-      x      = 16
-      y      = 42
+      type = "metric"
+      #x      = 16
+      #y      = 42
       width  = 8
       height = 8
       properties = {
@@ -298,9 +298,9 @@ locals {
     }
 
     EBSGraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 43
+      type = "text"
+      #x      = 0
+      #y      = 43
       width  = 24
       height = 1
       properties = {
@@ -310,9 +310,9 @@ locals {
     }
 
     EBSVolumeDiskIOPS = {
-      type   = "metric"
-      x      = 0
-      y      = 44
+      type = "metric"
+      #x      = 0
+      #y      = 44
       width  = 8
       height = 8
       properties = {
@@ -332,9 +332,9 @@ locals {
     }
 
     EBSVolumeDiskThroughput = {
-      type   = "metric"
-      x      = 8
-      y      = 44
+      type = "metric"
+      #x      = 8
+      #y      = 44
       width  = 8
       height = 8
       properties = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -5,36 +5,7 @@ locals {
   ])
 
   cloudwatch_dashboard_widgets = {
-    acm = {
-      cert-expires-soon = {
-        type = "metric"
-        properties = {
-          view    = "timeSeries"
-          stacked = false
-          region  = "eu-west-2"
-          title   = "ACM cert-expires-soon"
-          stat    = "Minimum"
-          metrics = [
-            [{ "expression" : "SELECT MIN(DaysToExpiry) FROM SCHEMA(\"AWS/CertificateManager\", CertificateArn) GROUP BY CertificateArn  ORDER BY MIN() ASC", "id" : "q1", "label" : "" }],
-          ]
-          #annotations = {
-          #  horizontal = [{
-          #    label = "Alarm Threshold"
-          #    value = local.cloudwatch_metric_alarms.acm.cert-expires-soon.threshold
-          #    fill  = "below"
-          #  }]
-          #}
-          yAxis = {
-            left = {
-              showUnits = false,
-              label     = "days"
-            }
-          }
-        }
-      }
-    }
-
-    ec2 = {
+    ec2_expression = {
       cpu-utilization-high = {
         type = "metric"
         properties = {
@@ -115,7 +86,7 @@ locals {
       }
     }
 
-    ec2_cwagent_windows = {
+    ec2_cwagent_windows_expression = {
       free-disk-space-low = {
         type = "metric"
         properties = {
@@ -170,7 +141,7 @@ locals {
       }
     }
 
-    ec2_cwagent_linux = {
+    ec2_cwagent_linux_expression = {
       free-disk-space-low = {
         type = "metric"
         properties = {
@@ -251,7 +222,7 @@ locals {
       }
     }
 
-    ec2_instance_cwagent_collectd_service_status_os = {
+    ec2_instance_cwagent_collectd_service_status_os_expression = {
       service-status-error-os-layer = {
         type = "metric"
         properties = {
@@ -279,7 +250,7 @@ locals {
         }
       }
     }
-    ec2_instance_cwagent_collectd_service_status_app = {
+    ec2_instance_cwagent_collectd_service_status_app_expression = {
       service-status-error-app-layer = {
         type = "metric"
         properties = {
@@ -307,7 +278,7 @@ locals {
         }
       }
     }
-    ec2_instance_cwagent_collectd_connectivity_test = {
+    ec2_instance_cwagent_collectd_connectivity_test_expression = {
       connectivity-test-all-failed = {
         type = "metric"
         properties = {
@@ -335,7 +306,7 @@ locals {
         }
       }
     }
-    ec2_instance_cwagent_collectd_textfile_monitoring = {
+    ec2_instance_cwagent_collectd_textfile_monitoring_expression = {
       textfile-monitoring-metric-error = {
         type = "metric"
         properties = {
@@ -390,7 +361,7 @@ locals {
       }
     }
 
-    ec2_instance_cwagent_collectd_oracle_db_connected = {
+    ec2_instance_cwagent_collectd_oracle_db_connected_expression = {
       oracle-db-disconnected = {
         type = "metric"
         properties = {
@@ -418,7 +389,7 @@ locals {
         }
       }
     }
-    ec2_instance_cwagent_collectd_oracle_db_backup = {
+    ec2_instance_cwagent_collectd_oracle_db_backup_expression = {
       oracle-db-rman-backup-error = {
         type = "metric"
         properties = {
@@ -473,7 +444,7 @@ locals {
       }
     }
 
-    lb = {
+    lb_expression = {
       load-balancer-requests = {
         type = "metric"
         properties = {
@@ -692,7 +663,7 @@ locals {
       }
     }
 
-    network_lb = {
+    network_lb_expression = {
       unhealthy-network-load-balancer-host = {
         type = "metric"
         properties = {
@@ -724,146 +695,117 @@ locals {
   }
 
   cloudwatch_dashboard_widget_groups = {
-    acm = {
-      header_markdown = "## ACM"
-      width           = 8
-      height          = 8
-      widgets = [
-        local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
-        null,
-        null,
-      ]
-    }
-    ec2_windows_only = {
+    ec2_windows_only_expression = {
       header_markdown = "## EC2"
       width           = 8
       height          = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
-        local.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+        local.cloudwatch_dashboard_widgets.ec2_expression.cpu-utilization-high,
+        local.cloudwatch_dashboard_widgets.ec2_expression.instance-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_expression.system-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows_expression.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows_expression.high-memory-usage,
         null,
       ]
     }
-    ec2_linux_only = {
+    ec2_linux_only_expression = {
       header_markdown = "## EC2"
       width           = 8
       height          = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
-        local.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+        local.cloudwatch_dashboard_widgets.ec2_expression.cpu-utilization-high,
+        local.cloudwatch_dashboard_widgets.ec2_expression.instance-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_expression.system-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.high-memory-usage,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.cpu-iowait-high,
       ]
     }
-    ec2_linux_and_windows = {
+    ec2_linux_and_windows_expression = {
       header_markdown = "## EC2"
       width           = 8
       height          = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
-        local.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+        local.cloudwatch_dashboard_widgets.ec2_expression.cpu-utilization-high,
+        local.cloudwatch_dashboard_widgets.ec2_expression.instance-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_expression.system-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows_expression.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows_expression.high-memory-usage,
         null,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
-        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.high-memory-usage,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_linux_expression.cpu-iowait-high,
       ]
     }
-    ec2_service_status = {
+    ec2_service_status_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os_expression.service-status-error-os-layer,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app_expression.service-status-error-app-layer,
         null,
       ]
     }
-    ec2_service_status_with_connectivity_test = {
+    ec2_service_status_with_connectivity_test_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_connectivity_test.connectivity-test-all-failed,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os_expression.service-status-error-os-layer,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app_expression.service-status-error-app-layer,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_connectivity_test_expression.connectivity-test-all-failed,
       ]
     }
-    ec2_textfile_monitoring = {
+    ec2_textfile_monitoring_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_textfile_monitoring.textfile-monitoring-metric-error,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_textfile_monitoring.textfile-monitoring-metric-not-updated,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_textfile_monitoring_expression.textfile-monitoring-metric-error,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_textfile_monitoring_expression.textfile-monitoring-metric-not-updated,
         null,
       ]
     }
-    ec2_oracle_db = {
+    ec2_oracle_db_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected_expression.oracle-db-disconnected,
         null,
         null,
       ]
     }
-    ec2_oracle_db_with_backup = {
+    ec2_oracle_db_with_backup_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-error,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected_expression.oracle-db-disconnected,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup_expression.oracle-db-rman-backup-error,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup_expression.oracle-db-rman-backup-did-not-run,
       ]
     }
-    lb = {
+    lb_expression = {
       header_markdown = "## ALB"
       width           = 8
       height          = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-requests,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-http-4XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-http-5XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-requests,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-4XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-5XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-connection-errors,
-        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-requests,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-http-4XXs,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-http-5XXs,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-target-group-requests,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-target-group-http-4XXs,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-target-group-http-5XXs,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-active-connections,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-new-connections,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-target-connection-errors,
+        local.cloudwatch_dashboard_widgets.lb_expression.unhealthy-load-balancer-host,
+        local.cloudwatch_dashboard_widgets.lb_expression.load-balancer-target-response-time,
         null,
       ]
     }
-    lb_with_acm = {
-      header_markdown = "## ALB"
-      width           = 8
-      height          = 8
-      widgets = [
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-requests,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-http-4XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-http-5XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-requests,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-4XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-5XXs,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-connection-errors,
-        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
-        local.cloudwatch_dashboard_widgets.acm.cert-expires-soon,
-      ]
-    }
-    network_lb = {
+    network_lb_expression = {
       width  = 8
       height = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.network_lb.unhealthy-network-load-balancer-host,
+        local.cloudwatch_dashboard_widgets.network_lb_expression.unhealthy-network-load-balancer-host,
         null,
         null,
       ]

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -325,8 +325,8 @@ locals {
           [{ "expression" : "m1/PERIOD(m1)", "label" : "Read IOPs", "id" : "e1" }],
           [{ "expression" : "m2/PERIOD(m2)", "label" : "Write IOPs", "id" : "e2" }],
           [{ "expression" : "e1+e2", "label" : "Total IOPs", "id" : "e3" }],
-          ["AWS/EBS", "VolumeReadOps", "*", { "id" : "m1", "visible" : false }],
-          ["AWS/EBS", "VolumeWriteOps", "*", { "id" : "m2", "visible" : false }]
+          ["AWS/EBS", "VolumeReadOps", "VolumeId", "*", { "id" : "m1", "visible" : false }],
+          ["AWS/EBS", "VolumeWriteOps", "VolumeId", "*", { "id" : "m2", "visible" : false }]
         ]
       }
     }

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -639,21 +639,21 @@ locals {
           metrics = [
             [{ "expression" : "SELECT MAX(UnHealthyHostCount) FROM SCHEMA(\"AWS/ApplicationELB\", LoadBalancer, TargetGroup) GROUP BY LoadBalancer, TargetGroup ORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
           ]
-          annotations = {
-            horizontal = [
-              {
-                label = "Alarm Threshold"
-                value = local.cloudwatch_metric_alarms.lb.unhealthy-load-balancer-host.threshold
-                fill  = "above"
-              }
-            ]
-          }
-          #yAxis = {
-          #  left = {
-          #    showUnits = false,
-          #    label     = "host count"
-          #  }
+          #annotations = {
+          #  horizontal = [
+          #    {
+          #      label = "Alarm Threshold"
+          #      value = local.cloudwatch_metric_alarms.lb.unhealthy-load-balancer-host.threshold
+          #      fill  = "above"
+          #    }
+          #  ]
           #}
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "host count"
+            }
+          }
         }
       }
       load-balancer-target-response-time = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -277,7 +277,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 service-status-error-os-layer"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_service_status_os_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -307,7 +307,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 service-status-error-app-layer"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_service_status_app_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -337,7 +337,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 connectivity-test-all-failed"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_connectivity_test_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -367,7 +367,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 textfile-monitoring-metric-error"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -395,7 +395,7 @@ locals {
           stacked = false
           region  = "eu-west-2"
           title   = "EC2 textfile-monitoring-metric-not-updated"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_seconds) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -426,7 +426,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 oracle-db-disconnected"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_oracle_db_connected_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -456,7 +456,7 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 oracle-db-rman-backup-error"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_rman_backup_value) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]
@@ -484,7 +484,7 @@ locals {
           stacked = false
           region  = "eu-west-2"
           title   = "EC2 oracle-db-rman-backup-did-not-run"
-          stat    = "Maxiumum"
+          stat    = "Maximum"
           metrics = [
             [{ "expression" : "SELECT MAX(collectd_textfile_monitoring_rman_backup_seconds) FROM SCHEMA(CWAgent, InstanceId, type, type_instance) GROUP BY InstanceId, type, type_instance ORDER BY MAX() DESC", "label" : "", "id" : "q1", "yAxis" : "left" }],
           ]

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -2,6 +2,18 @@ locals {
 
   cloudwatch_dashboard_widgets = {
 
+    EC2GraphedMetricsHeading = {
+      type   = "text"
+      x      = 0
+      y      = 0
+      width  = 24
+      height = 1
+      properties = {
+        markdown   = "## EC2 Graphed Metrics"
+        background = "solid"
+      }
+    }
+
     EC2CPUUtil = {
       type   = "metric"
       x      = 0
@@ -15,7 +27,9 @@ locals {
         title   = "Top 5 instances by highest CPU Utilization %"
         stat    = "Maximum"
         metrics = [
-          [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 5", "label" : "", "id" : "q1" }]
+          ["AWS/EC2", "CPUUtilization", "InstanceId", "*", { "id" : "m1", "visible" : false }],
+
+          #[{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC\nLIMIT 5", "label" : "", "id" : "q1" }]
         ]
       }
     }
@@ -215,18 +229,6 @@ locals {
       }
     }
 
-    EC2GraphedMetricsHeading = {
-      type   = "text"
-      x      = 0
-      y      = 0
-      width  = 24
-      height = 1
-      properties = {
-        markdown   = "## EC2 Graphed Metrics"
-        background = "solid"
-      }
-    }
-
     EBSGraphedMetricsHeading = {
       type   = "text"
       x      = 0
@@ -243,6 +245,7 @@ locals {
 
   cloudwatch_dashboards = {
     "CloudWatch-Default" = {
+      periodOverride = "auto"
       widgets = [
         local.cloudwatch_dashboard_widgets.EC2CPUUtil,
         local.cloudwatch_dashboard_widgets.EC2MemoryUtil,

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -101,6 +101,21 @@ locals {
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
+    ec2_instance_or_cwagent_stopped_windows = {
+      instance-or-cloudwatch-agent-stopped = {
+        comparison_operator = "LessThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "CPU_IDLE"
+        period              = "60"
+        namespace           = "CWAgent"
+        statistic           = "SampleCount"
+        threshold           = "0"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
 
     ec2_cwagent_linux = {
       free-disk-space-low = {
@@ -139,7 +154,21 @@ locals {
         alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 3 hours. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
-
+    }
+    ec2_instance_or_cwagent_stopped_linux = {
+      instance-or-cloudwatch-agent-stopped = {
+        comparison_operator = "LessThanOrEqualToThreshold"
+        evaluation_periods  = "5"
+        datapoints_to_alarm = "5"
+        metric_name         = "cpu_usage_idle"
+        period              = "60"
+        namespace           = "CWAgent"
+        statistic           = "SampleCount"
+        threshold           = "0"
+        treat_missing_data  = "breaching"
+        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+      }
     }
 
     ec2_instance_cwagent_collectd_service_status_os = {
@@ -250,36 +279,6 @@ locals {
         threshold           = "129600"
         treat_missing_data  = "breaching"
         alarm_description   = "Triggers if rman_backup metric not collected or not updated for over 36 hours"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-      }
-    }
-    ec2_instance_or_cwagent_stopped_linux = {
-      instance-or-cloudwatch-agent-stopped = {
-        comparison_operator = "LessThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "cpu_usage_idle"
-        period              = "60"
-        namespace           = "CWAgent"
-        statistic           = "SampleCount"
-        threshold           = "0"
-        treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
-        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-      }
-    }
-    ec2_instance_or_cwagent_stopped_windows = {
-      instance-or-cloudwatch-agent-stopped = {
-        comparison_operator = "LessThanOrEqualToThreshold"
-        evaluation_periods  = "5"
-        datapoints_to_alarm = "5"
-        metric_name         = "CPU_IDLE"
-        period              = "60"
-        namespace           = "CWAgent"
-        statistic           = "SampleCount"
-        threshold           = "0"
-        treat_missing_data  = "breaching"
-        alarm_description   = "Triggers if the instance or cloudwatch agent is stopped after 5 minutes since the metric will not be collected. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4671340764/EC2+instance-or-cloudwatch-agent-stopped+alarm"
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
       }
     }

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -14,6 +14,18 @@ output "backup_plans" {
   }
 }
 
+output "cloudwatch_dashboard_widgets" {
+  description = "Map of common cloudwatch dashboard widgets"
+  value       = local.cloudwatch_dashboard_widgets
+}
+
+output "cloudwatch_dashboards" {
+  description = "Map of common cloudwatch dashboards"
+  value = var.options.cloudwatch_dashboards != null ? {
+    for key, value in local.cloudwatch_dashboards : key => value if contains(var.options.cloudwatch_dashboards, key)
+  } : {}
+}
+
 output "cloudwatch_log_groups" {
   description = "Map of log groups"
 

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -15,15 +15,15 @@ output "backup_plans" {
 }
 
 output "cloudwatch_dashboard_widgets" {
-  description = "Map of common cloudwatch dashboard widgets"
+  description = "Map of common cloudwatch dashboard widgets grouped by namespace"
   value       = local.cloudwatch_dashboard_widgets
 }
 
 output "cloudwatch_dashboards" {
   description = "Map of common cloudwatch dashboards"
-  value = var.options.cloudwatch_dashboards != null ? {
-    for key, value in local.cloudwatch_dashboards : key => value if contains(var.options.cloudwatch_dashboards, key)
-  } : {}
+  value = {
+    for key, value in local.cloudwatch_dashboards : key => value if contains(local.cloudwatch_dashboards_filter, key)
+  }
 }
 
 output "cloudwatch_log_groups" {

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -15,7 +15,7 @@ variable "options" {
   type = object({
     backup_plan_daily_delete_after               = optional(number, 7)
     backup_plan_weekly_delete_after              = optional(number, 28)
-    cloudwatch_dashboards                        = optional(list(string))
+    cloudwatch_dashboard_default_widget_groups   = optional(list(string))
     cloudwatch_log_groups                        = optional(list(string))
     cloudwatch_metric_alarms_default_actions     = optional(list(string))
     cloudwatch_metric_oam_links_ssm_parameters   = optional(list(string))

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -15,6 +15,7 @@ variable "options" {
   type = object({
     backup_plan_daily_delete_after               = optional(number, 7)
     backup_plan_weekly_delete_after              = optional(number, 28)
+    cloudwatch_dashboards                        = optional(list(string))
     cloudwatch_log_groups                        = optional(list(string))
     cloudwatch_metric_alarms_default_actions     = optional(list(string))
     cloudwatch_metric_oam_links_ssm_parameters   = optional(list(string))

--- a/terraform/modules/cloudwatch_dashboard/README.md
+++ b/terraform/modules/cloudwatch_dashboard/README.md
@@ -1,0 +1,82 @@
+# Cloudwatch Dashboard Module
+
+Why bother?
+
+It can be a pain to manage widget x/y co-ordinates.
+If you don't set x,y co-ordinates, the dashboard will look OK
+but with some exceptions - the default dashboard won't display
+as you might expect on the AWS Console Cloudwatch page.
+
+This module will figure out the co-ordinates for you, and can
+easily add a header to each section of widgets.
+
+The idea of this module is you define a set of re-usable
+widgets without any x, y, width and height, e.g.:
+
+```
+widgets = {
+  cpu-utilization-high = {
+    type = "metric"
+    properties = {
+      view    = "timeSeries"
+      stacked = false
+      region  = "eu-west-2"
+      title   = "EC2 cpu-utilization-high"
+      stat    = "Maximum"
+      metrics = [
+        [{ "expression" : "SELECT MAX(CPUUtilization)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
+      ]
+    }
+  }
+  instance-status-check-failed = {
+    type = "metric"
+    properties = {
+      view    = "timeSeries"
+      stacked = true
+      region  = "eu-west-2"
+      title   = "EC2 instance-status-check-failed"
+      stat    = "Maximum"
+      metrics = [
+        [{ "expression" : "SELECT MAX(StatusCheckFailed_Instance)\nFROM SCHEMA(\"AWS/EC2\", InstanceId)\nGROUP BY InstanceId\nORDER BY MAX() DESC", "label" : "", "id" : "q1" }],
+      ]
+    }
+  }
+}
+```
+
+And then define your dashboard as a set of widget groups, e.g.
+all EC2 related widgets together. The module will add a header and
+the dimensions for you.
+
+```
+module "cloudwatch_dashboard" {
+  for_each = local.cloudwatch_dashboards
+
+  source = "../../modules/cloudwatch_dashboard"
+
+  dashboard_name = "Cloudwatch-Default"
+  periodOverride = "auto"
+  start          = "-PT3H"
+  widget_groups  = [
+    {
+      header_markdown = "## EC2"
+      width           = 8
+      height          = 8
+      widgets = [
+        local.widgets.cpu-utilization-high,
+        local.widgets.instance-status-check-failed,
+        null, # pad
+        local.widgets.another-ec2-widget-on-next-line
+      ]
+    },
+    {
+      header_markdown = "## ALB"
+      width           = 24
+      height          = 8
+      widgets = [
+        local.widgets.an-alb-widget,
+      ]
+    }
+  ]
+}
+```

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -1,0 +1,37 @@
+locals {
+
+  # add header widget and calculate x, y positions
+  # set y to 0 as AWS figures that out OK. 
+  widgets = flatten([
+    for widget_group in var.widget_groups : [
+      lookup(widget_group, "header_markdown", null) == null ? [] : [{
+        type   = "text"
+        width  = 24
+        height = 1
+        x      = 0
+        y      = 0
+        properties = {
+          markdown   = widget_group.header_markdown
+          background = "solid"
+        }
+      }],
+      [
+        for i in range(length(widget_group.widgets)) : merge(widget_group.widgets[i], {
+          width  = widget_group.width
+          height = widget_group.height
+          x      = i * widget_group.width % 24
+          y      = 0
+        }) if widget_group.widgets[i] != null
+      ]
+    ]
+  ])
+}
+
+resource "aws_cloudwatch_dashboard" "this" {
+  dashboard_name = var.dashboard_name
+  dashboard_body = jsonencode({
+    periodOverride = var.periodOverride
+    start          = var.start
+    widgets        = local.widgets
+  })
+}

--- a/terraform/modules/cloudwatch_dashboard/outputs.tf
+++ b/terraform/modules/cloudwatch_dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard" {
+  description = "aws_cloudwatch_dashboard resource"
+  value       = aws_cloudwatch_dashboard.this
+}

--- a/terraform/modules/cloudwatch_dashboard/variables.tf
+++ b/terraform/modules/cloudwatch_dashboard/variables.tf
@@ -1,0 +1,28 @@
+variable "dashboard_name" {
+  description = "The name of the dashboard"
+  type        = string
+}
+
+variable "periodOverride" {
+  description = "Use this field to specify the period for the graphs when the dashboard loads. Specifying auto causes the period of all graphs on the dashboard to automatically adapt to the time range of the dashboard. Specifying inherit ensures that the period set for each graph is always obeyed."
+  type        = string
+  default     = null
+}
+
+variable "start" {
+  description = "The start of the time range to use for each widget on the dashboard, e.g. -PT3H for last 3 hours"
+  type        = string
+  default     = null
+}
+
+variable "widget_groups" {
+  description = "list of objects defining a group of widgets. Automatically include a text widget if header_markdown defined. See README.md"
+  # tflint-ignore: terraform_typed_variables
+  # type = list(object({  
+  #   header_markdown = optional(string)     # include a header text widget if set
+  #   width           = number               # width of each widget, must be divisor of 24
+  #   height          = number               # height of each widget
+  #   widgets         = list(any)            # as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
+  # }))
+  default = []
+}


### PR DESCRIPTION
Added cloudwatch_dashboard module into baseline.
Common widgets in baseline_presets which match up with the alarms that we configure.
Tested in nomis-test
Plus some whitespace fixes
