### PR TITLE
Adding RAM shares and Lake Formation permissions to evaluator

### DIFF
--- a/scripts/terraform-plan-evaluator.sh
+++ b/scripts/terraform-plan-evaluator.sh
@@ -23,7 +23,11 @@ RESOURCES_TO_CHECK_FOR=(
   "aws_cloudformation_stack_set",
   "aws_cloudformation_stack_set_instance",
   "aws_cloudformation_type",
-  "aws_ec2_transit_gateway_vpc_attachment"
+  "aws_ec2_transit_gateway_vpc_attachment",
+  "aws_lakeformation_permissions",
+  "aws_ram_resource_share",
+  "aws_ram_principal_association",
+  "aws_ram_resource_association"
 )
 
 resourcesFound=false


### PR DESCRIPTION
Companion to this PR: https://github.com/ministryofjustice/modernisation-platform/pull/7455
Work tracked in: https://github.com/ministryofjustice/analytical-platform/issues/4358

Since the linked PR is asking for some Resource Access Manager read/write permissions, adding resources that can be created with those permissions to the plan evaluator.