### PR TITLE
ncr: TM-534: zap CMS as needs to be rebuilt

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -128,17 +128,17 @@ locals {
         })
       })
 
-      ppbipcms1 = merge(local.ec2_instances.bip_cms, {
-        config = merge(local.ec2_instances.bip_cms.config, {
-          availability_zone = "eu-west-2a"
-          instance_profile_policies = concat(local.ec2_instances.bip_cms.config.instance_profile_policies, [
-            "Ec2PPReportingPolicy",
-          ])
-        })
-        tags = merge(local.ec2_instances.bip_cms.tags, {
-          nomis-combined-reporting-environment = "pp"
-        })
-      })
+      #ppbipcms1 = merge(local.ec2_instances.bip_cms, {
+      #  config = merge(local.ec2_instances.bip_cms.config, {
+      #    availability_zone = "eu-west-2a"
+      #    instance_profile_policies = concat(local.ec2_instances.bip_cms.config.instance_profile_policies, [
+      #      "Ec2PPReportingPolicy",
+      #    ])
+      #  })
+      #  tags = merge(local.ec2_instances.bip_cms.tags, {
+      #    nomis-combined-reporting-environment = "pp"
+      #  })
+      #})
 
       pp-ncr-db-1-a = merge(local.ec2_instances.db, {
         cloudwatch_metric_alarms = merge(


### PR DESCRIPTION
There's a couple of issues with using standalone EC2 instances instead of ASG.  Need to try this again, zap it first.