### PR TITLE
Nomis: DSOS-2824: allow hmpp join domain

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_domain.tf
+++ b/terraform/environments/hmpps-domain-services/locals_domain.tf
@@ -11,7 +11,8 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.planetfm-test}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-development}:role/LambdaFunctionADObjectCleanUp",
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-test}:role/LambdaFunctionADObjectCleanUp",
-      "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-nonlive-role"
+      "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-nonlive-role",
+      "arn:aws:iam::${module.environment.account_ids.nomis-development}:role/EC2HmppsDomainSecretsRole",
     ]
     preproduction = []
     production = [

--- a/terraform/environments/hmpps-domain-services/locals_domain.tf
+++ b/terraform/environments/hmpps-domain-services/locals_domain.tf
@@ -13,6 +13,7 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-test}:role/LambdaFunctionADObjectCleanUp",
       "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-nonlive-role",
       "arn:aws:iam::${module.environment.account_ids.nomis-development}:role/EC2HmppsDomainSecretsRole",
+      "arn:aws:iam::${module.environment.account_ids.nomis-test}:role/EC2HmppsDomainSecretsRole",
     ]
     preproduction = []
     production = [
@@ -25,6 +26,8 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-preproduction}:role/LambdaFunctionADObjectCleanUp",
       "arn:aws:iam::${module.environment.account_ids.corporate-staff-rostering-production}:role/LambdaFunctionADObjectCleanUp",
       "arn:aws:iam::${module.environment.account_ids.core-shared-services-production}:role/ad-fixngo-ec2-live-role",
+      "arn:aws:iam::${module.environment.account_ids.nomis-preproduction}:role/EC2HmppsDomainSecretsRole",
+      "arn:aws:iam::${module.environment.account_ids.nomis-production}:role/EC2HmppsDomainSecretsRole",
     ]
   }
 

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -41,6 +41,7 @@ locals {
       enable_ec2_self_provision                   = true
       enable_ec2_oracle_enterprise_managed_server = true
       enable_ec2_user_keypair                     = true
+      enable_hmpps_domain                         = true # Syscon users are collaborators so need domain creds to access nomis-client EC2s
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       route53_resolver_rules = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -169,9 +169,9 @@ locals {
       }
 
       dev-nomis-client-a = local.jumpserver_ec2
-      nomis-client-b = merge(local.jumpserver_ec2, { # 15 char hostname limit as domain joined
+      dev-nomis-client-b = merge(local.jumpserver_ec2, {
         tags = merge(local.jumpserver_ec2.tags, {
-          domain-name = "azure.noms.root"
+          # domain-name = "azure.noms.root"
         })
       })
     }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -7,7 +7,6 @@ locals {
 
   baseline_presets_development = {
     options = {
-      enable_hmpps_domain = true # Syscon users are collaborators so need domain creds to access nomis-client EC2s
       sns_topics = {
         pagerduty_integrations = {
           dso_pagerduty               = "nomis_nonprod_alarms"
@@ -168,8 +167,7 @@ locals {
         }
       }
 
-      dev-nomis-client-a = local.jumpserver_ec2
-      dev-nomis-client-b = merge(local.jumpserver_ec2, {
+      dev-nomis-client-a = merge(local.jumpserver_ec2, {
         tags = merge(local.jumpserver_ec2.tags, {
           domain-name = "azure.noms.root"
         })

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -171,7 +171,7 @@ locals {
       dev-nomis-client-a = local.jumpserver_ec2
       dev-nomis-client-b = merge(local.jumpserver_ec2, {
         tags = merge(local.jumpserver_ec2.tags, {
-          # domain-name = "azure.noms.root"
+          domain-name = "azure.noms.root"
         })
       })
     }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -7,6 +7,7 @@ locals {
 
   baseline_presets_development = {
     options = {
+      enable_hmpps_domain = true # Syscon users are collaborators so need domain creds to access dev-nomis-client EC2
       sns_topics = {
         pagerduty_integrations = {
           dso_pagerduty               = "nomis_nonprod_alarms"
@@ -168,6 +169,11 @@ locals {
       }
 
       dev-nomis-client-a = local.jumpserver_ec2
+      dev-nomis-client-b = merge(local.jumpserver_ec2, {
+        tags = merge(local.jumpserver_ec2.tags, {
+          domain-name = "azure.noms.root"
+        })
+      })
     }
 
     ec2_instances = {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -7,7 +7,7 @@ locals {
 
   baseline_presets_development = {
     options = {
-      enable_hmpps_domain = true # Syscon users are collaborators so need domain creds to access dev-nomis-client EC2
+      enable_hmpps_domain = true # Syscon users are collaborators so need domain creds to access nomis-client EC2s
       sns_topics = {
         pagerduty_integrations = {
           dso_pagerduty               = "nomis_nonprod_alarms"
@@ -169,7 +169,7 @@ locals {
       }
 
       dev-nomis-client-a = local.jumpserver_ec2
-      dev-nomis-client-b = merge(local.jumpserver_ec2, {
+      nomis-client-b = merge(local.jumpserver_ec2, { # 15 char hostname limit as domain joined
         tags = merge(local.jumpserver_ec2.tags, {
           domain-name = "azure.noms.root"
         })

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -102,7 +102,11 @@ locals {
         })
       })
 
-      preprod-nomis-client-a = local.jumpserver_ec2
+      preprod-nomis-client-a = merge(local.jumpserver_ec2, {
+        tags = merge(local.jumpserver_ec2.tags, {
+          domain-name = "azure.hmpp.root"
+        })
+      })
     }
 
     ec2_instances = {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -135,7 +135,11 @@ locals {
         })
       })
 
-      prod-nomis-client-a = local.jumpserver_ec2
+      prod-nomis-client-a = merge(local.jumpserver_ec2, {
+        tags = merge(local.jumpserver_ec2.tags, {
+          domain-name = "azure.hmpp.root"
+        })
+      })
     }
 
     ec2_instances = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -207,7 +207,11 @@ locals {
         })
       })
 
-      test-nomis-client-a = local.jumpserver_ec2
+      test-nomis-client-a = merge(local.jumpserver_ec2, {
+        tags = merge(local.jumpserver_ec2.tags, {
+          domain-name = "azure.noms.root"
+        })
+      })
     }
 
     ec2_instances = {

--- a/terraform/modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml
+++ b/terraform/modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml
@@ -88,7 +88,7 @@ tasks:
           $ErrorActionPreference = "Stop"
           Write-Output "Downloading and running Run-GitScript.ps1"
           Set-Location -Path ([System.IO.Path]::GetTempPath())
-          $GitBranch = "nomis/DSOS-2824/jumpserver-fix"
+          $GitBranch = "main"
           $Script = "Invoke-UserDataScript.ps1"
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # since powershell 4 uses Tls1 as default
           Invoke-WebRequest "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-configuration-management/${GitBranch}/powershell/Scripts/Run-GitScript.ps1" -OutFile "Run-GitScript.ps1"

--- a/terraform/modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml
+++ b/terraform/modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml
@@ -88,7 +88,7 @@ tasks:
           $ErrorActionPreference = "Stop"
           Write-Output "Downloading and running Run-GitScript.ps1"
           Set-Location -Path ([System.IO.Path]::GetTempPath())
-          $GitBranch = "main"
+          $GitBranch = "nomis/DSOS-2824/jumpserver-fix"
           $Script = "Invoke-UserDataScript.ps1"
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # since powershell 4 uses Tls1 as default
           Invoke-WebRequest "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-configuration-management/${GitBranch}/powershell/Scripts/Run-GitScript.ps1" -OutFile "Run-GitScript.ps1"


### PR DESCRIPTION
Enable domain join for nomis jump servers.  Unfortunately required for end-users that are collaborators rather than members of MoJ org.  SSO access still works though.