### PR TITLE
issue/6991

### DIFF
--- a/scripts/terraform-plan-evaluator.sh
+++ b/scripts/terraform-plan-evaluator.sh
@@ -18,7 +18,11 @@ RESOURCES_TO_CHECK_FOR=(
   "aws_route_table"
   "aws_route_table_association"
   "aws_route",
-  "aws_iam_openid_connect_provider"
+  "aws_iam_openid_connect_provider",
+  "aws_cloudformation_stack",
+  "aws_cloudformation_stack_set",
+  "aws_cloudformation_stack_set_instance",
+  "aws_cloudformation_type"
 )
 
 resourcesFound=false


### PR DESCRIPTION
This adds the cloudformation resource types to the plan evaluator to  ensure MP is able to track the usage of such resource types. This is a temporary measure until a solution is found to limiting usage to specific resource types via IAM.

See issue https://github.com/ministryofjustice/modernisation-platform/issues/6991