### PR TITLE
Nomis - load balancer optimisation

### DIFF
--- a/terraform/environments/nomis/locals_lbs.tf
+++ b/terraform/environments/nomis/locals_lbs.tf
@@ -5,7 +5,7 @@ locals {
     private = {
       enable_delete_protection = false
       force_destroy_bucket     = true
-      idle_timeout             = 3600
+      idle_timeout             = 240
       internal_lb              = true
       subnets                  = module.environment.subnets["private"].ids
       security_groups          = ["private-lb"]


### PR DESCRIPTION
- Decreasing the idle timeout of the load balancer.
- AWS default is 60 so 240 may still be quite high but can drop it again providing there are no issues.
- https://dsdmoj.atlassian.net/browse/DSOS-2696