### PR TITLE
planetfm: TM-152: switch to network lb prod

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -405,7 +405,7 @@ locals {
         ]
         lb_alias_records = [
           { name = "cafmtrainweb", type = "A", lbs_map_key = "cafmtrainweb" },
-          { name = "cafmwebx2", type = "A", lbs_map_key = "private" },
+          { name = "cafmwebx2", type = "A", lbs_map_key = "cafmwebx2" },
         ]
       }
     }


### PR DESCRIPTION
Switch prod DNS entry from ALB to NLB. Glenn confirmed this URL is not in use by many people so minimal impact.