### PR TITLE
Nomis: DSOS: ha failover test prep and jumpserver schedule change

### DIFF
--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -156,7 +156,7 @@ locals {
         }
       }
       autoscaling_schedules = {
-        "scale_up"   = { recurrence = "0 7 * * Mon-Fri" }
+        "scale_up"   = { recurrence = "0 6 * * Mon-Fri" }
         "scale_down" = { desired_capacity = 0, recurrence = "0 19 * * Mon-Fri" }
       }
       config = {

--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -60,7 +60,7 @@ locals {
         }
       }
       autoscaling_schedules = {
-        "scale_up"   = { recurrence = "0 7 * * Mon-Fri" }
+        "scale_up"   = { recurrence = "0 6 * * Mon-Fri" }
         "scale_down" = { desired_capacity = 0, recurrence = "0 19 * * Mon-Fri" }
       }
       config = {
@@ -156,7 +156,7 @@ locals {
         }
       }
       autoscaling_schedules = {
-        "scale_up"   = { recurrence = "0 6 * * Mon-Fri" }
+        "scale_up"   = { recurrence = "0 7 * * Mon-Fri" }
         "scale_down" = { desired_capacity = 0, recurrence = "0 19 * * Mon-Fri" }
       }
       config = {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -176,8 +176,10 @@ locals {
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 4000, iops = 9000, throughput = 250 }
-          flash = { total_size = 1000, iops = 3000, throughput = 250 }
+          # data  = { total_size = 4000, iops = 9000, throughput = 250 }
+          # flash = { total_size = 1000, iops = 3000, throughput = 250 }
+          data  = { total_size = 4000, iops = 18000, throughput = 500 } # doubled for failover test
+          flash = { total_size = 1000, iops = 6000, throughput = 500 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -435,7 +435,7 @@ locals {
           { name = "pndh-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "por", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "por-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
-          { name = "por-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
+          { name = "por-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "ptrdat", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "ptrdat-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "ptrdat-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
@@ -447,7 +447,7 @@ locals {
           { name = "pmis-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-2-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "pnomisapiro", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "pnomisapiro-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
-          { name = "pnomisapiro-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
+          { name = "pnomisapiro-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
         ]
         lb_alias_records = [
           { name = "maintenance", type = "A", lbs_map_key = "private" },


### PR DESCRIPTION
Double iops/bandwidth on prod-nomis-db-1-a prior to failover test
Update DNS entries for the backup hostnames
Adjust schedule for client jump server