### PR TITLE
fix pagerduty alarm locals

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -27,6 +27,7 @@ locals {
         "ec2_instance_linux",
         "ec2_instance_oracle_db_with_backup",
       ]
+      cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters  = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]
       db_backup_bucket_name                       = "csr-db-backup-bucket"

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -2,7 +2,6 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "corporate-staff-rostering-preproduction"

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -2,8 +2,7 @@ locals {
 
   baseline_presets_production = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
-      db_backup_lifecycle_rule                 = "rman_backup_one_month"
+      db_backup_lifecycle_rule = "rman_backup_one_month"
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "corporate-staff-rostering-production"

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -27,6 +27,7 @@ locals {
         "ec2_instance_linux",
         "ec2_windows",
       ]
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
       enable_backup_plan_daily_and_weekly        = true

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -2,10 +2,9 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
-          pagerduty = "oasys-national-reporting-production"
+          pagerduty = "oasys-national-reporting-preproduction"
         }
       }
     }

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -2,7 +2,6 @@ locals {
 
   baseline_presets_production = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "oasys-national-reporting-production"

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -2,7 +2,6 @@ locals {
 
   baseline_presets_test = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "oasys-national-reporting-test"

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -25,7 +25,7 @@ locals {
         "ec2",
         "ec2_windows",
       ]
-      cloudwatch_metric_alarms_default_actions   = ["planetfm_pagerduty"]
+      cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]
       enable_backup_plan_daily_and_weekly        = true

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -2,7 +2,6 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "planetfm-preproduction"

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -2,7 +2,6 @@ locals {
 
   baseline_presets_production = {
     options = {
-      cloudwatch_metric_alarms_default_actions = ["pagerduty"]
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "planetfm-production"
@@ -33,7 +32,7 @@ locals {
     }
 
     ec2_instances = {
-      # app servers 
+      # app servers
       pd-cafm-a-10-b = merge(local.ec2_instances.app, {
         cloudwatch_metric_alarms = merge(
           local.ec2_instances.app.cloudwatch_metric_alarms,


### PR DESCRIPTION
- fix planetfm preproduction ref for pagerduty alarms
- move reference to cloudwatch_metric_alarms_default_actions = ["pagerduty"] into locals.tf in csr and other envs