### PR TITLE
use new pagerduty service definitions for alarms

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -30,7 +30,7 @@ locals {
         "ec2_instance_textfile_monitoring",
         "ec2_windows",
       ]
-      cloudwatch_metric_alarms_default_actions    = ["dso_pagerduty"]
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters  = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
       db_backup_bucket_name                       = "nomis-db-backup-bucket"

--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -48,7 +48,7 @@ locals {
           threshold           = "14400"
           treat_missing_data  = "notBreaching"
           alarm_description   = "Triggers if misload process is taking longer than 4 hours, see https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4615798942"
-          alarm_actions       = ["dba_pagerduty"]
+          alarm_actions       = ["pagerduty"]
           dimensions = {
             type          = "duration"
             type_instance = "misload_running"

--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -2,19 +2,19 @@ locals {
 
   cloudwatch_metric_alarms = {
     db = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
       local.environment == "production" ? {} : {
-        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2["cpu-utilization-high"], {
+        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2["cpu-utilization-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "95"
           alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
         })
-        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
+        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["cpu-iowait-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "40"
@@ -23,20 +23,20 @@ locals {
       },
     )
     db_connectivity_test = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_connectivity_test,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_connectivity_test,
     )
     db_connected = merge(
       # DBAs have slack integration via OEM for this so don't include pagerduty integration
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_connected,
     )
     db_backup = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
     )
     db_nomis_batch = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_textfile_monitoring
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring
     )
     db_misload = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_textfile_monitoring, {
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_textfile_monitoring, {
         misload-long-running = {
           comparison_operator = "GreaterThanOrEqualToThreshold"
           evaluation_periods  = "1"
@@ -58,27 +58,27 @@ locals {
     )
 
     web = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
     )
 
     xtag = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
     )
 
     # Does not contain ec2_instance_or_cwagent_stopped_linux block as these machines are off overnight
     # This avoids triggering an alarm for the DBS's
     xtag_t1_t2 = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
     )
   }
 }

--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -5,7 +5,7 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
       local.environment == "production" ? {} : {
         cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2["cpu-utilization-high"], {
@@ -23,7 +23,7 @@ locals {
       },
     )
     db_connectivity_test = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_connectivity_test,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_connectivity_test,
     )
     db_connected = merge(
       # DBAs have slack integration via OEM for this so don't include pagerduty integration
@@ -58,26 +58,26 @@ locals {
     )
 
     web = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )
 
     xtag = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )
 
     # Does not contain ec2_instance_or_cwagent_stopped_linux block as these machines are off overnight
     # This avoids triggering an alarm for the DBS's
     xtag_t1_t2 = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
     )
   }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -9,7 +9,7 @@ locals {
     options = {
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "nomis_nonprod_alarms"
+          pagerduty                   = "nomis-development"
           dba_pagerduty               = "hmpps_shef_dba_non_prod"
           dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
         }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -10,8 +10,6 @@ locals {
       sns_topics = {
         pagerduty_integrations = {
           pagerduty                   = "nomis-development"
-          dba_pagerduty               = "hmpps_shef_dba_non_prod"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
         }
       }
     }

--- a/terraform/environments/nomis/locals_lbs.tf
+++ b/terraform/environments/nomis/locals_lbs.tf
@@ -26,7 +26,7 @@ locals {
         }
 
         https = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.lb
           port                     = 443
           protocol                 = "HTTPS"
           ssl_policy               = "ELBSecurityPolicy-2016-08"

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -394,7 +394,7 @@ locals {
           https = merge(local.lbs.private.listeners.https, {
             alarm_target_group_names  = [] # don't enable as environments are powered up/down frequently
             certificate_names_or_arns = ["nomis_wildcard_cert"]
-            cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].lb
+            cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms.lb
 
             # /home/oracle/admin/scripts/lb_maintenance_mode.sh script on
             # weblogic servers can alter priorities to enable maintenance message

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -13,7 +13,7 @@ locals {
       }
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "nomis_alarms"
+          pagerduty                   = "nomis-preproduction"
           dba_pagerduty               = "hmpps_shef_dba_low_priority"
           dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
         }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -14,8 +14,6 @@ locals {
       sns_topics = {
         pagerduty_integrations = {
           pagerduty                   = "nomis-preproduction"
-          dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
         }
       }
     }

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -24,7 +24,7 @@ locals {
       }
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "nomis_alarms"
+          pagerduty                   = "nomis-production"
           dba_pagerduty               = "hmpps_shef_dba_low_priority"
           dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
         }

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -25,8 +25,6 @@ locals {
       sns_topics = {
         pagerduty_integrations = {
           pagerduty                   = "nomis-production"
-          dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
         }
       }
     }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -11,8 +11,6 @@ locals {
       sns_topics = {
         pagerduty_integrations = {
           pagerduty                   = "nomis-test"
-          dba_pagerduty               = "hmpps_shef_dba_non_prod"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
         }
       }
     }

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -10,7 +10,7 @@ locals {
       enable_observability_platform_monitoring = true
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "nomis_nonprod_alarms"
+          pagerduty                   = "nomis-test"
           dba_pagerduty               = "hmpps_shef_dba_non_prod"
           dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
         }
@@ -38,7 +38,7 @@ locals {
       }
     }
 
-    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ebs
+    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ebs
 
     ec2_autoscaling_groups = {
       # NOT-ACTIVE (blue deployment)


### PR DESCRIPTION
- replace dso_pagerduty alarms everything will go to nomis_alarms_non_prod channel apart from alarms raised in prod which will go to nomis_alarms_prod channel in slack