### PR TITLE
MS037 - Adding Missing Permission for Service Role Creation 

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -834,3 +834,11 @@ resource "aws_iam_role_policy" "analytical_platform_share_policy_attachment" {
   role   = aws_iam_role.analytical_platform_share_role[each.key].name
   policy = data.aws_iam_policy_document.analytical_platform_share_policy[each.key].json
 }
+
+# ref: https://docs.aws.amazon.com/lake-formation/latest/dg/cross-account-prereqs.html
+resource "aws_iam_role_policy_attachment" "analytical_platform_share_policy_attachment" {
+  for_each = local.analytical_platform_share
+
+  role       = aws_iam_role.analytical_platform_share_role[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+}


### PR DESCRIPTION
Original details:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7090
Tracking issue: https://github.com/ministryofjustice/analytical-platform/issues/4358

Follow-on to:
https://github.com/ministryofjustice/modernisation-platform-environments/pull/7152
Adding the `AWSLakeFormationCrossAccountManager`

ref: https://docs.aws.amazon.com/lake-formation/latest/dg/cross-account-prereqs.html
ref: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLakeFormationCrossAccountManager.html
This permission wasn't initially identified as required since I carried out testing on an account where it existed. Apologies!