### PR TITLE
DPR2-899: Increase timeout for migrations transfer component lambda

### DIFF
--- a/terraform/environments/digital-prison-reporting/transfer_component.tf
+++ b/terraform/environments/digital-prison-reporting/transfer_component.tf
@@ -26,7 +26,7 @@ module "transfer_comp_Lambda" {
   runtime        = local.lambda_transfercomp_runtime
   policies       = local.lambda_transfercomp_policies
   tracing        = local.lambda_transfercomp_tracing
-  timeout        = 60
+  timeout        = 300
   lambda_trigger = false
   layers         = [module.transfer_comp_lambda_layer.lambda_layer_arn, ]
 


### PR DESCRIPTION
* This allows for the prisoner_prisoner materialised view to be created which takes 2 or 3 minutes