### PR TITLE
✨ Migrate MoJAS CaDeT to APC's KEDA + Karpenter compute

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -12,14 +12,13 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.317.0"
+  version    = "2.318.0"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
       {
-        replicaCount         = 5
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string

--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -35,14 +35,13 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.317.0"
+  version    = "2.318.0"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
       {
-        replicaCount         = 1
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -1,5 +1,20 @@
 ---
-replicaCount: ${replicaCount}
+ephemeral:
+  enabled: true
+  karpenter:
+    enabled: true
+    nodePool: "general-on-demand"
+  keda:
+    maxReplicaCount: 10
+    pollingInterval: 15
+
+resources:
+  requests:
+    cpu: 2
+    memory: "16Gi"
+  limits:
+    cpu: 4
+    memory: "32Gi"
 
 github:
   organisation: ${github_organisation}


### PR DESCRIPTION
This pull request:

- Migrates `moj-analytical-services/create-a-derived-table` to ephemeral autoscaled compute capability

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 