### PR TITLE
DSOS-2914: oasys: extend t2 db storage

### DIFF
--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -160,9 +160,9 @@ locals {
         ebs_volumes = {
           "/dev/sdb" = { label = "app", size = 100 } # /u01
           "/dev/sdc" = { label = "app", size = 500 } # /u02
-          "/dev/sde" = { label = "data", size = 500, iops = 12000, throughput = 750 }
+          "/dev/sde" = { label = "data", size = 500 }
           "/dev/sdf" = { label = "data", size = 50 }
-          "/dev/sdj" = { label = "flash", size = 50, iops = 5000, throughput = 500 }
+          "/dev/sdj" = { label = "flash", size = 50 }
           "/dev/sds" = { label = "swap", size = 2 }
         }
         instance = merge(local.ec2_instances.db19c.instance, {

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -161,8 +161,8 @@ locals {
           "/dev/sdb" = { label = "app", size = 100 } # /u01
           "/dev/sdc" = { label = "app", size = 500 } # /u02
           "/dev/sde" = { label = "data", size = 500 }
-          "/dev/sdf" = { label = "data", size = 50 }
-          "/dev/sdj" = { label = "flash", size = 50 }
+          "/dev/sdf" = { label = "data", size = 500 }
+          "/dev/sdj" = { label = "flash", size = 200 }
           "/dev/sds" = { label = "swap", size = 2 }
         }
         instance = merge(local.ec2_instances.db19c.instance, {


### PR DESCRIPTION
Remove unnecessary iops/throughput config - just pouring money down the drain. That should have been prod only.
Add additional storage for database on DBA request