### PR TITLE
Update ami tag for testing new role

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -104,7 +104,7 @@ locals {
         autoscaling_schedules = module.baseline_presets.ec2_autoscaling_schedules.working_hours
         tags = {
           description = "RHEL8.5 for connection to Azure domain"
-          ami         = "hmpps_rhel_8_5"
+          ami         = "hmpps_domain_services_rhel_8_5"
           os-type     = "Linux"
           component   = "test"
           server-type = "hmpps-domain-services"


### PR DESCRIPTION
- There is no hmpps_rhel_8_5 in group_vars 