### PR TITLE
add new instances as EC2 not asg

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -23,7 +23,7 @@ locals {
       ebs_volumes = {
         "/dev/sda1" = { type = "gp3", size = 128 } # root volume
         "/dev/xvdg" = { type = "gp3", size = 128 } # D:/ Temp
-        "/dev/xvdh" = { type = "gp3", size = 128 } # E:/ App
+        "/dev/xvdj" = { type = "gp3", size = 128 } # E:/ App
         "/dev/xvdi" = { type = "gp3", size = 700 } # F:/ Storage
       }
       instance = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -22,9 +22,9 @@ locals {
       }
       ebs_volumes = {
         "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-        "/dev/xvdd" = { type = "gp3", size = 128 } # D:/ Temp
-        "/dev/xvde" = { type = "gp3", size = 128 } # E:/ App
-        "/dev/xvdf" = { type = "gp3", size = 700 } # F:/ Storage
+        "/dev/xvdf" = { type = "gp3", size = 128 } # D:/ Temp
+        "/dev/xvdg" = { type = "gp3", size = 128 } # E:/ App
+        "/dev/xvdh" = { type = "gp3", size = 700 } # F:/ Storage
       }
       instance = {
         disable_api_termination      = false

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -22,9 +22,9 @@ locals {
       }
       ebs_volumes = {
         "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-        "/dev/xvdf" = { type = "gp3", size = 128 } # D:/ Temp
-        "/dev/xvdg" = { type = "gp3", size = 128 } # E:/ App
-        "/dev/xvdh" = { type = "gp3", size = 700 } # F:/ Storage
+        "/dev/xvdg" = { type = "gp3", size = 128 } # D:/ Temp
+        "/dev/xvdh" = { type = "gp3", size = 128 } # E:/ App
+        "/dev/xvdi" = { type = "gp3", size = 700 } # F:/ Storage
       }
       instance = {
         disable_api_termination      = false

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -22,9 +22,9 @@ locals {
       }
       ebs_volumes = {
         "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-        "/dev/xvdg" = { type = "gp3", size = 128 } # D:/ Temp
-        "/dev/xvdi" = { type = "gp3", size = 700 } # F:/ Storage
-        "/dev/xvdj" = { type = "gp3", size = 128 } # E:/ App
+        "/dev/xvdk" = { type = "gp3", size = 128 } # D:/ Temp
+        "/dev/xvdl" = { type = "gp3", size = 128 } # E:/ App
+        "/dev/xvdm" = { type = "gp3", size = 700 } # F:/ Storage
       }
       instance = {
         disable_api_termination      = false

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -23,8 +23,8 @@ locals {
       ebs_volumes = {
         "/dev/sda1" = { type = "gp3", size = 128 } # root volume
         "/dev/xvdg" = { type = "gp3", size = 128 } # D:/ Temp
-        "/dev/xvdj" = { type = "gp3", size = 128 } # E:/ App
         "/dev/xvdi" = { type = "gp3", size = 700 } # F:/ Storage
+        "/dev/xvdj" = { type = "gp3", size = 128 } # E:/ App
       }
       instance = {
         disable_api_termination      = false

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,29 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch   = "TM/TM-494/ips-install"
-              hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-494/ips-install"
+      #         # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {
@@ -203,7 +203,7 @@ locals {
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
       #         branch   = "TM/TM-494/ips-install"
-      #         hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #         # hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
       #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,29 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "TM/TM-494/ips-install"
-              # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-494/ips-install"
+      #         # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -193,6 +193,7 @@ locals {
           oasys-national-reporting-environment = "t2"
           # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
         })
+        cloudwatch_metric_alarms = {}
       })
 
       # not needed yet
@@ -217,6 +218,7 @@ locals {
       #     oasys-national-reporting-environment = "t2"
       #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
       #   })
+      # cloudwatch_metric_alarms = {}
       # })
 
       t2-onr-boe-1-a = merge(local.ec2_instances.boe_app, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -181,11 +181,11 @@ locals {
               hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
             }
           ))
-          instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
             "Ec2SecretPolicy",
           ])
         })
-        instance = merge(local.ec2_autoscaling_groups.bods.instance, {
+        instance = merge(local.ec2_instances.bods.instance, {
           instance_type = "m4.xlarge"
         })
         cloudwatch_metric_alarms = null
@@ -206,11 +206,11 @@ locals {
       #         hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
-      #     instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
       #       "Ec2SecretPolicy",
       #     ])
       #   })
-      #   instance = merge(local.ec2_autoscaling_groups.bods.instance, {
+      #   instance = merge(local.ec2_instances.bods.instance, {
       #     instance_type = "m4.xlarge"
       #   })
       #   cloudwatch_metric_alarms = null

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -123,30 +123,6 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
-
-      t2-tst-bods-asg = merge(local.ec2_autoscaling_groups.bods, {
-        autoscaling_group = merge(local.ec2_autoscaling_groups.bods.autoscaling_group, {
-          desired_capacity = 0
-        })
-        config = merge(local.ec2_instances.bods.config, {
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch   = "TM/TM-494/ips-install"
-              hostname = "t2-tst-bods-asg" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_autoscaling_groups.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-        })
-      })
     }
 
     ec2_instances = {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,28 +172,29 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "TM/TM-494/ips-install"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-494/ips-install"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name = "azure.noms.root"
+      #     newHostname = "t2-onr-bods-1-b"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,29 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch   = "TM/TM-494/ips-install"
-              hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-        })
-        cloudwatch_metric_alarms = {}
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch   = "TM/TM-494/ips-install"
+      #         hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -150,6 +150,7 @@ locals {
     }
 
     ec2_instances = {
+      # Will be turned off temporarily for testing t2-onr-bods-1-b and 2-a automation
       t2-onr-bods-1-a = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
           ami_name          = "hmpps_windows_server_2019_release_2024-05-02T00-00-37.552Z"
@@ -170,6 +171,53 @@ locals {
           domain-name = "azure.noms.root"
         })
       })
+
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch   = "TM/TM-494/ips-install"
+              hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_autoscaling_groups.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+        })
+      })
+
+      # not needed yet
+      # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2a"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch   = "TM/TM-494/ips-install"
+      #         hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_autoscaling_groups.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+      #   })
+      # })
 
       t2-onr-boe-1-a = merge(local.ec2_instances.boe_app, {
         config = merge(local.ec2_instances.boe_app.config, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,29 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch   = "TM/TM-494/ips-install"
-      #         hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch   = "TM/TM-494/ips-install"
+              hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -178,6 +178,7 @@ locals {
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
       #         branch = "TM/TM-494/ips-install"
+      #         newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
       #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,28 +172,28 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "TM/TM-494/ips-install"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-494/ips-install"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,28 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-494/ips-install"
-      #         # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/TM-494/ips-install"
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,28 +172,28 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-494/ips-install"
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/TM-494/ips-install"
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -126,7 +126,7 @@ locals {
     }
 
     ec2_instances = {
-      # Will be turned off temporarily for testing t2-onr-bods-1-b and 2-a automation
+      # Currently turned off temporarily for testing t2-onr-bods-1-b and 2-a automation
       t2-onr-bods-1-a = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
           ami_name          = "hmpps_windows_server_2019_release_2024-05-02T00-00-37.552Z"
@@ -148,38 +148,37 @@ locals {
         })
       })
 
-      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "TM/TM-494/ips-install"
-              newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name = "azure.noms.root"
-          newHostname = "t2-onr-bods-1-b"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "main"
+      #         newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
-      # not needed yet
+      # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {
       #   config = merge(local.ec2_instances.bods.config, {
       #     availability_zone = "eu-west-2a"
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch   = "TM/TM-494/ips-install"
+      #         branch   = "main"
       #         # hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
@@ -193,7 +192,7 @@ locals {
       #   cloudwatch_metric_alarms = null
       #   tags = merge(local.ec2_instances.bods.tags, {
       #     oasys-national-reporting-environment = "t2"
-      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+      #     domain-name = "azure.noms.root"
       #   })
       # cloudwatch_metric_alarms = {}
       # })

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,30 +172,30 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-494/ips-install"
-      #         newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     domain-name = "azure.noms.root"
-      #     newHostname = "t2-onr-bods-1-b"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/TM-494/ips-install"
+              newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          domain-name = "azure.noms.root"
+          newHostname = "t2-onr-bods-1-b"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -172,29 +172,29 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-494/ips-install"
-      #         # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/TM-494/ips-install"
+              # hostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          # domain-name = "azure.noms.root" NOTE: not joined to the domain yet
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # not needed yet
       # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -8,22 +8,18 @@ tasks:
     inputs:
         initialize: devices
         devices:
-          - device: xvdg
+          - device: /dev/xvdg
             name: Temp
             letter: D
             partition: gpt
-          - device: xvdj
+          - device: /dev/xvdj
             name: App
             letter: E
             partition: gpt
-          - device: xvdi
+          - device: /dev/xvdi
             name: Storage
             letter: F
             partition: gpt
-  - task: setHostName
-    inputs:
-      hostName: "${hostname}"
-      reboot: true
   - task: executeScript
     inputs:
       - frequency: once

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -4,6 +4,10 @@
 # See C:\Windows\System32\config\systemprofile\AppData\Local\Temp\EC2Launch* for script output
 version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
+  - task: setHostName
+    inputs:
+        hostName: "${newhostname}"
+        reboot: true
   - task: initializeVolume
     inputs:
         initialize: all

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -7,16 +7,6 @@ tasks:
   - task: initializeVolume
     inputs:
         initialize: all
-        devices:
-          - name: Temp
-            letter: D
-            partition: gpt
-          - name: Storage
-            letter: F
-            partition: gpt
-          - name: App
-            letter: E
-            partition: gpt
   - task: executeScript
     inputs:
       - frequency: once

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -12,7 +12,7 @@ tasks:
             name: Temp
             letter: D
             partition: gpt
-          - device: xvdh
+          - device: xvdj
             name: App
             letter: E
             partition: gpt

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -8,15 +8,15 @@ tasks:
     inputs:
         initialize: devices
         devices:
-          - device: xvdf
+          - device: xvdg
             name: Temp
             letter: D
             partition: gpt
-          - device: xvdg
+          - device: xvdh
             name: App
             letter: E
             partition: gpt
-          - device: xvdh
+          - device: xvdi
             name: Storage
             letter: F
             partition: gpt

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -6,19 +6,16 @@ version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is r
 tasks:
   - task: initializeVolume
     inputs:
-        initialize: devices
+        initialize: all
         devices:
-          - device: /dev/xvdg
-            name: Temp
+          - name: Temp
             letter: D
             partition: gpt
-          - device: /dev/xvdj
-            name: App
-            letter: E
-            partition: gpt
-          - device: /dev/xvdi
-            name: Storage
+          - name: Storage
             letter: F
+            partition: gpt
+          - name: App
+            letter: E
             partition: gpt
   - task: executeScript
     inputs:

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -8,15 +8,15 @@ tasks:
     inputs:
         initialize: devices
         devices:
-          - device: xvdd
+          - device: xvdf
             name: Temp
             letter: D
             partition: gpt
-          - device: xvde
+          - device: xvdg
             name: App
             letter: E
             partition: gpt
-          - device: xvdf
+          - device: xvdh
             name: Storage
             letter: F
             partition: gpt


### PR DESCRIPTION
- add t2-onr-bods-1-b as new main CMS node but not deployed yet
- add t2-onr-bods-2-a node as secondary but not deployed yet
- ./templates/user-data-onr-bods-pwsh.yaml.tftpl file is a pre-requisite for installing BODS 4.2 successfully 
  - intializes drives as part of the setup
  - changes hostname based on value supplied directly to the template