### PR TITLE
🪵 Karpenter CRD deployment

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -116,7 +116,7 @@ resource "helm_release" "cluster_autoscaler" {
 /* Karpenter */
 resource "helm_release" "karpenter_crd" {
   /* https://github.com/aws/karpenter-provider-aws/releases */
-  name       = "karpenter"
+  name       = "karpenter-crd"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter-crd"
   version    = "0.37.0"

--- a/terraform/environments/analytical-platform-compute/src/helm/values/karpenter-crd/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/karpenter-crd/values.yml.tftpl
@@ -1,0 +1,3 @@
+---
+webhook:
+  serviceNamespace: ${service_namespace}


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5087
- Install Karpenter's CRD chart

TODO before merging/applying to production:

- [x] pause autoscaling
  - https://keda.sh/docs/2.15/concepts/scaling-deployments/#pausing-autoscaling 
- [x] delete nodepools
- [x] delete ec2nodeclasses
- [x] delete custom resource definitions
  - if ec2nodeclasses hangs then `kubectl patch crd/ec2nodeclasses.karpenter.k8s.aws -p '{"metadata":{"finalizers":[]}}' --type=merge`
- [x] delete karpenter helm charts

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 