### PR TITLE
DPR2-892: Add permission to access operational datastore secret

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -48,6 +48,7 @@ module "glue_reporting_hub_job" {
   account                      = local.account_id
   log_group_retention_in_days  = local.glue_log_retention_in_days
   connections                  = local.glue_connection_names
+  additional_secret_arns       = [aws_secretsmanager_secret.operational_datastore.arn]
 
   tags = merge(
     local.all_tags,
@@ -116,6 +117,7 @@ module "glue_reporting_hub_batch_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
+  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore.arn]
 
   tags = merge(
     local.all_tags,
@@ -171,6 +173,7 @@ module "glue_reporting_hub_cdc_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
+  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore.arn]
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -12,6 +12,7 @@ locals {
     "--dpr.operational.data.store.glue.connection.name" = aws_glue_connection.glue_operational_datastore_connection[0].name
     "--dpr.operational.data.store.loading.schema.name"  = "loading"
   } : {})
+  glue_datahub_job_extra_dev_secrets = (local.environment == "development" ? [aws_secretsmanager_secret.operational_datastore[0].arn] : [])
 }
 
 resource "aws_s3_object" "glue_job_shared_custom_log4j_properties" {
@@ -48,7 +49,7 @@ module "glue_reporting_hub_job" {
   account                      = local.account_id
   log_group_retention_in_days  = local.glue_log_retention_in_days
   connections                  = local.glue_connection_names
-  additional_secret_arns       = [aws_secretsmanager_secret.operational_datastore[0].arn]
+  additional_secret_arns       = glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,
@@ -117,7 +118,7 @@ module "glue_reporting_hub_batch_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore[0].arn]
+  additional_secret_arns        = glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,
@@ -173,7 +174,7 @@ module "glue_reporting_hub_cdc_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore[0].arn]
+  additional_secret_arns        = glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -49,7 +49,7 @@ module "glue_reporting_hub_job" {
   account                      = local.account_id
   log_group_retention_in_days  = local.glue_log_retention_in_days
   connections                  = local.glue_connection_names
-  additional_secret_arns       = glue_datahub_job_extra_dev_secrets
+  additional_secret_arns       = local.glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,
@@ -118,7 +118,7 @@ module "glue_reporting_hub_batch_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = glue_datahub_job_extra_dev_secrets
+  additional_secret_arns        = local.glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,
@@ -174,7 +174,7 @@ module "glue_reporting_hub_cdc_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = glue_datahub_job_extra_dev_secrets
+  additional_secret_arns        = local.glue_datahub_job_extra_dev_secrets
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -48,7 +48,7 @@ module "glue_reporting_hub_job" {
   account                      = local.account_id
   log_group_retention_in_days  = local.glue_log_retention_in_days
   connections                  = local.glue_connection_names
-  additional_secret_arns       = [aws_secretsmanager_secret.operational_datastore.arn]
+  additional_secret_arns       = [aws_secretsmanager_secret.operational_datastore[0].arn]
 
   tags = merge(
     local.all_tags,
@@ -117,7 +117,7 @@ module "glue_reporting_hub_batch_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore.arn]
+  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore[0].arn]
 
   tags = merge(
     local.all_tags,
@@ -173,7 +173,7 @@ module "glue_reporting_hub_cdc_job" {
   account                       = local.account_id
   log_group_retention_in_days   = local.glue_log_retention_in_days
   connections                   = local.glue_connection_names
-  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore.arn]
+  additional_secret_arns        = [aws_secretsmanager_secret.operational_datastore[0].arn]
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
@@ -25,6 +25,7 @@ module "glue_reporting_hub_cdc_job" {
   account                       = var.account_id
   log_group_retention_in_days   = var.glue_log_group_retention_in_days
   connections                   = var.glue_cdc_job_connections
+  additional_secret_arns        = var.glue_cdc_job_additional_secret_arns
 
   arguments = var.glue_cdc_arguments
 
@@ -63,6 +64,7 @@ module "glue_reporting_hub_batch_job" {
   account                       = var.account_id
   log_group_retention_in_days   = var.glue_log_group_retention_in_days
   connections                   = var.glue_batch_job_connections
+  additional_secret_arns        = var.glue_batch_job_additional_secret_arns
 
   arguments = var.glue_batch_arguments
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -109,6 +109,12 @@ variable "glue_batch_job_num_workers" {
   description = "(Optional) The number of workers of a defined workerType that are allocated when a job runs."
 }
 
+variable "glue_batch_job_additional_secret_arns" {
+  type        = list(string)
+  default     = []
+  description = "(Optional) The list of additional secrets this job needs access to."
+}
+
 variable "glue_batch_job_connections" {
   type        = list(string)
   default     = []
@@ -237,10 +243,16 @@ variable "glue_cdc_job_num_workers" {
   description = "(Optional) The number of workers of a defined workerType that are allocated when a job runs."
 }
 
+variable "glue_cdc_job_additional_secret_arns" {
+  type        = list(string)
+  default     = []
+  description = "(Optional) The list of additional secrets this job needs access to."
+}
+
 variable "glue_cdc_job_connections" {
   type        = list(string)
   default     = []
-  description = "The list of Glue connections used for the batch job."
+  description = "The list of Glue connections used for the CDC job."
 }
 
 variable "glue_cdc_additional_policies" {

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -19,6 +19,10 @@ locals {
       Dept = "Digital-Prison-Reporting"
     }
   )
+
+  secrets_job_needs_to_access = merge(var.additional_secret_arns, [
+    "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
+  ])
 }
 
 resource "aws_glue_job" "glue_job" {
@@ -144,9 +148,7 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
     ]
-    resources = merge([
-      "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
-    ], var.additional_secret_arns)
+    resources = local.secrets_job_needs_to_access
   }
   statement {
     actions = [

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
     ]
-    resources = merge(additional_secret_arns, [
+    resources = merge(var.additional_secret_arns, [
       "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
     ])
   }

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -144,9 +144,9 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
     ]
-    resources = merge(var.additional_secret_arns, [
+    resources = merge([
       "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
-    ])
+    ], var.additional_secret_arns)
   }
   statement {
     actions = [

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -19,10 +19,6 @@ locals {
       Dept = "Digital-Prison-Reporting"
     }
   )
-
-  secrets_job_needs_to_access = merge(var.additional_secret_arns, [
-    "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
-  ])
 }
 
 resource "aws_glue_job" "glue_job" {
@@ -148,7 +144,9 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
     ]
-    resources = local.secrets_job_needs_to_access
+    resources = concat(var.additional_secret_arns, [
+      "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
+    ])
   }
   statement {
     actions = [

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -144,9 +144,9 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret"
     ]
-    resources = [
+    resources = merge(additional_secret_arns, [
       "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
-    ]
+    ])
   }
   statement {
     actions = [

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/variables.tf
@@ -97,6 +97,12 @@ variable "python_version" {
   }
 }
 
+variable "additional_secret_arns" {
+  type        = list(string)
+  default     = []
+  description = "(Optional) The list of additional secrets this job needs access to."
+}
+
 variable "connections" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
* Updates glue job and domains/ingestion_jobs modules to allow addition of access to extra secrets
* Adds access to the operational datastore secret for the jobs in this repo