### PR TITLE
DPR2-894: Add connection name and data store write feature flag args to glue batch job in the dev environment

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -7,7 +7,7 @@ locals {
   glue_avro_registry           = split("/", module.glue_registry_avro.registry_name)
   shared_log4j_properties_path = "s3://${aws_s3_object.glue_job_shared_custom_log4j_properties.bucket}/${aws_s3_object.glue_job_shared_custom_log4j_properties.key}"
   # We only want to include the connection arg in the dev environment for now
-  glue_job_extra_args = (local.environment == "development" ? {
+  glue_batch_job_extra_args = (local.environment == "development" ? {
     "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection.name
   } : {})
 }
@@ -123,7 +123,7 @@ module "glue_reporting_hub_batch_job" {
     }
   )
 
-  arguments = merge(glue_job_extra_args, {
+  arguments = merge(glue_batch_job_extra_args, {
     "--extra-jars"                          = local.glue_jobs_latest_jar_location
     "--extra-files"                         = local.shared_log4j_properties_path
     "--class"                               = "uk.gov.justice.digital.job.DataHubBatchJob"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -123,7 +123,7 @@ module "glue_reporting_hub_batch_job" {
     }
   )
 
-  arguments = merge(glue_batch_job_extra_args, {
+  arguments = merge(local.glue_batch_job_extra_args, {
     "--extra-jars"                          = local.glue_jobs_latest_jar_location
     "--extra-files"                         = local.shared_log4j_properties_path
     "--class"                               = "uk.gov.justice.digital.job.DataHubBatchJob"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -8,7 +8,7 @@ locals {
   shared_log4j_properties_path = "s3://${aws_s3_object.glue_job_shared_custom_log4j_properties.bucket}/${aws_s3_object.glue_job_shared_custom_log4j_properties.key}"
   # We only want to include the connection arg in the dev environment for now
   glue_batch_job_extra_args = (local.environment == "development" ? {
-    "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection.name
+    "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection[0].name
   } : {})
 }
 

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -6,8 +6,9 @@
 locals {
   glue_avro_registry           = split("/", module.glue_registry_avro.registry_name)
   shared_log4j_properties_path = "s3://${aws_s3_object.glue_job_shared_custom_log4j_properties.bucket}/${aws_s3_object.glue_job_shared_custom_log4j_properties.key}"
-  # We only want to include the connection arg in the dev environment for now
+  # We only want to enable write to Operational DataStore in the dev environment until it is available in all environments
   glue_batch_job_extra_args = (local.environment == "development" ? {
+    "--dpr.operational.data.store.write.enabled"        = "true"
     "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection[0].name
   } : {})
 }

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -6,6 +6,10 @@
 locals {
   glue_avro_registry           = split("/", module.glue_registry_avro.registry_name)
   shared_log4j_properties_path = "s3://${aws_s3_object.glue_job_shared_custom_log4j_properties.bucket}/${aws_s3_object.glue_job_shared_custom_log4j_properties.key}"
+  # We only want to include the connection arg in the dev environment for now
+  glue_job_extra_args = (local.environment == "development" ? {
+    "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection.name
+  } : {})
 }
 
 resource "aws_s3_object" "glue_job_shared_custom_log4j_properties" {
@@ -119,7 +123,7 @@ module "glue_reporting_hub_batch_job" {
     }
   )
 
-  arguments = {
+  arguments = merge(glue_job_extra_args, {
     "--extra-jars"                          = local.glue_jobs_latest_jar_location
     "--extra-files"                         = local.shared_log4j_properties_path
     "--class"                               = "uk.gov.justice.digital.job.DataHubBatchJob"
@@ -136,7 +140,7 @@ module "glue_reporting_hub_batch_job" {
     "--dpr.datastorage.retry.maxWaitMillis" = local.reporting_hub_batch_job_retry_max_wait_millis
     "--dpr.schema.cache.max.size"           = local.reporting_hub_batch_job_schema_cache_max_size
     "--dpr.log.level"                       = local.reporting_hub_batch_job_log_level
-  }
+  })
 }
 
 # Glue Job, Reporting Hub CDC


### PR DESCRIPTION
- This is required for glue to access the connection
- If it is not provided then the job will not write to the operational datastore, so other environments will continue to function without an operational datastore available
- The `glue_job_extra_args` local will be inlined once all environments have a data store and so can have this parameter added