### PR TITLE
nomis: update pnomisapiro DNS entry to reflect recent DB changes

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -456,8 +456,8 @@ locals {
           { name = "pmis", type = "CNAME", ttl = "300", records = ["prod-nomis-db-2-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "pmis-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-2-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "pmis-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-2-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
-          { name = "pnomisapiro", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
-          { name = "pnomisapiro-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-b.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
+          { name = "pnomisapiro", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
+          { name = "pnomisapiro-a", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
           { name = "pnomisapiro-b", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },
         ]
         lb_alias_records = [


### PR DESCRIPTION
Following query in mod platform, some of our DNS entries / documentation is out of date re the production NOMIS_APIRO database. This is now running on prod-nomis-db-1-a.  DNS entries need correcting as a result. Safest to do this in 2 stages just in case.

Confirmed with DBAs the intention is to leave it in this configuration.