### PR TITLE
nomis: DSOS-2838: enable instance refresh for the weekend

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -110,6 +110,11 @@ locals {
         autoscaling_group = merge(module.baseline_presets.ec2_autoscaling_group.default_with_ready_hook_and_warm_pool, {
           desired_capacity = 8
           max_size         = 8
+
+          instance_refresh = {
+            strategy               = "Rolling"
+            min_healthy_percentage = 80
+          }
         })
         cloudwatch_metric_alarms = local.weblogic_cloudwatch_metric_alarms
         config = merge(local.weblogic_ec2.config, {
@@ -123,7 +128,7 @@ locals {
         })
         user_data_cloud_init = merge(local.weblogic_ec2.user_data_cloud_init, {
           args = merge(local.weblogic_ec2.user_data_cloud_init.args, {
-            branch = "main"
+            branch = "86471c5730194674959e03fff043a6b4d2d1a92f" # DSOS-2838 memory fix
           })
         })
         tags = merge(local.weblogic_ec2.tags, {


### PR DESCRIPTION
Enable instance refresh on production weblogic servers and lock to a particular commit
Will be applied Saturday a.m.