### PR TITLE
turn off alarm which triggers overnite for xtag t1 and t2

### DIFF
--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -71,5 +71,14 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )
+
+    # Does not contain ec2_instance_or_cwagent_stopped_linux block as these machines are off overnight
+    # This avoids triggering an alarm for the DBS's
+    xtag_t1_t2 = merge(
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+    )
   }
 }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -278,7 +278,7 @@ locals {
       })
 
       t1-nomis-xtag-a = merge(local.ec2_instances.xtag, {
-        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.xtag
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.xtag_t1_t2
         config = merge(local.ec2_instances.xtag.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "eu-west-2a"
@@ -333,7 +333,7 @@ locals {
       })
 
       t2-nomis-xtag-a = merge(local.ec2_instances.xtag, {
-        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.xtag
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.xtag_t1_t2
         config = merge(local.ec2_instances.xtag.config, {
           ami_name          = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-12-21T17-09-11.541Z"
           availability_zone = "eu-west-2a"


### PR DESCRIPTION
- these instances are being turned on/off overnight so disabling the 'this isn't running' alarm till we can implement a better approach