### PR TITLE
DSOS-2927: permissions for letsencrypt acme v2

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -88,41 +88,12 @@ locals {
       pp-rds-1-a = merge(local.ec2_instances.rds, {
         config = merge(local.ec2_instances.rds.config, {
           availability_zone = "eu-west-2a"
-          instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
-            "Ec2PpRdsPolicy",
-          ])
         })
         tags = merge(local.ec2_instances.rds.tags, {
           description = "Remote Desktop Services for azure.hmpp.root domain"
           domain-name = "azure.hmpp.root"
         })
       })
-    }
-
-    iam_policies = {
-      Ec2PpRdsPolicy = {
-        description = "Permissions required for POSH-ACME Route53 Plugin"
-        statements = [
-          {
-            effect = "Allow"
-            actions = [
-              "route53:ListHostedZones",
-            ]
-            resources = ["*"]
-          },
-          {
-            effect = "Allow"
-            actions = [
-              "route53:GetHostedZone",
-              "route53:ListResourceRecordSets",
-              "route53:ChangeResourceRecordSets"
-            ]
-            resources = [
-              "arn:aws:route53:::hostedzone/*",
-            ]
-          },
-        ]
-      }
     }
 
     lbs = {

--- a/terraform/environments/planetfm/locals_ec2_instances.tf
+++ b/terraform/environments/planetfm/locals_ec2_instances.tf
@@ -123,6 +123,7 @@ locals {
         backup           = "false"
         component        = "web"
         os-type          = "Windows"
+        server-type      = "PlanetFMWeb"
         update-ssm-agent = "patchgroup1"
       }
     }

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -118,7 +118,7 @@ locals {
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-4-b"
-          cert-cn             = "*.pp.planetfm.service.justice.gov.uk"
+          cert-cn             = "cafmwebx.pp.planetfm.service.justice.gov.uk"
           description         = "Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0004"
@@ -142,7 +142,7 @@ locals {
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-5-a"
-          cert-cn             = "*.pp.planetfm.service.justice.gov.uk"
+          cert-cn             = "cafmwebx.pp.planetfm.service.justice.gov.uk"
           description         = "Migrated server PPFWW0005 Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0005"

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -118,7 +118,6 @@ locals {
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-4-b"
-          cert-cn             = "cafmwebx.pp.planetfm.service.justice.gov.uk"
           description         = "Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0004"
@@ -142,7 +141,6 @@ locals {
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-5-a"
-          cert-cn             = "cafmwebx.pp.planetfm.service.justice.gov.uk"
           description         = "Migrated server PPFWW0005 Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0005"

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -94,7 +94,6 @@ locals {
         })
         tags = merge(local.ec2_instances.db.tags, {
           ami                 = "pp-cafm-db-a"
-          app-config-status   = "pending"
           description         = "SQL Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFDW0030"
@@ -106,6 +105,9 @@ locals {
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pp-cafm-w-4-b"
           availability_zone = "eu-west-2b"
+          instance_profile_policies = concat(local.ec2_instances.web.config.instance_profile_policies, [
+            "Ec2PpWebPolicy",
+          ])
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -116,6 +118,7 @@ locals {
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-4-b"
+          cert-cn             = "*.pp.planetfm.service.justice.gov.uk"
           description         = "Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0004"
@@ -126,21 +129,51 @@ locals {
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pp-cafm-w-5-a"
           availability_zone = "eu-west-2a"
-        })
-        instance = merge(local.ec2_instances.web.instance, {
-          disable_api_termination = true
-          instance_type           = "t3.large"
+          instance_profile_policies = concat(local.ec2_instances.web.config.instance_profile_policies, [
+            "Ec2PpWebPolicy",
+          ])
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
         }
+        instance = merge(local.ec2_instances.web.instance, {
+          disable_api_termination = true
+          instance_type           = "t3.large"
+        })
         tags = merge(local.ec2_instances.web.tags, {
           ami                 = "pp-cafm-w-5-a"
+          cert-cn             = "*.pp.planetfm.service.justice.gov.uk"
           description         = "Migrated server PPFWW0005 Web Portal Server"
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFWW0005"
         })
       })
+    }
+
+    iam_policies = {
+      Ec2PpWebPolicy = {
+        description = "Permissions required for POSH-ACME Route53 Plugin"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "route53:ListHostedZones",
+            ]
+            resources = ["*"]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "route53:GetHostedZone",
+              "route53:ListResourceRecordSets",
+              "route53:ChangeResourceRecordSets"
+            ]
+            resources = [
+              "arn:aws:route53:::hostedzone/*",
+            ]
+          },
+        ]
+      }
     }
 
     lbs = {

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -222,7 +222,6 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-36-b"
-          cert-cn          = "cafmwebx2.planetfm.service.justice.gov.uk"
           description      = "CAFM Asset Management"
           pre-migration    = "PDFWW00036"
           update-ssm-agent = "patchgroup2"
@@ -251,7 +250,6 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-37-a"
-          cert-cn          = "cafmwebx2.planetfm.service.justice.gov.uk"
           description      = "CAFM Assessment Management"
           pre-migration    = "PFWW00037"
           update-ssm-agent = "patchgroup1"
@@ -280,7 +278,6 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-38-b"
-          cert-cn          = "cafmtrainweb.planetfm.service.justice.gov.uk"
           description      = "CAFM Web Training"
           pre-migration    = "PDFWW3QCP660001"
           update-ssm-agent = "patchgroup2"

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -222,7 +222,7 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-36-b"
-          cert-cn          = "*.planetfm.service.justice.gov.uk"
+          cert-cn          = "cafmwebx2.planetfm.service.justice.gov.uk"
           description      = "CAFM Asset Management"
           pre-migration    = "PDFWW00036"
           update-ssm-agent = "patchgroup2"
@@ -251,7 +251,7 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-37-a"
-          cert-cn          = "*.planetfm.service.justice.gov.uk"
+          cert-cn          = "cafmwebx2.planetfm.service.justice.gov.uk"
           description      = "CAFM Assessment Management"
           pre-migration    = "PFWW00037"
           update-ssm-agent = "patchgroup1"
@@ -280,7 +280,7 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-38-b"
-          cert-cn          = "*.planetfm.service.justice.gov.uk"
+          cert-cn          = "cafmtrainweb.planetfm.service.justice.gov.uk"
           description      = "CAFM Web Training"
           pre-migration    = "PDFWW3QCP660001"
           update-ssm-agent = "patchgroup2"

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -160,11 +160,10 @@ locals {
           instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.ec2_instances.db.tags, {
-          app-config-status = "pending"
-          ami               = "pd-cafm-db-a"
-          description       = "SQL Server"
-          pre-migration     = "PDFDW0030"
-          update-ssm-agent  = "patchgroup1"
+          ami              = "pd-cafm-db-a"
+          description      = "SQL Server"
+          pre-migration    = "PDFDW0030"
+          update-ssm-agent = "patchgroup1"
         })
       })
 
@@ -193,11 +192,10 @@ locals {
           instance_type           = "r6i.4xlarge"
         })
         tags = merge(local.ec2_instances.db.tags, {
-          app-config-status = "pending"
-          ami               = "pd-cafm-db-b"
-          description       = "SQL resilient Server"
-          pre-migration     = "PDFDW0031"
-          update-ssm-agent  = "patchgroup2"
+          ami              = "pd-cafm-db-b"
+          description      = "SQL resilient Server"
+          pre-migration    = "PDFDW0031"
+          update-ssm-agent = "patchgroup2"
         })
       })
 
@@ -210,6 +208,9 @@ locals {
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pd-cafm-w-36-b"
           availability_zone = "eu-west-2b"
+          instance_profile_policies = concat(local.ec2_instances.web.config.instance_profile_policies, [
+            "Ec2PdWebPolicy",
+          ])
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -221,6 +222,7 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-36-b"
+          cert-cn          = "*.planetfm.service.justice.gov.uk"
           description      = "CAFM Asset Management"
           pre-migration    = "PDFWW00036"
           update-ssm-agent = "patchgroup2"
@@ -235,6 +237,9 @@ locals {
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pd-cafm-w-37-a"
           availability_zone = "eu-west-2a"
+          instance_profile_policies = concat(local.ec2_instances.web.config.instance_profile_policies, [
+            "Ec2PdWebPolicy",
+          ])
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -245,9 +250,10 @@ locals {
           instance_type           = "t3.xlarge"
         })
         tags = {
-          pre-migration    = "PFWW00037"
-          description      = "CAFM Assessment Management"
           ami              = "pd-cafm-w-37-a"
+          cert-cn          = "*.planetfm.service.justice.gov.uk"
+          description      = "CAFM Assessment Management"
+          pre-migration    = "PFWW00037"
           update-ssm-agent = "patchgroup1"
         }
       })
@@ -260,6 +266,9 @@ locals {
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pd-cafm-w-38-b"
           availability_zone = "eu-west-2b"
+          instance_profile_policies = concat(local.ec2_instances.web.config.instance_profile_policies, [
+            "Ec2PdWebPolicy",
+          ])
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
@@ -271,11 +280,38 @@ locals {
         })
         tags = {
           ami              = "pd-cafm-w-38-b"
+          cert-cn          = "*.planetfm.service.justice.gov.uk"
           description      = "CAFM Web Training"
           pre-migration    = "PDFWW3QCP660001"
           update-ssm-agent = "patchgroup2"
         }
       })
+    }
+
+    iam_policies = {
+      Ec2PdWebPolicy = {
+        description = "Permissions required for POSH-ACME Route53 Plugin"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "route53:ListHostedZones",
+            ]
+            resources = ["*"]
+          },
+          {
+            effect = "Allow"
+            actions = [
+              "route53:GetHostedZone",
+              "route53:ListResourceRecordSets",
+              "route53:ChangeResourceRecordSets"
+            ]
+            resources = [
+              "arn:aws:route53:::hostedzone/*",
+            ]
+          },
+        ]
+      }
     }
 
     lbs = {

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -382,6 +382,16 @@ locals {
     }
 
     route53_zones = {
+      "cafmtrainweb.az.justice.gov.uk" = {
+        lb_alias_records = [
+          { name = "", type = "A", lbs_map_key = "private" },
+        ]
+      }
+      "cafmwebx2.az.justice.gov.uk" = {
+        records = [
+          { name = "", type = "A", ttl = 300, records = ["10.40.15.201"] },
+        ]
+      }
       "planetfm.service.justice.gov.uk" = {
         records = [
           { name = "_a6a2b9e651b91ed3f1e906b4f1c3c317", type = "CNAME", ttl = 86400, records = ["_c4257165635a7b495df6c4fbd986c09f.mhbtsbpdnt.acm-validations.aws"] },


### PR DESCRIPTION
Removing the LetsEncrypt permissions from hmpps-domain-services as that was just for a test
Adding them to PlanetFM web servers instead.
Corrected some other tags while at it.