### PR TITLE
Adding transfer to the exception list

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -61,6 +61,7 @@ resource-types:
     - S3Object
     - SecretsManagerSecret
     - SecurityHub
+    - Transfer
     - WAFv2WebACL
 
 accounts:


### PR DESCRIPTION
As part of Some AWS Nuke workflows fail with error 255
[#7623](https://github.com/ministryofjustice/modernisation-platform/issues/7623)

i have looked at the errors and want to add in an exception for transfer to see if this fixes one of the errors