### PR TITLE
🧹 Set `spec.disruption.consolidationPolicy` to `WhenEmpty`

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: karpenter-configuration
 description: A Helm chart to deploy Karpenter's configuration
 type: application
-version: 1.2.0
+version: 1.3.0

--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-on-demand.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-on-demand.yaml
@@ -4,6 +4,9 @@ kind: NodePool
 metadata:
   name: general-on-demand
 spec:
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
   template:
     metadata:
       labels:

--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-spot.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-spot.yaml
@@ -4,6 +4,9 @@ kind: NodePool
 metadata:
   name: general-spot
 spec:
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
   template:
     metadata:
       labels:

--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-gpu-on-demand.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-gpu-on-demand.yaml
@@ -5,7 +5,8 @@ metadata:
   name: gpu-on-demand
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
   template:
     metadata:
       labels:


### PR DESCRIPTION
This pull request:

- Sets `spec.disruption.consolidationPolicy` to `WhenEmpty` as per https://karpenter.sh/preview/concepts/nodepools/

> If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods

It was noticed that if KEDA scheduled many GitHub Actions runners at once on a **large** node, once _some_ were complete, it would consolidate **even** if jobs were still running, as by design it would evict pods, but these are jobs with their restart policy set to never.

This pull request changes the `consolidationPolicy` from `WhenUnderutilized` to `WhenEmpty`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 