### PR TITLE
EM: Fixing broken step function

### DIFF
--- a/terraform/environments/electronic-monitoring-data/step_functions_main.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_main.tf
@@ -125,12 +125,12 @@ resource "aws_sfn_state_machine" "send_database_to_ap" {
               "GetTableFileNames" : {
                 "Type" : "Task",
                 "Resource" : "${module.get_file_keys_for_table.lambda_function_arn}",
-                "ResultPath" : "$.result",
+                "ResultPath" : "$.fileKeys",
                 "Next" : "LoopThroughFileKeys"
               },
               "LoopThroughFileKeys" : {
                 "Type" : "Map",
-                "ItemsPath" : "$.result",
+                "ItemsPath" : "$.fileKeys",
                 "MaxConcurrency" : 4,
                 "Iterator" : {
                   "StartAt" : "SendTableToAp",
@@ -138,7 +138,7 @@ resource "aws_sfn_state_machine" "send_database_to_ap" {
                     "SendTableToAp" : {
                       "Type" : "Task",
                       "Resource" : "${module.send_table_to_ap.lambda_function_arn}",
-                      "ResultPath" : "$.db_info",
+                      "ResultPath" : "$.dbInfo",
                       "End" : true
                     }
                   }
@@ -148,7 +148,7 @@ resource "aws_sfn_state_machine" "send_database_to_ap" {
               "UpdateLogTable" : {
                 "Type" : "Task",
                 "Resource" : "${module.update_log_table.lambda_function_arn}",
-                "ResultPath" : "$.final_result",
+                "ResultPath" : "$.updateLogResult",
                 "End" : true
               }
             },


### PR DESCRIPTION
Looks like the result paths were overlapping and caused a strange error once a few loops ran. Have been more specific here with the names of result paths