### PR TITLE
🔭 Switch APC to `kube-prometheus-stack`

### DIFF
--- a/terraform/environments/analytical-platform-compute/data.tf
+++ b/terraform/environments/analytical-platform-compute/data.tf
@@ -4,3 +4,20 @@ data "aws_iam_roles" "eks_sso_access_role" {
   name_regex  = "AWSReservedSSO_${local.environment_configuration.eks_sso_access_role}_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }
+
+data "http" "prometheus_operator_crds" {
+  for_each = {
+    alertmanagerconfigs = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml"
+    alertmanagers       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml"
+    podmonitors         = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml"
+    probes              = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml"
+    prometheus_agents   = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml"
+    prometheuses        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
+    prometheusrules     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml"
+    scrapeconfigs       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml"
+    servicemonitors     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
+    thanosrulers        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
+  }
+
+  url = each.value
+}

--- a/terraform/environments/analytical-platform-compute/data.tf
+++ b/terraform/environments/analytical-platform-compute/data.tf
@@ -7,16 +7,16 @@ data "aws_iam_roles" "eks_sso_access_role" {
 
 data "http" "prometheus_operator_crds" {
   for_each = {
-    alertmanagerconfigs = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml"
-    alertmanagers       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml"
-    podmonitors         = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml"
-    probes              = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml"
-    prometheus_agents   = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml"
-    prometheuses        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
-    prometheusrules     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml"
-    scrapeconfigs       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml"
-    servicemonitors     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
-    thanosrulers        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
+    alertmanagerconfigs = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml"
+    alertmanagers       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml"
+    podmonitors         = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml"
+    probes              = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml"
+    prometheus_agents   = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml"
+    prometheuses        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
+    prometheusrules     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml"
+    scrapeconfigs       = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml"
+    servicemonitors     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
+    thanosrulers        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${local.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
   }
 
   url = each.value

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -16,6 +16,8 @@ locals {
   eks_cloudwatch_log_group_name              = "/aws/eks/${local.eks_cluster_name}/logs"
   eks_cloudwatch_log_group_retention_in_days = 400
 
+  /* Kube Prometheus Stack */
+  prometheus_operator_crd_version = "v0.74.0"
 
   /* Environment Configuration */
   environment_configuration = local.environment_configurations[local.environment]

--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -63,11 +63,11 @@ resource "helm_release" "aws_for_fluent_bit" {
 }
 
 resource "helm_release" "amazon_prometheus_proxy" {
-  /* https://artifacthub.io/packages/helm/prometheus-community/prometheus */
+  /* https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack */
   name       = "amazon-prometheus-proxy"
   repository = "https://prometheus-community.github.io/helm-charts"
-  chart      = "prometheus"
-  version    = "25.21.0"
+  chart      = "kube-prometheus-stack"
+  version    = "59.1.0"
   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
   values = [
     templatefile(

--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -62,26 +62,26 @@ resource "helm_release" "aws_for_fluent_bit" {
   depends_on = [module.aws_for_fluent_bit_iam_role]
 }
 
-resource "helm_release" "amazon_prometheus_proxy" {
-  /* https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack */
-  name       = "amazon-prometheus-proxy"
-  repository = "https://prometheus-community.github.io/helm-charts"
-  chart      = "kube-prometheus-stack"
-  version    = "59.1.0"
-  namespace  = kubernetes_namespace.aws_observability.metadata[0].name
-  values = [
-    templatefile(
-      "${path.module}/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl",
-      {
-        aws_region       = data.aws_region.current.name
-        eks_role_arn     = module.amazon_prometheus_proxy_iam_role.iam_role_arn
-        amp_workspace_id = aws_prometheus_workspace.main.id
-      }
-    )
-  ]
+# resource "helm_release" "amazon_prometheus_proxy" {
+#   /* https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack */
+#   name       = "amazon-prometheus-proxy"
+#   repository = "https://prometheus-community.github.io/helm-charts"
+#   chart      = "kube-prometheus-stack"
+#   version    = "59.1.0"
+#   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
+#   values = [
+#     templatefile(
+#       "${path.module}/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl",
+#       {
+#         aws_region       = data.aws_region.current.name
+#         eks_role_arn     = module.amazon_prometheus_proxy_iam_role.iam_role_arn
+#         amp_workspace_id = aws_prometheus_workspace.main.id
+#       }
+#     )
+#   ]
 
-  depends_on = [module.amazon_prometheus_proxy_iam_role]
-}
+#   depends_on = [module.amazon_prometheus_proxy_iam_role]
+# }
 
 /* Cluster Autoscaler */
 resource "helm_release" "cluster_autoscaler" {

--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -62,26 +62,30 @@ resource "helm_release" "aws_for_fluent_bit" {
   depends_on = [module.aws_for_fluent_bit_iam_role]
 }
 
-# resource "helm_release" "amazon_prometheus_proxy" {
-#   /* https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack */
-#   name       = "amazon-prometheus-proxy"
-#   repository = "https://prometheus-community.github.io/helm-charts"
-#   chart      = "kube-prometheus-stack"
-#   version    = "59.1.0"
-#   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
-#   values = [
-#     templatefile(
-#       "${path.module}/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl",
-#       {
-#         aws_region       = data.aws_region.current.name
-#         eks_role_arn     = module.amazon_prometheus_proxy_iam_role.iam_role_arn
-#         amp_workspace_id = aws_prometheus_workspace.main.id
-#       }
-#     )
-#   ]
+resource "helm_release" "amazon_prometheus_proxy" {
+  /* https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack */
+  /* If you are upgrading this chart, check whether the CRD version needs updating */
+  name       = "amazon-prometheus-proxy"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  version    = "59.1.0"
+  namespace  = kubernetes_namespace.aws_observability.metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl",
+      {
+        aws_region       = data.aws_region.current.name
+        eks_role_arn     = module.amazon_prometheus_proxy_iam_role.iam_role_arn
+        amp_workspace_id = aws_prometheus_workspace.main.id
+      }
+    )
+  ]
 
-#   depends_on = [module.amazon_prometheus_proxy_iam_role]
-# }
+  depends_on = [
+    kubernetes_manifest.prometheus_operator_crds,
+    module.amazon_prometheus_proxy_iam_role
+  ]
+}
 
 /* Cluster Autoscaler */
 resource "helm_release" "cluster_autoscaler" {

--- a/terraform/environments/analytical-platform-compute/kubernetes-manifests.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-manifests.tf
@@ -1,5 +1,5 @@
 resource "kubernetes_manifest" "prometheus_operator_crds" {
   for_each = data.http.prometheus_operator_crds
 
-  manifest = yamldecode(each.value)
+  manifest = yamldecode(each.value.response_body)
 }

--- a/terraform/environments/analytical-platform-compute/kubernetes-manifests.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-manifests.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_manifest" "prometheus_operator_crds" {
+  for_each = data.http.prometheus_operator_crds
+
+  manifest = yamldecode(each.value)
+}

--- a/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
@@ -1,6 +1,10 @@
 ---
 namespaceOverride: aws-observability
 
+# These are handled by kubernetes_manifest.prometheus_operator_crds
+crds:
+  enabled: false
+
 defaultRules:
   create: false
 

--- a/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
@@ -1,16 +1,28 @@
 ---
-serviceAccounts:
-  server:
+namespaceOverride: aws-observability
+
+defaultRules:
+  create: false
+
+alertmanager:
+  enabled: false
+
+grafana:
+  enabled: false
+
+prometheus:
+  agentMode: true
+  serviceAccount:
+    create: true
     name: amazon-prometheus-proxy
     annotations:
       eks.amazonaws.com/role-arn: ${eks_role_arn}
-
-server:
-  remoteWrite:
-    - url: https://aps-workspaces.${aws_region}.amazonaws.com/workspaces/${amp_workspace_id}/api/v1/remote_write
-      sigv4:
-        region: ${aws_region}
-      queue_config:
-        max_samples_per_send: 1000
-        max_shards: 200
-        capacity: 2500
+  prometheusSpec:
+    remoteWrite:
+      - url: https://aps-workspaces.${aws_region}.amazonaws.com/workspaces/${amp_workspace_id}/api/v1/remote_write
+        sigv4:
+          region: ${aws_region}
+        queueConfig:
+          maxSamplesPerSend: 1000
+          maxShards: 200
+          capacity: 2500


### PR DESCRIPTION
This pull request:

Resolves https://github.com/ministryofjustice/analytical-platform/issues/4424

- Switches from vanilla Prometheus to `kube-prometheus-stack` which includes `prometheus-operator` 

TODO before merging:
- [x] Scrub `amazon-prometheus-proxy` from APC Production
- [x] Clean any PV(C)s leftover
  - [x] Development
  - [x] Test
  - [x] Production