### PR TITLE
🪵 Add GPU Spot NodePool to APC

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: karpenter-configuration
 description: A Helm chart to deploy Karpenter's configuration
 type: application
-version: 1.3.0
+version: 1.4.0

--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-gpu-spot.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-gpu-spot.yaml
@@ -2,7 +2,7 @@
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: gpu-on-demand
+  name: gpu-spot
 spec:
   disruption:
     consolidationPolicy: WhenEmpty
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-        compute.analytical-platform.service.justice.gov.uk/karpenter-node-pool: "gpu-on-demand"
+        compute.analytical-platform.service.justice.gov.uk/karpenter-node-pool: "gpu-spot"
     spec:
       nodeClassRef:
         apiVersion: karpenter.k8s.aws/v1beta1
@@ -18,7 +18,7 @@ spec:
         name: bottlerocket-gpu
       taints:
         - key: compute.analytical-platform.service.justice.gov.uk/karpenter-node-pool
-          value: "gpu-on-demand"
+          value: "gpu-spot"
           effect: NoSchedule
       requirements:
         - key: kubernetes.io/arch
@@ -29,7 +29,7 @@ spec:
           values: ["linux"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["on-demand"]
+          values: ["spot"]
         - key: node.kubernetes.io/instance-type
           operator: In
           values: ["p3.2xlarge","p3.8xlarge"]


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4757
- Adds `p3.8xlarge`
- Adds `gpu-spot`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 