### PR TITLE
📌 Update Bottlerocket, EKS pod identity and EFS CSI versions

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -40,14 +40,14 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.1-7c3e9198"
+      eks_node_version    = "1.20.2-536d69d0"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
-        eks_pod_identity_agent = "v1.2.0-eksbuild.1"
+        eks_pod_identity_agent = "v1.3.0-eksbuild.1"
         vpc_cni                = "v1.18.2-eksbuild.1"
       }
 

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -78,14 +78,14 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.1-7c3e9198"
+      eks_node_version    = "1.20.2-536d69d0"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
-        aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
+        aws_efs_csi_driver     = "v2.0.4-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
-        eks_pod_identity_agent = "v1.2.0-eksbuild.1"
+        eks_pod_identity_agent = "v1.3.0-eksbuild.1"
         vpc_cni                = "v1.18.2-eksbuild.1"
       }
 
@@ -116,14 +116,14 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.30"
-      eks_node_version    = "1.20.1-7c3e9198"
+      eks_node_version    = "1.20.2-536d69d0"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
-        aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
+        aws_efs_csi_driver     = "v2.0.4-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
-        eks_pod_identity_agent = "v1.2.0-eksbuild.1"
+        eks_pod_identity_agent = "v1.3.0-eksbuild.1"
         vpc_cni                = "v1.18.2-eksbuild.1"
       }
 

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -45,7 +45,7 @@ locals {
         coredns                = "v1.11.1-eksbuild.9"
         kube_proxy             = "v1.30.0-eksbuild.3"
         aws_ebs_csi_driver     = "v1.31.0-eksbuild.1"
-        aws_efs_csi_driver     = "v2.0.3-eksbuild.1"
+        aws_efs_csi_driver     = "v2.0.4-eksbuild.1"
         aws_guardduty_agent    = "v1.6.1-eksbuild.1"
         eks_pod_identity_agent = "v1.3.0-eksbuild.1"
         vpc_cni                = "v1.18.2-eksbuild.1"


### PR DESCRIPTION
This pull request:

- Updates Bottlerocket OS to [`v1.20.2`](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.20.2)
- Updates EKS pod identity to `v1.3.0-eksbuild.1`
- Updates EFS CSI to `v2.0.4-eksbuild.1`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 