### PR TITLE
add nat endpoints to ip_addresses module

### DIFF
--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -3,7 +3,7 @@ locals {
   baseline_presets_preproduction = {
     options = {
 
-      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
+      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "oasys-preproduction"

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -4,13 +4,13 @@ locals {
 
   baseline_presets_production = {
     options = {
-      cloudwatch_log_groups_retention_in_days = 90
-      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
-      db_backup_lifecycle_rule                = "rman_backup_one_month"
+      cloudwatch_log_groups_retention_in_days  = 90
+      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
+      db_backup_lifecycle_rule                 = "rman_backup_one_month"
 
       sns_topics = {
         pagerduty_integrations = {
-          pagerduty               = "oasys-production"
+          pagerduty = "oasys-production"
         }
       }
     }

--- a/terraform/environments/oasys/locals_security_groups.tf
+++ b/terraform/environments/oasys/locals_security_groups.tf
@@ -15,6 +15,7 @@ locals {
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
       module.ip_addresses.external_cidrs.cloud_platform,
       module.ip_addresses.azure_studio_hosting_public.devtest,
+      module.ip_addresses.mp_cidrs.non_live_eu_west_nat,
     ])
     oracle_db = flatten([
       "10.0.0.0/8",
@@ -92,6 +93,7 @@ locals {
       module.ip_addresses.external_cidrs.dtv,
       module.ip_addresses.external_cidrs.nps_wales,
       module.ip_addresses.external_cidrs.dxw,
+      module.ip_addresses.mp_cidrs.live_eu_west_nat,
     ])
     oracle_db = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -3,7 +3,7 @@ locals {
   baseline_presets_test = {
     options = {
 
-      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
+      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       enable_observability_platform_monitoring = true
       sns_topics = {
         pagerduty_integrations = {

--- a/terraform/modules/ip_addresses/modernisation_platform.tf
+++ b/terraform/modules/ip_addresses/modernisation_platform.tf
@@ -9,6 +9,16 @@ locals {
     ad-azure-dc-a  = "10.20.104.5"
     ad-azure-dc-b  = "10.20.106.5"
     ad-azure-rdlic = "10.20.108.6"
+
+    # Nat Endpoints Non-Live
+    non-live-eu-west-2a-nat = "13.43.9.198"
+    non-live-eu-west-2b-nat = "13.42.163.245"
+    non-live-eu-west-2c-nat = "18.132.208.127"
+
+    # Nat Endpoints Live
+    live-eu-west-2a-nat = "13.41.38.176"
+    live-eu-west-2b-nat = "3.8.81.175"
+    live-eu-west-2c-nat = "3.11.197.133"
   }
 
   mp_ips = {
@@ -44,6 +54,15 @@ locals {
       local.mp_cidr["ad-azure-dc-a"],
       local.mp_cidr["ad-azure-dc-b"],
     ]
+    non_live_eu_west_nat = [
+      local.mp_cidr["non-live-eu-west-2a-nat"],
+      local.mp_cidr["non-live-eu-west-2b-nat"],
+      local.mp_cidr["non-live-eu-west-2c-nat"],
+    ]
+    live_eu_west_nat = [
+      local.mp_cidr["live-eu-west-2a-nat"],
+      local.mp_cidr["live-eu-west-2b-nat"],
+      local.mp_cidr["live-eu-west-2c-nat"],
+    ]
   }
-
 }


### PR DESCRIPTION
- need these to allow monitoring from hmpps-oem accounts to things like public endpoints
- this will allow adding the nat gateway endpoints to the "allow" lists for PUBLIC_lb security groups for each application we're wanting to monitor an external endpoint for
- adding these to oasys to test the idea overall