### PR TITLE
Ignoring QS author and admin groups as those are not managed in code

### DIFF
--- a/terraform/environments/analytical-platform-compute/quicksight.tf
+++ b/terraform/environments/analytical-platform-compute/quicksight.tf
@@ -11,4 +11,5 @@ resource "aws_quicksight_account_subscription" "subscription" {
       author_group, # not managed in code
       admin_group
     ]
+  }
 }

--- a/terraform/environments/analytical-platform-compute/quicksight.tf
+++ b/terraform/environments/analytical-platform-compute/quicksight.tf
@@ -6,4 +6,9 @@ resource "aws_quicksight_account_subscription" "subscription" {
   admin_group                      = ["analytical-platform"]
   author_group                     = ["analytical-platform"]
   notification_email               = local.environment_configuration.quicksight_notification_email
+  lifecycle {
+    ignore_changes = [
+      author_group, # not managed in code
+      admin_group
+    ]
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/5383

We manage quicksight groups manually at the moment, so adding an ignore block so they're not reset on every run.