### PR TITLE
remove nomis client asg's for testing OU defaults for mod-platform

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -123,12 +123,6 @@ locals {
           domain-name = "azure.hmpp.root"
         })
       })
-      # BEING USED FOR TESTING
-      prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
-        tags = merge(local.ec2_autoscaling_groups.client.tags, {
-          domain-name = "azure.hmpp.root"
-        })
-      })
     }
 
     ec2_instances = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -204,12 +204,6 @@ locals {
           domain-name = "azure.noms.root"
         })
       })
-      # Temporary client to test RDP and OU default changes
-      test-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
-        tags = merge(local.ec2_autoscaling_groups.client.tags, {
-          domain-name = "azure.noms.root"
-        })
-      })
     }
 
     ec2_instances = {


### PR DESCRIPTION
- remove test-nomis-client-b asg, no longer needed for testing
- remove prod-nomis-client-b asg, no longer needed for testing