### PR TITLE
Nomis: connectivity test fix

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -288,7 +288,7 @@ locals {
           description        = "Disaster-Recovery/High-Availability production databases for AUDIT/MIS"
           oracle-sids        = "DRMIS DRCNMAUD"
           misload-dbname     = "DRMIS"
-          connectivity-tests = "10.40.0.136:4903 10.40.129.79:22"
+          connectivity-tests = "10.40.0.133:53 10.40.129.79:22"
         })
       })
     }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -11,7 +11,7 @@ locals {
         "lb",
         "ec2_linux_only",
         "ec2_oracle_db_with_backup",
-        "ec2_service_status_with",
+        "ec2_service_status",
         "ec2_textfile_monitoring",
       ]
       enable_observability_platform_monitoring = true

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -11,7 +11,7 @@ locals {
         "lb",
         "ec2_linux_only",
         "ec2_oracle_db_with_backup",
-        "ec2_service_status_with_connectivity_test",
+        "ec2_service_status_with",
         "ec2_textfile_monitoring",
       ]
       enable_observability_platform_monitoring = true


### PR DESCRIPTION
One of the servers has been taken down, use Domain Controller instead.
Also, the test is only in nomis-production.  Update nomis-test dashboard to reflect this.