### PR TITLE
remove prod-nomis-client-b temporarily

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -123,12 +123,12 @@ locals {
           domain-name = "azure.hmpp.root"
         })
       })
-      # BEING USED FOR TESTING
-      prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
-        tags = merge(local.ec2_autoscaling_groups.client.tags, {
-          domain-name = "azure.hmpp.root"
-        })
-      })
+      # # BEING USED FOR TESTING
+      # prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
+      #   tags = merge(local.ec2_autoscaling_groups.client.tags, {
+      #     domain-name = "azure.hmpp.root"
+      #   })
+      # })
     }
 
     ec2_instances = {


### PR DESCRIPTION
- delete this temporarily
- expect a PR to put it back shortly
  - goal is to re-create this from scratch and make sure it all still works under the revised GPO 