### PR TITLE
Bump AP UI to 0.2.4

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-applications.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-applications.tf
@@ -2,7 +2,7 @@ resource "helm_release" "ui" {
   /* https://github.com/ministryofjustice/analytical-platform-ui */
   name       = "ui"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.2.3"
+  version    = "0.2.4"
   chart      = "analytical-platform-ui"
   namespace  = kubernetes_namespace.ui.metadata[0].name
   values = [


### PR DESCRIPTION
Fixes bug that prevents users from assigning permissions to tables with duplicated names across different databases