### PR TITLE
🎹 Tune Karpenter instance generations 

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: karpenter-configuration
 description: A Helm chart to deploy Karpenter's configuration
 type: application
-version: 1.7.0
+version: 1.8.0

--- a/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-on-demand.yaml
+++ b/terraform/environments/analytical-platform-compute/src/helm/charts/karpenter-configuration/templates/node-pool-general-on-demand.yaml
@@ -35,4 +35,4 @@ spec:
           values: ["c", "m", "r"]
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
-          values: ["2"]
+          values: ["4"]


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5192
- Sets `karpenter.k8s.aws/instance-generation` to greater than 4

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 