### PR TITLE
DPR2-1053: Stop pipeline before ingestion

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
@@ -23,7 +23,19 @@ variable "pipeline_additional_policies" {
   default     = []
 }
 
-variable "dms_replication_task_arn" {}
+variable "glue_s3_data_deletion_job" {
+  description = "Name of glue job which deletes parquet files from s3 bucket(s)"
+  type        = string
+  default     = ""
+}
+
+variable "dms_replication_task_arn" {
+  type = string
+}
+
+variable "replication_task_id" {
+  type = string
+}
 
 variable "pipeline_notification_lambda_function" {
   description = "Pipeline Notification Lambda Name"
@@ -57,6 +69,54 @@ variable "s3_raw_bucket_id" {
 
 variable "s3_raw_archive_bucket_id" {
   description = "S3, RAW Archive Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_structured_bucket_id" {
+  description = "S3, Structured Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_curated_bucket_id" {
+  description = "S3, Curated Bucket ID"
+  type        = string
+  default     = ""
+}
+
+variable "s3_temp_reload_bucket_id" {
+  description = "S3 Bucket ID for the temporary location to store reload data"
+  type        = string
+  default     = ""
+}
+
+variable "glue_stop_glue_instance_job" {
+  description = "Name of job to stop the current running instance of the streaming job"
+  type        = string
+  default     = ""
+}
+
+variable "stop_dms_task_job" {
+  description = "Name of job to stop a running DMS task"
+  type        = string
+  default     = ""
+}
+
+variable "glue_trigger_activation_job" {
+  description = "Name of job to which activates/deactivates a glue trigger"
+  type        = string
+  default     = ""
+}
+
+variable "archive_job_trigger_name" {
+  description = "Name of the trigger for a glue trigger"
+  type        = string
+  default     = ""
+}
+
+variable "glue_archive_job" {
+  description = "Name of the glue job which archives the raw data"
   type        = string
   default     = ""
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -134,15 +134,15 @@ module "reload_pipeline" {
               "--dpr.config.key" : var.domain
             }
           },
-          "Next" : "Empty Structured and Curated Data"
+          "Next" : "Empty Raw, Structured and Curated Data"
         },
-        "Empty Structured and Curated Data" : {
+        "Empty Raw, Structured and Curated Data" : {
           "Type" : "Task",
           "Resource" : "arn:aws:states:::glue:startJobRun.sync",
           "Parameters" : {
             "JobName" : var.glue_s3_data_deletion_job,
             "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
               "--dpr.config.key" : var.domain
             }
           },


### PR DESCRIPTION
This PR modifies the ingestion pipeline so it can be used to re-ingest an already running data pipeline.
It also makes a minor modification to the reload pipeline so that the raw-zone data is deleted before restarting the DMS load thus ensuring that any left over data does not corrupt the archive.