### PR TITLE
issue/6709

### DIFF
--- a/terraform/environments/example/ec2_complete.tf
+++ b/terraform/environments/example/ec2_complete.tf
@@ -55,7 +55,8 @@ locals {
           component   = "ndh"
           environment = "development"
           flexi-startup     = "8am"
-          flexi-shutdown    = "6pm" 
+          flexi-shutdown    = "7pm"
+          instance-scheduling = "skip-scheduling"
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }
@@ -88,8 +89,10 @@ locals {
           os-type     = "Linux"
           component   = "ndh"
           environment = "development"
-          flexi-startup     = "9am"
-          flexi-shutdown    = "7pm" 
+          flexi-startup     = "8am"
+          flexi-shutdown    = "7pm"
+          instance-scheduling = "skip-scheduling"
+
         }
         ebs_volumes = {
           "/dev/sdf" = { size = 20, type = "gp3" }

--- a/terraform/environments/example/rds.tf
+++ b/terraform/environments/example/rds.tf
@@ -43,7 +43,8 @@ resource "aws_db_instance" "example-rds" {
   performance_insights_kms_key_id     = "" #tfsec:ignore:aws-rds-enable-performance-insights-encryption Left empty so that it will run, however should be populated with real key in scenario.
   enabled_cloudwatch_logs_exports     = local.application_data.accounts[local.environment].db_enabled_cloudwatch_logs_exports
   tags = merge(local.tags,
-    { Name = lower(format("%s-%s-example", local.application_name, local.environment)) }
+    { Name = lower(format("%s-%s-example", local.application_name, local.environment)) },
+    { instance-scheduling = "skip-scheduling" } # This is now managed by the flexible shutdown & startup workflow.
   )
 }
 


### PR DESCRIPTION
Amends tag of RDS so it is managed by the flexible restart workflow. Also amends ec2 tags so that only two of the ec2s are in scope of the workflow.