### PR TITLE
Refactor dns/route53 records so only 1 certificate gets created

### DIFF
--- a/terraform/environments/wardship/dns_ssl.tf
+++ b/terraform/environments/wardship/dns_ssl.tf
@@ -55,10 +55,23 @@ resource "aws_route53_record" "external_validation_subdomain" {
 
 // Route53 DNS record for directing traffic to the service
 // Provider, zone and name dependent on production or non-production environment
+resource "aws_route53_record" "external-prod" {
+  provider = aws.core-network-services
+  zone_id = data.aws_route53_zone.application_zone.zone_id
+  name    = "wardship-agreements-register.service.justice.gov.uk"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.wardship_lb.dns_name
+    zone_id                = aws_lb.wardship_lb.zone_id
+    evaluate_target_health = true
+  }
+}
+
 resource "aws_route53_record" "external" {
-  provider = local.is-production ? aws.core-network-services : aws.core-vpc
-  zone_id = local.is-production ? data.aws_route53_zone.application_zone.zone_id : data.aws_route53_zone.external.zone_id
-  name    = local.is-production ? "wardship-agreements-register.service.justice.gov.uk" : "${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"
+  provider = aws.core-vpc
+  zone_id = data.aws_route53_zone.external.zone_id
+  name    = "${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"
   type    = "A"
 
   alias {

--- a/terraform/environments/wardship/dns_ssl.tf
+++ b/terraform/environments/wardship/dns_ssl.tf
@@ -1,11 +1,9 @@
-// DEV + PRE-PRODUCTION DNS CONFIGURATION
-
 // ACM Public Certificate
 resource "aws_acm_certificate" "external" {
-  domain_name       = "modernisation-platform.service.justice.gov.uk"
+  domain_name       = local.is-production ? "wardship-agreements-register.service.justice.gov.uk" : "modernisation-platform.service.justice.gov.uk"
   validation_method = "DNS"
 
-  subject_alternative_names = ["${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+  subject_alternative_names = local.is-production ? null : ["${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
   tags = {
     Environment = local.environment
   }
@@ -15,24 +13,36 @@ resource "aws_acm_certificate" "external" {
   }
 }
 
+// Validate Cert based on external route53 fqdn
 resource "aws_acm_certificate_validation" "external" {
   certificate_arn         = aws_acm_certificate.external.arn
-  validation_record_fqdns = [local.domain_name_main[0], local.domain_name_sub[0]]
+  validation_record_fqdns  = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
 
-// Route53 DNS records for certificate validation
-resource "aws_route53_record" "external_validation" {
+// Non production zone for validation is network-services (production is application zone)
+resource "aws_route53_record" "cert_validation" {
+
   provider = aws.core-network-services
 
+  for_each = {
+    for dvo in aws_acm_certificate.external.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      value  = dvo.resource_record_value
+    }
+  }
   allow_overwrite = true
-  name            = local.domain_name_main[0]
-  records         = local.domain_record_main
-  ttl             = 60
-  type            = local.domain_type_main[0]
-  zone_id         = data.aws_route53_zone.network-services.zone_id
+  name    = each.value.name
+  records = [each.value.value]
+  ttl     = 300
+  type    = each.value.type
+  zone_id = local.is-production ? data.aws_route53_zone.application_zone.zone_id : data.aws_route53_zone.network-services.zone_id
 }
 
+// sub-domain validation only required for non-production sites
 resource "aws_route53_record" "external_validation_subdomain" {
+
+  count = local.is-production ? 0 : 1
   provider = aws.core-vpc
 
   allow_overwrite = true
@@ -44,63 +54,11 @@ resource "aws_route53_record" "external_validation_subdomain" {
 }
 
 // Route53 DNS record for directing traffic to the service
+// Provider, zone and name dependent on production or non-production environment
 resource "aws_route53_record" "external" {
-  provider = aws.core-vpc
-
-  zone_id = data.aws_route53_zone.external.zone_id
-  name    = "${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.wardship_lb.dns_name
-    zone_id                = aws_lb.wardship_lb.zone_id
-    evaluate_target_health = true
-  }
-}
-
-// PRODUCTION DNS CONFIGURATION
-
-// ACM Public Certificate
-resource "aws_acm_certificate" "external_prod" {
-  count = local.is-production ? 1 : 0
-
-  domain_name       = "wardship-agreements-register.service.justice.gov.uk"
-  validation_method = "DNS"
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_acm_certificate_validation" "external_prod" {
-  count = local.is-production ? 1 : 0
-
-  certificate_arn         = aws_acm_certificate.external_prod[0].arn
-  validation_record_fqdns = [aws_route53_record.external_validation_prod[0].fqdn]
-  timeouts {
-    create = "10m"
-  }
-}
-
-// Route53 DNS record for certificate validation
-resource "aws_route53_record" "external_validation_prod" {
-  count    = local.is-production ? 1 : 0
-  provider = aws.core-network-services
-
-  allow_overwrite = true
-  name            = tolist(aws_acm_certificate.external_prod[0].domain_validation_options)[0].resource_record_name
-  records         = [tolist(aws_acm_certificate.external_prod[0].domain_validation_options)[0].resource_record_value]
-  type            = tolist(aws_acm_certificate.external_prod[0].domain_validation_options)[0].resource_record_type
-  zone_id         = data.aws_route53_zone.application_zone.zone_id
-  ttl             = 60
-}
-
-// Route53 DNS record for directing traffic to the service
-resource "aws_route53_record" "external_prod" {
-  count    = local.is-production ? 1 : 0
-  provider = aws.core-network-services
-
-  zone_id = data.aws_route53_zone.application_zone.zone_id
-  name    = "wardship-agreements-register.service.justice.gov.uk"
+  provider = local.is-production ? aws.core-network-services : aws.core-vpc
+  zone_id = local.is-production ? data.aws_route53_zone.application_zone.zone_id : data.aws_route53_zone.external.zone_id
+  name    = local.is-production ? "wardship-agreements-register.service.justice.gov.uk" : "${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"
   type    = "A"
 
   alias {

--- a/terraform/environments/wardship/dns_ssl.tf
+++ b/terraform/environments/wardship/dns_ssl.tf
@@ -56,6 +56,7 @@ resource "aws_route53_record" "external_validation_subdomain" {
 // Route53 DNS record for directing traffic to the service
 // Provider, zone and name dependent on production or non-production environment
 resource "aws_route53_record" "external-prod" {
+  count = local.is-production ? 1 : 0
   provider = aws.core-network-services
   zone_id = data.aws_route53_zone.application_zone.zone_id
   name    = "wardship-agreements-register.service.justice.gov.uk"
@@ -69,6 +70,7 @@ resource "aws_route53_record" "external-prod" {
 }
 
 resource "aws_route53_record" "external" {
+  count = local.is-production ? 0 : 1
   provider = aws.core-vpc
   zone_id = data.aws_route53_zone.external.zone_id
   name    = "${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"

--- a/terraform/environments/wardship/load_balancer.tf
+++ b/terraform/environments/wardship/load_balancer.tf
@@ -269,7 +269,7 @@ resource "aws_lb_listener" "wardship_lb" {
   depends_on = [
     aws_acm_certificate.external
   ]
-  certificate_arn   = local.is-production ? aws_acm_certificate.external_prod[0].arn : aws_acm_certificate.external.arn
+  certificate_arn   = aws_acm_certificate.external.arn
   load_balancer_arn = aws_lb.wardship_lb.arn
   port              = local.application_data.accounts[local.environment].server_port_2
   protocol          = local.application_data.accounts[local.environment].lb_listener_protocol_2


### PR DESCRIPTION
Add conditional resources to dns_ssl.tf to create different certificate/dns entries based on whether it is production or non-production. Previously, 2 certs were created in production