### PR TITLE
Allowed optional exclusion of protection IDs from shield module

### DIFF
--- a/terraform/environments/example/application_variables.json
+++ b/terraform/environments/example/application_variables.json
@@ -1,6 +1,7 @@
 {
   "accounts": {
     "development": {
+      "excluded_protections": ["e9e3fbe2-6b74-4624-84e0-8e3e7ba62806"],
       "app_name": "example",
       "launch_type": "EC2",
       "allow_major_version_upgrade": "false",

--- a/terraform/environments/example/shield.tf
+++ b/terraform/environments/example/shield.tf
@@ -3,7 +3,8 @@ module "shield" {
   providers = {
     aws.modernisation-platform = aws.modernisation-platform
   }
-  application_name = local.application_name
+  application_name     = local.application_name
+  excluded_protections = local.application_data.accounts[local.environment].excluded_protections
   monitored_resources = {
     public_lb      = aws_lb.external.arn,
     certificate_lb = aws_lb.certificate_example_lb.arn

--- a/terraform/modules/shield_advanced/shield.tf
+++ b/terraform/modules/shield_advanced/shield.tf
@@ -23,6 +23,7 @@ locals {
 
   shield_protections = {
     for k, v in local.shield_protections_json : k => jsondecode(v)
+    if !(contains(var.excluded_protections, k))
   }
 }
 
@@ -35,3 +36,5 @@ resource "aws_wafv2_web_acl_association" "this" {
   resource_arn = each.value["ResourceArn"]
   web_acl_arn  = data.external.shield_waf.result["arn"]
 }
+
+output "shield_protections"{ value = local.shield_protections}

--- a/terraform/modules/shield_advanced/variables.tf
+++ b/terraform/modules/shield_advanced/variables.tf
@@ -7,3 +7,8 @@ variable "monitored_resources" {
   type        = map(string)
   description = "A map of names to ARNs for resources to be included by AWS Shield."
 }
+
+variable "excluded_protections" {
+  type        = set(string)
+  description = "A list of strings to not associate with the AWS Shield WAF ACL"
+}


### PR DESCRIPTION
As noted, this allows a module user to supply values which can be excluded from association with the AWS Shield managed WAF ACL. I don't have a good way to supply them without hard-coding, so in `example` I've placed the relevant ID to be excluded into the application json.

Ideally I'd be able to use a data source like `data.aws_shield_protections` but as I'm currently using an `external` data source to get this information there are limits to what I can achieve without adding extra complication.