### PR TITLE
DPR2-1058 add lifecycle to Athena query folder

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -935,7 +935,8 @@ module "s3_working_bucket" {
   enable_lifecycle            = true
   enable_lifecycle_expiration = true
   expiration_days             = 2
-  expiration_prefix           = "reports/"
+  expiration_prefix_redshift  = "reports/"
+  expiration_prefix_athena    = "dpr/"
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/main.tf
@@ -54,7 +54,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
     status = var.enable_lifecycle_expiration ? "Enabled" : "Disabled"
 
     filter {
-      prefix = var.expiration_prefix
+      prefix = var.expiration_prefix_redshift
+    }
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+
+  rule {
+    id     = "${var.name}-dpr"
+    status = var.enable_lifecycle_expiration ? "Enabled" : "Disabled"
+
+    filter {
+      prefix = var.expiration_prefix_athena
     }
 
     expiration {

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/variables.tf
@@ -68,8 +68,13 @@ variable "expiration_days" {
   default     = 90
 }
 
-variable "expiration_prefix" {
-  description = "Prefix to apply expiration to."
+variable "expiration_prefix_redshift" {
+  description = "Directory Prefix where Redshift Async query results are stored to apply expiration to."
+  default     = "/"
+}
+
+variable "expiration_prefix_athena" {
+  description = "Directory Prefix where Athena Async query results are stored to apply expiration to."
   default     = "/"
 }
 


### PR DESCRIPTION
These changes modify the S3 bucket lifecycle policy to remove the data also for Athena results not just for Redshift.
The lifecycle policy currently is in place only for Redshift results stored under the reports folder.
Since the Athena queries now run in a workgroup, the workgroup outputs its results to `dpr-working-development/dpr/` .