### PR TITLE
:fire: Remove AD admin secret version

### DIFF
--- a/terraform/environments/delius-iaps/ad.tf
+++ b/terraform/environments/delius-iaps/ad.tf
@@ -18,7 +18,7 @@ resource "aws_directory_service_directory" "active_directory" {
   type    = "MicrosoftAD"
   edition = "Standard"
 
-  password   = aws_secretsmanager_secret_version.ad_password.secret_string
+  password   = data.aws_secretsmanager_secret_version.ad_password.secret_string
   enable_sso = false
 
   vpc_settings {

--- a/terraform/environments/delius-iaps/rds.tf
+++ b/terraform/environments/delius-iaps/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_instance" "iaps" {
 
   # tflint-ignore: aws_db_instance_default_parameter_group
   parameter_group_name        = "default.oracle-ee-19"
-  ca_cert_identifier          = "rds-ca-rsa4096-g1"
+  ca_cert_identifier          = "rds-ca-rsa2048-g1"
   skip_final_snapshot         = local.application_data.accounts[local.environment].db_skip_final_snapshot
   allocated_storage           = local.application_data.accounts[local.environment].db_allocated_storage
   max_allocated_storage       = local.application_data.accounts[local.environment].db_max_allocated_storage

--- a/terraform/environments/delius-iaps/secrets.tf
+++ b/terraform/environments/delius-iaps/secrets.tf
@@ -22,10 +22,6 @@ resource "aws_secretsmanager_secret" "ad_password" {
   )
 }
 
-resource "aws_secretsmanager_secret_version" "ad_password" {
-  secret_id     = aws_secretsmanager_secret.ad_password.id
-  secret_string = random_password.ad_password.result
-  lifecycle {
-    ignore_changes = all # ignore everything as we only want to create this once at env initialisation
-  }
+data "aws_secretsmanager_secret_version" "ad_password" {
+  secret_id = aws_secretsmanager_secret.ad_password.id
 }


### PR DESCRIPTION
Removes version from terraform management so that the data refresh process doesn't try to recreate it