### PR TITLE
DSOS: ha failover prep - increase iops

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -178,7 +178,7 @@ locals {
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
           # data  = { total_size = 4000, iops = 9000, throughput = 250 }
           # flash = { total_size = 1000, iops = 3000, throughput = 250 }
-          data  = { total_size = 4000, iops = 18000, throughput = 500 } # doubled for failover test
+          data  = { total_size = 4000, iops = 16000, throughput = 500 } # doubled for failover test. 16000 is the max iops
           flash = { total_size = 1000, iops = 6000, throughput = 500 }
         })
         instance = merge(local.ec2_instances.db.instance, {


### PR DESCRIPTION
18000 not allowed... 16000 is the max