### PR TITLE
set new alarm sns topics

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -46,11 +46,6 @@ locals {
       enable_s3_software_bucket                   = true
       s3_iam_policies                             = ["EC2S3BucketWriteAndDeleteAccessPolicy"]
       software_bucket_name                        = "csr-software"
-      sns_topics = {
-        pagerduty_integrations = {
-          csr_pagerduty = "csr_alarms"
-        }
-      }
     }
   }
 

--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_metric_alarms.tf
@@ -34,11 +34,11 @@ locals {
       }
     }
     app = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
       {
-        high-memory-usage = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows["high-memory-usage"], {
+        high-memory-usage = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows["high-memory-usage"], {
           threshold           = "75"
           period              = "60" # seconds
           evaluation_periods  = "20"
@@ -49,17 +49,17 @@ locals {
     )
 
     db = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
       local.environment == "production" ? {} : {
-        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2["cpu-utilization-high"], {
+        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2["cpu-utilization-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "95"
           alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
         })
-        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
+        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["cpu-iowait-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "40"
@@ -69,13 +69,13 @@ locals {
     )
 
     db_backup = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
     )
 
     web = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_cwagent_windows,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].ec2_instance_or_cwagent_stopped_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
     )
   }
 }

--- a/terraform/environments/corporate-staff-rostering/locals_lbs.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_lbs.tf
@@ -106,27 +106,27 @@ locals {
       }
       listeners = {
         http = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.network_lb
           port                     = 80
           protocol                 = "TCP"
         }
         http-7770 = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.network_lb
           port                     = 7770
           protocol                 = "TCP"
         }
         http-7771 = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.network_lb
           port                     = 7771
           protocol                 = "TCP"
         }
         http-7780 = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.network_lb
           port                     = 7780
           protocol                 = "TCP"
         }
         http-7781 = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["csr_pagerduty"].network_lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.network_lb
           port                     = 7781
           protocol                 = "TCP"
         }

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -2,6 +2,11 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
+      sns_topics = {
+        pagerduty_integrations = {
+          csr_pagerduty = "corporate-staff-rostering-preproduction"
+        }
+      }
     }
   }
 
@@ -720,11 +725,6 @@ locals {
         secrets = {
           passwords = { description = "database passwords" }
         }
-      }
-    }
-    sns_topics = {
-      pagerduty_integrations = {
-        csr_pagerduty = "corporate-staff-rostering-preproduction"
       }
     }
   }

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -2,9 +2,10 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
-          csr_pagerduty = "corporate-staff-rostering-preproduction"
+          pagerduty = "corporate-staff-rostering-preproduction"
         }
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -722,5 +722,10 @@ locals {
         }
       }
     }
+    sns_topics = {
+      pagerduty_integrations = {
+        csr_pagerduty = "corporate-staff-rostering-preproduction"
+      }
+    }
   }
 }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -2,10 +2,11 @@ locals {
 
   baseline_presets_production = {
     options = {
-      db_backup_lifecycle_rule = "rman_backup_one_month"
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
+      db_backup_lifecycle_rule = "rman_backup_one_month"      
       sns_topics = {
         pagerduty_integrations = {
-          csr_pagerduty = "corporate-staff-rostering-production"
+          pagerduty = "corporate-staff-rostering-production"
         }
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -3,6 +3,11 @@ locals {
   baseline_presets_production = {
     options = {
       db_backup_lifecycle_rule = "rman_backup_one_month"
+      sns_topics = {
+        pagerduty_integrations = {
+          csr_pagerduty = "corporate-staff-rostering-production"
+        }
+      }
     }
   }
 
@@ -586,11 +591,6 @@ locals {
         secrets = {
           passwords = { description = "database passwords" }
         }
-      }
-    }
-    sns_topics = {
-      pagerduty_integrations = {
-        csr_pagerduty = "corporate-staff-rostering-production"
       }
     }
   }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -588,5 +588,10 @@ locals {
         }
       }
     }
+    sns_topics = {
+      pagerduty_integrations = {
+        csr_pagerduty = "corporate-staff-rostering-production"
+      }
+    }
   }
 }


### PR DESCRIPTION
- use new corporate-staff-rostering-production and preproduction sns topics
- allows users to quickly see who/what is failing
- should also make it obvious 'which' LB or other shared resource is having an issue