### PR TITLE
add sns topics

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -2,11 +2,11 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-        pagerduty_integrations = {
-          dso_pagerduty               = "nomis_alarms"
-          # dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          # dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
-      }
+      #   pagerduty_integrations = {
+      #     dso_pagerduty               = "oasys_alarms"
+      #     dba_pagerduty               = "hmpps_shef_dba_low_priority"
+      #     dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
+      # }
     }
   }
   

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -2,8 +2,14 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
+        pagerduty_integrations = {
+          dso_pagerduty               = "nomis_alarms"
+          # dba_pagerduty               = "hmpps_shef_dba_low_priority"
+          # dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
+      }
     }
   }
+  
 
   # please keep resources in alphabetical order
   baseline_preproduction = {

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -2,6 +2,13 @@ locals {
 
   baseline_presets_production = {
     options = {
+      sns_topics = {
+        pagerduty_integrations = {
+          dso_pagerduty               = "nomis_alarms"
+          # dba_pagerduty               = "hmpps_shef_dba_low_priority"
+          # dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
+        }
+      }      
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -2,13 +2,13 @@ locals {
 
   baseline_presets_production = {
     options = {
-      sns_topics = {
-        pagerduty_integrations = {
-          dso_pagerduty               = "nomis_alarms"
-          # dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          # dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
-        }
-      }      
+      # sns_topics = {
+      #   pagerduty_integrations = {
+      #     dso_pagerduty               = "oasys_alarms"
+      #     dba_pagerduty               = "hmpps_shef_dba_low_priority"
+      #     dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
+      #   }
+      # }      
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,6 +2,13 @@ locals {
 
   baseline_presets_test = {
     options = {
+      sns_topics = {
+        pagerduty_integrations = {
+          dso_pagerduty               = "nomis_nonprod_alarms"
+          # dba_pagerduty               = "hmpps_shef_dba_non_prod" 
+          # dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
+        }
+      }
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,13 +2,13 @@ locals {
 
   baseline_presets_test = {
     options = {
-      sns_topics = {
-        pagerduty_integrations = {
-          dso_pagerduty               = "nomis_nonprod_alarms"
-          # dba_pagerduty               = "hmpps_shef_dba_non_prod" 
-          # dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
-        }
-      }
+      # sns_topics = {
+      #   pagerduty_integrations = {
+      #     dso_pagerduty               = "oasys_nonprod_alarms"
+      #     dba_pagerduty               = "hmpps_shef_dba_non_prod" 
+      #     dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
+      #   }
+      # }
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/platform_versions.tf
+++ b/terraform/environments/oasys-national-reporting/platform_versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "5.53.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/oasys-national-reporting/platform_versions.tf
+++ b/terraform/environments/oasys-national-reporting/platform_versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "5.53.0"
+      version = "5.53.0" # hardcoded from "~> 5.0" as currently broken, fix expected in 5.57.0 - change back when this is released
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
HARDCODE AWS PROVIDER VERSION to 5.53.0 for now as currently a bug - due to be fixed in 5.57.0

- add sns topics / pagerduty links for test, preproduction and production
- commented out for now as we don't want these to be live yet
- using oasys_alarms value to send alarms to about things like "server down" etc.