### PR TITLE
update pagerduty integration for test, preproduction and production env

### DIFF
--- a/terraform/environments/nomis-data-hub/locals.tf
+++ b/terraform/environments/nomis-data-hub/locals.tf
@@ -27,7 +27,7 @@ locals {
         "ec2_instance_textfile_monitoring",
         "ec2_windows",
       ]
-      cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
       enable_azure_sas_token                     = true

--- a/terraform/environments/nomis-data-hub/locals_development.tf
+++ b/terraform/environments/nomis-data-hub/locals_development.tf
@@ -5,11 +5,6 @@ locals {
       # disabling some features in development as the environment gets nuked
       cloudwatch_metric_oam_links_ssm_parameters = []
       cloudwatch_metric_oam_links                = []
-      sns_topics = {
-        pagerduty_integrations = {
-          dso_pagerduty = "nomis_data_hub_nonprod_alarms"
-        }
-      }
     }
   }
 

--- a/terraform/environments/nomis-data-hub/locals_preproduction.tf
+++ b/terraform/environments/nomis-data-hub/locals_preproduction.tf
@@ -4,7 +4,7 @@ locals {
     options = {
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty = "nomis_data_hub_prod_alarms"
+          pagerduty = "nomis-data-hub-preproduction"
         }
       }
     }

--- a/terraform/environments/nomis-data-hub/locals_production.tf
+++ b/terraform/environments/nomis-data-hub/locals_production.tf
@@ -11,7 +11,7 @@ locals {
       ]
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty = "nomis_data_hub_prod_alarms"
+          pagerduty = "nomis-data-hub-production"
         }
       }
     }

--- a/terraform/environments/nomis-data-hub/locals_test.tf
+++ b/terraform/environments/nomis-data-hub/locals_test.tf
@@ -4,7 +4,7 @@ locals {
     options = {
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty = "nomis_data_hub_nonprod_alarms"
+          pagerduty = "nomis-data-hub-test"
         }
       }
     }


### PR DESCRIPTION
- update pagerduty settings for nomis-data-hub environments
- no settings required for development env as nothing is deployed in there