### PR TITLE
planetfm: TM-152: switch preprod to network LB

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -215,7 +215,7 @@ locals {
           { name = "cafmtx", type = "CNAME", ttl = 3600, records = ["rdweb1.preproduction.hmpps-domain.service.justice.gov.uk"] },
         ]
         lb_alias_records = [
-          { name = "cafmwebx", type = "A", lbs_map_key = "private" },
+          { name = "cafmwebx", type = "A", lbs_map_key = "pp-cafmwebx" },
         ]
       }
     }


### PR DESCRIPTION
Swap cafmwebx preprod URL from Application LB to Network LB.
Tested manually on JumpServer by hacking around with /etc/hosts. Stakeholders aware.