### PR TITLE
DSOS-2876: fix csr alarm

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -56,7 +56,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
+        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
         local.environment == "production" ? {} : {
           cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2["cpu-utilization-high"], {


### PR DESCRIPTION
Typo - used windows instead of linux alarm for CSR DB