### PR TITLE
Set `shield_advanced` variable input to optional

### DIFF
--- a/terraform/modules/shield_advanced/variables.tf
+++ b/terraform/modules/shield_advanced/variables.tf
@@ -5,6 +5,7 @@ variable "application_name" {
 
 variable "excluded_protections" {
   type        = set(string)
+  default     = []
   description = "A list of strings to not associate with the AWS Shield WAF ACL."
 }
 


### PR DESCRIPTION
Adds a `default` to `var.excluded_protections` so that it's correctly optional. Tested through local Terraform plan.