### PR TITLE
use pagerduty integration and remove defaults from development env

### DIFF
--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -29,7 +29,6 @@ locals {
         "ec2_instance_oracle_db_with_backup",
         "ec2_instance_textfile_monitoring",
       ]
-      cloudwatch_metric_alarms_default_actions    = ["dso_pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters  = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
       db_backup_more_permissions                  = true

--- a/terraform/environments/oasys/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys/locals_cloudwatch_metric_alarms.tf
@@ -12,8 +12,8 @@ locals {
         statistic           = "Maximum"
         threshold           = "85"
         alarm_description   = "Triggers if free inodes falls below the threshold for an hour"
-        alarm_actions       = ["dso_pagerduty"]
-        ok_actions          = ["dso_pagerduty"]
+        alarm_actions       = ["pagerduty"]
+        ok_actions          = ["pagerduty"]
       }
     }
   }
@@ -21,20 +21,20 @@ locals {
   cloudwatch_metric_alarms = {
 
     db = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_or_cwagent_stopped_linux,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dso_pagerduty"].ec2_instance_cwagent_collectd_service_status_os,
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
       local.cloudwatch_metric_alarms_additional.ec2,
       local.environment == "production" ? {} : {
-        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2["cpu-utilization-high"], {
+        cpu-utilization-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2["cpu-utilization-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "95"
           alarm_description   = "Triggers if the average cpu remains at 95% utilization or above for 8 hours to allow for DB refreshes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4326064583"
         })
-        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_cwagent_linux["cpu-iowait-high"], {
+        cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["cpu-iowait-high"], {
           evaluation_periods  = "480"
           datapoints_to_alarm = "480"
           threshold           = "40"
@@ -46,7 +46,7 @@ locals {
     )
 
     db_backup = merge(
-      module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].ec2_instance_cwagent_collectd_oracle_db_backup,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_oracle_db_backup,
     )
 
     bip = merge(

--- a/terraform/environments/oasys/locals_development.tf
+++ b/terraform/environments/oasys/locals_development.tf
@@ -5,14 +5,6 @@ locals {
       # disabling some features in development as the environment gets nuked
       cloudwatch_metric_oam_links_ssm_parameters = []
       cloudwatch_metric_oam_links                = []
-
-      sns_topics = {
-        pagerduty_integrations = {
-          dso_pagerduty               = "oasys_nonprod_alarms"
-          dba_pagerduty               = "hmpps_shef_dba_non_prod"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
-        }
-      }
     }
   }
 

--- a/terraform/environments/oasys/locals_lbs.tf
+++ b/terraform/environments/oasys/locals_lbs.tf
@@ -13,7 +13,7 @@ locals {
 
       listeners = {
         https = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.lb
           port                     = 443
           protocol                 = "HTTPS"
           ssl_policy               = "ELBSecurityPolicy-TLS13-1-2-2021-06"
@@ -41,7 +41,7 @@ locals {
 
       listeners = {
         https = {
-          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["dba_pagerduty"].lb
+          cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.lb
           port                     = 443
           protocol                 = "HTTPS"
           ssl_policy               = "ELBSecurityPolicy-TLS13-1-2-2021-06"

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -2,11 +2,11 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
+
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "oasys_alarms"
-          dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_low_priority"
+          pagerduty = "oasys-preproduction"
         }
       }
     }

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -5,12 +5,12 @@ locals {
   baseline_presets_production = {
     options = {
       cloudwatch_log_groups_retention_in_days = 90
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       db_backup_lifecycle_rule                = "rman_backup_one_month"
+
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "oasys_alarms"
-          dba_pagerduty               = "hmpps_shef_dba_low_priority"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_high_priority"
+          pagerduty               = "oasys-production"
         }
       }
     }

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -2,12 +2,12 @@ locals {
 
   baseline_presets_test = {
     options = {
+
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       enable_observability_platform_monitoring = true
       sns_topics = {
         pagerduty_integrations = {
-          dso_pagerduty               = "oasys_nonprod_alarms"
-          dba_pagerduty               = "hmpps_shef_dba_non_prod"
-          dba_high_priority_pagerduty = "hmpps_shef_dba_non_prod"
+          pagerduty = "oasys-test"
         }
       }
     }


### PR DESCRIPTION
- set up oasys-test, production and preproduction services
- alarms will show services so easier to trace
- remove dba_* sns topics as not used by DBA's anyway
