### PR TITLE
DSOS: iops tweaks for Nomis and CSR

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -24,7 +24,7 @@ locals {
           "/dev/sdc"  = { label = "app", size = 500 } # /u02
         })
         ebs_volume_config = merge(local.defaults_database_ec2.ebs_volume_config, {
-          data  = { total_size = 1500 }
+          data  = { total_size = 1500, iops = 6000 }
           flash = { total_size = 500 }
         })
         instance = merge(local.defaults_database_ec2.instance, {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -176,10 +176,8 @@ locals {
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          # data  = { total_size = 4000, iops = 9000, throughput = 250 }
-          # flash = { total_size = 1000, iops = 3000, throughput = 250 }
-          data  = { total_size = 4000, iops = 16000, throughput = 500 } # doubled for failover test. 16000 is the max iops
-          flash = { total_size = 1000, iops = 6000, throughput = 500 }
+          data  = { total_size = 4000, iops = 9000, throughput = 250 }
+          flash = { total_size = 1000, iops = 3000, throughput = 250 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true


### PR DESCRIPTION
Reduce Nomis IOPS.  Seems existing settings were good enough even with the HA DB running on the -a server.
Increase CSR IOPS on request from DBAs.