### PR TITLE
:wrench: Update Image Release Versions

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -13,9 +13,9 @@ locals {
       observability_platform = "development"
 
       /* Image Versions */
-      scan_image_version     = "0.0.6"
-      transfer_image_version = "0.0.11"
-      notify_image_version   = "0.0.12"
+      scan_image_version     = "0.0.7"
+      transfer_image_version = "0.0.12"
+      notify_image_version   = "0.0.13"
 
       /* Target Buckets */
       target_buckets = ["mojap-land-dev"]
@@ -44,9 +44,9 @@ locals {
       observability_platform = "production"
 
       /* Image Versions */
-      scan_image_version     = "0.0.6"
-      transfer_image_version = "0.0.11"
-      notify_image_version   = "0.0.12"
+      scan_image_version     = "0.0.7"
+      transfer_image_version = "0.0.12"
+      notify_image_version   = "0.0.13"
 
       /* Target Buckets */
       target_buckets = ["mojap-land"]


### PR DESCRIPTION
This PR relates to the newly released versions of the images used in the Analytical Platform Ingestion service: 

- https://github.com/ministryofjustice/analytical-platform-ingestion-transfer/releases/tag/0.0.12
- https://github.com/ministryofjustice/analytical-platform-ingestion-notify/releases/tag/0.0.13
- https://github.com/ministryofjustice/analytical-platform-ingestion-scan/releases/tag/0.0.7