### PR TITLE
create prod-nomis-client-b instance for testing GPO changes to allow SSO

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -123,6 +123,12 @@ locals {
           domain-name = "azure.hmpp.root"
         })
       })
+      # BEING USED FOR TESTING
+      prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
+        tags = merge(local.ec2_autoscaling_groups.client.tags, {
+          domain-name = "azure.hmpp.root"
+        })
+      })
     }
 
     ec2_instances = {


### PR DESCRIPTION
- add another nomis client instance
- temporary, being used for GPO SSO allow testing