### PR TITLE
Dba 699 no auto minor version upgrade

### DIFF
--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -172,7 +172,7 @@ locals {
 
   dms_config_dev = {
     replication_instance_class = "dms.t3.small"
-    engine_version             = "3.5.1"
+    engine_version             = "3.5.2"
     # This map overlaps with the Ansible database configuration in delius-environment-configuration-management/ansible/group_vars
     # Please ensure any changes made here are consistent with Ansible variables.
     audit_source_endpoint = {

--- a/terraform/environments/delius-core/locals_preproduction.tf
+++ b/terraform/environments/delius-core/locals_preproduction.tf
@@ -169,7 +169,7 @@ locals {
 
   dms_config_preprod = {
     replication_instance_class = "dms.t3.medium"
-    engine_version             = "3.5.1"
+    engine_version             = "3.5.2"
     # This map overlaps with the Ansible database configuration in delius-environment-configuration-management/ansible/group_vars
     # Please ensure any changes made here are consistent with Ansible variables.
     audit_source_endpoint = {

--- a/terraform/environments/delius-core/locals_stage.tf
+++ b/terraform/environments/delius-core/locals_stage.tf
@@ -171,7 +171,7 @@ locals {
 
   dms_config_stage = {
     replication_instance_class = "dms.t3.medium"
-    engine_version             = "3.5.1"
+    engine_version             = "3.5.2"
 
     # This map overlaps with the Ansible database configuration in delius-environment-configuration-management/ansible/group_vars
     # Please ensure any changes made here are consistent with Ansible variables.

--- a/terraform/environments/delius-core/locals_test.tf
+++ b/terraform/environments/delius-core/locals_test.tf
@@ -171,7 +171,7 @@ locals {
 
   dms_config_test = {
     replication_instance_class = "dms.t3.medium"
-    engine_version             = "3.5.1"
+    engine_version             = "3.5.2"
     # This map overlaps with the Ansible database configuration in delius-environment-configuration-management/ansible/group_vars
     # Please ensure any changes made here are consistent with Ansible variables.
     audit_source_endpoint = {}

--- a/terraform/environments/delius-core/modules/components/dms/dms_db_endpoints.tf
+++ b/terraform/environments/delius-core/modules/components/dms/dms_db_endpoints.tf
@@ -46,6 +46,6 @@ resource "aws_dms_endpoint" "dms_user_source_endpoint_db" {
   engine_name                 = "oracle"
   username                    = local.dms_audit_username
   password                    = join(",", [jsondecode(data.aws_secretsmanager_secret_version.delius_core_application_passwords.secret_string)[local.dms_audit_username], jsondecode(data.aws_secretsmanager_secret_version.delius_core_application_passwords.secret_string)[local.dms_audit_username]])
-  server_name                 = join(".", [var.oracle_db_server_names[var.dms_config.audit_source_endpoint.read_host], var.account_config.route53_inner_zone_info.name])
+  server_name                 = join(".", [var.oracle_db_server_names[var.dms_config.user_source_endpoint.read_host], var.account_config.route53_inner_zone_info.name])
   extra_connection_attributes = "ArchivedLogDestId=1;AdditionalArchivedLogDestId=32;asm_server=${join(".", [var.oracle_db_server_names[var.dms_config.user_source_endpoint.read_host], var.account_config.route53_inner_zone_info.name])}:1521/+ASM;asm_user=${local.dms_audit_username};UseBFile=true;UseLogminerReader=false;"
 }

--- a/terraform/environments/delius-core/modules/components/dms/instance.tf
+++ b/terraform/environments/delius-core/modules/components/dms/instance.tf
@@ -1,7 +1,7 @@
 resource "aws_dms_replication_instance" "dms_replication_instance" {
   allocated_storage            = 30
   apply_immediately            = true
-  auto_minor_version_upgrade   = true
+  auto_minor_version_upgrade   = false
   availability_zone            = "${data.aws_region.current.name}a"
   engine_version               = var.dms_config.engine_version
   kms_key_arn                  = var.account_config.kms_keys.general_shared


### PR DESCRIPTION
Disable auto_minor_version_upgrade for DMS instances as this does not work well when specifying an engine version, since workflows will continually attempt to downgrade auto-upgraded instances. 