### PR TITLE
(csr, onr, planetfm): add procstat metric and alarms

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
@@ -1,6 +1,38 @@
 locals {
 
   cloudwatch_metric_alarms = {
+    windows = {
+      cwagent-process-count = {
+        alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # CloudWatch agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe        = "amazon-cloudwatch-agent"
+          pid_finder = "native"
+        }
+      }
+      ssm-agent-process-count = {
+        alarm_description   = "The SSM agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # SSM agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe        = "ssm-agent"
+          pid_finder = "native"
+        }
+      }
+    }
     app = merge(
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,

--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -3,7 +3,10 @@ locals {
   ec2_instances = {
 
     app = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.app
+      cloudwatch_metric_alarms = merge(
+        local.cloudwatch_metric_alarms.windows,
+        local.cloudwatch_metric_alarms.app,
+      )
       config = {
         ami_owner                     = "self"
         availability_zone             = "eu-west-2a"
@@ -112,7 +115,10 @@ locals {
     }
 
     web = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.web
+      cloudwatch_metric_alarms = merge(
+        local.cloudwatch_metric_alarms.windows,
+        local.cloudwatch_metric_alarms.web,
+      )
       config = {
         ami_owner                     = "self"
         availability_zone             = "eu-west-2a"

--- a/terraform/environments/corporate-staff-rostering/templates/cloud_watch_windows.json
+++ b/terraform/environments/corporate-staff-rostering/templates/cloud_watch_windows.json
@@ -74,7 +74,35 @@
           "Requests Queued",
           "Application Restarts"
         ]
-      }
+      },
+      "procstat": [
+        {
+          "exe": "ssm-agent",
+          "measurement": [
+            "cpu_time_system",
+            "cpu_time_user",
+            "memory_rss",
+            "num_threads",
+            "pid_count",
+            "pid",
+            "read_bytes",
+            "write_bytes"
+          ]
+        },
+        {
+          "exe": "amazon-cloudwatch-agent",
+          "measurement": [
+            "cpu_time_system",
+            "cpu_time_user",
+            "memory_rss",
+            "num_threads",
+            "pid_count",
+            "pid",
+            "read_bytes",
+            "write_bytes"
+          ]
+        },
+      ],
     },
     "append_dimensions": {
       "InstanceId": "${aws:InstanceId}",

--- a/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
@@ -12,7 +12,8 @@ locals {
         threshold           = 2 # CloudWatch agent runs 2 processes
         treat_missing_data  = "breaching"
         dimensions = {
-          exe = "amazon-cloudwatch-agent"
+          exe        = "amazon-cloudwatch-agent"
+          pid_finder = "native"
         }
       }
       ssm-agent-process-count = {
@@ -26,7 +27,8 @@ locals {
         threshold           = 2 # SSM agent runs 2 processes
         treat_missing_data  = "breaching"
         dimensions = {
-          exe = "ssm-agent"
+          exe        = "ssm-agent"
+          pid_finder = "native"
         }
       }
     }
@@ -42,7 +44,8 @@ locals {
         threshold           = 1
         treat_missing_data  = "breaching"
         dimensions = {
-          exe = "CMS"
+          exe        = "CMS"
+          pid_finder = "native"
         }
       }
       bods-svcmgr-process-count = {
@@ -56,7 +59,8 @@ locals {
         threshold           = 1
         treat_missing_data  = "breaching"
         dimensions = {
-          exe = "SvcMgr"
+          exe        = "SvcMgr"
+          pid_finder = "native"
         }
       }
     }

--- a/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
@@ -1,0 +1,34 @@
+locals {
+  cloudwatch_metric_alarms = {
+    windows = {
+      cwagent-process-count = {
+        alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # CloudWatch agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "amazon-cloudwatch-agent"
+        }
+      }
+      ssm-agent-process-count = {
+        alarm_description   = "The SSM agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # SSM agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "ssm-agent"
+        }
+      }
+    }
+  }
+}

--- a/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
@@ -30,5 +30,35 @@ locals {
         }
       }
     }
+    bods = {
+      bods-cms-process-count = {
+        alarm_description   = "This alarm checks that the PID count for the BODS CMS does not drop below 1."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 1
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "CMS"
+        }
+      }
+      bods-svcmgr-process-count = {
+        alarm_description   = "This alarm checks that the PID count for the BODS SvcMGR does not drop below 1."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 1
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "SvcMgr"
+        }
+      }
+    }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -16,6 +16,20 @@ locals {
           exe = "amazon-cloudwatch-agent"
         }
       }
+      ssm-agent-process-count = {
+        alarm_description   = "The SSM agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # SSM agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "ssm-agent"
+        }
+      }
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -66,7 +66,7 @@ locals {
         server-type      = "OnrBods"
         update-ssm-agent = "patchgroup1"
       }
-      cloudwatch_metric_alarms = locals.ec2_instances.windows.cloudwatch_metric_alarms
+      cloudwatch_metric_alarms = local.ec2_instances.windows.cloudwatch_metric_alarms
     }
 
     boe_app = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -1,38 +1,5 @@
 locals {
 
-  cloudwatch_metric_alarms = {
-    windows = {
-      cwagent-process-count = {
-        alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
-        namespace           = "CWAgent"
-        metric_name         = "procstat_lookup pid_count"
-        period              = 60
-        evaluation_periods  = 1
-        statistic           = "Average"
-        comparison_operator = "LessThanThreshold"
-        threshold           = 2 # CloudWatch agent runs 2 processes
-        treat_missing_data  = "breaching"
-        dimensions = {
-          exe = "amazon-cloudwatch-agent"
-        }
-      }
-      ssm-agent-process-count = {
-        alarm_description   = "The SSM agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
-        namespace           = "CWAgent"
-        metric_name         = "procstat_lookup pid_count"
-        period              = 60
-        evaluation_periods  = 1
-        statistic           = "Average"
-        comparison_operator = "LessThanThreshold"
-        threshold           = 2 # SSM agent runs 2 processes
-        treat_missing_data  = "breaching"
-        dimensions = {
-          exe = "ssm-agent"
-        }
-      }
-    }
-  }
-
   ec2_instances = {
 
     bods = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -214,6 +214,7 @@ locals {
         server-type            = "OnrClient"
         update-ssm-agent       = "patchgroup1"
       }
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.windows
     }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -2,6 +2,25 @@ locals {
 
   ec2_instances = {
 
+    windows = {
+      cloudwatch_metric_alarms = {
+        cwagent-process-count = {
+          alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+          namespace           = "CWAgent"
+          metric_name         = "procstat_lookup pid_count"
+          period              = 60
+          evaluation_periods  = 1
+          statistic           = "Average"
+          comparison_operator = "LessThanThreshold"
+          threshold           = 2 # CloudWatch agent runs 2 processes
+          treat_missing_data  = "breaching"
+          dimensions = {
+            exe = "amazon-cloudwatch-agent"
+          }
+        }
+      }
+    }
+
     bods = {
       config = {
         ami_name                      = "hmpps_windows_server_2019_release_*"
@@ -47,6 +66,7 @@ locals {
         server-type      = "OnrBods"
         update-ssm-agent = "patchgroup1"
       }
+      cloudwatch_metric_alarms = locals.ec2_instances.windows.cloudwatch_metric_alarms
     }
 
     boe_app = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -47,7 +47,10 @@ locals {
         server-type      = "OnrBods"
         update-ssm-agent = "patchgroup1"
       }
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.windows
+      cloudwatch_metric_alarms = merge(
+        local.cloudwatch_metric_alarms.windows,
+        local.cloudwatch_metric_alarms.bods,
+      )
     }
 
     boe_app = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -1,25 +1,25 @@
 locals {
 
-  ec2_instances = {
-
+  cloudwatch_metric_alarms = {
     windows = {
-      cloudwatch_metric_alarms = {
-        cwagent-process-count = {
-          alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
-          namespace           = "CWAgent"
-          metric_name         = "procstat_lookup pid_count"
-          period              = 60
-          evaluation_periods  = 1
-          statistic           = "Average"
-          comparison_operator = "LessThanThreshold"
-          threshold           = 2 # CloudWatch agent runs 2 processes
-          treat_missing_data  = "breaching"
-          dimensions = {
-            exe = "amazon-cloudwatch-agent"
-          }
+      cwagent-process-count = {
+        alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # CloudWatch agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe = "amazon-cloudwatch-agent"
         }
       }
     }
+  }
+
+  ec2_instances = {
 
     bods = {
       config = {
@@ -66,7 +66,7 @@ locals {
         server-type      = "OnrBods"
         update-ssm-agent = "patchgroup1"
       }
-      cloudwatch_metric_alarms = local.ec2_instances.windows.cloudwatch_metric_alarms
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.windows
     }
 
     boe_app = {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -75,6 +75,7 @@ locals {
         tags = merge(local.ec2_autoscaling_groups.boe_web.tags, {
           oasys-national-reporting-environment = "t2"
         })
+        cloudwatch_metric_alarms = null
       })
 
       # IMPORTANT: this is just for testing at the moment
@@ -96,6 +97,7 @@ locals {
           ami                                  = "base_rhel_6_10"
           oasys-national-reporting-environment = "t2"
         })
+        cloudwatch_metric_alarms = null
       })
 
       # TODO: this is just for testing, remove when not needed
@@ -114,6 +116,7 @@ locals {
         tags = merge(local.ec2_autoscaling_groups.boe_app.tags, {
           oasys-national-reporting-environment = "t2"
         })
+        cloudwatch_metric_alarms = null
       })
 
       test-bods-asg = merge(local.ec2_autoscaling_groups.bods, {
@@ -125,6 +128,7 @@ locals {
         instance = merge(local.ec2_autoscaling_groups.bods.instance, {
           instance_type = "m4.xlarge"
         })
+        cloudwatch_metric_alarms = null
       })
     }
 

--- a/terraform/environments/planetfm/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/planetfm/locals_cloudwatch_metric_alarms.tf
@@ -1,0 +1,36 @@
+locals {
+  cloudwatch_metric_alarms = {
+    windows = {
+      cwagent-process-count = {
+        alarm_description   = "The CloudWatch agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # CloudWatch agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe        = "amazon-cloudwatch-agent"
+          pid_finder = "native"
+        }
+      }
+      ssm-agent-process-count = {
+        alarm_description   = "The SSM agent runs 2 processes. If the PID count drops below 2, the agent is not functioning as expected."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 2 # SSM agent runs 2 processes
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe        = "ssm-agent"
+          pid_finder = "native"
+        }
+      }
+    }
+  }
+}

--- a/terraform/environments/planetfm/locals_ec2_instances.tf
+++ b/terraform/environments/planetfm/locals_ec2_instances.tf
@@ -6,6 +6,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+        locals.cloudwatch_metric_alarms.windows,
       )
       config = {
         ami_owner                     = "self"
@@ -88,6 +89,7 @@ locals {
       cloudwatch_metric_alarms = merge(
         module.baseline_presets.cloudwatch_metric_alarms.ec2,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+        locals.cloudwatch_metric_alarms.windows,
       )
       config = {
         availability_zone             = "eu-west-2a"

--- a/terraform/environments/planetfm/templates/cloud_watch_windows.json
+++ b/terraform/environments/planetfm/templates/cloud_watch_windows.json
@@ -74,7 +74,35 @@
           "Requests Queued",
           "Application Restarts"
         ]
-      }
+      },
+      "procstat": [
+        {
+          "exe": "ssm-agent",
+          "measurement": [
+            "cpu_time_system",
+            "cpu_time_user",
+            "memory_rss",
+            "num_threads",
+            "pid_count",
+            "pid",
+            "read_bytes",
+            "write_bytes"
+          ]
+        },
+        {
+          "exe": "amazon-cloudwatch-agent",
+          "measurement": [
+            "cpu_time_system",
+            "cpu_time_user",
+            "memory_rss",
+            "num_threads",
+            "pid_count",
+            "pid",
+            "read_bytes",
+            "write_bytes"
+          ]
+        },
+      ],
     },
     "append_dimensions": {
       "InstanceId": "${aws:InstanceId}",


### PR DESCRIPTION
For now, we are only monitoring the CloudWatch and SSM agents.

ONR has received extra alarms for BODS processes (this is supported by PRs #7060, #7116, #7455). However, these metrics will need to be revised in future. This is because the CloudWatch config applies to all instances. Not all instances have BODS processes.

- Add CloudWatch config for procstat for CSR and PlanetFM
- Add metric alarms to watch the procstat metrics
  - Additionally apply the alarms to instances
- Set metric alarms to null in ONR ASGs (they don't need alarms)