### PR TITLE
MS037 - Adding Missing Permission & Ability to Assume Role from Central Terraform-running Account

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -577,6 +577,8 @@
       "analytical_platform_share": [{
         "target_account_name": "analytical-platform-data-production",
         "target_account_id": "593291632749",
+        "assume_account_name": "analytical-platform-management-production",
+        "assume_account_id": "042130406152",
         "data_locations": [
           "dpr-structured-historical-preproduction"
         ],

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -757,8 +757,11 @@ data "aws_iam_policy_document" "analytical_platform_share_policy" {
   }
 
   statement {
-    effect  = "Allow"
-    actions = ["iam:PutRolePolicy"]
+    effect = "Allow"
+    actions = [
+      "iam:PutRolePolicy",
+      "iam:GetRole"
+    ]
     resources = [
       "arn:aws:iam::${local.current_account_id}:role/*/AWSServiceRoleForLakeFormationDataAccess"
     ]
@@ -803,7 +806,8 @@ resource "aws_iam_role" "analytical_platform_share_role" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${each.value.target_account_id}:root"
+          # In case consumer has a central location for terraform state storage that isn't the target account.
+          AWS = "arn:aws:iam::${try(each.value.assume_account_id, each.value.target_account_id)}:root"
         }
         Action = "sts:AssumeRole"
       }


### PR DESCRIPTION
Original details:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7090
Tracking issue: https://github.com/ministryofjustice/analytical-platform/issues/4358

The share role is missing an `iam:GetRole` permission on the LakeFormationServiceRole. Additionally, Analytical Platform terraform is managed in a hub and spoke model. The initial terraform runs all originate with a role housed in the same account that holds our terraform state. So the role needs to be assumed from that account instead of the target account. As Modernisation Platform is configured similarly, added an option to specify a assume account if different from target.

