### PR TITLE
Issue 13 - Adds additional sed statements to the redact-output script.

### DIFF
--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -6,4 +6,7 @@ sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
     -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
     -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
     -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
-    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g' \
+    -e 's/::[0-9]\{12\}:/::REDACTED:/g' \
+    -e 's/:[0-9]\{12\}:/:REDACTED:/g'
+


### PR DESCRIPTION
This adds two additional patterns to the redact script to pick out occurrences of account numbers listed in terraform plan and apply outputs and replace them with a mask. Two additional sed statements are required as some ARNS have double colons "::" and sone just one ":".