### PR TITLE
Feature/7395 filter resources from nuke

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -101,15 +101,11 @@ presets:
       EC2VPC:
         - property: tag:component
           value: "secure-baselines"
-      ElasticacheCacheParameterGroup:
-        - property: GroupName
-          type: glob
-          value: "default.*"
       KMSKey:
         - property: tag:component
           value: "secure-baselines"
       OSPackage:
-        - property: Packagename
+        - property: PackageName
           type: regex
           value: "^(opensearch-)?analysis-.+$"
       S3Bucket:

--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -69,40 +69,49 @@ $accounts_str
 presets:
   common:
     filters:
+      AccessAnalyzer:
+        - property: tag:component
+          value: "secure-baselines"
       AWSBackupPlan:
         - property: tag:component
           value: "secure-baselines"
       AWSBackupVault:
         - property: tag:component
           value: "secure-baselines"
-      EC2RouteTable:
-        - property: tag:component
-          value: "secure-baselines"
-      EC2VPC:
-        - property: tag:component
-          value: "secure-baselines"
-      EC2NetworkACL:
-        - property: tag:component
-          value: "secure-baselines"
-      KMSKey:
-        - property: tag:component
-          value: "secure-baselines"
-      S3Bucket:
+      ConfigServiceConfigRule:
+        - type: glob
+          value: "securityhub-*"
+        - type: glob
+          value: "FMManagedShieldConfigRule*"
+      EC2DHCPOption:
         - property: tag:component
           value: "secure-baselines"
       EC2InternetGatewayAttachment:
         - property: tag:vpc:component
           value: "secure-baselines"
-      AccessAnalyzer:
+      EC2NetworkACL:
         - property: tag:component
           value: "secure-baselines"
-      SNSTopic:
+      EC2RouteTable:
         - property: tag:component
           value: "secure-baselines"
       EC2SecurityGroup:
         - property: tag:component
           value: "secure-baselines"
-      EC2DHCPOption:
+      EC2VPC:
+        - property: tag:component
+          value: "secure-baselines"
+      ElasticacheCacheParameterGroup:
+        - type: glob
+          value: "default.*"
+      KMSKey:
+        - property: tag:component
+          value: "secure-baselines"
+      OSPackage:
+        - property: Packagename
+          type: regex
+          value: "^(opensearch-)?analysis-.+$"
+      S3Bucket:
         - property: tag:component
           value: "secure-baselines"
       SSMParameter:
@@ -110,8 +119,6 @@ presets:
           value: "delegate-access"
         - property: tag:component
           value: "member-bootstrap"
-      ConfigServiceConfigRule:
-        - type: glob
-          value: "securityhub-*"
-        - type: glob
-          value: "FMManagedShieldConfigRule*"
+      SNSTopic:
+        - property: tag:component
+          value: "secure-baselines"

--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -102,7 +102,8 @@ presets:
         - property: tag:component
           value: "secure-baselines"
       ElasticacheCacheParameterGroup:
-        - type: glob
+        - property: GroupName
+          type: glob
           value: "default.*"
       KMSKey:
         - property: tag:component


### PR DESCRIPTION
This PR relates to [this issue](https://github.com/ministryofjustice/modernisation-platform/issues/7395) tracked in the `modernisation-platform` repository.

The update to a recent version of `AWS Nuke` appears to have resolved most of our issues with resource deletions, but the new version is trying to remove OpenSearch filters which cannot be deleted. This PR filters out those defaults.