### PR TITLE
😞 disable caching on runners

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
@@ -5,3 +5,7 @@ github:
   token: ${github_token}
   runner:
     labels: ${github_runner_labels}
+
+runner:
+  cache:
+    enabled: false

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow/values.yml.tftpl
@@ -6,6 +6,10 @@ github:
   runner:
     labels: ${github_runner_labels}
 
+runner:
+  cache:
+    enabled: false
+
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: ${eks_role_arn}

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -6,6 +6,10 @@ github:
   runner:
     labels: ${github_runner_labels}
 
+runner:
+  cache:
+    enabled: false
+
 resources:
   requests:
     cpu: 2


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4995
- Disables caching of self-hosted runners

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 