### PR TITLE
Update `ssl_policy` for performance-hub https listeners

### DIFF
--- a/terraform/environments/performance-hub/loadbalancer.tf
+++ b/terraform/environments/performance-hub/loadbalancer.tf
@@ -76,6 +76,7 @@ resource "aws_lb_listener" "https_listener" {
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = format("arn:aws:acm:eu-west-2:%s:certificate/%s", data.aws_caller_identity.current.account_id, local.app_data.accounts[local.environment].cert_arn)
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 
   default_action {
     target_group_arn = aws_lb_target_group.target_group.id


### PR DESCRIPTION
Hello! I'm working on a Modernisation Platform story on behalf of the SOC team. The story is about load balancer listeners that support less-than-secure versions (TLS 1.1 and 1.0). I can see some alerts in the story that point at performance-hub load balancers, and long story short if you don't specify a listener in terraform, you get assigned an old default policy that supports less-than-secure listeners.

The `ELBSecurityPolicy-2016-08` policy is the default security policy for HTTPS listeners created using the AWS CLI.