### PR TITLE
Add django app secret

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -49,12 +49,12 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
           }
           "secretKey" = "client-id"
         },
-        {
-          "remoteRef" = {
-            "key" = module.ui_azure_tenant_secret.secret_id
-          }
-          "secretKey" = "tenant-id"
-        },
+        # {
+        #   "remoteRef" = {
+        #     "key" = module.ui_azure_tenant_secret.secret_id
+        #   }
+        #   "secretKey" = "tenant-id"
+        # },
       ]
     }
   }

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -45,7 +45,7 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
       "data" = [
         {
           "remoteRef" = {
-            "key" = module.ui_azure_client_secret.secret_id
+            "key" = "a-test-string"
           }
           "secretKey" = "client-id"
         },

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -45,7 +45,7 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
       "data" = [
         {
           "remoteRef" = {
-            "key" = "a-test-string"
+            "key" = module.ui_azure_client_secret.secret_id
           }
           "secretKey" = "client-id"
         },

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -26,36 +26,42 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
   }
 }
 
-# resource "kubernetes_manifest" "ui_azure_external_secret" {
-#   manifest = {
-#     "apiVersion" = "external-secrets.io/v1beta1"
-#     "kind"       = "ExternalSecret"
-#     "metadata" = {
-#       "name"      = "ui-azure"
-#       "namespace" = kubernetes_namespace.ui.metadata[0].name
-#     }
-#     "spec" = {
-#       "secretStoreRef" = {
-#         "kind" = "ClusterSecretStore"
-#         "name" = "aws-secretsmanager"
-#       }
-#       "target" = {
-#         "name" = "ui-azure"
-#       }
-#       "data" = [
-#         {
-#           "remoteRef" = {
-#             "key" = module.ui_azure_client_secret.secret_id
-#           }
-#           "secretKey" = "client-id"
-#         },
-#         {
-#           "remoteRef" = {
-#             "key" = module.ui_azure_tenant_secret.secret_id
-#           }
-#           "secretKey" = "tenant-id"
-#         },
-#       ]
-#     }
-#   }
-# }
+resource "kubernetes_manifest" "ui_azure_external_secret" {
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "ui-azure"
+      "namespace" = kubernetes_namespace.ui.metadata[0].name
+    }
+    "spec" = {
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "ui-azure"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key" = module.ui_azure_client_secret.secret_id
+          }
+          "secretKey" = "client-id"
+        },
+        {
+          "remoteRef" = {
+            "key" = module.ui_azure_tenant_secret.secret_id
+          }
+          "secretKey" = "tenant-id"
+        },
+      ]
+    }
+  }
+
+  depends_on = [
+    module.ui_azure_client_secret,
+    module.ui_azure_tenant_secret,
+  ]
+
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -45,13 +45,13 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
       "data" = [
         {
           "remoteRef" = {
-            "key" = module.ui_azure_secret.client_id
+            "key" = module.ui_azure_client_secret.secret_id
           }
           "secretKey" = "client-id"
         },
         {
           "remoteRef" = {
-            "key" = module.ui_azure_secret.tenant_id
+            "key" = module.ui_azure_tenant_secret.secret_id
           }
           "secretKey" = "tenant-id"
         },

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -25,3 +25,37 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
     }
   }
 }
+
+resource "kubernetes_manifest" "ui_azure_external_secret" {
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "ui-azure"
+      "namespace" = kubernetes_namespace.ui.metadata[0].name
+    }
+    "spec" = {
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "ui-azure"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key" = module.ui_azure_secret.client_id
+          }
+          "secretKey" = "client-id"
+        },
+        {
+          "remoteRef" = {
+            "key" = module.ui_azure_secret.tenant_id
+          }
+          "secretKey" = "tenant-id"
+        },
+      ]
+    }
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -49,12 +49,12 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
 #           }
 #           "secretKey" = "client-id"
 #         },
-#         # {
-#         #   "remoteRef" = {
-#         #     "key" = module.ui_azure_tenant_secret.secret_id
-#         #   }
-#         #   "secretKey" = "tenant-id"
-#         # },
+#         {
+#           "remoteRef" = {
+#             "key" = module.ui_azure_tenant_secret.secret_id
+#           }
+#           "secretKey" = "tenant-id"
+#         },
 #       ]
 #     }
 #   }

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -26,42 +26,42 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
   }
 }
 
-resource "kubernetes_manifest" "ui_azure_external_secret" {
-  manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
-    "kind"       = "ExternalSecret"
-    "metadata" = {
-      "name"      = "ui-azure"
-      "namespace" = kubernetes_namespace.ui.metadata[0].name
-    }
-    "spec" = {
-      "secretStoreRef" = {
-        "kind" = "ClusterSecretStore"
-        "name" = "aws-secretsmanager"
-      }
-      "target" = {
-        "name" = "ui-azure"
-      }
-      "data" = [
-        {
-          "remoteRef" = {
-            "key" = module.ui_azure_client_secret.secret_id
-          }
-          "secretKey" = "client-id"
-        },
-        {
-          "remoteRef" = {
-            "key" = module.ui_azure_tenant_secret.secret_id
-          }
-          "secretKey" = "tenant-id"
-        },
-      ]
-    }
-  }
+# resource "kubernetes_manifest" "ui_azure_external_secret" {
+#   manifest = {
+#     "apiVersion" = "external-secrets.io/v1beta1"
+#     "kind"       = "ExternalSecret"
+#     "metadata" = {
+#       "name"      = "ui-azure"
+#       "namespace" = kubernetes_namespace.ui.metadata[0].name
+#     }
+#     "spec" = {
+#       "secretStoreRef" = {
+#         "kind" = "ClusterSecretStore"
+#         "name" = "aws-secretsmanager"
+#       }
+#       "target" = {
+#         "name" = "ui-azure"
+#       }
+#       "data" = [
+#         {
+#           "remoteRef" = {
+#             "key" = module.ui_azure_client_secret.secret_id
+#           }
+#           "secretKey" = "client-id"
+#         },
+#         {
+#           "remoteRef" = {
+#             "key" = module.ui_azure_tenant_secret.secret_id
+#           }
+#           "secretKey" = "tenant-id"
+#         },
+#       ]
+#     }
+#   }
 
-  depends_on = [
-    module.ui_azure_client_secret,
-    module.ui_azure_tenant_secret,
-  ]
+#   depends_on = [
+#     module.ui_azure_client_secret,
+#     module.ui_azure_tenant_secret,
+#   ]
 
-}
+# }

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -26,36 +26,36 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
   }
 }
 
-resource "kubernetes_manifest" "ui_azure_external_secret" {
-  manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
-    "kind"       = "ExternalSecret"
-    "metadata" = {
-      "name"      = "ui-azure"
-      "namespace" = kubernetes_namespace.ui.metadata[0].name
-    }
-    "spec" = {
-      "secretStoreRef" = {
-        "kind" = "ClusterSecretStore"
-        "name" = "aws-secretsmanager"
-      }
-      "target" = {
-        "name" = "ui-azure"
-      }
-      "data" = [
-        {
-          "remoteRef" = {
-            "key" = module.ui_azure_client_secret.secret_id
-          }
-          "secretKey" = "client-id"
-        },
-        # {
-        #   "remoteRef" = {
-        #     "key" = module.ui_azure_tenant_secret.secret_id
-        #   }
-        #   "secretKey" = "tenant-id"
-        # },
-      ]
-    }
-  }
-}
+# resource "kubernetes_manifest" "ui_azure_external_secret" {
+#   manifest = {
+#     "apiVersion" = "external-secrets.io/v1beta1"
+#     "kind"       = "ExternalSecret"
+#     "metadata" = {
+#       "name"      = "ui-azure"
+#       "namespace" = kubernetes_namespace.ui.metadata[0].name
+#     }
+#     "spec" = {
+#       "secretStoreRef" = {
+#         "kind" = "ClusterSecretStore"
+#         "name" = "aws-secretsmanager"
+#       }
+#       "target" = {
+#         "name" = "ui-azure"
+#       }
+#       "data" = [
+#         {
+#           "remoteRef" = {
+#             "key" = module.ui_azure_client_secret.secret_id
+#           }
+#           "secretKey" = "client-id"
+#         },
+#         # {
+#         #   "remoteRef" = {
+#         #     "key" = module.ui_azure_tenant_secret.secret_id
+#         #   }
+#         #   "secretKey" = "tenant-id"
+#         # },
+#       ]
+#     }
+#   }
+# }

--- a/terraform/environments/analytical-platform-compute/kubernetes-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-secrets.tf
@@ -57,3 +57,15 @@ resource "kubernetes_secret" "ui_rds" {
     postgres_connection_string = "postgresql://${module.ui_rds.db_instance_username}:${random_password.ui_rds.result}@${module.ui_rds.db_instance_address}:${module.ui_rds.db_instance_port}/ui"
   }
 }
+
+resource "kubernetes_secret" "ui_app_secrets" {
+  metadata {
+    name      = "ui-app-secrets"
+    namespace = kubernetes_namespace.ui.metadata[0].name
+  }
+
+  type = "Opaque"
+  data = {
+    secret_key                 = random_password.ui_app_secrets.result
+  }
+}

--- a/terraform/environments/analytical-platform-compute/random.tf
+++ b/terraform/environments/analytical-platform-compute/random.tf
@@ -17,3 +17,8 @@ resource "random_password" "ui_rds" {
   length  = 32
   special = false
 }
+
+resource "random_password" "ui_app_secrets" {
+  length  = 32
+  special = false
+}

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -66,7 +66,7 @@ module "ui_sentry_dsn_secret" {
   tags = local.tags
 }
 
-module "ui_azure_secret" {
+module "ui_azure_client_secret" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
@@ -74,7 +74,24 @@ module "ui_azure_secret" {
   version = "1.1.2"
 
   name        = "ui/azure"
-  description = "Azure secrets for Analytical Platform UI"
+  description = "Azure client secret for Analytical Platform UI"
+  kms_key_id  = module.common_secrets_manager_kms.key_arn
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = local.tags
+}
+
+module "ui_azure_tenant_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.1.2"
+
+  name        = "ui/azure"
+  description = "Azure tenant secret for Analytical Platform UI"
   kms_key_id  = module.common_secrets_manager_kms.key_arn
 
   secret_string         = "CHANGEME"

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -73,7 +73,7 @@ module "ui_azure_client_secret" {
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "1.1.2"
 
-  name        = "ui/azure"
+  name        = "ui/azure-client"
   description = "Azure client secret for Analytical Platform UI"
   kms_key_id  = module.common_secrets_manager_kms.key_arn
 

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -83,19 +83,19 @@ module "ui_azure_client_secret" {
   tags = local.tags
 }
 
-# module "ui_azure_tenant_secret" {
-#   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-#   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+module "ui_azure_tenant_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-#   source  = "terraform-aws-modules/secrets-manager/aws"
-#   version = "1.1.2"
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.1.2"
 
-#   name        = "ui/azure-tenant"
-#   description = "Azure tenant secret for Analytical Platform UI"
-#   kms_key_id  = module.common_secrets_manager_kms.key_arn
+  name        = "ui/azure-tenant"
+  description = "Azure tenant secret for Analytical Platform UI"
+  kms_key_id  = module.common_secrets_manager_kms.key_arn
 
-#   secret_string         = "CHANGEME"
-#   ignore_secret_changes = true
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
 
-#   tags = local.tags
-# }
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -83,19 +83,19 @@ module "ui_azure_client_secret" {
   tags = local.tags
 }
 
-module "ui_azure_tenant_secret" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+# module "ui_azure_tenant_secret" {
+#   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+#   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.1.2"
+#   source  = "terraform-aws-modules/secrets-manager/aws"
+#   version = "1.1.2"
 
-  name        = "ui/azure"
-  description = "Azure tenant secret for Analytical Platform UI"
-  kms_key_id  = module.common_secrets_manager_kms.key_arn
+#   name        = "ui/azure-tenant"
+#   description = "Azure tenant secret for Analytical Platform UI"
+#   kms_key_id  = module.common_secrets_manager_kms.key_arn
 
-  secret_string         = "CHANGEME"
-  ignore_secret_changes = true
+#   secret_string         = "CHANGEME"
+#   ignore_secret_changes = true
 
-  tags = local.tags
-}
+#   tags = local.tags
+# }

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -65,3 +65,20 @@ module "ui_sentry_dsn_secret" {
 
   tags = local.tags
 }
+
+module "ui_azure_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.1.2"
+
+  name        = "ui/azure"
+  description = "Azure secrets for Analytical Platform UI"
+  kms_key_id  = module.common_secrets_manager_kms.key_arn
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = local.tags
+}


### PR DESCRIPTION
Adds secrets to be used to create env vars in the AP UI helm chart:
- django secret key
- azure tenant ID and client ID