### PR TITLE
DPR2-713: Refactor replay pipeline step names

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
@@ -78,9 +78,9 @@ module "replay_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Copy Data to Temp-Reload Bucket"
+          "Next" : "Copy Curated Data to Temp-Reload Bucket"
         },
-        "Copy Data to Temp-Reload Bucket" : {
+        "Copy Curated Data to Temp-Reload Bucket" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -105,9 +105,9 @@ module "replay_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Truncate Data"
+          "Next" : "Empty Structured and Curated Data"
         },
-        "Truncate Data" : {
+        "Empty Structured and Curated Data" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -184,9 +184,9 @@ module "replay_pipeline" {
               "--dpr.orchestration.wait.interval.seconds" : "60"
             }
           },
-          "Next" : "Truncate Raw Data"
+          "Next" : "Empty Raw Data"
         },
-        "Truncate Raw Data" : {
+        "Empty Raw Data" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {


### PR DESCRIPTION
This PR updates the names of the steps in the replay pipeline to make them clearer:
- `Copy Data to Temp-Reload Bucket` was changed to `Copy Curated Data to Temp-Reload Bucket`
- `Truncate Data` was changed to `Empty Structured and Curated Data`
- `Truncate Raw Data` was changed to `Empty Raw Data`