### PR TITLE
Amend nuke filter

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -108,6 +108,8 @@ presets:
       SSMParameter:
         - property: tag:component
           value: "delegate-access"
+        - property: tag:component
+          value: "member-bootstrap"
       ConfigServiceConfigRule:
         - type: glob
           value: "securityhub-*"


### PR DESCRIPTION
This PR is part of [this issue](https://github.com/ministryofjustice/modernisation-platform/issues/7395) tracked in the `modernisation-platform` repository.

Our recent runs of the `nuke-rebuild` job have failed due to a missing SSM parameter. This parameter - `data.aws_ssm_parameter.modernisation_platform_account_id` - is created from the `modernisation-platform` repository through our bootstrap process.

While it can be recreated through a run of our scheduled baselines, I think it's appropriate to keep the parameters made by the bootstrap from being removed by the Nuke process.