### PR TITLE
Remove input variables that are not needed any longer

### DIFF
--- a/terraform/environments/xhibit-portal/bastion_linux.tf
+++ b/terraform/environments/xhibit-portal/bastion_linux.tf
@@ -13,9 +13,7 @@ module "bastion_linux" {
   }
 
   # s3 - used for logs and user ssh public keys
-  bucket_name          = "bastion"
-  bucket_versioning    = true
-  bucket_force_destroy = true
+  bucket_name = "bastion"
   # public keys
   public_key_data = local.public_key_data.keys[local.environment]
   # logs


### PR DESCRIPTION
The Bastion Linux Terraform module v4.2.1 does not require multiple S3 input values any longer but `bucket_name`.