### PR TITLE
Using suggested IAMs from documentation

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -493,8 +493,10 @@ data "aws_iam_policy_document" "load_json_table_s3_policy_document" {
     sid    = "S3PermissionsForLoadingJsonTable"
     effect = "Allow"
     actions = [
-      "s3:GetObject",
       "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:GetObjectAttributes",
       "s3:ListBucket",
       "s3:GetBucketLocation"
     ]


### PR DESCRIPTION
the dlt documentation suggests at a minimum we will need [these permissions](https://dlthub.com/docs/dlt-ecosystem/destinations/filesystem#:~:text=You%20can%20create%20the%20S3,and%20permissions%20to%20the%20bucket.&text=To%20grant%20permissions%20to%20the,click%20on%20%E2%80%9CAdd%20Permissions%E2%80%9D.) to look at files in s3. So I've added them. They made no difference in dev, but im guessing maybe because the files are slightly bigger it is doing something slightly different to them.