### PR TITLE
DSOS-2890: terraform alignment mop up v2

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -55,6 +55,10 @@ locals {
   }
 
   baseline_all_environments = {
+    options = {
+      enable_resource_explorer = true
+    }
+
     cloudwatch_log_groups = merge(local.ssm_doc_cloudwatch_log_groups, {
       cwagent-windows-application = {
         retention_in_days = 30

--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
@@ -1,0 +1,50 @@
+locals {
+
+  cloudwatch_metric_alarms = {
+    app = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
+      local.cloudwatch_app_log_metric_alarms.app, {
+        high-memory-usage = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows["high-memory-usage"], {
+          threshold           = "75"
+          period              = "60" # seconds
+          evaluation_periods  = "20"
+          datapoints_to_alarm = "20"
+          alarm_description   = "Triggers if the average memory utilization is 75% or above for 20 minutes. Set below the default of 95% to allow enough time to establish an RDP session to fix the issue."
+        })
+      }
+    )
+
+    db = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
+      local.environment == "production" ? {} : {
+        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2["cpu-utilization-high"], {
+          evaluation_periods  = "480"
+          datapoints_to_alarm = "480"
+          threshold           = "95"
+          alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
+        })
+        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
+          evaluation_periods  = "480"
+          datapoints_to_alarm = "480"
+          threshold           = "40"
+          alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 8 hours allowing for DB refreshes.  See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
+        })
+      }
+    )
+
+    db_backup = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
+    )
+
+    web = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
+      local.cloudwatch_app_log_metric_alarms.web,
+    )
+  }
+}

--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -3,20 +3,7 @@ locals {
   ec2_instances = {
 
     app = {
-      cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
-        local.cloudwatch_app_log_metric_alarms.app, {
-          high-memory-usage = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows["high-memory-usage"], {
-            threshold           = "75"
-            period              = "60" # seconds
-            evaluation_periods  = "20"
-            datapoints_to_alarm = "20"
-            alarm_description   = "Triggers if the average memory utilization is 75% or above for 20 minutes. Set below the default of 95% to allow enough time to establish an RDP session to fix the issue."
-          })
-        }
-      )
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.app
       config = {
         ami_owner                     = "self"
         availability_zone             = "eu-west-2a"
@@ -53,24 +40,8 @@ locals {
 
     db = {
       cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
-        local.environment == "production" ? {} : {
-          cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2["cpu-utilization-high"], {
-            evaluation_periods  = "480"
-            datapoints_to_alarm = "480"
-            threshold           = "95"
-            alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
-          })
-          cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
-            evaluation_periods  = "480"
-            datapoints_to_alarm = "480"
-            threshold           = "40"
-            alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 8 hours allowing for DB refreshes.  See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
-          })
-        }
+        local.cloudwatch_metric_alarms.db,
+        local.cloudwatch_metric_alarms.db_backup,
       )
       config = {
         ami_owner                     = "self"
@@ -141,12 +112,7 @@ locals {
     }
 
     web = {
-      cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
-        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
-        local.cloudwatch_app_log_metric_alarms.web,
-      )
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.web
       config = {
         ami_owner                     = "self"
         availability_zone             = "eu-west-2a"

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -400,15 +400,6 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-            ]
-            resources = [
-              "arn:aws:ssm:*:*:parameter/azure/*",
-            ]
-          },
-          {
-            effect = "Allow"
-            actions = [
               "secretsmanager:GetSecretValue",
               "secretsmanager:PutSecretValue",
             ]

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -37,6 +37,10 @@ locals {
       })
 
       pd-csr-db-b = merge(local.ec2_instances.db, {
+        cloudwatch_metric_alarms = merge(
+          local.cloudwatch_metric_alarms.db,
+          # local.cloudwatch_metric_alarms.db_backup,
+        )
         config = merge(local.ec2_instances.db.config, {
           ami_name          = "hmpps_ol_8_5_oracledb_19c_release_2023-07-14T15-36-30.795Z"
           availability_zone = "eu-west-2b"

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -325,15 +325,6 @@ locals {
           {
             effect = "Allow"
             actions = [
-              "ssm:GetParameter",
-            ]
-            resources = [
-              "arn:aws:ssm:*:*:parameter/azure/*",
-            ]
-          },
-          {
-            effect = "Allow"
-            actions = [
               "secretsmanager:GetSecretValue",
               "secretsmanager:PutSecretValue",
             ]

--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -43,6 +43,10 @@ locals {
   }
 
   baseline_all_environments = {
+    options = {
+      enable_resource_explorer = true
+    }
+
     security_groups = local.security_groups
   }
 }

--- a/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
@@ -3,10 +3,10 @@ locals {
   ec2_instances = {
     rdgw = {
       cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarm.ec2,
+        module.baseline_presets.cloudwatch_metric_alarms.ec2,
         # TODO: enable below once CWAgent configured
-        # module.baseline_presets.cloudwatch_metric_alarm.ec2_cwagent_windows,
-        # module.baseline_presets.cloudwatch_metric_alarm.ec2_instance_or_cwagent_stopped_windows
+        # module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+        # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
       )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2024-01-16T09-48-13.663Z"
@@ -49,10 +49,10 @@ locals {
 
     rds = {
       cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarm.ec2,
+        module.baseline_presets.cloudwatch_metric_alarms.ec2,
         # TODO: enable below once CWAgent configured
-        # module.baseline_presets.cloudwatch_metric_alarm.ec2_cwagent_windows,
-        # module.baseline_presets.cloudwatch_metric_alarm.ec2_instance_or_cwagent_stopped_windows
+        # module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+        # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
       )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2024-01-16T09-48-13.663Z"

--- a/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
@@ -2,6 +2,12 @@ locals {
 
   ec2_instances = {
     rdgw = {
+      cloudwatch_metric_alarms = merge(
+        module.baseline_presets.cloudwatch_metric_alarm.ec2,
+        # TODO: enable below once CWAgent configured
+        # module.baseline_presets.cloudwatch_metric_alarm.ec2_cwagent_windows,
+        # module.baseline_presets.cloudwatch_metric_alarm.ec2_instance_or_cwagent_stopped_windows
+      )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2024-01-16T09-48-13.663Z"
         availability_zone             = "eu-west-2a"
@@ -42,6 +48,12 @@ locals {
     }
 
     rds = {
+      cloudwatch_metric_alarms = merge(
+        module.baseline_presets.cloudwatch_metric_alarm.ec2,
+        # TODO: enable below once CWAgent configured
+        # module.baseline_presets.cloudwatch_metric_alarm.ec2_cwagent_windows,
+        # module.baseline_presets.cloudwatch_metric_alarm.ec2_instance_or_cwagent_stopped_windows
+      )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2024-01-16T09-48-13.663Z"
         availability_zone             = "eu-west-2a"

--- a/terraform/environments/hmpps-domain-services/locals_lbs.tf
+++ b/terraform/environments/hmpps-domain-services/locals_lbs.tf
@@ -26,10 +26,12 @@ locals {
           }
         }
         https = {
+          certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
+          cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms.lb
           port                      = 443
           protocol                  = "HTTPS"
           ssl_policy                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-          certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
+
           default_action = {
             type = "fixed-response"
             fixed_response = {

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -112,6 +112,10 @@ locals {
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
+            alarm_target_group_names = [
+              "pp-rdgw-1-http",
+              "pp-rds-1-https",
+            ]
             certificate_names_or_arns = ["remote_desktop_and_planetfm_wildcard_cert"]
             rules = {
               pp-rdgw-1-http = {

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -102,6 +102,12 @@ locals {
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
             certificate_names_or_arns = ["remote_desktop_wildcard_and_planetfm_cert_v2"]
+
+            alarm_target_group_names = [
+              "pd-rdgw-1-http",
+              "pd-rds-1-https",
+            ]
+
             rules = {
               pd-rdgw-1-http = {
                 priority = 100

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -149,6 +149,9 @@ locals {
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
+            alarm_target_group_names = [
+              "test-rdgw-1-http",
+            ]
             rules = {
               test-rdgw-1-http = {
                 priority = 100

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -21,6 +21,7 @@ locals {
   baseline_presets_all_environments = {
     options = {
       cloudwatch_dashboard_default_widget_groups = [
+        "network_lb",
         "lb",
         "ec2",
         "ec2_linux",
@@ -59,6 +60,7 @@ locals {
         periodOverride = "auto"
         start          = "-PT6H"
         widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
@@ -99,6 +101,7 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_windows,
         ]
       }
       "nomis-combined-reporting-${local.environment}" = {
@@ -125,6 +128,20 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_filesystems,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_windows,
+        ]
+      }
+      "oasys-${local.environment}" = {
+        account_name   = "oasys-${local.environment}"
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_autoscaling_group_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
         ]
       }
       "oasys-national-reporting-${local.environment}" = {

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -49,6 +49,10 @@ locals {
   }
 
   baseline_all_environments = {
+    options = {
+      enable_resource_explorer = true
+    }
+
     cloudwatch_dashboards = {
       "corporate-staff-rostering-${local.environment}" = {
         account_name   = "corporate-staff-rostering-${local.environment}"
@@ -145,6 +149,7 @@ locals {
         ]
       }
     }
+
     iam_policies = {
       Ec2OracleEnterpriseManagerPolicy = {
         description = "Permissions required for Oracle Enterprise Manager"

--- a/terraform/environments/hmpps-oem/locals_ec2_instances.tf
+++ b/terraform/environments/hmpps-oem/locals_ec2_instances.tf
@@ -7,6 +7,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
+        module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
         module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_connected,

--- a/terraform/environments/nomis-combined-reporting/locals.tf
+++ b/terraform/environments/nomis-combined-reporting/locals.tf
@@ -48,6 +48,10 @@ locals {
   }
 
   baseline_all_environments = {
+    options = {
+      enable_resource_explorer = true
+    }
+
     security_groups = local.security_groups
   }
 }

--- a/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
@@ -4,22 +4,26 @@ locals {
     bip_app = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       # module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_app, # add in once there are custom services monitored
     )
     bip_web = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       # module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_app, # add in once there are custom services monitored
     )
     bods = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
     )
     db = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )

--- a/terraform/environments/nomis-combined-reporting/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_ec2_autoscaling_groups.tf
@@ -23,7 +23,7 @@ locals {
           "EC2S3BucketWriteAndDeleteAccessPolicy",
           "ImageBuilderS3BucketWriteAndDeleteAccessPolicy",
         ]
-        subnet_name   = "private"
+        subnet_name = "private"
         user_data_raw = base64encode(templatefile(
           "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
             branch = "main"

--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -47,6 +47,10 @@ locals {
   }
 
   baseline_all_environments = {
+    options = {
+      enable_resource_explorer = true
+    }
+
     s3_buckets = {
       offloc-upload = {
         custom_kms_key = module.environment.kms_keys["general"].arn

--- a/terraform/environments/nomis-data-hub/locals_ec2_instances.tf
+++ b/terraform/environments/nomis-data-hub/locals_ec2_instances.tf
@@ -6,6 +6,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+        module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring,
@@ -57,6 +58,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+        module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
       )
@@ -107,6 +109,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+        module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
       )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2023-*"

--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -4,6 +4,7 @@ locals {
     db = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
       local.environment == "production" ? {} : {
@@ -66,6 +67,7 @@ locals {
     xtag = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -45,19 +45,11 @@ locals {
   }
 
   baseline_all_environments = {
-    cloudwatch_log_groups = local.ssm_doc_cloudwatch_log_groups
-    iam_policies = {
-      SSMPolicy = {
-        description = "Policy to allow ssm actions"
-        statements = [{
-          effect = "Allow"
-          actions = [
-            "ssm:SendCommand"
-          ]
-          resources = ["*"]
-        }]
-      }
+    options = {
+      enable_resource_explorer = true
     }
-    security_groups = local.security_groups
+
+    cloudwatch_log_groups = local.ssm_doc_cloudwatch_log_groups
+    security_groups       = local.security_groups
   }
 }

--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -55,6 +55,7 @@ locals {
     options = {
       enable_resource_explorer = true
     }
+
     security_groups = local.security_groups
   }
 

--- a/terraform/environments/oasys/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys/locals_cloudwatch_metric_alarms.tf
@@ -23,6 +23,7 @@ locals {
     db = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
       local.cloudwatch_metric_alarms_additional.ec2,
@@ -51,6 +52,7 @@ locals {
     bip = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
       local.cloudwatch_metric_alarms_additional.ec2,

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -50,20 +50,11 @@ locals {
   }
 
   baseline_all_environments = {
-    cloudwatch_log_groups = local.ssm_doc_cloudwatch_log_groups
-    iam_policies = {
-      SSMPolicy = {
-        description = "Policy to allow ssm actions"
-        statements = [{
-          effect = "Allow"
-          actions = [
-            "ssm:SendCommand"
-          ]
-          resources = ["*"]
-        }]
-      }
+    options = {
+      enable_resource_explorer = true
     }
-    resource_explorer = true
-    security_groups   = local.security_groups
+
+    cloudwatch_log_groups = local.ssm_doc_cloudwatch_log_groups
+    security_groups       = local.security_groups
   }
 }

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -837,14 +837,10 @@ locals {
     }
 
     network_lb = {
-
-      #UnHealthyHostCount
       load-balancer-unhealthy-host-count = {
-        height : 6
-        width : 24,
         type = "metric"
         properties = {
-          view    = "singleValue"
+          view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
           title   = "NLB unhealthy-host-count"
@@ -860,8 +856,6 @@ locals {
           }
         }
       }
-
-      #ActiveFlowCount
       load-balancer-active-flow-count = {
         type = "metric"
         properties = {
@@ -873,7 +867,6 @@ locals {
           metrics = [
             [{ "expression" : "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"ActiveFlowCount\"','Average'),AVG,DESC)", "label" : "", "id" : "q1" }],
           ]
-
           yAxis = {
             left = {
               showUnits = false,
@@ -882,8 +875,6 @@ locals {
           }
         }
       }
-
-      #NewFlowCount
       load-balancer-new-flow-count = {
         type = "metric"
         properties = {
@@ -895,7 +886,6 @@ locals {
           metrics = [
             [{ "expression" : "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"NewFlowCount\"','Sum'),SUM,DESC)", "label" : "", "id" : "q1" }],
           ]
-
           yAxis = {
             left = {
               showUnits = false,
@@ -904,8 +894,6 @@ locals {
           }
         }
       }
-
-      #PeakPacketsPerSecond
       load-balancer-peak-packets-per-second = {
         type = "metric"
         properties = {
@@ -917,7 +905,6 @@ locals {
           metrics = [
             [{ "expression" : "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"PeakPacketsPerSecond\"','Maximum'),MAX,DESC)", "label" : "", "id" : "q1" }],
           ]
-
           yAxis = {
             left = {
               showUnits = false,
@@ -926,8 +913,6 @@ locals {
           }
         }
       }
-
-      #ProcessedBytes
       load-balancer-processed-bytes = {
         type = "metric"
         properties = {
@@ -939,7 +924,6 @@ locals {
           metrics = [
             [{ "expression" : "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"ProcessedBytes\"','Sum'),SUM,DESC)", "label" : "", "id" : "q1" }],
           ]
-
           yAxis = {
             left = {
               showUnits = false,
@@ -948,8 +932,6 @@ locals {
           }
         }
       }
-
-      #ProcessedPackets
       load-balancer-processed-packets = {
         type = "metric"
         properties = {
@@ -961,7 +943,6 @@ locals {
           metrics = [
             [{ "expression" : "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"ProcessedPackets\"','Sum'),SUM,DESC)", "label" : "", "id" : "q1" }],
           ]
-
           yAxis = {
             left = {
               showUnits = false,
@@ -1096,11 +1077,9 @@ locals {
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-unhealthy-host-count,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-active-flow-count,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-new-flow-count,
-        local.cloudwatch_dashboard_widgets.network_lb.load-balancer-peak-packets-per-second,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-bytes,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-packets,
-        null,
-        null,
+        local.cloudwatch_dashboard_widgets.network_lb.load-balancer-peak-packets-per-second,
       ]
     }
   }


### PR DESCRIPTION
More alignment:
- enable resource explorer across accounts
- remove unused Azure policy
- ensure EC2 stopped alarm is enabled across accounts where appropriate
- fixed CSR DR DB alarm
- enable LB unhealthy host alarms in hmpps-domain-services
- remove unattached policies
- added missing dashboard to OEM account
- tweaked network LB dashboard