### PR TITLE
DPR2-709: Set maintenance window to Sun at 2am for CDC jobs

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
@@ -21,6 +21,7 @@ module "glue_reporting_hub_cdc_job" {
   worker_type                   = var.glue_cdc_job_worker_type
   number_of_workers             = var.glue_cdc_job_num_workers
   max_concurrent                = var.glue_cdc_max_concurrent
+  maintenance_window            = var.glue_cdc_maintenance_window
   region                        = var.account_region
   account                       = var.account_id
   log_group_retention_in_days   = var.glue_log_group_retention_in_days

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -267,6 +267,11 @@ variable "glue_cdc_max_concurrent" {
   description = "(Optional) The maximum number of concurrent runs allowed for a job."
 }
 
+variable "glue_cdc_maintenance_window" {
+  type        = string
+  description = "The maintenance window during which the glue job will be restarted"
+}
+
 variable "glue_cdc_create_role" {
   type        = bool
   default     = false

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -35,6 +35,7 @@ resource "aws_glue_job" "glue_job" {
   worker_type            = var.worker_type
   number_of_workers      = var.number_of_workers
   execution_class        = var.execution_class
+  maintenance_window     = var.maintenance_window
   tags                   = local.tags
 
   command {

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/variables.tf
@@ -198,6 +198,12 @@ variable "number_of_workers" {
   description = "(Optional) The number of workers of a defined workerType that are allocated when a job runs."
 }
 
+variable "maintenance_window" {
+  type        = string
+  default     = null
+  description = "(Optional) The maintenance window during which the glue job will be restarted"
+}
+
 
 variable "security_configuration" {
   type        = string


### PR DESCRIPTION
This PR makes the maintenance window during which the glue job will be restarted configurable