### PR TITLE
📁 Switch all self-hosted runners over to use cache and spot

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -1,57 +1,3 @@
-/* create-a-derived-table */
-
-data "aws_secretsmanager_secret_version" "actions_runners_create_a_derived_table" {
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-  secret_id = module.actions_runners_create_a_derived_table_secret[0].secret_id
-}
-
-resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-  /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
-  name       = "actions-runner-mojas-create-a-derived-table"
-  repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.319.1"
-  chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
-  values = [
-    templatefile(
-      "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
-      {
-        github_organisation  = "moj-analytical-services"
-        github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
-        github_runner_labels = "analytical-platform"
-        eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
-      }
-    )
-  ]
-}
-
-resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-  /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
-  name       = "actions-runner-mojas-create-a-derived-table-dpr"
-  repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.319.1"
-  chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
-  values = [
-    templatefile(
-      "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
-      {
-        github_organisation  = "moj-analytical-services"
-        github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
-        github_runner_labels = "digital-prison-reporting"
-        eks_role_arn         = "arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role"
-      }
-    )
-  ]
-}
-
 /* Airflow */
 
 data "aws_secretsmanager_secret_version" "actions_runners_airflow" {
@@ -97,7 +43,7 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow-create-a-pipeline"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.319.1"
+  version    = "2.319.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -108,6 +54,60 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
         github_repository    = "airflow-create-a-pipeline"
         github_token         = data.aws_secretsmanager_secret_version.actions_runners_airflow_create_a_pipeline[0].secret_string
         github_runner_labels = "analytical-platform"
+      }
+    )
+  ]
+}
+
+/* create-a-derived-table */
+
+data "aws_secretsmanager_secret_version" "actions_runners_create_a_derived_table" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  secret_id = module.actions_runners_create_a_derived_table_secret[0].secret_id
+}
+
+resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
+  name       = "actions-runner-mojas-create-a-derived-table"
+  repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
+  version    = "2.319.1-1"
+  chart      = "actions-runner"
+  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
+      {
+        github_organisation  = "moj-analytical-services"
+        github_repository    = "create-a-derived-table"
+        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
+        github_runner_labels = "analytical-platform"
+        eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
+      }
+    )
+  ]
+}
+
+resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
+  name       = "actions-runner-mojas-create-a-derived-table-dpr"
+  repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
+  version    = "2.319.1-1"
+  chart      = "actions-runner"
+  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
+      {
+        github_organisation  = "moj-analytical-services"
+        github_repository    = "create-a-derived-table"
+        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
+        github_runner_labels = "digital-prison-reporting"
+        eks_role_arn         = "arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role"
       }
     )
   ]

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
@@ -1,13 +1,4 @@
 ---
-ephemeral:
-  enabled: true
-  karpenter:
-    enabled: true
-    nodePool: "general-on-demand"
-  keda:
-    maxReplicaCount: 10
-    pollingInterval: 15
-
 github:
   organisation: ${github_organisation}
   repository: ${github_repository}

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -1,12 +1,10 @@
 ---
-ephemeral:
-  enabled: true
-  karpenter:
-    enabled: true
-    nodePool: "general-on-demand"
-  keda:
-    maxReplicaCount: 10
-    pollingInterval: 15
+github:
+  organisation: ${github_organisation}
+  repository: ${github_repository}
+  token: ${github_token}
+  runner:
+    labels: ${github_runner_labels}
 
 resources:
   requests:
@@ -15,13 +13,6 @@ resources:
   limits:
     cpu: 4
     memory: "32Gi"
-
-github:
-  organisation: ${github_organisation}
-  repository: ${github_repository}
-  token: ${github_token}
-  runner:
-    labels: ${github_runner_labels}
 
 serviceAccount:
   annotations:


### PR DESCRIPTION
This pull request:

- Switches all self-hosted runners over to 2.319.1-1

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 