### PR TITLE
planetfm: DSOS-2918: add HTTP redirect for old azure URL to new AWS URL

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -149,6 +149,25 @@ locals {
         listeners = merge(local.lbs.private.listeners, {
           https = merge(local.lbs.private.listeners.https, {
             rules = {
+              redirect = {
+                priority = 100
+                actions = [{
+                  type = "redirect"
+                  redirect = {
+                    host        = "cafmwebx.pp.planetfm.service.justice.gov.uk"
+                    port        = "443"
+                    protocol    = "HTTPS"
+                    status_code = "HTTP_302"
+                  }
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "pp-cafmwebx.az.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
               web-45-80 = {
                 priority = 4580
                 actions = [{
@@ -159,7 +178,6 @@ locals {
                   host_header = {
                     values = [
                       "cafmwebx.pp.planetfm.service.justice.gov.uk",
-                      "pp-cafmwebx.az.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -296,6 +296,25 @@ locals {
             ]
 
             rules = {
+              redirect = {
+                priority = 100
+                actions = [{
+                  type = "redirect"
+                  redirect = {
+                    host        = "cafmwebx2.planetfm.service.justice.gov.uk"
+                    port        = "443"
+                    protocol    = "HTTPS"
+                    status_code = "HTTP_302"
+                  }
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "cafmwebx2.az.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
               web-3637-80 = {
                 priority = 3637
                 actions = [{
@@ -306,7 +325,6 @@ locals {
                   host_header = {
                     values = [
                       "cafmwebx2.planetfm.service.justice.gov.uk",
-                      "cafmwebx2.az.justice.gov.uk",
                     ]
                   }
                 }]


### PR DESCRIPTION
Add HTTP re-direct from the old AZ URL to new service URL to ensure cookies and any cached login details are reset when migration to AWS.
Note that production PlanetFM web servers are still in Azure, only a handful of people using AWS.