### PR TITLE
nomis: DSOS: fix lsast alarm

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -466,8 +466,8 @@ locals {
                   host_header = {
                     values = [
                       "maintenance.preproduction.nomis.service.justice.gov.uk",
-                      "preprod-nomis-web-a.preproduction.nomis.service.justice.gov.uk",
-                      "preprod-nomis-web-b.preproduction.nomis.service.justice.gov.uk",
+                      "c.pp-nomis.az.justice.gov.uk",
+                      "c.lsast-nomis.az.justice.gov.uk",
                       "c.preproduction.nomis.service.justice.gov.uk",
                       "c-lsast.preproduction.nomis.service.justice.gov.uk",
                     ]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -125,7 +125,7 @@ locals {
       # ACTIVE (green deployment)
       t2-nomis-web-b = merge(local.ec2_autoscaling_groups.web, {
         autoscaling_group = merge(local.ec2_autoscaling_groups.web.autoscaling_group, {
-          desired_capacity = 1
+          desired_capacity = 0
         })
         cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.web
         config = merge(local.ec2_autoscaling_groups.web.config, {
@@ -585,6 +585,7 @@ locals {
                       "t3-nomis-web-b.test.nomis.service.justice.gov.uk",
                       "c-t3.test.nomis.service.justice.gov.uk",
                       "t3-cn.hmpp-azdt.justice.gov.uk",
+                      "t3-cn-ha.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]
@@ -606,6 +607,7 @@ locals {
                       "c-t1.test.nomis.service.justice.gov.uk",
                       "c-t2.test.nomis.service.justice.gov.uk",
                       "c-t3.test.nomis.service.justice.gov.uk",
+                      "t3-cn-ha.hmpp-azdt.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -530,7 +530,7 @@ locals {
                 }]
               }
               t2-nomis-web-a-http-7777 = {
-                priority = 550
+                priority = 1550
                 actions = [{
                   type              = "forward"
                   target_group_name = "t2-nomis-web-a-http-7777"
@@ -544,7 +544,7 @@ locals {
                 }]
               }
               t2-nomis-web-b-http-7777 = {
-                priority = 600
+                priority = 1600
                 actions = [{
                   type              = "forward"
                   target_group_name = "t2-nomis-web-b-http-7777"


### PR DESCRIPTION
Include legacy URLs to prevent alarms when environment in maintenance mode
Also shutdown T2 which is now started on demand