### PR TITLE
DPR2-1127: Update job so that current counts reconciliation works with DPS Activities and Nomis

### DIFF
--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -42,17 +42,20 @@ data "aws_secretsmanager_secret_version" "datamart" {
   depends_on = [aws_secretsmanager_secret.redshift]
 }
 
-# Source DPS Activities Secrets
-data "aws_secretsmanager_secret" "dps_activities" {
-  name = "external/dpr-dps-activities-source-secrets"
+# Source DPS Secrets
+data "aws_secretsmanager_secret" "dps" {
+  for_each = toset(local.dps_domains_list)
+  name     = "external/${local.project}-${each.value}-source-secrets"
 
-  depends_on = [aws_secretsmanager_secret_version.dps]
+  depends_on = [aws_secretsmanager_secret_version.dps[each.value]]
 }
 
-data "aws_secretsmanager_secret_version" "dps_activities" {
-  secret_id = data.aws_secretsmanager_secret.dps_activities.id
+data "aws_secretsmanager_secret_version" "dps" {
+  for_each = toset(local.dps_domains_list)
 
-  depends_on = [aws_secretsmanager_secret.dps]
+  secret_id = data.aws_secretsmanager_secret.dps[each.value].id
+
+  depends_on = [aws_secretsmanager_secret.dps[each.value]]
 }
 
 # AWS _IAM_ Policy

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -42,6 +42,19 @@ data "aws_secretsmanager_secret_version" "datamart" {
   depends_on = [aws_secretsmanager_secret.redshift]
 }
 
+# Source DPS Activities Secrets
+data "aws_secretsmanager_secret" "dps_activities" {
+  name = "external/dpr-dps-activities-source-secrets"
+
+  depends_on = [aws_secretsmanager_secret_version.dps]
+}
+
+data "aws_secretsmanager_secret_version" "dps_activities" {
+  secret_id = data.aws_secretsmanager_secret.dps_activities.id
+
+  depends_on = [aws_secretsmanager_secret.dps]
+}
+
 # AWS _IAM_ Policy
 data "aws_iam_policy" "rds_full_access" {
   #checkov:skip=CKV_AWS_275:Disallow policies from using the AWS AdministratorAccess policy

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -47,7 +47,7 @@ data "aws_secretsmanager_secret" "dps" {
   for_each = toset(local.dps_domains_list)
   name     = "external/${local.project}-${each.value}-source-secrets"
 
-  depends_on = [aws_secretsmanager_secret_version.dps[each.value]]
+  depends_on = [aws_secretsmanager_secret_version.dps]
 }
 
 data "aws_secretsmanager_secret_version" "dps" {
@@ -55,7 +55,7 @@ data "aws_secretsmanager_secret_version" "dps" {
 
   secret_id = data.aws_secretsmanager_secret.dps[each.value].id
 
-  depends_on = [aws_secretsmanager_secret.dps[each.value]]
+  depends_on = [aws_secretsmanager_secret.dps]
 }
 
 # AWS _IAM_ Policy

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,10 +1,22 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dps_activities_endpoint               = jsondecode(data.aws_secretsmanager_secret_version.dps_activities.secret_string)["endpoint"]
-  dps_activities_port                   = jsondecode(data.aws_secretsmanager_secret_version.dps_activities.secret_string)["port"]
-  dps_activities_database               = jsondecode(data.aws_secretsmanager_secret_version.dps_activities.secret_string)["db_name"]
-  dps_activities_connection_string      = "jdbc:postgresql://${local.dps_activities_endpoint}:${local.dps_activities_port}/${local.dps_activities_database}"
+  dps_activities_endpoint               = [
+    for item in toset(local.dps_domains_list) :
+    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
+  ]
+  dps_activities_port                   = [
+    for item in toset(local.dps_domains_list) :
+    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
+  ]
+  dps_activities_database               = [
+    for item in toset(local.dps_domains_list) :
+    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
+  ]
+  dps_connection_strings                = [
+    for item in toset(local.dps_domains_list) :
+    "jdbc:postgresql://${local.dps_activities_endpoint[item]}:${local.dps_activities_port[item]}/${local.dps_activities_database[item]}"
+  ]
 }
 
 # Operational DataStore
@@ -46,15 +58,15 @@ resource "aws_glue_connection" "glue_nomis_connection" {
 }
 
 # DPS Activities
-resource "aws_glue_connection" "glue_dps_activities_connection" {
-  count           = local.create_glue_connection ? 1 : 0
-  name            = "${local.project}-dps-activities-connection"
+resource "aws_glue_connection" "glue_dps_connection" {
+  for_each        = local.create_glue_connection ? toset(local.dps_domains_list) : []
+  name            = "${local.project}-${each.value}-connection"
   connection_type = "JDBC"
 
   connection_properties = {
-    JDBC_CONNECTION_URL    = local.dps_activities_connection_string
+    JDBC_CONNECTION_URL    = local.dps_connection_strings[item]
     JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
-    SECRET_ID              = data.aws_secretsmanager_secret.dps_activities.name
+    SECRET_ID              = aws_secretsmanager_secret.dps[each.value].name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -48,7 +48,7 @@ resource "aws_glue_connection" "glue_nomis_connection" {
 # DPS Activities
 resource "aws_glue_connection" "glue_dps_activities_connection" {
   count           = local.create_glue_connection ? 1 : 0
-  name            = "${local.project}-dps-actvities-connection"
+  name            = "${local.project}-dps-activities-connection"
   connection_type = "JDBC"
 
   connection_properties = {

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,19 +1,19 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dps_endpoint                          = toset([
+  dps_endpoint                          = tomap([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
   ])
-  dps_port = toset([
+  dps_port = tomap([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
   ])
-  dps_database = toset([
+  dps_database = tomap([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
   ])
-  dps_connection_string = toset([
+  dps_connection_string = tomap([
     for item in toset(local.dps_domains_list) :
     "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   ])

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,22 +1,22 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dps_endpoint                          = [
+  dps_endpoint                          = toset([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
-  ]
-  dps_port = [
+  ])
+  dps_port = toset([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
-  ]
-  dps_database = [
+  ])
+  dps_database = toset([
     for item in toset(local.dps_domains_list) :
     jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
-  ]
-  dps_connection_string = [
+  ])
+  dps_connection_string = toset([
     for item in toset(local.dps_domains_list) :
     "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
-  ]
+  ])
 }
 
 # Operational DataStore

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,22 +1,22 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dps_endpoint                          = tomap([
+  dps_endpoint                          = {
     for item in toset(local.dps_domains_list) :
-    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
-  ])
-  dps_port = tomap([
+    item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
+  }
+  dps_port = {
     for item in toset(local.dps_domains_list) :
-    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
-  ])
-  dps_database = tomap([
+    item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
+  }
+  dps_database = {
     for item in toset(local.dps_domains_list) :
-    jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
-  ])
-  dps_connection_string = tomap([
+    item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
+  }
+  dps_connection_string = {
     for item in toset(local.dps_domains_list) :
-    "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
-  ])
+    item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
+  }
 }
 
 # Operational DataStore

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,20 +1,21 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dps_endpoint                          = {
-    for item in toset(local.dps_domains_list) :
+
+  dps_endpoint = {
+    for item in local.dps_domains_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["endpoint"]
   }
   dps_port = {
-    for item in toset(local.dps_domains_list) :
+    for item in local.dps_domains_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["port"]
   }
   dps_database = {
-    for item in toset(local.dps_domains_list) :
+    for item in local.dps_domains_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.dps[item].secret_string)["db_name"]
   }
   dps_connection_string = {
-    for item in toset(local.dps_domains_list) :
+    for item in local.dps_domains_list :
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 }

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -607,14 +607,14 @@ module "glue_s3_data_reconciliation_job" {
   region                      = local.account_region
   account                     = local.account_id
   log_group_retention_in_days = local.glue_log_retention_in_days
-  connections = local.create_glue_connection ? merge([
+  connections = local.create_glue_connection ? concat([
     aws_glue_connection.glue_operational_datastore_connection[0].name,
     aws_glue_connection.glue_nomis_connection[0].name
-  ], aws_glue_connection.glue_dps_connection[*].name) : []
+  ], values(aws_glue_connection.glue_dps_connection)[*].name) : []
   additional_secret_arns = concat([
     aws_secretsmanager_secret.operational_db_secret.arn,
     aws_secretsmanager_secret.nomis.arn
-  ], data.aws_secretsmanager_secret.dps[*].arn)
+  ], values(aws_secretsmanager_secret.dps)[*].arn)
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -607,16 +607,14 @@ module "glue_s3_data_reconciliation_job" {
   region                      = local.account_region
   account                     = local.account_id
   log_group_retention_in_days = local.glue_log_retention_in_days
-  connections = local.create_glue_connection ? [
+  connections = local.create_glue_connection ? merge([
     aws_glue_connection.glue_operational_datastore_connection[0].name,
-    aws_glue_connection.glue_nomis_connection[0].name,
-    aws_glue_connection.glue_dps_activities_connection[0].name
-  ] : []
-  additional_secret_arns = [
+    aws_glue_connection.glue_nomis_connection[0].name
+  ], aws_glue_connection.glue_dps_connection[*].name) : []
+  additional_secret_arns = merge([
     aws_secretsmanager_secret.operational_db_secret.arn,
-    aws_secretsmanager_secret.nomis.arn,
-    data.aws_secretsmanager_secret.dps_activities.arn
-  ]
+    aws_secretsmanager_secret.nomis.arn
+  ], aws_secretsmanager_secret.dps[*].arn)
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -611,10 +611,10 @@ module "glue_s3_data_reconciliation_job" {
     aws_glue_connection.glue_operational_datastore_connection[0].name,
     aws_glue_connection.glue_nomis_connection[0].name
   ], aws_glue_connection.glue_dps_connection[*].name) : []
-  additional_secret_arns = merge([
+  additional_secret_arns = concat([
     aws_secretsmanager_secret.operational_db_secret.arn,
     aws_secretsmanager_secret.nomis.arn
-  ], tolist(aws_secretsmanager_secret.dps[*].arn))
+  ], aws_secretsmanager_secret.dps[*].arn)
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -611,10 +611,10 @@ module "glue_s3_data_reconciliation_job" {
     aws_glue_connection.glue_operational_datastore_connection[0].name,
     aws_glue_connection.glue_nomis_connection[0].name
   ], aws_glue_connection.glue_dps_connection[*].name) : []
-  additional_secret_arns = merge(aws_secretsmanager_secret.dps[*].arn, [
+  additional_secret_arns = merge([
     aws_secretsmanager_secret.operational_db_secret.arn,
     aws_secretsmanager_secret.nomis.arn
-  ])
+  ], tolist(aws_secretsmanager_secret.dps[*].arn))
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -611,10 +611,10 @@ module "glue_s3_data_reconciliation_job" {
     aws_glue_connection.glue_operational_datastore_connection[0].name,
     aws_glue_connection.glue_nomis_connection[0].name
   ], aws_glue_connection.glue_dps_connection[*].name) : []
-  additional_secret_arns = merge([
+  additional_secret_arns = merge(aws_secretsmanager_secret.dps[*].arn, [
     aws_secretsmanager_secret.operational_db_secret.arn,
     aws_secretsmanager_secret.nomis.arn
-  ], aws_secretsmanager_secret.dps[*].arn)
+  ])
 
   tags = merge(
     local.all_tags,

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -614,7 +614,7 @@ module "glue_s3_data_reconciliation_job" {
   additional_secret_arns = concat([
     aws_secretsmanager_secret.operational_db_secret.arn,
     aws_secretsmanager_secret.nomis.arn
-  ], aws_secretsmanager_secret.dps[*].arn)
+  ], data.aws_secretsmanager_secret.dps[*].arn)
 
   tags = merge(
     local.all_tags,


### PR DESCRIPTION
- Add glue connections for each configured dps service
- Add glue connection and perms to access secrets for configured dps services to the reconciliation job
- Update job params