### PR TITLE
Removes the "test" certificate.

### DIFF
--- a/terraform/environments/sprinkler/main.tf
+++ b/terraform/environments/sprinkler/main.tf
@@ -815,11 +815,3 @@ resource "aws_cloudwatch_log_group" "app" {
     },
   )
 }
-
-resource "aws_acm_certificate" "us_east_1_test" {
-  domain_name       = "test.modernisation-platform.service.justice.gov.uk"
-  validation_method = "DNS"
-  provider          = aws.us-east-1
-
-  tags = local.tags
-}


### PR DESCRIPTION
This removes the certificate with the domain name test.modernisation-platform.service.justice.gov.uk as this was causing a number of problems for ops eng.