### PR TITLE
MS037 - Adding Missing Permission for Service Role Creation 

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -749,7 +749,9 @@ data "aws_iam_policy_document" "analytical_platform_share_policy" {
       "lakeformation:BatchRevokePermissions",
       "lakeformation:RegisterResource",
       "lakeformation:DeregisterResource",
-      "lakeformation:ListPermissions"
+      "lakeformation:ListPermissions",
+      "lakeformation:DescribeResource",
+
     ]
     resources = [
       "arn:aws:lakeformation:${local.current_account_region}:${local.current_account_id}:catalog:${local.current_account_id}"


### PR DESCRIPTION
Original details:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7090
Tracking issue: https://github.com/ministryofjustice/analytical-platform/issues/4358

Follow-on to:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7150
Adding the missing `lakeformation:DescribeResource`

This permission wasn't initially identified as required since I carried out testing on an account where it existed. Apologies!