### PR TITLE
DSOS-2797: add oem dashboards

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -46,6 +46,45 @@ locals {
   }
 
   baseline_all_environments = {
+    cloudwatch_dashboards = {
+      "hmpps-oem-${local.environment}" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        accountId      = "module.environment.account_ids.hmpps-oem-${local.environment}"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
+        ]
+      }
+      "nomis-${local.environment}" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        accountId      = "module.environment.account_ids.nomis-${local.environment}"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_autoscaling_group_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
+        ]
+      }
+      "corporate-staff-rostering-${local.environment}" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        accountId      = "module.environment.account_ids.corporate-staff-rostering-${local.environment}"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
+        ]
+      }
+    }
     iam_policies = {
       Ec2OracleEnterpriseManagerPolicy = {
         description = "Permissions required for Oracle Enterprise Manager"

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -48,9 +48,9 @@ locals {
   baseline_all_environments = {
     cloudwatch_dashboards = {
       "hmpps-oem-${local.environment}" = {
+        account_name   = "hmpps-oem-${local.environment}"
         periodOverride = "auto"
         start          = "-PT6H"
-        accountId      = "module.environment.account_ids.hmpps-oem-${local.environment}"
         widget_groups = [
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
@@ -60,9 +60,9 @@ locals {
         ]
       }
       "nomis-${local.environment}" = {
+        account_name   = "nomis-${local.environment}"
         periodOverride = "auto"
         start          = "-PT6H"
-        accountId      = "module.environment.account_ids.nomis-${local.environment}"
         widget_groups = [
           module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
@@ -74,9 +74,9 @@ locals {
         ]
       }
       "corporate-staff-rostering-${local.environment}" = {
+        account_name   = "corporate-staff-rostering-${local.environment}"
         periodOverride = "auto"
         start          = "-PT6H"
-        accountId      = "module.environment.account_ids.corporate-staff-rostering-${local.environment}"
         widget_groups = [
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -31,10 +31,10 @@ module "cloudwatch_dashboard" {
   source = "../../modules/cloudwatch_dashboard"
 
   dashboard_name = each.key
-  accountId      = each.value.account_name == null ? null : var.environment.account_ids[each.value.account_name]
-  periodOverride = each.value.periodOverride
-  start          = each.value.start
-  widget_groups  = each.value.widget_groups
+  accountId      = lookup(each.value, "account_name", null) == null ? null : var.environment.account_ids[lookup(each.value, "account_name", null)]
+  periodOverride = lookup(each.value, "periodOverride", null)
+  start          = lookup(each.value, "start", null)
+  widget_groups  = lookup(each.value, "widget_groups", [])
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -31,6 +31,7 @@ module "cloudwatch_dashboard" {
   source = "../../modules/cloudwatch_dashboard"
 
   dashboard_name = each.key
+  accountId      = each.value.account_name == null ? null : var.environment.account_ids[each.value.account_name]
   periodOverride = each.value.periodOverride
   start          = each.value.start
   widget_groups  = each.value.widget_groups

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -87,6 +87,7 @@ variable "cloudwatch_dashboards" {
   # tflint-ignore: terraform_typed_variables
   description = "map of cloudwatch dashboards where key is the dashboard name. Use widget_groups if you want baseline to work out x,y,width,height"
   #type = map(object({
+  #  account_name   = optional(string)        # for monitoring account, limit to given account
   #  periodOverride = optional(string)
   #  start          = optional(string)
   #  widgets        = optional(list(any), []) # use if you want to set x,y,width,height yourself

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -1,3 +1,10 @@
+# Widgets generally correspond to equivalent cloudwatch_metric_alarm
+# SELECT expressions only allow last 3 hours data, so SEARCH is used instead
+# x,y,width,height are not defined here - the cloudwatch_dashboard module populates these
+# AccountIds also not defined here - the cloudwatch_dashboard module can add
+# AccountIds can be defined per widget like this:
+#   SORT(SEARCH('{AWS/EC2,InstanceId} MetricName="CPUUtilization" :aws.AccountId= "272983201692"','Maximum'),MAX,DESC)
+
 locals {
 
   cloudwatch_dashboards_filter = flatten([

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -19,6 +19,11 @@ output "cloudwatch_dashboard_widgets" {
   value       = local.cloudwatch_dashboard_widgets
 }
 
+output "cloudwatch_dashboard_widget_groups" {
+  description = "Map of common cloudwatch dashboard widget groups"
+  value       = local.cloudwatch_dashboard_widget_groups
+}
+
 output "cloudwatch_dashboards" {
   description = "Map of common cloudwatch dashboards"
   value = {

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -28,12 +28,16 @@ locals {
         }
       }],
       [
-        for j in range(length(var.widget_groups[i].widgets)) : merge(var.widget_groups[i].widgets[j], {
-          width  = var.widget_groups[i].width
-          height = var.widget_groups[i].height
-          x      = j * var.widget_groups[i].width % 24
-          y      = (floor(j * var.widget_groups[i].width / 24) * var.widget_groups[i].height) + local.widget_group_y[i] + local.widget_group_header_height[i]
-        }) if var.widget_groups[i].widgets[j] != null
+        for j in range(length(var.widget_groups[i].widgets)) : merge(
+          var.accountId == null ? {} : { accountId = var.accountId },
+          {
+            width  = var.widget_groups[i].width
+            height = var.widget_groups[i].height
+            x      = j * var.widget_groups[i].width % 24
+            y      = (floor(j * var.widget_groups[i].width / 24) * var.widget_groups[i].height) + local.widget_group_y[i] + local.widget_group_header_height[i]
+          },
+          var.widget_groups[i].widgets[j]
+        ) if var.widget_groups[i].widgets[j] != null
       ]
     ]
   ])

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -29,14 +29,18 @@ locals {
       }],
       [
         for j in range(length(var.widget_groups[i].widgets)) : merge(
-          var.accountId == null ? {} : { accountId = var.accountId },
           {
             width  = var.widget_groups[i].width
             height = var.widget_groups[i].height
             x      = j * var.widget_groups[i].width % 24
             y      = (floor(j * var.widget_groups[i].width / 24) * var.widget_groups[i].height) + local.widget_group_y[i] + local.widget_group_header_height[i]
           },
-          var.widget_groups[i].widgets[j]
+          var.widget_groups[i].widgets[j],
+          var.accountId == null ? {} : {
+            properties = merge(var.widget_groups[i].widgets[j].properties, {
+              accountId = var.accountId
+            })
+          }
         ) if var.widget_groups[i].widgets[j] != null
       ]
     ]

--- a/terraform/modules/cloudwatch_dashboard/variables.tf
+++ b/terraform/modules/cloudwatch_dashboard/variables.tf
@@ -1,3 +1,9 @@
+variable "accountId" {
+  description = "For monitoring accounts, apply this accountId to all widgets in dashboard"
+  type        = string
+  default     = null
+}
+
 variable "dashboard_name" {
   description = "The name of the dashboard"
   type        = string


### PR DESCRIPTION
Add additional dashboards in OEM account for nomis and corporate-staff-rostering. Not fully working yet due to permission issue which I'll fix separately.