### PR TITLE
💼 Add `gp3` storage class

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-annotations.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-annotations.tf
@@ -2,6 +2,8 @@ resource "kubernetes_annotations" "gp2" {
   api_version = "storage.k8s.io/v1"
   kind        = "StorageClass"
 
+  force = true
+
   metadata {
     name = "gp2"
   }

--- a/terraform/environments/analytical-platform-compute/kubernetes-annotations.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-annotations.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_annotations" "gp2" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+
+  metadata {
+    name = "gp2"
+  }
+
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-storageclasses.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-storageclasses.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  allow_volume_expansion = "true"
+
+  parameters = {
+    type      = "gp3"
+    encrypted = "true"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-storageclasses.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-storageclasses.tf
@@ -9,9 +9,12 @@ resource "kubernetes_storage_class" "gp3" {
   storage_provisioner    = "ebs.csi.aws.com"
   reclaim_policy         = "Delete"
   allow_volume_expansion = "true"
+  volume_binding_mode    = "WaitForFirstConsumer"
 
   parameters = {
     type      = "gp3"
     encrypted = "true"
   }
+
+  depends_on = [kubernetes_annotations.gp2]
 }


### PR DESCRIPTION
This pull request:

- Adds a new storage class for `gp3` and makes it the default
- Annotates `gp2` to unset it as default

Note:

I have rolled the Prometheus Proxy deployment to pick up the new storage class

```
$ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                              STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-86f303de-ee95-4cc1-b508-9145d4eb83f8   2Gi        RWO            Delete           Bound    aws-observability/storage-amazon-prometheus-proxy-alertmanager-0   gp3            <unset>                          3m52s
pvc-ed8e583f-428d-4e13-bab1-30afa16a03bd   8Gi        RWO            Delete           Bound    aws-observability/amazon-prometheus-proxy-server                   gp3            <unset>                          3m51s
```

I have removed production's Prometheus Proxy ahead of merging to main

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 