### PR TITLE
DPR2-757 fix cancel statement action

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -538,8 +538,7 @@ data "aws_iam_policy_document" "redshift_dataapi" {
       "redshift-data:DescribeTable",
       "redshift-data:ListSchemas",
       "redshift-data:ListDatabases",
-      "redshift-data:ExecuteStatement",
-      "redshift-data:CancelStatement"
+      "redshift-data:ExecuteStatement"
     ]
     resources = [
       "arn:aws:redshift:${local.account_region}:${local.account_id}:cluster:*"
@@ -550,7 +549,8 @@ data "aws_iam_policy_document" "redshift_dataapi" {
     actions = [
       "redshift-data:GetStatementResult",
       "redshift-data:DescribeStatement",
-      "redshift-data:ListStatements"
+      "redshift-data:ListStatements",
+      "redshift-data:CancelStatement"
     ]
     resources = [
       "*"


### PR DESCRIPTION
Fixed the redshift-data:CancelStatement policy action. 
Based on the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonredshiftdataapi.html) for the cancel statement action all resources ("*") to which the policy applies must be specified.