### PR TITLE
🤐 Create secret for airflow-create-a-pipeline

### DIFF
--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -44,9 +44,27 @@ module "actions_runners_airflow_secret" {
   )
 }
 
-moved {
-  from = module.actions_runners_airflow
-  to   = module.actions_runners_airflow_secret
+module "actions_runners_airflow_create_a_pipeline_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.1.2"
+
+  name        = "actions-runners/airflow-create-a-pipeline"
+  description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/3733767"
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    {
+      "expiry-date" = "2025-07-31"
+    }
+  )
 }
 
 module "ui_sentry_dsn_secret" {


### PR DESCRIPTION
This pull request:

- Creates a new secret `actions-runners/airflow-create-a-pipeline`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 