### PR TITLE
Lake Formation Data Access role added to Github Actons runner role

### DIFF
--- a/terraform/environments/digital-prison-reporting/cross-account.tf
+++ b/terraform/environments/digital-prison-reporting/cross-account.tf
@@ -8,7 +8,7 @@ resource "aws_iam_openid_connect_provider" "cluster" {
 }
 
 ## Role
-## CrossAccount DataAPI Cross Account Role, 
+## CrossAccount DataAPI Cross Account Role,
 # CrossAccount DataAPI Assume Policy
 data "aws_iam_policy_document" "dataapi_cross_assume" {
   statement {
@@ -89,3 +89,8 @@ resource "aws_iam_role_policy_attachment" "glue_catalog_readonly" {
   policy_arn = aws_iam_policy.glue_catalog_readonly.arn
 }
 
+# Lake Formation Data Access Attachement
+resource "aws_iam_role_policy_attachment" "lake_formation_data_access" {
+  role       = aws_iam_role.dataapi_cross_role.name
+  policy_arn = aws_iam_policy.lake_formation_data_access.arn
+}

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -124,3 +124,9 @@ data "aws_secretsmanager_secret_version" "transfer_component_role_secret_version
 data "aws_iam_session_context" "current" {
   arn = data.aws_caller_identity.current.arn
 }
+
+# Retrieves role for data-engineers
+
+data "aws_iam_roles" "data_engineering_roles" {
+  name_regex = "AWSReservedSSO_modernisation-platform-data-eng.*"
+}

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -1,5 +1,5 @@
 resource "aws_lakeformation_data_lake_settings" "lake_formation" {
-  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn])
+  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn, try(one(data.aws_iam_roles.data_engineering_roles.arns),[])])
 
   # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
   create_database_default_permissions {

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -1,5 +1,5 @@
 resource "aws_lakeformation_data_lake_settings" "lake_formation" {
-  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn, try(one(data.aws_iam_roles.data_engineering_roles.arns),[])])
+  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn, try(one(data.aws_iam_roles.data_engineering_roles.arns), [])])
 
   # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
   create_database_default_permissions {

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -735,6 +735,26 @@ resource "aws_iam_policy" "glue_catalog_readonly" {
   policy      = data.aws_iam_policy_document.glue_catalog_readonly.json
 }
 
+# LakeFormation Data Access
+# Policy Document
+
+data "aws_iam_policy_document" "lake_formation_data_access" {
+  statement {
+    actions = [
+      "lakeformation:GetDataAccess"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lake_formation_data_access" {
+  name        = "${local.project}-lake-formation-data-access"
+  description = "LakeFormation Get Data Access Policy"
+  policy      = data.aws_iam_policy_document.lake_formation_data_access.json
+}
+
 # Analytical Platform Share Policy & Role
 
 data "aws_iam_policy_document" "analytical_platform_share_policy" {


### PR DESCRIPTION
Analytical Platform tracking ticket: https://github.com/ministryofjustice/analytical-platform/issues/4358

This PR adds `lakeformation:GetDataAccess` permission to the Github role because it interacts with resources that are managed via Lake Formation.

Note: All roles that interact with objects whose underlying location is registered with LakeFormation **must** have this policy attached.