### PR TITLE
🗺️ APC Transit Gateway routing

### DIFF
--- a/terraform/environments/analytical-platform-compute/data.tf
+++ b/terraform/environments/analytical-platform-compute/data.tf
@@ -4,33 +4,35 @@ data "aws_ssoadmin_instances" "main" {
   provider = aws.sso-readonly
 }
 
-data "aws_ec2_transit_gateway" "pttp" {
+data "aws_ec2_transit_gateway" "moj_tgw" {
   id = "tgw-026162f1ba39ce704"
 }
 
-# data "aws_ram_resource_share" "moj_tgw" {
-#   filter {
-#     name   = "resourceType"
-#     values = ["ec2:TransitGateway"]
-#   }
-# }
+/* TODO: Unhardcode aws_ec2_transit_gateway.moj_tgw
+data "aws_ram_resource_share" "moj_tgw" {
+  filter {
+    name   = "resourceType"
+    values = ["ec2:TransitGateway"]
+  }
+}
 
-# data "aws_arn" "moj_tgw" {
-#   arn = data.aws_ram_resource_share.moj_tgw.resource_arns[0]
-# }
+data "aws_arn" "moj_tgw" {
+  arn = data.aws_ram_resource_share.moj_tgw.resource_arns[0]
+}
 
-# TODO: revisit this to unhardcode the tgw ID above
-# data "aws_ram_resource_share" "tgw_moj" {
-#   name           = "tgw-moj"
-#   resource_owner = "OTHER-ACCOUNTS"
-# }
+TODO: revisit this to unhardcode the tgw ID above
+data "aws_ram_resource_share" "tgw_moj" {
+  name           = "tgw-moj"
+  resource_owner = "OTHER-ACCOUNTS"
+}
 
-# data "aws_ec2_transit_gateway" "pttp" {
-#   filter {
-#     name   = "owner-id"
-#     values = [data.aws_ram_resource_share.tgw_moj.resource_arns]
-#   }
-# }
+data "aws_ec2_transit_gateway" "pttp" {
+  filter {
+    name   = "owner-id"
+    values = [data.aws_ram_resource_share.tgw_moj.resource_arns]
+  }
+}
+*/
 
 data "aws_iam_roles" "eks_sso_access_role" {
   name_regex  = "AWSReservedSSO_${local.environment_configuration.eks_sso_access_role}_.*"

--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -166,6 +166,7 @@ module "eks" {
   tags = local.tags
 }
 
+#tfsec:ignore:avd-aws-0104 NACLs not restricted
 module "karpenter" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -34,6 +34,13 @@ locals {
       vpc_one_nat_gateway_per_az = true
       vpc_single_nat_gateway     = false
 
+      /* Transit Gateway */
+      transit_gateway_routes = [
+        "10.26.0.0/15", # modernisation-platform
+        "10.40.0.0/18", # noms-live-vnet
+        "10.205.0.0/20" # laa-lz-prod
+      ]
+
       /* Route53 */
       route53_zone = "compute.development.analytical-platform.service.justice.gov.uk"
 
@@ -75,6 +82,13 @@ locals {
       vpc_one_nat_gateway_per_az = true
       vpc_single_nat_gateway     = false
 
+      /* Transit Gateway */
+      transit_gateway_routes = [
+        "10.26.0.0/15", # modernisation-platform
+        "10.40.0.0/18", # noms-live-vnet
+        "10.205.0.0/20" # laa-lz-prod
+      ]
+
       /* Route53 */
       route53_zone = "compute.test.analytical-platform.service.justice.gov.uk"
 
@@ -115,6 +129,12 @@ locals {
       vpc_enable_nat_gateway     = true
       vpc_one_nat_gateway_per_az = true
       vpc_single_nat_gateway     = false
+
+      /* Transit Gateway */
+      transit_gateway_routes = [
+        "10.26.0.0/15", # modernisation-platform
+        "10.40.0.0/18"  # noms-live-vnet
+      ]
 
       /* Route53 */
       route53_zone = "compute.analytical-platform.service.justice.gov.uk"

--- a/terraform/environments/analytical-platform-compute/modules/routes/main.tf
+++ b/terraform/environments/analytical-platform-compute/modules/routes/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route" "this" {
+  for_each = toset(var.destination_cidr_blocks)
+
+  route_table_id         = var.route_table_id
+  destination_cidr_block = each.value
+  transit_gateway_id     = var.transit_gateway_id
+}

--- a/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
+++ b/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/analytical-platform-compute/modules/routes/variables.tf
+++ b/terraform/environments/analytical-platform-compute/modules/routes/variables.tf
@@ -1,0 +1,11 @@
+variable "route_table_id" {
+  type = string
+}
+
+variable "destination_cidr_blocks" {
+  type = list(string)
+}
+
+variable "transit_gateway_id" {
+  type = string
+}

--- a/terraform/environments/analytical-platform-compute/routes.tf
+++ b/terraform/environments/analytical-platform-compute/routes.tf
@@ -1,0 +1,9 @@
+module "transit_gateway_routes" {
+  for_each = toset(module.vpc.private_route_table_ids)
+
+  source = "./modules/routes"
+
+  route_table_id          = each.value
+  destination_cidr_blocks = local.environment_configuration.transit_gateway_routes
+  transit_gateway_id      = data.aws_ec2_transit_gateway.moj_tgw.id
+}

--- a/terraform/environments/analytical-platform-compute/transit-gateway-vpc-attachments.tf
+++ b/terraform/environments/analytical-platform-compute/transit-gateway-vpc-attachments.tf
@@ -1,8 +1,12 @@
-resource "aws_ec2_transit_gateway_vpc_attachment" "pttp" {
-  transit_gateway_id = data.aws_ec2_transit_gateway.pttp.id
-  # transit_gateway_id = data.aws_arn.moj_tgw.resource
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
+resource "aws_ec2_transit_gateway_vpc_attachment" "moj_tgw" {
+  transit_gateway_id = data.aws_ec2_transit_gateway.moj_tgw.id
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
 
   tags = local.tags
+}
+
+moved {
+  from = aws_ec2_transit_gateway_vpc_attachment.pttp
+  to   = aws_ec2_transit_gateway_vpc_attachment.moj_tgw
 }


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4490
- Creates a module to add transit gateway routes to the existing private route tables

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 