### PR TITLE
MS037 - Adding Missing Permission & Ability to Assume Role from Central Terraform-running Account

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -760,13 +760,22 @@ data "aws_iam_policy_document" "analytical_platform_share_policy" {
     effect = "Allow"
     actions = [
       "iam:PutRolePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${local.current_account_id}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess"
+    ]
+  }
+  # Needed for LakeFormationAdmin to check the presense of the Lake Formation Service Role
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:GetRolePolicy",
       "iam:GetRole"
     ]
     resources = [
-      "arn:aws:iam::${local.current_account_id}:role/*/AWSServiceRoleForLakeFormationDataAccess"
+      "*"
     ]
   }
-
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
Original details:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7090
Tracking issue: https://github.com/ministryofjustice/analytical-platform/issues/4358

Follow-on to:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7145

`iam:GetRole` and `iam:GetRolePolicy` broken out to a separate statement block and arn of the LakeFormation service role corrected.