### PR TITLE
put in a nomis-client-b for testing, number of instances is 0 by default

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -135,7 +135,7 @@ locals {
       prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
         autoscaling_group = merge(local.ec2_autoscaling_groups.client.autoscaling_group, {
           desired_capacity = 0
-          max_size         = 1
+          max_size         = 0
         })
         tags = merge(local.ec2_autoscaling_groups.client.tags, {
           domain-name = "azure.hmpp.root"

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -131,6 +131,16 @@ locals {
           domain-name = "azure.hmpp.root"
         })
       })
+      # Being used for testing, capacity defaults to 0 
+      prod-nomis-client-b = merge(local.ec2_autoscaling_groups.client, {
+        autoscaling_group = merge(local.ec2_autoscaling_groups.client.autoscaling_group, {
+          desired_capacity = 0
+          max_size         = 1
+        })
+        tags = merge(local.ec2_autoscaling_groups.client.tags, {
+          domain-name = "azure.hmpp.root"
+        })
+      })
     }
 
     ec2_instances = {


### PR DESCRIPTION
- add a prod-nomis-client-b instance for testing but default it to zero instances
- leave this in for testing purposes this time