### PR TITLE
Oasys: DSOS-2829: put securitygroup fix in baseline

### DIFF
--- a/terraform/environments/oasys/locals_security_groups.tf
+++ b/terraform/environments/oasys/locals_security_groups.tf
@@ -1,77 +1,77 @@
 locals {
 
   security_group_cidrs_devtest = {
-    icmp = distinct(flatten([
+    icmp = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
-    ]))
+    ])
     ssh = module.ip_addresses.azure_fixngo_cidrs.devtest
-    https_internal = distinct(flatten([
+    https_internal = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
-    ]))
-    https_external = distinct(flatten([
+    ])
+    https_external = flatten([
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
       module.ip_addresses.external_cidrs.cloud_platform,
       module.ip_addresses.azure_studio_hosting_public.devtest,
-    ]))
-    oracle_db = distinct(flatten([
+    ])
+    oracle_db = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
-    ]))
-    oracle_oem_agent = distinct(flatten([
+    ])
+    oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ]))
-    http7xxx = distinct(flatten([
+    ])
+    http7xxx = flatten([
       "10.0.0.0/8",
-    ]))
+    ])
   }
   security_group_cidrs_preprod = {
-    icmp = distinct(flatten([
+    icmp = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
-    ]))
+    ])
     ssh = module.ip_addresses.azure_fixngo_cidrs.prod
-    https_internal = distinct(flatten([
+    https_internal = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       "10.0.0.0/8",
-    ]))
-    https_external = distinct(flatten([
+    ])
+    https_external = flatten([
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
       module.ip_addresses.external_cidrs.cloud_platform,
       module.ip_addresses.azure_studio_hosting_public.prod,
       "10.0.0.0/8"
-    ]))
-    oracle_db = distinct(flatten([
+    ])
+    oracle_db = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       "10.40.40.0/24", # pp oasys
       "10.40.37.0/24", # pp prison nomis
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
       module.ip_addresses.moj_cidr.aws_data_engineering_stage,
-    ]))
-    oracle_oem_agent = distinct(flatten([
+    ])
+    oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ]))
-    http7xxx = distinct(flatten([
+    ])
+    http7xxx = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
-    ]))
+    ])
   }
   security_group_cidrs_prod = {
-    icmp = distinct(flatten([
+    icmp = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
-    ]))
+    ])
     ssh = module.ip_addresses.azure_fixngo_cidrs.prod
-    https_internal = distinct(flatten([
+    https_internal = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
-    ]))
-    https_external = distinct(flatten([
+    ])
+    https_external = flatten([
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
@@ -90,8 +90,8 @@ locals {
       module.ip_addresses.external_cidrs.dtv,
       module.ip_addresses.external_cidrs.nps_wales,
       module.ip_addresses.external_cidrs.dxw,
-    ]))
-    oracle_db = distinct(flatten([
+    ])
+    oracle_db = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
       "10.40.6.0/24", # prod oasys
@@ -100,15 +100,15 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.azure_studio_hosting_cidrs.prod,
       module.ip_addresses.moj_cidr.aws_data_engineering_prod,
-    ]))
-    oracle_oem_agent = distinct(flatten([
+    ])
+    oracle_oem_agent = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ]))
-    http7xxx = distinct(flatten([
+    ])
+    http7xxx = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
-    ]))
+    ])
   }
   security_group_cidrs_by_environment = {
     development   = local.security_group_cidrs_devtest
@@ -218,10 +218,10 @@ locals {
           from_port   = 0
           to_port     = 8080
           protocol    = "tcp"
-          cidr_blocks = distinct(flatten([
+          cidr_blocks = flatten([
             local.security_group_cidrs.https_internal,
             local.security_group_cidrs.https_external,
-          ]))
+          ])
           security_groups = ["private_lb", "public_lb"]
         }
       }

--- a/terraform/modules/baseline/security_groups.tf
+++ b/terraform/modules/baseline/security_groups.tf
@@ -104,7 +104,7 @@ resource "aws_security_group_rule" "this" {
   from_port                = each.value.from_port
   to_port                  = each.value.to_port
   protocol                 = each.value.protocol
-  cidr_blocks              = each.value.cidr_blocks
+  cidr_blocks              = each.value.cidr_blocks == null ? null : distinct(each.value.cidr_blocks)
   source_security_group_id = each.value.source_security_group_id == null ? null : lookup(local.security_group_ids, each.value.source_security_group_id, each.value.source_security_group_id)
   self                     = each.value.self
   prefix_list_ids          = each.value.prefix_list_ids


### PR DESCRIPTION
SG fails if there are duplicate cidrs, try to prevent accidents by putting distinct logic in baseline