### PR TITLE
chore: Update instance types for delius-core development, preproduction, stage, and test environments

### DIFF
--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -29,7 +29,7 @@ locals {
   }
 
   db_config_dev = {
-    instance_type  = "r6i.xlarge"
+    instance_type  = "r7i.xlarge"
     ami_name_regex = "^delius_core_ol_8_5_oracle_db_19c_patch_2024-01-31T16-06-00.575Z"
 
     instance_policies = {

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -29,7 +29,7 @@ locals {
   }
 
   db_config_dev = {
-    instance_type  = "r7i.xlarge"
+    instance_type  = "r7i.large"
     ami_name_regex = "^delius_core_ol_8_5_oracle_db_19c_patch_2024-01-31T16-06-00.575Z"
 
     instance_policies = {

--- a/terraform/environments/delius-core/locals_preproduction.tf
+++ b/terraform/environments/delius-core/locals_preproduction.tf
@@ -28,7 +28,7 @@ locals {
 
 
   db_config_preprod = {
-    instance_type  = "r6i.xlarge"
+    instance_type  = "r7i.4xlarge"
     ami_name_regex = "^delius_core_ol_8_5_oracle_db_19c_patch_2024-06-04T11-24-58.162Z"
     instance_policies = {
       "business_unit_kms_key_access" = aws_iam_policy.business_unit_kms_key_access

--- a/terraform/environments/delius-core/locals_stage.tf
+++ b/terraform/environments/delius-core/locals_stage.tf
@@ -28,7 +28,7 @@ locals {
 
 
   db_config_stage = {
-    instance_type  = "r6i.xlarge"
+    instance_type  = "r7i.2xlarge"
     ami_name_regex = "^delius_core_ol_8_5_oracle_db_19c_patch_2024-06-04T11-24-58.162Z"
     standby_count  = 0
 

--- a/terraform/environments/delius-core/locals_test.tf
+++ b/terraform/environments/delius-core/locals_test.tf
@@ -30,7 +30,7 @@ locals {
 
 
   db_config_test = {
-    instance_type  = "r6i.xlarge"
+    instance_type  = "r7i.xlarge"
     ami_name_regex = "^delius_core_ol_8_5_oracle_db_19c_patch_2024-01-31T16-06-00.575Z"
     instance_policies = {
       "business_unit_kms_key_access" = aws_iam_policy.business_unit_kms_key_access


### PR DESCRIPTION
dev: r6i.xlarge to r7i.large
test: r6i.xlarge to r7i.xlarge
stage: r6i.xlarge to r7i.2xlarge
preprod: r6i.xlarge to r7i.4xlarge