### PR TITLE
Manage `tipstaff-production` shield response team access through code

### DIFF
--- a/terraform/environments/tipstaff/platform_versions.tf
+++ b/terraform/environments/tipstaff/platform_versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.2"
     }
+    github = {
+      source = "integrations/github"
+      version = "6.2.2"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/tipstaff/shield.tf
+++ b/terraform/environments/tipstaff/shield.tf
@@ -1,0 +1,7 @@
+data "aws_iam_role" "srt_access" {
+  name = "AWSSRTSupport"
+}
+
+resource "aws_shield_drt_access_role_arn_association" "srt_access" {
+  role_arn = data.aws_iam_role.srt_access.arn
+}


### PR DESCRIPTION
Tracked via [#7185](https://github.com/ministryofjustice/modernisation-platform/issues/7185).

This PR does the following:

* Manages Shield Response Team access through code
* Sets the GitHub provider to prevent implicit use of the latest version (due to [this bug](https://github.com/integrations/terraform-provider-github/issues/2357)).

From a code review, other steps such as associating resources with a WAFv2 ACL and alerting are already in place.
