### PR TITLE
Dso/dsos 2903/oasys national reporting alarm changes

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -27,7 +27,6 @@ locals {
         "ec2_instance_linux",
         "ec2_windows",
       ]
-      # cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
       enable_backup_plan_daily_and_weekly        = true

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -27,7 +27,7 @@ locals {
         "ec2_instance_linux",
         "ec2_windows",
       ]
-      # cloudwatch_metric_alarms_default_actions   = ["dso_pagerduty"]
+      # cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
       enable_backup_plan_daily_and_weekly        = true

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -2,11 +2,12 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      #   pagerduty_integrations = {
-      #     dso_pagerduty               = "oasys_alarms"
-      #     dba_pagerduty               = "hmpps_shef_dba_low_priority"
-      #     dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
-      # }
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
+      sns_topics = {
+        pagerduty_integrations = {
+          pagerduty = "oasys-national-reporting-production"
+        }
+      }
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -2,6 +2,12 @@ locals {
 
   baseline_presets_production = {
     options = {
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
+      sns_topics = {
+        pagerduty_integrations = {
+          pagerduty = "oasys-national-reporting-production"
+        }
+      }
     }
   }
 

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,6 +2,12 @@ locals {
 
   baseline_presets_test = {
     options = {
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
+      sns_topics = {
+        pagerduty_integrations = {
+          pagerduty = "oasys-national-reporting-test"
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- no alarms/integration for development
- use pagerduty alarm integration for test/preproduction and production