### PR TITLE
update bastion module commit hash

### DIFF
--- a/terraform/modules/baseline/bastion_linux.tf
+++ b/terraform/modules/baseline/bastion_linux.tf
@@ -3,7 +3,7 @@ module "bastion_linux" {
 
   count = var.bastion_linux.public_key_data != null ? 1 : 0
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=6c4f0918a2db00ababbb40648b2ee57556ab90ab" # temp guid will be replaced with a release ref=v4.2.2? next week
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=836db079348a2b40d59bd9cb953111e8ad61aec1" 
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts


### PR DESCRIPTION
- use reference which shouldn't smash into static analysis issues in S3 module call from bastion-linux module call