### PR TITLE
Test removing `types` from `pull_request:` for MP Workflows

### DIFF
--- a/.github/workflows/cooker.yml
+++ b/.github/workflows/cooker.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/cooker/**'
       - '.github/workflows/cooker.yml'

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/example/**'
       - '.github/workflows/example.yml'

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited, reopened, synchronize]
     paths:
       - 'terraform/environments/sprinkler/**'
       - '.github/workflows/sprinkler.yml'


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/7160

## Changes

I've removed `types` from `pull_request` in all the MP-owned workflows so I can test the behaviour of the workflows when I merge this in for all the applications in MPE in PR https://github.com/ministryofjustice/modernisation-platform-environments/pull/6578
