### PR TITLE
planetfm: TM-151: change apex DNS test record from CNAME to A

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -186,8 +186,8 @@ locals {
 
     route53_zones = {
       "pp-cafmwebx.az.justice.gov.uk" = {
-        records = [
-          { name = "", type = "CNAME", ttl = 3600, records = ["cafmwebx.pp.planetfm.service.justice.gov.uk"] },
+        lb_alias_records = [
+          { name = "", type = "A", lbs_map_key = "private" },
         ]
       }
       "pp.planetfm.service.justice.gov.uk" = {


### PR DESCRIPTION
Bug fix - you shouldn't have a CNAME as the Apex DNS record. Changing to A record.