### PR TITLE
Address `equip` SCA failures

### DIFF
--- a/terraform/environments/equip/platform_versions.tf
+++ b/terraform/environments/equip/platform_versions.tf
@@ -8,6 +8,14 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/equip/platform_versions.tf
+++ b/terraform/environments/equip/platform_versions.tf
@@ -8,14 +8,6 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
-    random = {
-      source = "hashicorp/random"
-      version = "~> 3.6"
-    }
-    tls = {
-      source = "hashicorp/tls"
-      version = "~> 4.0"
-    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/equip/s3-awslogs.tf
+++ b/terraform/environments/equip/s3-awslogs.tf
@@ -7,6 +7,7 @@ resource "random_string" "bucket_suffix" {
 }
 
 #tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-block-public-acls  tfsec:ignore:aws-s3-block-public-policy  tfsec:ignore:aws-s3-ignore-public-acls  tfsec:ignore:aws-s3-no-public-buckets  tfsec:ignore:aws-s3-specify-public-access-block
+#trivy:ignore:avd-aws-0087 trivy:ignore:avd-aws-0089 trivy:ignore:avd-aws-0090 trivy:ignore:avd-aws-0091 trivy:ignore:avd-aws-0093
 resource "aws_s3_bucket" "this" {
   bucket_prefix = "moj-alb-citrix-access-logs-bucket"
 
@@ -14,6 +15,14 @@ resource "aws_s3_bucket" "this" {
     Environment = "Development"
     Name        = "S3 Access Logs for ALB"
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket-config" {

--- a/terraform/environments/equip/securitygroup.tf
+++ b/terraform/environments/equip/securitygroup.tf
@@ -561,13 +561,13 @@ resource "aws_security_group_rule" "egress_equip_to_spotfire_traffic" {
   source_security_group_id = aws_security_group.aws_spotfire_security_group.id
 }
 
+#trivy:ignore:avd-aws-0104
 resource "aws_security_group_rule" "aws_equip_security_group_egress_1" {
   type        = "egress"
   protocol    = "-1"
   description = "Open all outbound ports"
   from_port   = 0
   to_port     = 0
-  #tfsec:ignore:AWS009
   cidr_blocks = [
     "0.0.0.0/0",
   ]
@@ -674,13 +674,13 @@ resource "aws_security_group_rule" "egress_spotfire_to_equip_traffic" {
   source_security_group_id = aws_security_group.aws_equip_security_group.id
 }
 
+#trivy:ignore:avd-aws-0104
 resource "aws_security_group_rule" "aws_spotfire_security_group_egress_1" {
   type        = "egress"
   protocol    = "-1"
   description = "Open all outbound ports"
   from_port   = 0
   to_port     = 0
-  #tfsec:ignore:AWS009
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.aws_spotfire_security_group.id
 }
@@ -730,13 +730,13 @@ resource "aws_security_group_rule" "egress_proxy_host_to_citrix-adc-mgmt" {
   source_security_group_id = aws_security_group.citrix_adc_mgmt.id
 }
 
+#trivy:ignore:avd-aws-0104
 resource "aws_security_group_rule" "aws_proxy_security_group_egress_1" {
   type        = "egress"
   protocol    = "-1"
   description = "Open all outbound ports"
   from_port   = 0
   to_port     = 0
-  #tfsec:ignore:AWS009
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.aws_proxy_security_group.id
 }
@@ -831,13 +831,13 @@ resource "aws_security_group_rule" "egress_domain_controller_to_proxies" {
   source_security_group_id = aws_security_group.aws_proxy_security_group.id
 }
 
+#trivy:ignore:avd-aws-0104
 resource "aws_security_group_rule" "aws_domain_security_group_egress_1" {
   type        = "egress"
   protocol    = "-1"
   description = "Open all outbound ports"
   from_port   = 0
   to_port     = 0
-  #tfsec:ignore:AWS009
   cidr_blocks       = ["0.0.0.0/0", ]
   security_group_id = aws_security_group.aws_domain_security_group.id
 }


### PR DESCRIPTION
Addressed some SCA failures that the switch to Trivy has identified.