### PR TITLE
nomis: DSO: increase default instance size for web19c project

### DIFF
--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -185,7 +185,7 @@ locals {
       }
       instance = {
         disable_api_termination      = false
-        instance_type                = "t3.medium"
+        instance_type                = "t3.large"
         key_name                     = "ec2-user"
         vpc_security_group_ids       = ["private-web"]
         metadata_options_http_tokens = "required"


### PR DESCRIPTION
On request from DBAs - 8GB min memory requirement