### PR TITLE
DPR2-893: Glue connection and placeholder operational datastore secret

### DIFF
--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -31,15 +31,17 @@ data "aws_secretsmanager_secret_version" "datamart" {
 
 # Operational DataStore Secrets for use in DataHub
 data "aws_secretsmanager_secret" "operational_datastore" {
-  name = aws_secretsmanager_secret.operational_datastore.id
+  count = (local.environment == "development" ? 1 : 0)
+  name  = aws_secretsmanager_secret.operational_datastore[0].id
 
-  depends_on = [aws_secretsmanager_secret_version.operational_datastore]
+  depends_on = [aws_secretsmanager_secret_version.operational_datastore[0]]
 }
 
 data "aws_secretsmanager_secret_version" "operational_datastore" {
-  secret_id = data.aws_secretsmanager_secret.operational_datastore.id
+  count     = (local.environment == "development" ? 1 : 0)
+  secret_id = data.aws_secretsmanager_secret.operational_datastore[0].id
 
-  depends_on = [aws_secretsmanager_secret.operational_datastore]
+  depends_on = [aws_secretsmanager_secret.operational_datastore[0]]
 }
 
 

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -29,6 +29,19 @@ data "aws_secretsmanager_secret_version" "datamart" {
   depends_on = [aws_secretsmanager_secret.redshift]
 }
 
+# Operational DataStore Secrets for use in DataHub
+data "aws_secretsmanager_secret" "operational_datastore" {
+  name = aws_secretsmanager_secret.operational_datastore.id
+
+  depends_on = [aws_secretsmanager_secret_version.operational_datastore]
+}
+
+data "aws_secretsmanager_secret_version" "operational_datastore" {
+  secret_id = data.aws_secretsmanager_secret.operational_datastore.id
+
+  depends_on = [aws_secretsmanager_secret.operational_datastore]
+}
+
 
 # AWS _IAM_ Policy
 data "aws_iam_policy" "rds_full_access" {

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -323,6 +323,12 @@ locals {
     port     = "5432"
   }
 
+  # Operational DataStore Secrets PlaceHolder
+  operational_datastore_secrets_placeholder = {
+    username = "placeholder"
+    password = "placeholder"
+  }
+
   # biprws Secrets Placeholder
   enable_biprws_secrets = local.application_data.accounts[local.environment].biprws.enable
   biprws_secrets_placeholder = {

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -39,12 +39,4 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
     protocol  = "-1"
     self      = true
   }
-
-  # Allow all traffic out
-  egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -16,7 +16,7 @@ resource "aws_glue_connection" "glue_operational_datastore_connection" {
   }
 }
 
-resource aws_security_group "glue_vpc_access_connection_sg" {
+resource aws_security_group "glue_operational_datastore_connection_sg" {
   count       = (local.environment == "development" ? 1 : 0)
   name        = "${local.project}-operational-datastore-connection_sg"
   description = "Security group to allow glue access to Operational Datastore via JDBC Connection"

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -1,16 +1,50 @@
 resource "aws_glue_connection" "glue_operational_datastore_connection" {
+  count           = (local.environment == "development" ? 1 : 0)
   name            = "${local.project}-operational-datastore-connection"
   connection_type = "JDBC"
 
   connection_properties = {
     # This will be replaced by the details for the real Operational Data Store
     JDBC_CONNECTION_URL = "jdbc:postgresql://dpr2-834-instance-1.cja8lnnvvipo.eu-west-2.rds.amazonaws.com:5432/postgres"
-    SECRET_ID           = data.aws_secretmanager_secret.operational_datastore.name
+    SECRET_ID           = data.aws_secretsmanager_secret.operational_datastore.name
   }
 
   physical_connection_requirements {
     availability_zone = data.aws_subnet.private_subnets_a.availability_zone
     security_group_id_list = [aws_security_group.glue_vpc_access_connection_sg[0].id]
     subnet_id         = data.aws_subnet.private_subnets_a.id
+  }
+}
+
+resource aws_security_group "glue_vpc_access_connection_sg" {
+  count       = (local.environment == "development" ? 1 : 0)
+  name        = "${local.project}-operational-datastore-connection_sg"
+  description = "Security group to allow glue access to Operational Datastore via JDBC Connection"
+  vpc_id      = data.aws_vpc.shared.id
+
+  # TODO Tighten these up if necessary once it works
+  # Allow all traffic in from this security group
+  ingress {
+    from_port = 0
+    to_port   = 65535
+    protocol  = "-1"
+    self      = true
+    description = "Security Group can Ingress to itself on all ports - required by Glue"
+  }
+
+  # Allow all traffic out to this security group
+  egress {
+    from_port = 0
+    to_port   = 65535
+    protocol  = "-1"
+    self      = true
+  }
+
+  # Allow all traffic out
+  egress {
+    from_port = 0
+    to_port   = 65535
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -39,4 +39,12 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
     protocol  = "-1"
     self      = true
   }
+
+  # Allow all traffic out
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -6,7 +6,7 @@ resource "aws_glue_connection" "glue_operational_datastore_connection" {
   connection_properties = {
     # This will be replaced by the details for the real Operational Data Store
     JDBC_CONNECTION_URL = "jdbc:postgresql://dpr2-834-instance-1.cja8lnnvvipo.eu-west-2.rds.amazonaws.com:5432/postgres"
-    SECRET_ID           = data.aws_secretsmanager_secret.operational_datastore.name
+    SECRET_ID           = data.aws_secretsmanager_secret.operational_datastore[0].name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -1,0 +1,16 @@
+resource "aws_glue_connection" "glue_operational_datastore_connection" {
+  name            = "${local.project}-operational-datastore-connection"
+  connection_type = "JDBC"
+
+  connection_properties = {
+    # This will be replaced by the details for the real Operational Data Store
+    JDBC_CONNECTION_URL = "jdbc:postgresql://dpr2-834-instance-1.cja8lnnvvipo.eu-west-2.rds.amazonaws.com:5432/postgres"
+    SECRET_ID           = data.aws_secretmanager_secret.operational_datastore.name
+  }
+
+  physical_connection_requirements {
+    availability_zone = data.aws_subnet.private_subnets_a.availability_zone
+    security_group_id_list = [aws_security_group.glue_vpc_access_connection_sg[0].id]
+    subnet_id         = data.aws_subnet.private_subnets_a.id
+  }
+}

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -22,7 +22,6 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
   description = "Security group to allow glue access to Operational Datastore via JDBC Connection"
   vpc_id      = data.aws_vpc.shared.id
 
-  # TODO Tighten these up if necessary once it works
   # Allow all traffic in from this security group
   ingress {
     from_port = 0
@@ -30,14 +29,6 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
     protocol  = "-1"
     self      = true
     description = "Security Group can Ingress to itself on all ports - required by Glue"
-  }
-
-  # Allow all traffic out to this security group
-  egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
   }
 
   # Allow all traffic out

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -22,13 +22,16 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
   description = "Security group to allow glue access to Operational Datastore via JDBC Connection"
   vpc_id      = data.aws_vpc.shared.id
 
-  # Allow all traffic in from this security group
+  # This SG is attached to the Glue connection and should also be attached to the Operational Datastore RDS
+  # See https://docs.aws.amazon.com/glue/latest/dg/setup-vpc-for-glue-access.html
+
+  # A self-referencing inbound rule for all TCP ports to enable AWS Glue to communicate between its components
   ingress {
     from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    to_port   = 65535
+    protocol  = "TCP"
     self      = true
-    description = "Security Group can Ingress to itself on all ports - required by Glue"
+    description = "Security Group can Ingress to itself on all ports - required for Glue to communicate with itself"
   }
 
   # Allow all traffic out
@@ -37,5 +40,6 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
     to_port   = 0
     protocol  = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all traffic out from this Security Group"
   }
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -11,7 +11,7 @@ resource "aws_glue_connection" "glue_operational_datastore_connection" {
 
   physical_connection_requirements {
     availability_zone = data.aws_subnet.private_subnets_a.availability_zone
-    security_group_id_list = [aws_security_group.glue_vpc_access_connection_sg[0].id]
+    security_group_id_list = [aws_security_group.glue_operational_datastore_connection_sg[0].id]
     subnet_id         = data.aws_subnet.private_subnets_a.id
   }
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -26,7 +26,7 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
   # Allow all traffic in from this security group
   ingress {
     from_port = 0
-    to_port   = 65535
+    to_port   = 0
     protocol  = "-1"
     self      = true
     description = "Security Group can Ingress to itself on all ports - required by Glue"
@@ -35,7 +35,7 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
   # Allow all traffic out to this security group
   egress {
     from_port = 0
-    to_port   = 65535
+    to_port   = 0
     protocol  = "-1"
     self      = true
   }
@@ -43,7 +43,7 @@ resource aws_security_group "glue_operational_datastore_connection_sg" {
   # Allow all traffic out
   egress {
     from_port = 0
-    to_port   = 65535
+    to_port   = 0
     protocol  = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -53,6 +53,29 @@ resource "aws_secretsmanager_secret_version" "dps" {
   }
 }
 
+# Operational DataStore Secrets for use in DataHub
+# PlaceHolder Secrets
+resource "aws_secretsmanager_secret" "operational_datastore" {
+  name = "external/operational_data_store"
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "external/operational_data_store"
+      Resource_Type = "Secrets"
+    }
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "operational_datastore" {
+  secret_id     = aws_secretsmanager_secret.operational_datastore.id
+  secret_string = jsonencode(local.operational_datastore_secrets_placeholder)
+
+  lifecycle {
+    ignore_changes = [secret_string, ]
+  }
+}
+
 # Redshift Access Secrets
 resource "aws_secretsmanager_secret" "redshift" {
   name = "dpr-redshift-sqlworkbench-${local.env}"

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -56,7 +56,8 @@ resource "aws_secretsmanager_secret_version" "dps" {
 # Operational DataStore Secrets for use in DataHub
 # PlaceHolder Secrets
 resource "aws_secretsmanager_secret" "operational_datastore" {
-  name = "external/operational_data_store"
+  count = (local.environment == "development" ? 1 : 0)
+  name  = "external/operational_data_store"
 
   tags = merge(
     local.all_tags,
@@ -68,11 +69,12 @@ resource "aws_secretsmanager_secret" "operational_datastore" {
 }
 
 resource "aws_secretsmanager_secret_version" "operational_datastore" {
-  secret_id     = aws_secretsmanager_secret.operational_datastore.id
+  count     = (local.environment == "development" ? 1 : 0)
+  secret_id = aws_secretsmanager_secret.operational_datastore[0].id
   secret_string = jsonencode(local.operational_datastore_secrets_placeholder)
 
   lifecycle {
-    ignore_changes = [secret_string, ]
+    ignore_changes = [secret_string,]
   }
 }
 


### PR DESCRIPTION
- Limit created resources to Dev/Sandbox only
- Create a Glue JDBC Data Connection for attachment to DataHub Glue jobs to give them Operational Datastore access
- Temporarily populate it with the manually created Dev/Sandbox RDS details which will be replaced by the actual Operational Datastore details
- Create a secret for the credentials used by the DataHub Glue jobs to write to the Operational Datastore
- Create a Security Group associated with the Glue JDBC Data Connection
    - it will be associated with a glue job automatically when the connection is attached to it
    - this is a requirement of Glue and it allows Glue to communicate with itself by allowing TCP ingress on all ports from the security group. See https://docs.aws.amazon.com/glue/latest/dg/setup-vpc-for-glue-access.html
    - the same security group is attached to the RDS as well as the glue job so the same ingress rule also allows access to the RDS instance. Instead, a separate security group could be attached to the RDS allowing Ingress from this security group.
    - it allows egress on all ports which allows it to communicate with services such as S3 without having an S3 service endpoint in the VPC.
- I've tested this by attaching the connection to the activities glue batch job, manually giving the job access to read the secret and verifying it can write to the RDS database using the connection and secret provided here