### PR TITLE
stop ndh alarms firing overnight when instance stopped

### DIFF
--- a/terraform/environments/nomis-data-hub/locals_ec2_instances.tf
+++ b/terraform/environments/nomis-data-hub/locals_ec2_instances.tf
@@ -109,7 +109,8 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
-        module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
+        # Disable these alarms until some way of handling "stopped" instances is implemented
+        # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
       )
       config = {
         ami_name                      = "hmpps_windows_server_2022_release_2023-*"


### PR DESCRIPTION
- disable alarm as this always triggers overnight
- needs re-instating when there's a 'alarm within timeframe' solution