### PR TITLE
Update WAF rule and resource actions from "Count" to "Block" for better protection against DDOS attacks

### DIFF
--- a/terraform/environments/cdpt-chaps/shield.tf
+++ b/terraform/environments/cdpt-chaps/shield.tf
@@ -7,13 +7,13 @@ module "shield" {
   application_name = local.application_name
   resources = {
     format("%s-alb", local.application_name) = {
-      action = "count"
+      action = "block"
       arn    = module.lb_access_logs_enabled.load_balancer_arn
     }
   }
   waf_acl_rules = {
     example = {
-      "action"    = "count",
+      "action"    = "block",
       "name"      = "ddos-protection",
       "priority"  = 0,
       "threshold" = "250"


### PR DESCRIPTION
Tracked as part of ticket [#7975](https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=80386408) 

- These changes are intended to enhance the security posture by proactively blocking unwanted or malicious traffic.
- No Count Action Triggered Previously: Looking at the CloudWatch metrics, the "count" action did not trigger, which suggests the traffic patterns have not reached the defined threshold, and it is safe to move to blocking action.
- Consistent Protection: Changing both actions to "block" ensures consistency in how traffic is managed, with requests being denied both at the resource level (load balancer) and at the WAF level.