### PR TITLE
Optimise load balancer timeout

### DIFF
--- a/terraform/environments/oasys/locals_lbs.tf
+++ b/terraform/environments/oasys/locals_lbs.tf
@@ -4,7 +4,7 @@ locals {
     public = {
       access_logs              = true
       enable_delete_protection = false
-      idle_timeout             = 3600 # 60 is default
+      idle_timeout             = 240
       internal_lb              = false
       force_destroy_bucket     = true
       s3_versioning            = false


### PR DESCRIPTION
- Decreasing the idle timeout of the load balancer.
- AWS default is 60 so 240 may still be quite high but can drop it again providing there are no issues.

https://dsdmoj.atlassian.net/browse/DSOS-2696