### PR TITLE
planetfm: TM-152: remove alb

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -21,6 +21,7 @@ locals {
   baseline_presets_all_environments = {
     options = {
       cloudwatch_dashboard_default_widget_groups = [
+        "custom",
         "network_lb",
         "lb",
         "ec2",
@@ -31,7 +32,7 @@ locals {
         "ec2_instance_textfile_monitoring",
         "ec2_windows",
       ]
-      # cloudwatch_metric_alarms_default_actions = ["pagerduty"] # disabled to prevent duplication on cross-account alarms
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       enable_backup_plan_daily_and_weekly         = true
       enable_business_unit_kms_cmks               = true
       enable_ec2_cloud_watch_agent                = true
@@ -161,7 +162,7 @@ locals {
         periodOverride = "auto"
         start          = "-PT6H"
         widget_groups = [
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_windows,
         ]

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -21,7 +21,7 @@ locals {
   baseline_presets_all_environments = {
     options = {
       cloudwatch_dashboard_default_widget_groups = [
-        "lb",
+        "network_lb",
         "ec2",
         "ec2_windows",
       ]

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -162,45 +162,6 @@ locals {
           })
         }
       })
-      private = merge(local.lbs.private, {
-        instance_target_groups = {
-          web-45-80 = merge(local.lbs.private.instance_target_groups.web-80, {
-            attachments = [
-              { ec2_instance_name = "pp-cafm-w-4-b" },
-              { ec2_instance_name = "pp-cafm-w-5-a" },
-            ]
-          })
-        }
-        listeners = merge(local.lbs.private.listeners, {
-          https = merge(local.lbs.private.listeners.https, {
-            default_action = {
-              type = "redirect"
-              redirect = {
-                host        = "cafmwebx.pp.planetfm.service.justice.gov.uk"
-                port        = "443"
-                protocol    = "HTTPS"
-                status_code = "HTTP_302"
-              }
-            }
-            rules = {
-              web-45-80 = {
-                priority = 4580
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "web-45-80"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "cafmwebx.pp.planetfm.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-            }
-          })
-        })
-      })
     }
 
     route53_zones = {

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -308,80 +308,13 @@ locals {
 
         listeners = {
           https = merge(local.lbs.web.listeners.https, {
+            alarm_target_group_names = ["cafmwebx2-https"]
             default_action = {
               type              = "forward"
               target_group_name = "cafmwebx2-https"
             }
           })
         }
-      })
-
-      private = merge(local.lbs.private, {
-        access_logs_lifecycle_rule = [module.baseline_presets.s3_lifecycle_rules.general_purpose_one_year]
-
-        instance_target_groups = {
-          web-3637-80 = merge(local.lbs.private.instance_target_groups.web-80, {
-            attachments = [
-              { ec2_instance_name = "pd-cafm-w-36-b" },
-              { ec2_instance_name = "pd-cafm-w-37-a" },
-            ]
-          })
-          web-38-80 = merge(local.lbs.private.instance_target_groups.web-80, {
-            attachments = [
-              { ec2_instance_name = "pd-cafm-w-38-b" },
-            ]
-          })
-        }
-
-        listeners = merge(local.lbs.private.listeners, {
-          https = merge(local.lbs.private.listeners.https, {
-            alarm_target_group_names = [
-              "web-3637-80",
-            ]
-
-            default_action = {
-              type = "redirect"
-              redirect = {
-                host        = "cafmwebx2.planetfm.service.justice.gov.uk"
-                port        = "443"
-                protocol    = "HTTPS"
-                status_code = "HTTP_302"
-              }
-            }
-
-            rules = {
-              web-3637-80 = {
-                priority = 3637
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "web-3637-80"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "cafmwebx2.planetfm.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-              web-38-80 = {
-                priority = 3880
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "web-38-80"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "cafmtrainweb.planetfm.service.justice.gov.uk",
-                      "cafmtrainweb.az.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-            }
-          })
-        })
       })
     }
 


### PR DESCRIPTION
Final tidy up for planetfm NLB migration:
- add network lb widgets to dashboard
- remove ALBs
- add alarms to network lb
Also fixed couple of things in OEM while at it:
- custom widgets in default dashboard
- enable pagerduty integration