### PR TITLE
MS037 - Adding Missing Permission for Service Role Creation

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -760,6 +760,7 @@ data "aws_iam_policy_document" "analytical_platform_share_policy" {
     effect = "Allow"
     actions = [
       "iam:PutRolePolicy",
+      "iam:CreateServiceLinkedRole"
     ]
     resources = [
       "arn:aws:iam::${local.current_account_id}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess"


### PR DESCRIPTION
Original details:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7090
Tracking issue: https://github.com/ministryofjustice/analytical-platform/issues/4358

Follow-on to:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7148

Adding the missing `iam:CreateServiceLinkedRole`

This permission wasn't initially identified as required since I carried out testing on an account where it existed. Apologies!