### PR TITLE
DSOS-2690: s3 lifecycle changes

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -29,7 +29,6 @@ locals {
         "ec2_instance_oracle_db_with_backup",
         "ec2_instance_textfile_monitoring",
       ]
-      db_backup_s3                                = true
       enable_backup_plan_daily_and_weekly         = true
       enable_business_unit_kms_cmks               = true
       enable_image_builder                        = true
@@ -38,7 +37,8 @@ locals {
       enable_ec2_self_provision                   = true
       enable_ec2_oracle_enterprise_managed_server = true
       enable_ec2_user_keypair                     = true
-      enable_shared_s3                            = true
+      enable_s3_db_backup_bucket                  = true
+      enable_s3_shared_bucket                     = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -33,6 +33,7 @@ locals {
       cloudwatch_metric_alarms_default_actions    = ["dso_pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters  = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
+      db_backup_bucket_name                       = "nomis-db-backup-bucket"
       enable_backup_plan_daily_and_weekly         = true
       enable_business_unit_kms_cmks               = true
       enable_ec2_cloud_watch_agent                = true
@@ -41,6 +42,8 @@ locals {
       enable_ec2_session_manager_cloudwatch_logs  = true
       enable_ec2_ssm_agent_update                 = true
       enable_ec2_user_keypair                     = true
+      enable_s3_bucket                            = true
+      enable_s3_db_backup_bucket                  = true
       enable_image_builder                        = true
       enable_hmpps_domain                         = true # Syscon users are collaborators so need domain creds to access nomis-client EC2s
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
@@ -55,12 +58,6 @@ locals {
   baseline_all_environments = {
     options = {
       enable_resource_explorer = true
-    }
-
-    s3_buckets = {
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
     }
 
     security_groups = local.security_groups

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -479,17 +479,12 @@ locals {
       nomis-audit-archives = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
-      }
-      nomis-db-backup-bucket = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-      }
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
       }
       syscon-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
       }
     }
 

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -528,10 +528,6 @@ locals {
           module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
         ]
       }
-      nomis-db-backup-bucket = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-      }
     }
 
     secretsmanager_secrets = {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -458,21 +458,14 @@ locals {
 
     s3_buckets = {
       nomis-audit-archives = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
         lifecycle_rule = [
           module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
         ]
-      }
-      nomis-db-backup-bucket = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
       }
     }
 

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -677,29 +677,23 @@ locals {
 
     s3_buckets = {
       nomis-audit-archives = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.DevelopmentReadOnlyAccessBucketPolicy
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-
-      nomis-db-backup-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.DevelopmentReadOnlyAccessBucketPolicy
-        ]
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
       }
 
       # use this bucket for storing artefacts for use across all accounts
       ec2-image-builder-nomis = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
           module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
+        custom_kms_key = module.environment.kms_keys["general"].arn
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
       }
     }
 

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -33,7 +33,6 @@ locals {
       cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       # cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
-      db_backup_s3                                = true # adds db backup buckets
       db_backup_more_permissions                  = true
       enable_azure_sas_token                      = true
       enable_backup_plan_daily_and_weekly         = true
@@ -43,7 +42,8 @@ locals {
       enable_ec2_oracle_enterprise_managed_server = true
       enable_ec2_self_provision                   = true
       enable_ec2_user_keypair                     = true
-      enable_shared_s3                            = true
+      enable_s3_db_backup_bucket                  = true
+      enable_s3_shared_bucket                     = true
       enable_vmimport                             = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy", "Ec2OracleEnterpriseManagerPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/modules/baseline_presets/iam_policies.tf
+++ b/terraform/modules/baseline_presets/iam_policies.tf
@@ -9,7 +9,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["CloudWatchAgentServerReducedPolicy"] : [],
     var.options.enable_ec2_delius_dba_secrets_access ? ["DeliusDbaSecretsPolicy"] : [],
     var.options.enable_ec2_self_provision ? ["Ec2SelfProvisionPolicy"] : [],
-    var.options.enable_shared_s3 ? ["Ec2AccessSharedS3Policy"] : [],
+    var.options.enable_s3_shared_bucket ? ["Ec2AccessSharedS3Policy"] : [],
     var.options.enable_ec2_reduced_ssm_policy ? ["SSMManagedInstanceCoreReducedPolicy"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["OracleEnterpriseManagementSecretsPolicy", "Ec2OracleEnterpriseManagedServerPolicy"] : [],
     var.options.enable_vmimport ? ["vmimportPolicy"] : [],
@@ -36,7 +36,7 @@ locals {
     var.options.enable_business_unit_kms_cmks ? local.iam_policy_statements_ec2.business_unit_kms_cmk : [],
     var.options.enable_ec2_cloud_watch_agent ? local.iam_policy_statements_ec2.CloudWatchAgentServerReduced : [],
     var.options.enable_ec2_self_provision ? local.iam_policy_statements_ec2.Ec2SelfProvision : [],
-    var.options.enable_shared_s3 ? local.iam_policy_statements_ec2.S3ReadSharedWrite : [],
+    var.options.enable_s3_shared_bucket ? local.iam_policy_statements_ec2.S3ReadSharedWrite : [],
     var.options.enable_ec2_reduced_ssm_policy ? local.iam_policy_statements_ec2.SSMManagedInstanceCoreReduced : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? local.iam_policy_statements_ec2.OracleEnterpriseManagedServer : [],
   ])
@@ -56,7 +56,7 @@ locals {
       statements = flatten([
         local.iam_policy_statements_in_ec2_default,
         local.iam_policy_statements_ec2.OracleLicenseTracking,
-        var.options.db_backup_s3 ? local.iam_policy_statements_ec2.S3DbBackupRead : [],
+        var.options.enable_s3_db_backup_bucket ? local.iam_policy_statements_ec2.S3DbBackupRead : [],
       ])
     }
 

--- a/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
+++ b/terraform/modules/baseline_presets/iam_policy_statements_ec2.tf
@@ -115,8 +115,8 @@ locals {
           "s3:PutObjectAcl",
         ]
         resources = [
-          "arn:aws:s3:::${local.shared_s3_name_prefix}*/*",
-          "arn:aws:s3:::${local.shared_s3_name_prefix}*",
+          "arn:aws:s3:::${local.s3_environment_specific.shared_bucket_name}*/*",
+          "arn:aws:s3:::${local.s3_environment_specific.shared_bucket_name}*",
           "arn:aws:s3:::ec2-image-builder-*/*",
           "arn:aws:s3:::ec2-image-builder-*",
           "arn:aws:s3:::*-software*/*",
@@ -347,20 +347,20 @@ locals {
         ]
         resources = flatten([
           var.environment.environment == "production" ? [
-            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*",
-            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*/*",
-            "arn:aws:s3:::prod-${var.environment.application_name}-db-backup-bucket-*",
-            "arn:aws:s3:::prod-${var.environment.application_name}-db-backup-bucket-*/*",
+            "arn:aws:s3:::${local.s3_environments_specific.preproduction.db_backup_bucket_name}*",
+            "arn:aws:s3:::${local.s3_environments_specific.preproduction.db_backup_bucket_name}*/*",
+            "arn:aws:s3:::${local.s3_environments_specific.production.db_backup_bucket_name}*",
+            "arn:aws:s3:::${local.s3_environments_specific.production.db_backup_bucket_name}*/*",
           ] : [],
           var.environment.environment == "preproduction" ? [
-            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*",
-            "arn:aws:s3:::preprod-${var.environment.application_name}-db-backup-bucket-*/*",
+            "arn:aws:s3:::${local.s3_environments_specific.preproduction.db_backup_bucket_name}*",
+            "arn:aws:s3:::${local.s3_environments_specific.preproduction.db_backup_bucket_name}*/*",
           ] : [],
           contains(["development", "test"], var.environment.environment) ? [
-            "arn:aws:s3:::dev-${var.environment.application_name}-db-backup-bucket-*",
-            "arn:aws:s3:::dev-${var.environment.application_name}-db-backup-bucket-*/*",
-            "arn:aws:s3:::devtest-${var.environment.application_name}-db-backup-bucket-*",
-            "arn:aws:s3:::devtest-${var.environment.application_name}-db-backup-bucket-*/*",
+            "arn:aws:s3:::${local.s3_environments_specific.development.db_backup_bucket_name}*",
+            "arn:aws:s3:::${local.s3_environments_specific.development.db_backup_bucket_name}*/*",
+            "arn:aws:s3:::${local.s3_environments_specific.test.db_backup_bucket_name}*",
+            "arn:aws:s3:::${local.s3_environments_specific.test.db_backup_bucket_name}*/*",
           ] : [],
         ])
       }

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -143,6 +143,13 @@ output "route53_resolvers" {
   value       = local.route53_resolvers
 }
 
+output "s3_buckets" {
+  description = "Map of requested s3_buckets"
+  value = {
+    for key, value in local.s3_buckets : key => value if contains(local.s3_buckets_filter, key)
+  }
+}
+
 output "s3_bucket_policies" {
   description = "Map of common bucket policies to use on s3_buckets"
 
@@ -153,11 +160,6 @@ output "s3_iam_policies" {
   description = "Map of common iam_policies that can be used to give access to s3_buckets"
 
   value = local.requested_s3_iam_policies
-}
-
-output "s3_buckets" {
-  description = "Map of s3_buckets"
-  value       = local.s3_buckets
 }
 
 output "s3_lifecycle_rules" {

--- a/terraform/modules/baseline_presets/s3.tf
+++ b/terraform/modules/baseline_presets/s3.tf
@@ -1,71 +1,73 @@
 locals {
 
-  devtest_or_prodpreprod = var.environment.environment == "development" || var.environment.environment == "test" ? "devtest" : "prodpreprod"
-  shared_s3_name_prefix  = substr("${local.devtest_or_prodpreprod}-${var.environment.application_name}-", 0, 37)
-
   requested_s3_iam_policies = var.options.s3_iam_policies != null ? {
     for key, value in local.s3_iam_policies : key => value if contains(var.options.s3_iam_policies, key)
   } : local.s3_iam_policies
 
-  s3_buckets = merge(
+  s3_environments_specific = {
+    development = {
+      db_backup_bucket_name   = coalesce(var.options.db_backup_bucket_name, substr("dev-${var.environment.application_name}-db-backup-bucket-", 0, 37))
+      db_backup_bucket_policy = [local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy]
+      shared_bucket_name      = substr("devtest-${var.environment.application_name}-", 0, 37)
+      shared_bucket_policy = [
+        local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
+        local.s3_bucket_policies.DevTestEnvironmentsWriteAndDeleteAccessBucketPolicy,
+      ]
+    }
+    test = {
+      db_backup_bucket_name   = coalesce(var.options.db_backup_bucket_name, substr("devtest-${var.environment.application_name}-db-backup-bucket-", 0, 37))
+      db_backup_bucket_policy = [local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy]
+      shared_bucket_name      = substr("devtest-${var.environment.application_name}-", 0, 37)
+      shared_bucket_policy = [
+        local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
+        local.s3_bucket_policies.DevTestEnvironmentsWriteAndDeleteAccessBucketPolicy,
+      ]
+    }
+    preproduction = {
+      db_backup_bucket_name   = coalesce(var.options.db_backup_bucket_name, substr("preprod-${var.environment.application_name}-db-backup-bucket-", 0, 37))
+      db_backup_bucket_policy = null
+      shared_bucket_name      = substr("prodpreprod-${var.environment.application_name}-", 0, 37)
+      shared_bucket_policy = [
+        local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
+        local.s3_bucket_policies.ProdPreprodEnvironmentsWriteAccessBucketPolicy,
+      ]
+    }
+    production = {
+      db_backup_bucket_name   = coalesce(var.options.db_backup_bucket_name, substr("prod-${var.environment.application_name}-db-backup-bucket", 0, 37))
+      db_backup_bucket_policy = [var.options.db_backup_more_permissions ? local.s3_bucket_policies.ProdPreprodReadWriteDeleteBucketPolicy : local.s3_bucket_policies.ProdPreprodEnvironmentsReadOnlyAccessBucketPolicy]
+      shared_bucket_name      = substr("prodpreprod-${var.environment.application_name}-", 0, 37)
+      shared_bucket_policy = [
+        local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
+        local.s3_bucket_policies.ProdPreprodEnvironmentsWriteAccessBucketPolicy,
+      ]
+    }
+  }
+  s3_environment_specific = local.s3_environments_specific[var.environment.environment]
 
-    # if enable_shared_s3 set, create a bucket in test and production which can be used by dev and test / preprod and prod respectively
-    var.options.enable_shared_s3 && var.environment.environment == "production" ? {
-      (local.shared_s3_name_prefix) = {
-        bucket_policy_v2 = [
-          local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          local.s3_bucket_policies.ProdPreprodEnvironmentsWriteAccessBucketPolicy
-        ]
-        custom_kms_key = var.environment.kms_keys["general"].arn
-        iam_policies   = local.requested_s3_iam_policies
-      }
-    } : {},
-    var.options.enable_shared_s3 && var.environment.environment == "test" ? {
-      (local.shared_s3_name_prefix) = {
-        bucket_policy_v2 = [
-          local.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          local.s3_bucket_policies.DevTestEnvironmentsWriteAndDeleteAccessBucketPolicy
-        ]
-        custom_kms_key = var.environment.kms_keys["general"].arn
-        iam_policies   = local.requested_s3_iam_policies
-      }
-    } : {},
+  s3_buckets_filter = flatten([
+    var.options.enable_s3_db_backup_bucket ? [local.s3_environment_specific.db_backup_bucket_name] : [],
+    var.options.enable_s3_bucket ? ["s3-bucket"] : [],
+    var.options.enable_s3_shared_bucket && contains(["test", "production"], var.environment.environment) ? [local.s3_environment_specific.shared_bucket_name] : [],
+  ])
 
-    # If db_backup_s3 enabled, create db_backups in all environments.
-    # Dev and Test can both access each other: Preprod can access prod but not vice-versa
-    var.options.db_backup_s3 && var.environment.environment == "production" && !var.options.db_backup_more_permissions ? { "prod-${var.environment.application_name}-db-backup-bucket-" = {
-      bucket_policy_v2 = [
-        local.s3_bucket_policies.PreprodReadOnlyAccessBucketPolicy,
-      ]
-      custom_kms_key = var.environment.kms_keys["general"].arn
+  s3_buckets = {
+    s3-bucket = {
       iam_policies   = local.requested_s3_iam_policies
-    } } : {},
-    var.options.db_backup_s3 && var.environment.environment == "production" && var.options.db_backup_more_permissions ? { "prod-${var.environment.application_name}-db-backup-bucket-" = {
-      bucket_policy_v2 = [
-        local.s3_bucket_policies.ProdPreprodReadWriteDeleteBucketPolicy
-      ]
-      custom_kms_key = var.environment.kms_keys["general"].arn
-      iam_policies   = local.requested_s3_iam_policies
-    } } : {},
-    var.options.db_backup_s3 && var.environment.environment == "preproduction" ? { "preprod-${var.environment.application_name}-db-backup-bucket-" = {
-      custom_kms_key = var.environment.kms_keys["general"].arn
-      iam_policies   = local.s3_iam_policies
-    } } : {},
-    var.options.db_backup_s3 && var.environment.environment == "test" ? { "devtest-${var.environment.application_name}-db-backup-bucket-" = {
-      bucket_policy_v2 = [
-        local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy
-      ]
-      custom_kms_key = var.environment.kms_keys["general"].arn
-      iam_policies   = local.requested_s3_iam_policies
-    } } : {},
-    var.options.db_backup_s3 && var.environment.environment == "development" ? { "dev-${var.environment.application_name}-db-backup-bucket-" = {
-      bucket_policy_v2 = [
-        local.s3_bucket_policies.DevTestEnvironmentsReadOnlyAccessBucketPolicy
-      ]
-      custom_kms_key = var.environment.kms_keys["general"].arn
-      iam_policies   = local.requested_s3_iam_policies
-    } } : {},
-  )
+      lifecycle_rule = [local.s3_lifecycle_rules.default]
+    }
+    (local.s3_environment_specific.db_backup_bucket_name) = {
+      bucket_policy_v2 = local.s3_environment_specific.db_backup_bucket_policy
+      custom_kms_key   = var.environment.kms_keys["general"].arn
+      iam_policies     = local.requested_s3_iam_policies
+      lifecycle_rule   = [local.s3_lifecycle_rules.default]
+    }
+    (local.s3_environment_specific.shared_bucket_name) = {
+      bucket_policy_v2 = local.s3_environment_specific.shared_bucket_policy
+      custom_kms_key   = var.environment.kms_keys["general"].arn
+      iam_policies     = local.requested_s3_iam_policies
+      lifecycle_rule   = [local.s3_lifecycle_rules.default]
+    }
+  }
 
   s3_bucket_policies = {
     ImageBuilderWriteAccessBucketPolicy                 = local.iam_policy_statements_s3.S3ReadWriteCoreSharedServicesProduction[0]
@@ -88,6 +90,41 @@ locals {
   }
 
   s3_lifecycle_rules = {
+
+    default = {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+      expiration = {
+        days = 730
+      }
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+        },
+        {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+      noncurrent_version_expiration = {
+        days = 730
+      }
+    }
 
     ninety_day_standard_ia_ten_year_expiry = {
       id      = "ninety_day_standard_ia_ten_year_expiry"
@@ -115,6 +152,5 @@ locals {
         days = 3650
       }
     }
-
   }
 }

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -20,6 +20,8 @@ variable "options" {
     cloudwatch_metric_alarms_default_actions     = optional(list(string))          # default alarm_action to apply to cloudwatch metrics returned by this module
     cloudwatch_metric_oam_links_ssm_parameters   = optional(list(string))          # list of account names to send cloudwatch metrics to, creates placeholder SSM param for each
     cloudwatch_metric_oam_links                  = optional(list(string))          # list of account names to send cloudwatch metrics to, creates oam link for each
+    db_backup_bucket_name                        = optional(string)                # override default backup bucket name
+    db_backup_more_permissions                   = optional(bool, false)           # allow cross-account delete access for db-backup S3 buckets
     enable_application_environment_wildcard_cert = optional(bool, false)           # create ACM cert with mod platform business unit
     enable_azure_sas_token                       = optional(bool, false)           # create /azure SSM parameter and pipeline role
     enable_offloc_sync                           = optional(bool, false)           # create role for offloc pipeline
@@ -35,11 +37,11 @@ variable "options" {
     enable_ec2_session_manager_cloudwatch_logs   = optional(bool, false)           # create SSM doc and log group for session manager logs
     enable_ec2_ssm_agent_update                  = optional(bool, false)           # create SSM association for auto-update of SSM agent. update-ssm-agent tag needs to be set on EC2s also
     enable_ec2_user_keypair                      = optional(bool, false)           # create secret and key-pair for ec2-user
-    enable_shared_s3                             = optional(bool, false)           # create devtest and preprodprod S3 bucket
     enable_observability_platform_monitoring     = optional(bool, false)           # create role for observability platform monitroing
+    enable_s3_bucket                             = optional(bool, false)           # create s3-bucket S3 bucket for general use
+    enable_s3_db_backup_bucket                   = optional(bool, false)           # create db-backup S3 buckets
+    enable_s3_shared_bucket                      = optional(bool, false)           # create devtest and preprodprod S3 bucket for sharing between accounts
     enable_vmimport                              = optional(bool, false)           # create role for vm imports
-    db_backup_s3                                 = optional(bool, false)           # create db-backup S3 buckets
-    db_backup_more_permissions                   = optional(bool, false)           # additional permissions for db-backup S3 buckets
     route53_resolver_rules                       = optional(map(list(string)), {}) # create route53 resolver rules; list of map keys to filter local.route53_resolver_rules_all
     iam_policies_filter                          = optional(list(string), [])      # any policies to add from local.iam_policies which haven't been added automatically by the enable options
     iam_policies_ec2_default                     = optional(list(string), [])      # any policies to add to the default EC2 policy which haven't been added automatically the above enable_ec2 options


### PR DESCRIPTION
A bit of tidy up before updating S3 lifecycles across accounts:
- updated baseline presets db backup so it works with nomis
- tidy up baseline s3 code a little, make it consistent with other resources
- updating variable naming for s3 buckets for consistency
- added the default bucket lifecycle into baseline_presets