### PR TITLE
Implement `cdpt-ifs-production` AWS Shield Advanced through code

### DIFF
--- a/terraform/environments/cdpt-ifs/shield.tf
+++ b/terraform/environments/cdpt-ifs/shield.tf
@@ -1,0 +1,28 @@
+module "shield" {
+  source   = "../../modules/shield_advanced"
+  for_each = local.is-production ? { "build" = true } : {}
+  providers = {
+    aws.modernisation-platform = aws.modernisation-platform
+  }
+  application_name = local.application_name
+  resources = {
+    format("%s-alb", local.application_name) = {
+      action = "count"
+      arn    = module.lb_access_logs_enabled.load_balancer_arn
+    }
+  }
+  waf_acl_rules = {
+    example = {
+      "action"    = "count",
+      "name"      = "ddos-protection",
+      "priority"  = 0,
+      "threshold" = "250"
+    }
+  }
+}
+
+import {
+  for_each = local.is-production ? { "build" = true } : {}
+  id = "1302dec0-8c83-45ba-a371-0b1599aac5ed/FMManagedWebACLV2-shield_advanced_auto_remediate-1701773787672/REGIONAL"
+  to = module.shield["build"].aws_wafv2_web_acl.main
+}


### PR DESCRIPTION
Tracked via [#7185](https://github.com/ministryofjustice/modernisation-platform/issues/7185).

This PR does the following:

* removes the standalone DDOS monitoring that was implemented through the previous clickops approach to AWS Shield Advanced.
* implements AWS Shield Advanced through code, removing reliance on clickops and allowing better visibility as to the current configuration.
