### PR TITLE
Bump AWS Nuke version to most recent

### DIFF
--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -102,7 +102,7 @@ jobs:
           chmod +x $HOME/bin/aws-nuke
           echo "END: Install AWS Nuke"
         env:
-          AWS_NUKE_VERSION: v2.19.0
+          AWS_NUKE_VERSION: v2.25.0
       - name: Nuke Plan (Dry Run)
         run: |
           aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds
@@ -186,7 +186,7 @@ jobs:
           chmod +x $HOME/bin/aws-nuke
           echo "END: Install AWS Nuke"
         env:
-          AWS_NUKE_VERSION: v2.19.0
+          AWS_NUKE_VERSION: v2.25.0
       - name: Nuke Plan (Dry Run)
         run: |
           aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds


### PR DESCRIPTION
This PR relates to [this issue](https://github.com/ministryofjustice/modernisation-platform/issues/7395) tracked in the Modernisation Platform repository.

Our AWS Nuke action is using a version from [May 2022](https://github.com/rebuy-de/aws-nuke/releases/tag/v2.19.0). The most recent version available is dated [August 2023](https://github.com/rebuy-de/aws-nuke/releases/tag/v2.25.0).

While our AWS Nuke action does run and delete the majority of unfiltered resources in our sandbox-level accounts, the newer version of this tool offers a broader range of resources, uses a more recent version of `Go`, prevents attempts to remove SSO-created roles & policies, among other improvements.