### PR TITLE
planetfm: fix for cafmtx RDWeb

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -134,6 +134,7 @@ locals {
                     values = [
                       "rdweb1.hmpps-domain.service.justice.gov.uk",
                       "cafmtx.planetfm.service.justice.gov.uk",
+                      "cafmtx.az.justice.gov.uk",
                     ]
                   }
                 }]


### PR DESCRIPTION
Need to allow the existing URL on the LB