### PR TITLE
Manage `dacp-production` shield response team access through code

### DIFF
--- a/terraform/environments/dacp/shield.tf
+++ b/terraform/environments/dacp/shield.tf
@@ -1,0 +1,7 @@
+data "aws_iam_role" "srt_access" {
+  name = "AWSSRTSupport"
+}
+
+resource "aws_shield_drt_access_role_arn_association" "srt_access" {
+  role_arn = data.aws_iam_role.srt_access.arn
+}


### PR DESCRIPTION
Tracked via [#7185](https://github.com/ministryofjustice/modernisation-platform/issues/7185).

This PR does the following:

* Manages Shield Response Team access through code

From a code review, other steps such as associating resources with a WAFv2 ACL and alerting are already in place.
