### PR TITLE
DPR2-714: Preserve archive data during reload

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -580,60 +580,6 @@ module "activate_glue_trigger_job" {
   }
 }
 
-# Glue Job, Create Reload Diff Between the Raw Data And Archived Data
-module "create_reload_diff_job" {
-  source                        = "./modules/glue_job"
-  create_job                    = local.create_job
-  name                          = "${local.project}-create-reload-diff-job-${local.env}"
-  short_name                    = "${local.project}-create-reload-diff-job"
-  command_type                  = "glueetl"
-  description                   = "Creates A Diff Between The Reload and Archive Data.\nArguments:\n--dpr.raw.s3.path: (Required) Path to the raw bucket\n--dpr.raw.archive.s3.path: (Required) Path to the raw archive bucket\n--dpr.temp.reload.s3.path: (Required) Bucket where the diffs will be written to\n--dpr.temp.reload.output.folder: (Required) Folder within the temp reload bucket where the diffs will be written to\n--dpr.config.s3.bucket: (Required) Bucket in which the configs are located\n--dpr.config.key: (Required) The configuration value e.g prisoner\n--dpr.contract.registryName: (Required) Bucket containing the schema contracts\n--dpr.batch.load.fileglobpattern: (Required) The file glob pattern to use"
-  create_security_configuration = local.create_sec_conf
-  job_language                  = "scala"
-  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-create-reload-diff-job-${local.env}/"
-  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-create-reload-diff-job-${local.env}/"
-  # Placeholder Script Location
-  script_location               = local.glue_placeholder_script_location
-  enable_continuous_log_filter  = false
-  project_id                    = local.project
-  aws_kms_key                   = local.s3_kms_arn
-
-  execution_class             = "STANDARD"
-  worker_type                 = "G.2X"
-  number_of_workers           = 5
-  max_concurrent              = 64
-  region                      = local.account_region
-  account                     = local.account_id
-  log_group_retention_in_days = local.glue_log_retention_in_days
-
-  tags = merge(
-    local.all_tags,
-    {
-      Name          = "${local.project}-create-reload-diff-job-${local.env}"
-      Resource_Type = "Glue Job"
-      Jira          = "DPR2-714"
-    }
-  )
-
-  arguments = {
-#    "--extra-jars"     = local.glue_jobs_latest_jar_location
-    "--extra-jars"                     = "s3://dpr-artifact-store-development/digital-prison-reporting-jobs-0.0.1-SNAPSHOT-DPR2-714_test_1.jar"
-    "--extra-files"                    = local.shared_log4j_properties_path
-    "--class"                          = "uk.gov.justice.digital.job.CreateReloadDiffJob"
-    "--dpr.contract.registryName"      = module.s3_schema_registry_bucket.bucket_id
-    "--dpr.batch.load.fileglobpattern" = "*.parquet"
-    "--dpr.aws.region"                 = local.account_region
-    "--dpr.log.level"                  = local.glue_job_common_log_level
-  }
-
-  depends_on = [
-    module.s3_raw_bucket.bucket_id,
-    module.s3_raw_archive_bucket.bucket_id,
-    module.s3_temp_reload_bucket.bucket_id,
-    module.s3_schema_registry_bucket.bucket_id
-  ]
-}
-
 # kinesis Data Stream Ingestor
 module "kinesis_stream_ingestor" {
   source                    = "./modules/kinesis_stream"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -580,6 +580,57 @@ module "activate_glue_trigger_job" {
   }
 }
 
+# Glue Job, Create Reload Diff Between the Raw Data And Archived Data
+module "create_reload_diff_job" {
+  source                        = "./modules/glue_job"
+  create_job                    = local.create_job
+  name                          = "${local.project}-create-reload-diff-job-${local.env}"
+  short_name                    = "${local.project}-create-reload-diff-job"
+  command_type                  = "glueetl"
+  description                   = "Creates A Diff Between The Reload and Archive Data.\nArguments:\n--dpr.raw.s3.path: (Required) Path to the raw bucket\n--dpr.raw.archive.s3.path: (Required) Path to the raw archive bucket\n--dpr.temp.reload.s3.path: (Required) Bucket where the diffs will be written to\n--dpr.temp.reload.output.folder: (Required) Folder within the temp reload bucket where the diffs will be written to\n--dpr.config.s3.bucket: (Required) Bucket in which the configs are located\n--dpr.config.key: (Required) The configuration value e.g prisoner"
+  create_security_configuration = local.create_sec_conf
+  job_language                  = "scala"
+  temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-create-reload-diff-job-${local.env}/"
+  spark_event_logs              = "s3://${module.s3_glue_job_bucket.bucket_id}/spark-logs/${local.project}-create-reload-diff-job-${local.env}/"
+  # Placeholder Script Location
+  script_location               = local.glue_placeholder_script_location
+  enable_continuous_log_filter  = false
+  project_id                    = local.project
+  aws_kms_key                   = local.s3_kms_arn
+
+  execution_class             = "STANDARD"
+  worker_type                 = "G.1X"
+  number_of_workers           = 3
+  max_concurrent              = 64
+  region                      = local.account_region
+  account                     = local.account_id
+  log_group_retention_in_days = local.glue_log_retention_in_days
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "${local.project}-create-reload-diff-job-${local.env}"
+      Resource_Type = "Glue Job"
+      Jira          = "DPR2-714"
+    }
+  )
+
+  arguments = {
+#    "--extra-jars"     = local.glue_jobs_latest_jar_location
+    "--extra-jars"     = "s3://dpr-artifact-store-development/digital-prison-reporting-jobs-0.0.1-SNAPSHOT-DPR2-714_test_1.jar"
+    "--extra-files"    = local.shared_log4j_properties_path
+    "--class"          = "uk.gov.justice.digital.job.CreateReloadDiffJob"
+    "--dpr.aws.region" = local.account_region
+    "--dpr.log.level"  = local.glue_job_common_log_level
+  }
+
+  depends_on = [
+    module.s3_raw_bucket.bucket_id,
+    module.s3_raw_archive_bucket.bucket_id,
+    module.s3_temp_reload_bucket.bucket_id
+  ]
+}
+
 # kinesis Data Stream Ingestor
 module "kinesis_stream_ingestor" {
   source                    = "./modules/kinesis_stream"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -600,7 +600,7 @@ module "create_reload_diff_job" {
 
   execution_class             = "STANDARD"
   worker_type                 = "G.2X"
-  number_of_workers           = 3
+  number_of_workers           = 5
   max_concurrent              = 64
   region                      = local.account_region
   account                     = local.account_id

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -587,7 +587,7 @@ module "create_reload_diff_job" {
   name                          = "${local.project}-create-reload-diff-job-${local.env}"
   short_name                    = "${local.project}-create-reload-diff-job"
   command_type                  = "glueetl"
-  description                   = "Creates A Diff Between The Reload and Archive Data.\nArguments:\n--dpr.raw.s3.path: (Required) Path to the raw bucket\n--dpr.raw.archive.s3.path: (Required) Path to the raw archive bucket\n--dpr.temp.reload.s3.path: (Required) Bucket where the diffs will be written to\n--dpr.temp.reload.output.folder: (Required) Folder within the temp reload bucket where the diffs will be written to\n--dpr.config.s3.bucket: (Required) Bucket in which the configs are located\n--dpr.config.key: (Required) The configuration value e.g prisoner"
+  description                   = "Creates A Diff Between The Reload and Archive Data.\nArguments:\n--dpr.raw.s3.path: (Required) Path to the raw bucket\n--dpr.raw.archive.s3.path: (Required) Path to the raw archive bucket\n--dpr.temp.reload.s3.path: (Required) Bucket where the diffs will be written to\n--dpr.temp.reload.output.folder: (Required) Folder within the temp reload bucket where the diffs will be written to\n--dpr.config.s3.bucket: (Required) Bucket in which the configs are located\n--dpr.config.key: (Required) The configuration value e.g prisoner\n--dpr.contract.registryName: (Required) Bucket containing the schema contracts\n--dpr.batch.load.fileglobpattern: (Required) The file glob pattern to use"
   create_security_configuration = local.create_sec_conf
   job_language                  = "scala"
   temp_dir                      = "s3://${module.s3_glue_job_bucket.bucket_id}/tmp/${local.project}-create-reload-diff-job-${local.env}/"
@@ -599,7 +599,7 @@ module "create_reload_diff_job" {
   aws_kms_key                   = local.s3_kms_arn
 
   execution_class             = "STANDARD"
-  worker_type                 = "G.1X"
+  worker_type                 = "G.2X"
   number_of_workers           = 3
   max_concurrent              = 64
   region                      = local.account_region
@@ -617,17 +617,20 @@ module "create_reload_diff_job" {
 
   arguments = {
 #    "--extra-jars"     = local.glue_jobs_latest_jar_location
-    "--extra-jars"     = "s3://dpr-artifact-store-development/digital-prison-reporting-jobs-0.0.1-SNAPSHOT-DPR2-714_test_1.jar"
-    "--extra-files"    = local.shared_log4j_properties_path
-    "--class"          = "uk.gov.justice.digital.job.CreateReloadDiffJob"
-    "--dpr.aws.region" = local.account_region
-    "--dpr.log.level"  = local.glue_job_common_log_level
+    "--extra-jars"                     = "s3://dpr-artifact-store-development/digital-prison-reporting-jobs-0.0.1-SNAPSHOT-DPR2-714_test_1.jar"
+    "--extra-files"                    = local.shared_log4j_properties_path
+    "--class"                          = "uk.gov.justice.digital.job.CreateReloadDiffJob"
+    "--dpr.contract.registryName"      = module.s3_schema_registry_bucket.bucket_id
+    "--dpr.batch.load.fileglobpattern" = "*.parquet"
+    "--dpr.aws.region"                 = local.account_region
+    "--dpr.log.level"                  = local.glue_job_common_log_level
   }
 
   depends_on = [
     module.s3_raw_bucket.bucket_id,
     module.s3_raw_archive_bucket.bucket_id,
-    module.s3_temp_reload_bucket.bucket_id
+    module.s3_temp_reload_bucket.bucket_id,
+    module.s3_schema_registry_bucket.bucket_id
   ]
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
@@ -150,6 +150,44 @@ module "glue_archive_job" {
   )
 }
 
+# Glue Job, Create Reload Diff Between the Raw Data And Archived Data
+module "create_reload_diff_job" {
+  source                        = "../../glue_job"
+  create_job                    = var.setup_create_reload_diff_job
+  create_role                   = var.glue_create_reload_diff_job_role # Needs to Set to TRUE
+  name                          = var.glue_create_reload_diff_job_name
+  short_name                    = var.glue_create_reload_diff_job_short_name
+  command_type                  = "glueetl"
+  description                   = var.glue_create_reload_diff_job_description
+  create_security_configuration = var.glue_create_reload_diff_job_create_sec_conf
+  job_language                  = var.glue_create_reload_diff_job_language
+  temp_dir                      = var.glue_create_reload_diff_job_temp_dir
+  spark_event_logs              = var.glue_create_reload_diff_job_spark_event_logs
+  # Placeholder Script Location
+  script_location               = "s3://${var.project_id}-artifact-store-${var.env}/build-artifacts/digital-prison-reporting-jobs/scripts/${var.script_version}"
+  enable_continuous_log_filter  = var.glue_create_reload_diff_job_enable_cont_log_filter
+  project_id                    = var.project_id
+  aws_kms_key                   = var.s3_kms_arn
+  execution_class               = var.glue_create_reload_diff_job_execution_class
+  additional_policies           = var.glue_create_reload_diff_job_additional_policies
+  worker_type                   = var.glue_create_reload_diff_job_worker_type
+  number_of_workers             = var.glue_create_reload_diff_job_num_workers
+  max_concurrent                = var.glue_create_reload_diff_job_max_concurrent #64
+  region                        = var.account_region
+  account                       = var.account_id
+  log_group_retention_in_days   = var.glue_log_group_retention_in_days
+
+  tags = merge(
+    var.tags,
+    {
+      Resource_Type = "Glue Job"
+      Jira          = "DPR2-714"
+    }
+  )
+
+  arguments = var.glue_create_reload_diff_job_arguments
+}
+
 resource "aws_glue_trigger" "glue_file_archive_job_trigger" {
   count    = var.setup_archive_job ? 1 : 0
   name     = "${module.glue_archive_job.name}-trigger"

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -558,7 +558,7 @@ variable "glue_create_reload_diff_job_language" {
   description = "(Optional) The script programming language."
 
   validation {
-    condition     = contains(["scala", "python"], var.glue_archive_language)
+    condition     = contains(["scala", "python"], var.glue_create_reload_diff_job_language)
     error_message = "Accepts a value of 'scala' or 'python'."
   }
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -515,6 +515,104 @@ variable "glue_archive_arguments" {
   default = {}
 }
 
+# Create Reload Diff Job
+variable "setup_create_reload_diff_job" {
+  description = "Enable Job which creates the reload diff, True or False"
+  type        = bool
+  default     = false
+}
+
+variable "glue_create_reload_diff_job_role" {
+  type        = bool
+  default     = false
+  description = "(Optional) Create AWS IAM role associated with the job."
+}
+
+variable "glue_create_reload_diff_job_name" {
+  description = "Name of the Glue Create Reload Diff Job"
+  default     = ""
+  type        = string
+}
+
+variable "glue_create_reload_diff_job_short_name" {
+  description = "Short name of the Glue Create Reload Diff Job"
+  default     = ""
+  type        = string
+}
+
+variable "glue_create_reload_diff_job_description" {
+  description = "Job Description"
+  default     = ""
+  type        = string
+}
+
+variable "glue_create_reload_diff_job_create_sec_conf" {
+  type        = bool
+  default     = false
+  description = "(Optional) Create AWS Glue Security Configuration associated with the job."
+}
+
+variable "glue_create_reload_diff_job_language" {
+  type        = string
+  default     = "python"
+  description = "(Optional) The script programming language."
+
+  validation {
+    condition     = contains(["scala", "python"], var.glue_archive_language)
+    error_message = "Accepts a value of 'scala' or 'python'."
+  }
+}
+
+variable "glue_create_reload_diff_job_temp_dir" {
+  type        = string
+  default     = null
+  description = "(Optional) Specifies an Amazon S3 path to a bucket that can be used as a temporary directory for the job."
+}
+
+variable "glue_create_reload_diff_job_enable_cont_log_filter" {
+  type        = bool
+  default     = false
+  description = "(Optional) Specifies a standard filter or no filter when you create or edit a job enabled for continuous logging."
+}
+
+variable "glue_create_reload_diff_job_execution_class" {
+  default     = "STANDARD"
+  description = "Execution CLass Standard or FLex"
+  type        = string
+}
+
+variable "glue_create_reload_diff_job_additional_policies" {
+  type        = string
+  default     = ""
+  description = "(Optional) The list of Policies used for this job."
+}
+
+variable "glue_create_reload_diff_job_worker_type" {
+  type    = string
+  default = "G.1X"
+}
+
+variable "glue_create_reload_diff_job_num_workers" {
+  type    = number
+  default = 2
+}
+
+variable "glue_create_reload_diff_job_max_concurrent" {
+  type    = number
+  default = 1
+}
+
+variable "glue_create_reload_diff_job_arguments" {
+  type    = map(any)
+  default = {}
+}
+
+variable "glue_create_reload_diff_job_spark_event_logs" {
+  type        = string
+  default     = null
+  description = "(Optional) Specifies an Amazon S3 path to a bucket that can be used as a Spark Event Logs directory for the job."
+}
+
 
 variable "s3_kms_arn" {
   type        = string

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -11,8 +11,31 @@ module "reload_pipeline" {
   definition = jsonencode(
     {
       "Comment" : "Reload Pipeline Step Function",
-      "StartAt" : "Stop DMS Replication Task",
+      "StartAt" : "Deactivate Archive Trigger",
       "States" : {
+        "Deactivate Archive Trigger" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_trigger_activation_job,
+            "Arguments" : {
+              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+              "--dpr.glue.trigger.activate" : "false"
+            }
+          },
+          "Next" : "Stop Archive Job"
+        },
+        "Stop Archive Job" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_stop_glue_instance_job,
+            "Arguments" : {
+              "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
+            }
+          },
+          "Next" : "Stop DMS Replication Task"
+        },
         "Stop DMS Replication Task" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
@@ -20,6 +43,17 @@ module "reload_pipeline" {
             "JobName" : var.stop_dms_task_job,
             "Arguments" : {
               "--dpr.dms.replication.task.id" : var.replication_task_id
+            }
+          },
+          "Next" : "Check All Pending Files Have Been Processed"
+        },
+        "Check All Pending Files Have Been Processed" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun",
+          "Parameters" : {
+            "JobName" : var.glue_unprocessed_raw_files_check_job,
+            "Arguments" : {
+              "--dpr.orchestration.wait.interval.seconds" : "60"
             }
           },
           "Next" : "Stop Glue Streaming Job"
@@ -31,6 +65,21 @@ module "reload_pipeline" {
             "JobName" : var.glue_stop_glue_instance_job,
             "Arguments" : {
               "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
+            }
+          },
+          "Next" : "Archive Remaining Raw Files"
+        },
+        "Archive Remaining Raw Files" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_file_transfer_job,
+            "Arguments" : {
+              "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
+              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+              "--dpr.file.transfer.delete.copied.files" : "true",
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
             }
           },
           "Next" : "Update Hive Tables"
@@ -57,9 +106,9 @@ module "reload_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Copy Data to Temp-Reload Bucket"
+          "Next" : "Copy Curated Data to Temp-Reload Bucket"
         },
-        "Copy Data to Temp-Reload Bucket" : {
+        "Copy Curated Data to Temp-Reload Bucket" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -85,15 +134,15 @@ module "reload_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Truncate Data"
+          "Next" : "Empty Structured and Curated Data"
         },
-        "Truncate Data" : {
+        "Empty Structured and Curated Data" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+              "--dpr.file.deletion.buckets" : "${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
               "--dpr.config.key" : var.domain
             }
           },
@@ -132,9 +181,9 @@ module "reload_pipeline" {
               "BackoffRate" : 2
             }
           ],
-          "Next" : "Start Glue Batch Job"
+          "Next" : "Run Glue Batch Job"
         },
-        "Start Glue Batch Job" : {
+        "Run Glue Batch Job" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
@@ -144,19 +193,49 @@ module "reload_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Archive Raw Data"
+          "Next" : "Delete Existing Reload Diffs"
         },
-        "Archive Raw Data" : {
+        "Delete Existing Reload Diffs" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_s3_data_deletion_job,
+            "Arguments" : {
+              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+              "--dpr.file.source.prefix" : var.reload_diff_folder,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Run Create Reload Diff Batch Job"
+        },
+        "Run Create Reload Diff Batch Job" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_create_reload_diff_job,
+            "Arguments" : {
+              "--dpr.raw.s3.path" : var.s3_raw_bucket_id,
+              "--dpr.raw.archive.s3.path" : var.s3_raw_archive_bucket_id,
+              "--dpr.temp.reload.s3.path" : var.s3_temp_reload_bucket_id,
+              "--dpr.temp.reload.output.folder" : var.reload_diff_folder,
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+              "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Move Reload Diffs to Archive Bucket"
+        },
+        "Move Reload Diffs to Archive Bucket" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
             "JobName" : var.glue_s3_file_transfer_job,
             "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
+              "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
+              "--dpr.file.source.prefix" : var.reload_diff_folder,
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.allowed.s3.file.extensions" : ".parquet",
+              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
           },
@@ -191,6 +270,18 @@ module "reload_pipeline" {
             "Arguments" : {
               "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
               "--dpr.config.key" : var.domain
+            }
+          },
+          "Next" : "Reactivate Archive Trigger"
+        },
+        "Reactivate Archive Trigger" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_trigger_activation_job,
+            "Arguments" : {
+              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+              "--dpr.glue.trigger.activate" : "true"
             }
           },
           "Next" : "Empty Temp Reload Bucket Data"

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -226,7 +226,7 @@ module "reload_pipeline" {
               "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toInsert",
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "false",
+              "--dpr.file.transfer.delete.copied.files" : "true",
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -243,7 +243,7 @@ module "reload_pipeline" {
               "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toDelete",
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "false",
+              "--dpr.file.transfer.delete.copied.files" : "true",
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -260,7 +260,7 @@ module "reload_pipeline" {
               "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toUpdate",
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "false",
+              "--dpr.file.transfer.delete.copied.files" : "true",
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -212,16 +212,7 @@ module "reload_pipeline" {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
-            "JobName" : var.glue_create_reload_diff_job,
-            "Arguments" : {
-              "--dpr.raw.s3.path" : "s3://${var.s3_raw_bucket_id}/",
-              "--dpr.raw.archive.s3.path" : "s3://${var.s3_raw_archive_bucket_id}/",
-              "--dpr.temp.reload.s3.path" : "s3://${var.s3_temp_reload_bucket_id}/",
-              "--dpr.temp.reload.output.folder" : var.reload_diff_folder,
-              "--dpr.dms.replication.task.id" : var.replication_task_id,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
+            "JobName" : var.glue_create_reload_diff_job
           },
           "Next" : "Move Reload Diffs toInsert to Archive Bucket"
         },

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -34,6 +34,36 @@ variable "stop_dms_task_job" {
   default     = ""
 }
 
+variable "glue_unprocessed_raw_files_check_job" {
+  description = "Name of job to ensure raw files have been processed"
+  type        = string
+  default     = ""
+}
+
+variable "glue_trigger_activation_job" {
+  description = "Name of job to which activates/deactivates a glue trigger"
+  type        = string
+  default     = ""
+}
+
+variable "archive_job_trigger_name" {
+  description = "Name of the trigger for a glue trigger"
+  type        = string
+  default     = ""
+}
+
+variable "glue_archive_job" {
+  description = "Name of the glue job which archives the raw data"
+  type        = string
+  default     = ""
+}
+
+variable "glue_create_reload_diff_job" {
+  description = "Name of job which generates the diffs between the load and the archive"
+  type        = string
+  default     = ""
+}
+
 variable "glue_s3_file_transfer_job" {
   description = "Name of s3 file transfer job"
   type        = string
@@ -130,4 +160,10 @@ variable "domain" {
   type        = string
   default     = ""
   description = "Domain Name"
+}
+
+variable "reload_diff_folder" {
+  type        = string
+  default     = "diffs"
+  description = "Folder for the reload diff"
 }


### PR DESCRIPTION
This PR modifies the reload pipeline so it does not delete records from the archive but instead computes the diff between the reload dataset and the archive and then copies (moves) the generated diffs to their respective archive locations.

In summary, the reload process does:

1. Stops the ingestion
2. Ensures all pending files have been processed and archived
3. Make the full-load to the raw zone
4. Computes the diffs between the raw data and the archive
5. Moves the diffs to the archive
6. Start the ongoing replication pipeline

The actual steps of the reload pipeline are:

1. Deactivate Archive Trigger
7. Stop Archive Job
8. Stop DMS Replication Task
9. Check All Pending Files Have Been Processed
10. Stop Glue Streaming Job
11. Archive Remaining Raw Files
12. Update Hive Tables
13. Prepare Temp Reload Bucket Data
14. Copy Curated Data to Temp-Reload Bucket
15. Switch Hive Tables for Prisons to Temp-Reload Bucket
16. Empty Structured and Curated Data
17. Start DMS Replication Task
18. Invoke DMS State Control Lambda
19. Run Glue Batch Job
20. Delete Existing Reload Diffs
21. Run Create Reload Diff Batch Job
22. Move Reload Diffs toInsert to Archive Bucket
23. Move Reload Diffs toDelete to Archive Bucket
24. Move Reload Diffs toUpdate to Archive Bucket
25. Empty Raw Data
26. Resume DMS Replication Task
27. Start Glue Streaming Job
28. Switch Hive Tables for Prisons to Curated
29. Reactivate Archive Trigger
30. Empty Temp Reload Bucket Data
