### PR TITLE
DPR2-899: Add parameter group entry to set pg_cron database to the operational datastore database

### DIFF
--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -99,7 +99,7 @@ module "aurora_operational_db" {
     {
       name         = "cron.database_name"
       value        = local.operational_db_default_database
-      apply_method = "immediate"
+      apply_method = "pending-reboot"
     }
   ]
 

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -95,6 +95,11 @@ module "aurora_operational_db" {
       name         = "shared_preload_libraries"
       value        = "pg_stat_statements,pg_cron"
       apply_method = "pending-reboot"
+    },
+    {
+      name         = "cron.database_name"
+      value        = local.operational_db_default_database
+      apply_method = "immediate"
     }
   ]
 


### PR DESCRIPTION
- This is necessary for the migrations to be able to enable the pg_cron extension
- It requires a restart for the setting to take effect before the migration enabling pg_cron can be run