### PR TITLE
DSOS-2690: s3 lifecycle changes

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -42,9 +42,11 @@ locals {
       enable_s3_bucket                            = true
       enable_s3_db_backup_bucket                  = true
       enable_s3_shared_bucket                     = true
+      enable_s3_software_bucket                   = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+      software_bucket_name                        = "csr-software"
       sns_topics = {
         pagerduty_integrations = {
           csr_pagerduty = "csr_alarms"

--- a/terraform/environments/corporate-staff-rostering/locals_test.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_test.tf
@@ -10,17 +10,5 @@ locals {
     route53_zones = {
       "test.csr.service.justice.gov.uk" = {}
     }
-
-    s3_buckets = {
-      # use this bucket for storing artefacts for use across all accounts
-      csr-software = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
   }
 }

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -39,7 +39,6 @@ locals {
       enable_ec2_user_keypair                     = true
       enable_s3_db_backup_bucket                  = true
       enable_s3_bucket                            = true
-      enable_s3_shared_bucket                     = true
       enable_s3_software_bucket                   = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -39,6 +39,7 @@ locals {
       enable_ec2_user_keypair                     = true
       enable_s3_db_backup_bucket                  = true
       enable_s3_bucket                            = true
+      enable_s3_shared_bucket                     = true
       enable_s3_software_bucket                   = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -38,7 +38,9 @@ locals {
       enable_ec2_oracle_enterprise_managed_server = true
       enable_ec2_user_keypair                     = true
       enable_s3_db_backup_bucket                  = true
+      enable_s3_bucket                            = true
       enable_s3_shared_bucket                     = true
+      enable_s3_software_bucket                   = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
@@ -151,12 +153,6 @@ locals {
           "oasys-national-reporting-${local.environment}",
           "planetfm-${local.environment}",
         ]
-      }
-    }
-
-    s3_buckets = {
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
       }
     }
 

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -60,18 +60,6 @@ locals {
       })
     }
 
-    s3_buckets = {
-      # use this bucket for storing artefacts for use across all accounts
-      hmpps-oem-software = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     route53_zones = {
       "hmpps-test.modernisation-platform.service.justice.gov.uk" = {
         records = [

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -31,6 +31,7 @@ locals {
       enable_ec2_user_keypair                     = true
       enable_s3_bucket                            = true
       enable_s3_db_backup_bucket                  = true
+      enable_s3_software_bucket                   = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]

--- a/terraform/environments/nomis-combined-reporting/locals_test.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_test.tf
@@ -267,21 +267,15 @@ locals {
 
     s3_buckets = {
       nomis-combined-reporting-bip-packages = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.AllEnvironmentsReadOnlyAccessBucketPolicy
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-
-      # the shared image builder bucket is just created in test
-      nomis-combined-reporting-software = {
         custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.software]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -35,6 +35,8 @@ locals {
       enable_ec2_self_provision           = true
       enable_ec2_user_keypair             = true
       enable_offloc_sync                  = true
+      enable_s3_bucket                    = true
+      enable_s3_software_bucket           = true
       iam_policies_filter                 = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default            = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies                     = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
@@ -42,12 +44,6 @@ locals {
   }
 
   baseline_all_environments = {
-    s3_buckets = {
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     security_groups = local.security_groups
   }
 }

--- a/terraform/environments/nomis-data-hub/locals_production.tf
+++ b/terraform/environments/nomis-data-hub/locals_production.tf
@@ -122,7 +122,11 @@ locals {
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.general_purpose_three_months]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -100,22 +100,16 @@ locals {
     }
 
     s3_buckets = {
-      # the shared image builder bucket is just created in one account
-      nomis-data-hub-software = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-
       offloc-upload = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         bucket_policy_v2 = [
           module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
         ]
-        iam_policies = module.baseline_presets.s3_iam_policies
+        iam_policies   = module.baseline_presets.s3_iam_policies
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.general_purpose_three_months]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -44,14 +44,14 @@ locals {
       enable_ec2_user_keypair                     = true
       enable_s3_bucket                            = true
       enable_s3_db_backup_bucket                  = true
+      enable_s3_software_bucket                   = true
       enable_image_builder                        = true
       enable_hmpps_domain                         = true # Syscon users are collaborators so need domain creds to access nomis-client EC2s
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
-      route53_resolver_rules = {
-        outbound-data-and-private-subnets = ["azure-fixngo-domain"]
-      }
-      s3_iam_policies = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+      route53_resolver_rules                      = { outbound-data-and-private-subnets = ["azure-fixngo-domain"] }
+      s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
+      software_bucket_name                        = "ec2-image-builder-nomis"
     }
   }
 

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -476,15 +476,13 @@ locals {
     }
 
     s3_buckets = {
-      # nomis-audit-archives = {
-      #   custom_kms_key = module.environment.kms_keys["general"].arn
-      #   iam_policies   = module.baseline_presets.s3_iam_policies
-      #   lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.rman_backup_one_month]
-      # }
       syscon-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
         lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.software]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -476,15 +476,15 @@ locals {
     }
 
     s3_buckets = {
-      nomis-audit-archives = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
-      }
+      # nomis-audit-archives = {
+      #   custom_kms_key = module.environment.kms_keys["general"].arn
+      #   iam_policies   = module.baseline_presets.s3_iam_policies
+      #   lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.rman_backup_one_month]
+      # }
       syscon-bucket = {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
-        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
+        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.software]
       }
     }
 

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -521,13 +521,13 @@ locals {
     }
 
     s3_buckets = {
-      nomis-audit-archives = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-        lifecycle_rule = [
-          module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
-        ]
-      }
+      # nomis-audit-archives = {
+      #   custom_kms_key = module.environment.kms_keys["general"].arn
+      #   iam_policies   = module.baseline_presets.s3_iam_policies
+      #   lifecycle_rule = [
+      #     module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
+      #   ]
+      # }
     }
 
     secretsmanager_secrets = {

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -520,16 +520,6 @@ locals {
       }
     }
 
-    s3_buckets = {
-      # nomis-audit-archives = {
-      #   custom_kms_key = module.environment.kms_keys["general"].arn
-      #   iam_policies   = module.baseline_presets.s3_iam_policies
-      #   lifecycle_rule = [
-      #     module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
-      #   ]
-      # }
-    }
-
     secretsmanager_secrets = {
       "/oracle/weblogic/lsast"  = local.secretsmanager_secrets.web
       "/oracle/database/LSCNOM" = local.secretsmanager_secrets.db_cnom

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -466,6 +466,9 @@ locals {
         lifecycle_rule = [
           module.baseline_presets.s3_lifecycle_rules.ninety_day_standard_ia_ten_year_expiry
         ]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -684,17 +684,6 @@ locals {
         iam_policies   = module.baseline_presets.s3_iam_policies
         lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
       }
-
-      # use this bucket for storing artefacts for use across all accounts
-      ec2-image-builder-nomis = {
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        iam_policies   = module.baseline_presets.s3_iam_policies
-        lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
-      }
     }
 
     secretsmanager_secrets = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -683,6 +683,9 @@ locals {
         custom_kms_key = module.environment.kms_keys["general"].arn
         iam_policies   = module.baseline_presets.s3_iam_policies
         lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.default]
+        tags = {
+          backup = "false"
+        }
       }
     }
 

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -25,6 +25,7 @@ locals {
       enable_ec2_cloud_watch_agent  = true
       enable_ec2_self_provision     = true
       enable_ec2_user_keypair       = true
+      enable_s3_bucket              = true
       enable_s3_shared_bucket       = true
       iam_policies_filter           = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default      = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
@@ -44,11 +45,6 @@ locals {
           ]
           resources = ["*"]
         }]
-      }
-    }
-    s3_buckets = {
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
       }
     }
     security_groups = local.security_groups

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -49,7 +49,7 @@ locals {
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy", "Ec2OracleEnterpriseManagerPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_service_linked_roles                    = [] # ASG must have been created automatically by AWS
-      s3_bucket_name                              = "${local.application_name}-bucket"
+      s3_bucket_name                              = "${local.application_name}-${local.environment}"
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     }
   }

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -44,10 +44,12 @@ locals {
       enable_ec2_user_keypair                     = true
       enable_s3_db_backup_bucket                  = true
       enable_s3_shared_bucket                     = true
+      enable_s3_bucket                            = true
       enable_vmimport                             = true
       iam_policies_filter                         = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy", "Ec2OracleEnterpriseManagerPolicy"]
       iam_policies_ec2_default                    = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_service_linked_roles                    = [] # ASG must have been created automatically by AWS
+      s3_bucket_name                              = "${local.application_name}-bucket"
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
     }
   }

--- a/terraform/environments/oasys/locals_development.tf
+++ b/terraform/environments/oasys/locals_development.tf
@@ -23,11 +23,5 @@ locals {
       cwagent-oasys-autologoff = { retention_in_days = 1 }
       cwagent-web-logs         = { retention_in_days = 1 }
     }
-
-    s3_buckets = {
-      oasys-development = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
   }
 }

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -337,12 +337,6 @@ locals {
       }
     }
 
-    s3_buckets = {
-      oasys-preproduction = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     secretsmanager_secrets = {
       "/oracle/bip/preproduction" = local.secretsmanager_secrets_bip
       "/oracle/database/PPOASYS"  = local.secretsmanager_secrets_oasys_db

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -643,12 +643,6 @@ locals {
       }
     }
 
-    s3_buckets = {
-      oasys-production = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     secretsmanager_secrets = {
       "/oracle/bip/production" = local.secretsmanager_secrets_bip
       "/oracle/bip/trn"        = local.secretsmanager_secrets_bip

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -473,12 +473,6 @@ locals {
       }
     }
 
-    s3_buckets = {
-      oasys-test = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
-
     secretsmanager_secrets = {
       "/oracle/bip/t1" = local.secretsmanager_secrets_bip
       "/oracle/bip/t2" = local.secretsmanager_secrets_bip

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -60,6 +60,6 @@ locals {
       }
     }
     resource_explorer = true
-    security_groups = local.security_groups
+    security_groups   = local.security_groups
   }
 }

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -31,6 +31,8 @@ locals {
       enable_hmpps_domain           = true
       enable_image_builder          = true
       enable_oracle_secure_web      = true
+      enable_s3_bucket              = true
+      enable_s3_software_bucket     = true
       iam_policies_filter           = ["ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       iam_policies_ec2_default      = ["EC2S3BucketWriteAndDeleteAccessPolicy", "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"]
       s3_iam_policies               = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
@@ -58,11 +60,6 @@ locals {
       }
     }
     resource_explorer = true
-    s3_buckets = {
-      s3-bucket = {
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
     security_groups = local.security_groups
   }
 }

--- a/terraform/environments/planetfm/locals_test.tf
+++ b/terraform/environments/planetfm/locals_test.tf
@@ -10,17 +10,5 @@ locals {
     route53_zones = {
       "test.planetfm.service.justice.gov.uk" = {}
     }
-
-    s3_buckets = {
-      # use this bucket for storing artefacts for use across all accounts
-      planetfm-software = {
-        custom_kms_key = module.environment.kms_keys["general"].arn
-        bucket_policy_v2 = [
-          module.baseline_presets.s3_bucket_policies.ImageBuilderWriteAccessBucketPolicy,
-          module.baseline_presets.s3_bucket_policies.AllEnvironmentsWriteAccessBucketPolicy,
-        ]
-        iam_policies = module.baseline_presets.s3_iam_policies
-      }
-    }
   }
 }

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -852,44 +852,12 @@ variable "s3_buckets" {
     })), [])
     custom_kms_key             = optional(string)
     custom_replication_kms_key = optional(string)
-    lifecycle_rule = optional(any, [{
-      id      = "main"
-      enabled = "Enabled"
-      prefix  = ""
-      tags = {
-        rule      = "log"
-        autoclean = "true"
-      }
-      transition = [
-        {
-          days          = 90
-          storage_class = "STANDARD_IA"
-          }, {
-          days          = 365
-          storage_class = "GLACIER"
-        }
-      ]
-      expiration = {
-        days = 730
-      }
-      noncurrent_version_transition = [
-        {
-          days          = 90
-          storage_class = "STANDARD_IA"
-          }, {
-          days          = 365
-          storage_class = "GLACIER"
-        }
-      ]
-      noncurrent_version_expiration = {
-        days = 730
-      }
-    }])
-    log_bucket           = optional(string, "")
-    log_prefix           = optional(string, "")
-    replication_role_arn = optional(string, "")
-    force_destroy        = optional(bool, false)
-    sse_algorithm        = optional(string, "aws:kms")
+    lifecycle_rule             = any # see module baseline_presets.s3 for examples
+    log_bucket                 = optional(string, "")
+    log_prefix                 = optional(string, "")
+    replication_role_arn       = optional(string, "")
+    force_destroy              = optional(bool, false)
+    sse_algorithm              = optional(string, "aws:kms")
     iam_policies = optional(map(list(object({
       sid     = optional(string, null)
       effect  = string

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -47,6 +47,7 @@ variable "options" {
     iam_policies_filter                          = optional(list(string), [])      # any policies to add from local.iam_policies which haven't been added automatically by the enable options
     iam_policies_ec2_default                     = optional(list(string), [])      # any policies to add to the default EC2 policy which haven't been added automatically the above enable_ec2 options
     iam_service_linked_roles                     = optional(list(string))          # create iam service linked roles; list of map keys to filter local.iam_service_linked_roles; default is to create all
+    s3_bucket_name                               = optional(string)                # override default general purpose bucket name
     s3_iam_policies                              = optional(list(string))          # create default iam policies for bucket access, list of map keys to filter local.s3_iam_policies
     software_bucket_name                         = optional(string)                # override default software/artefacts bucket name
 

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -20,7 +20,7 @@ variable "options" {
     cloudwatch_metric_alarms_default_actions     = optional(list(string))          # default alarm_action to apply to cloudwatch metrics returned by this module
     cloudwatch_metric_oam_links_ssm_parameters   = optional(list(string))          # list of account names to send cloudwatch metrics to, creates placeholder SSM param for each
     cloudwatch_metric_oam_links                  = optional(list(string))          # list of account names to send cloudwatch metrics to, creates oam link for each
-    db_backup_bucket_name                        = optional(string)                # override default backup bucket name
+    db_backup_bucket_name                        = optional(string)                # override default backup bucket name
     db_backup_more_permissions                   = optional(bool, false)           # allow cross-account delete access for db-backup S3 buckets
     enable_application_environment_wildcard_cert = optional(bool, false)           # create ACM cert with mod platform business unit
     enable_azure_sas_token                       = optional(bool, false)           # create /azure SSM parameter and pipeline role
@@ -38,15 +38,17 @@ variable "options" {
     enable_ec2_ssm_agent_update                  = optional(bool, false)           # create SSM association for auto-update of SSM agent. update-ssm-agent tag needs to be set on EC2s also
     enable_ec2_user_keypair                      = optional(bool, false)           # create secret and key-pair for ec2-user
     enable_observability_platform_monitoring     = optional(bool, false)           # create role for observability platform monitroing
-    enable_s3_bucket                             = optional(bool, false)           # create s3-bucket S3 bucket for general use
+    enable_s3_bucket                             = optional(bool, false)           # create s3-bucket S3 bucket for general use
     enable_s3_db_backup_bucket                   = optional(bool, false)           # create db-backup S3 buckets
     enable_s3_shared_bucket                      = optional(bool, false)           # create devtest and preprodprod S3 bucket for sharing between accounts
+    enable_s3_software_bucket                    = optional(bool, false)           # create software S3 bucket in test account for image builder/configuration-management
     enable_vmimport                              = optional(bool, false)           # create role for vm imports
     route53_resolver_rules                       = optional(map(list(string)), {}) # create route53 resolver rules; list of map keys to filter local.route53_resolver_rules_all
     iam_policies_filter                          = optional(list(string), [])      # any policies to add from local.iam_policies which haven't been added automatically by the enable options
     iam_policies_ec2_default                     = optional(list(string), [])      # any policies to add to the default EC2 policy which haven't been added automatically the above enable_ec2 options
     iam_service_linked_roles                     = optional(list(string))          # create iam service linked roles; list of map keys to filter local.iam_service_linked_roles; default is to create all
     s3_iam_policies                              = optional(list(string))          # create default iam policies for bucket access, list of map keys to filter local.s3_iam_policies
+    software_bucket_name                         = optional(string)                # override default software/artefacts bucket name
 
     sns_topics = optional(object({
       pagerduty_integrations = optional(map(string), {}) # create sns topics where map key is name and value is modernisation platform pagerduty_integration_keys


### PR DESCRIPTION
Remaining S3 lifecycle changes across DSO accounts. In summary
- disable backup
- general purpose lifecycle for s3 bucket and shared bucket for logs etc (1yr retention in prod, 3 months elsewhere)
- software lifecycle (no expiration)