### PR TITLE
fix onr-bods ami at specific version

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_defaults.tf
+++ b/terraform/environments/oasys-national-reporting/locals_defaults.tf
@@ -108,7 +108,7 @@ locals {
 
   defaults_bods_ec2 = merge(local.defaults_ec2, {
     config = merge(local.defaults_ec2.config, {
-      ami_name = "hmpps_windows_server_2019_release_*"
+      ami_name = "hmpps_windows_server_2019_release_2024-05-02T00-00-37.552Z" # fixed to a specific version
     })
     instance = merge(local.defaults_ec2.instance, {
       vpc_security_group_ids = ["bods", "oasys_db"]

--- a/terraform/environments/oasys-national-reporting/locals_defaults.tf
+++ b/terraform/environments/oasys-national-reporting/locals_defaults.tf
@@ -108,7 +108,7 @@ locals {
 
   defaults_bods_ec2 = merge(local.defaults_ec2, {
     config = merge(local.defaults_ec2.config, {
-      ami_name = "hmpps_windows_server_2019_release_2024-05-02T00-00-37.552Z" # fixed to a specific version
+      ami_name = "hmpps_windows_server_2019_release_*" # wildcard to latest. EC2 instance versions ami_name must be fixed
     })
     instance = merge(local.defaults_ec2.instance, {
       vpc_security_group_ids = ["bods", "oasys_db"]

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -39,6 +39,7 @@ locals {
           availability_zone             = "${local.region}a"
           ebs_volumes_copy_all_from_ami = false
           user_data_raw                 = module.baseline_presets.ec2_instance.user_data_raw["user-data-pwsh"]
+          ami_name = "hmpps_windows_server_2019_release_2024-05-02T00-00-37.552Z" # fixed to a specific version
         })
         instance = merge(local.defaults_bods_ec2.instance, {
           instance_type = "m4.xlarge"


### PR DESCRIPTION
- Deployed EC2 instances used fixed ami references when deployed so disks/instance doesn't change
- ASG's use wildcards/latest for testing