### PR TITLE
change web-36-b alarm params

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -202,7 +202,19 @@ locals {
       pd-cafm-w-36-b = merge(local.ec2_instances.web, {
         cloudwatch_metric_alarms = merge(
           local.ec2_instances.web.cloudwatch_metric_alarms,
-          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows, {
+            "cpu-utilization-high" = {
+              alarm_description   = "CPU Utilization is above 75% or above for 15 minutes"
+              comparison_operator = "GreaterThanOrEqualToThreshold"
+              evaluation_periods  = "15"
+              datapoints_to_alarm = "15"
+              metric_name         = "CPUUtilization"
+              namespace           = "AWS/EC2"
+              period              = "60"
+              statistic           = "Maximum"
+              threshold           = "75"
+            }
+          }
         )
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pd-cafm-w-36-b"

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -239,7 +239,19 @@ locals {
       pd-cafm-w-37-a = merge(local.ec2_instances.web, {
         cloudwatch_metric_alarms = merge(
           local.ec2_instances.web.cloudwatch_metric_alarms,
-          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows, {
+            "cpu-utilization-high" = {
+              alarm_description   = "CPU Utilization is above 75% or above for 15 minutes"
+              comparison_operator = "GreaterThanOrEqualToThreshold"
+              evaluation_periods  = "15"
+              datapoints_to_alarm = "15"
+              metric_name         = "CPUUtilization"
+              namespace           = "AWS/EC2"
+              period              = "60"
+              statistic           = "Maximum"
+              threshold           = "75"
+            }
+          }
         )
         config = merge(local.ec2_instances.web.config, {
           ami_name          = "pd-cafm-w-37-a"


### PR DESCRIPTION
- change params on web-37-a and web-36-b instances to fire if CPU max sits about 75%
- should give us a better chance to see what's going on before it collapses