### PR TITLE
DPR2-1170: Disable alerts for stopped glue jobs

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/pipeline.tf
@@ -30,6 +30,7 @@ module "cdc_stop_pipeline" {
             "JobName" : var.glue_unprocessed_raw_files_check_job,
             "Arguments" : {
               "--dpr.orchestration.wait.interval.seconds" : "60"
+              "--dpr.orchestration.max.attempts" : "120"
             }
           },
           "Next" : "Stop Glue Streaming Job"

--- a/terraform/environments/digital-prison-reporting/notifications.tf
+++ b/terraform/environments/digital-prison-reporting/notifications.tf
@@ -63,7 +63,7 @@ module "glue_status_change_rule" {
   "source": ["aws.glue"],
   "detail-type": ["Glue Job State Change"],
   "detail": {
-    "state": ["STOPPED", "FAILED", "TIMEOUT"]
+    "state": ["FAILED", "TIMEOUT"]
   }
 }
 PATTERN


### PR DESCRIPTION
This PR
- Disables alerts for stopped glue jobs. This will prevent noise when the CDC pipelines are stopped
- Set the maximum period for which the CDC stop pipeline should wait to ensure all pending files are processed to 120 minutes