### PR TITLE
Prevent `eipalloc` ARNs from being applied through `aws_wafv2_web_acl_association` resource

### DIFF
--- a/terraform/environments/equip/shield.tf
+++ b/terraform/environments/equip/shield.tf
@@ -5,7 +5,6 @@ module "shield" {
     aws.modernisation-platform = aws.modernisation-platform
   }
   application_name = local.application_name
-  excluded_protections = ["aae73c82-0ce9-442a-89e4-13cab23f26e0"]
   resources = {
     citrix_alb = {
       action = "count"

--- a/terraform/modules/shield_advanced/shield.tf
+++ b/terraform/modules/shield_advanced/shield.tf
@@ -23,7 +23,8 @@ locals {
 
   shield_protections = {
     for k, v in local.shield_protections_json : k => jsondecode(v)
-    if !(contains(var.excluded_protections, k))
+    if !(contains(var.excluded_protections, k)) &&
+       !can(regex("eipalloc", jsondecode(v)["ResourceArn"]))
   }
 }
 
@@ -88,4 +89,8 @@ resource "aws_wafv2_web_acl" "main" {
       }
     }
   }
+}
+
+output "shield_protections_json" {
+  value = local.shield_protections_json
 }

--- a/terraform/modules/shield_advanced/shield.tf
+++ b/terraform/modules/shield_advanced/shield.tf
@@ -90,7 +90,3 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 }
-
-output "shield_protections_json" {
-  value = local.shield_protections_json
-}


### PR DESCRIPTION
From the [terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association):

> [resource_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association#resource_arn) - (Required) The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer, an Amazon API Gateway stage (REST only, HTTP is unsupported), an Amazon Cognito User Pool, an Amazon AppSync GraphQL API, an Amazon App Runner service, or an Amazon Verified Access instance.

We associate the following resources with AWS Shield Advanced through the [organisation-security account code](https://github.com/ministryofjustice/aws-root-account/blob/main/organisation-security/terraform/firewall-manager.tf): 

>   "AWS::EC2::EIP",
    "AWS::ElasticLoadBalancing::LoadBalancer",
    "AWS::ElasticLoadBalancingV2::LoadBalancer",

Therefore, this PR adds a simple regex to exclude any resource ARNs with `eipalloc` to prevent ineligible resources from be associated with a wafv2 web acl.
