### PR TITLE
DSOS-2759: allow warm pool with zero instances

### DIFF
--- a/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline_presets/ec2_autoscaling_group.tf
@@ -39,6 +39,7 @@ locals {
       vpc_zone_identifier = var.environment.subnets["private"].ids
 
       warm_pool = {
+        min_size          = 0
         reuse_on_scale_in = true
       }
     }
@@ -59,6 +60,7 @@ locals {
       }
 
       warm_pool = {
+        min_size          = 0
         reuse_on_scale_in = true
       }
     }


### PR DESCRIPTION
Forgot to commit this - allow min size of 0 for warm pools.  So you can delete instances if you really want to.