### PR TITLE
DSOS: glacier restore fix

### DIFF
--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -109,6 +109,7 @@ locals {
         effect = "Allow"
         actions = [
           "s3:GetObject",
+          "s3:GetObjectTagging", # required for aws cp if restoring grom Glacier
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",
@@ -140,6 +141,7 @@ locals {
         effect = "Allow"
         actions = [
           "s3:GetObject",
+          "s3:GetObjectTagging",
           "s3:ListBucket",
         ]
         resources = [
@@ -161,6 +163,7 @@ locals {
         effect = "Allow"
         actions = [
           "s3:GetObject",
+          "s3:GetObjectTagging",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",
@@ -276,8 +279,9 @@ locals {
         sid    = "OracleLicenseTracking"
         effect = "Allow"
         actions = [
-          "s3:PutObject",
           "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:PutObject",
           "s3:PutObjectAcl",
           "s3:ListBucket",
           "s3:DeleteObject"
@@ -342,6 +346,7 @@ locals {
         effect = "Allow"
         actions = [
           "s3:GetObject",
+          "s3:GetObjectTagging",
           "s3:ListBucket",
         ]
         resources = flatten([

--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -184,6 +184,7 @@ locals {
         effect = "Allow"
         actions = [
           "s3:GetObject",
+          "s3:GetObjectTagging",
           "s3:ListBucket",
           "s3:PutObject",
           "s3:PutObjectAcl",


### PR DESCRIPTION
s3:GetObjectTagging is required by `aws s3 cp` command when restoring from Glacier. Adding this permission so this can be triggered from EC2 instances.
Tested against the artefact bucket in core-shared-services-production