### PR TITLE
🛂 Airflow repository access to APC

### DIFF
--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -151,6 +151,12 @@ module "eks" {
       username          = "data-engineering-airflow"
       kubernetes_groups = ["airflow"]
     }
+    github-actions-mojas-airflow = {
+      # principal_arn doesn't use the module output because they reference each other
+      principal_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-actions-mojas-airflow"
+      username          = "github-actions-mojas-airflow"
+      kubernetes_groups = ["airflow-serviceaccount-management"]
+    }
   }
 
   tags = local.tags

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -120,3 +120,24 @@ module "mlflow_iam_policy" {
 
   policy = data.aws_iam_policy_document.mlflow.json
 }
+
+data "aws_iam_policy_document" "gha_mojas_airflow" {
+  statement {
+    sid       = "EKSAccess"
+    effect    = "Allow"
+    actions   = ["eks:DescribeCluster"]
+    resources = [module.eks.cluster_arn]
+  }
+}
+
+module "gha_mojas_airflow_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.39.1"
+
+  name_prefix = "github-actions-mojas-airflow"
+
+  policy = data.aws_iam_policy_document.gha_mojas_airflow.json
+}

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -192,3 +192,21 @@ module "mlflow_iam_role" {
 
   tags = local.tags
 }
+
+module "gha_mojas_airflow_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.39.1"
+
+  name = "github-actions-mojas-airflow"
+
+  policies = {
+    GHAMoJASAirflow = module.gha_mojas_airflow_iam_policy.arn
+  }
+
+  subjects = ["moj-analytical-services/airflow:*"]
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-role-bindings.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-role-bindings.tf
@@ -14,3 +14,20 @@ resource "kubernetes_role_binding" "airflow_execution" {
     name      = "airflow"
   }
 }
+
+resource "kubernetes_role_binding" "airflow_serviceaccount_management" {
+  metadata {
+    name      = "airflow-serviceaccount-management"
+    namespace = kubernetes_namespace.airflow.metadata[0].name
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.airflow_serviceaccount_management.metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = "airflow-serviceaccount-management"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -32,3 +32,20 @@ resource "kubernetes_role" "airflow_execution" {
     ]
   }
 }
+
+resource "kubernetes_role" "airflow_serviceaccount_management" {
+  metadata {
+    name      = "airflow-serviceaccount-management"
+    namespace = kubernetes_namespace.airflow.metadata[0].name
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["serviceaccounts"]
+    verbs = [
+      "create",
+      "delete",
+      "get",
+      "update"
+    ]
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -45,6 +45,7 @@ resource "kubernetes_role" "airflow_serviceaccount_management" {
       "create",
       "delete",
       "get",
+      "list",
       "update"
     ]
   }


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4319
- Is being tested in https://github.com/moj-analytical-services/airflow/pull/3605
- Adds GitHub assumable role for https://github.com/moj-analytical-services/airflow
- Creates Kubernetes role and role binding for SA management in Airflow namespace
- Adds EKS access entry for role

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 