### PR TITLE
📌 Update APC EKS

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -78,7 +78,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.0-fcf71a47"
+      eks_node_version    = "1.20.1-7c3e9198"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
@@ -86,7 +86,7 @@ locals {
         aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
         eks_pod_identity_agent = "v1.2.0-eksbuild.1"
-        vpc_cni                = "v1.18.1-eksbuild.3"
+        vpc_cni                = "v1.18.2-eksbuild.1"
       }
 
       /* Observability Platform */
@@ -116,7 +116,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.0-fcf71a47"
+      eks_node_version    = "1.20.1-7c3e9198"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
@@ -124,7 +124,7 @@ locals {
         aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
         eks_pod_identity_agent = "v1.2.0-eksbuild.1"
-        vpc_cni                = "v1.18.1-eksbuild.3"
+        vpc_cni                = "v1.18.2-eksbuild.1"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -40,7 +40,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.0-fcf71a47"
+      eks_node_version    = "1.20.1-7c3e9198"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
@@ -48,7 +48,7 @@ locals {
         aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
         eks_pod_identity_agent = "v1.2.0-eksbuild.1"
-        vpc_cni                = "v1.18.1-eksbuild.3"
+        vpc_cni                = "v1.18.2-eksbuild.1"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/kubernetes-namespaces.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-namespaces.tf
@@ -50,7 +50,7 @@ resource "kubernetes_namespace" "airflow" {
   metadata {
     name = "airflow"
     labels = {
-      "pod-security.kubernetes.io/enforce"                          = "restricted"
+      "pod-security.kubernetes.io/enforce"                          = "baseline" # This was restricted, but the current pod specification doesn't set the right metadata
       "compute.analytical-platform.service.justice.gov.uk/workload" = "airflow"
     }
   }

--- a/terraform/environments/analytical-platform-compute/route53-zones.tf
+++ b/terraform/environments/analytical-platform-compute/route53-zones.tf
@@ -3,7 +3,7 @@ module "route53_zones" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/route53/aws//modules/zones"
-  version = "2.11.1"
+  version = "3.1.0"
 
   zones = {
     # tflint-ignore: terraform_deprecated_interpolation


### PR DESCRIPTION
This pull request:

- Updates EKS node version
- Updates VPC CNI version
- Updates Route53 module
- Sets `pod-security.kubernetes.io/enforce` to `baseline` for `airflow` namespace, we found that jobs wouldn't schedule when using `restricted` due to security context not being set

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 