### PR TITLE
Tm/onr preprod bods

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -143,37 +143,38 @@ locals {
       }
     }
 
-    lbs = {
-      public = merge(local.lbs.public, {
-        instance_target_groups = {
-          pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
-            attachments = [
-              { ec2_instance_name = "pp-onr-bods-1" },
-            ]
-          })
-        }
-        listeners = merge(local.lbs.public.listeners, {
-          https = merge(local.lbs.public.listeners.https, {
-            alarm_target_group_names = []
-            rules = {
-              pp-onr-bods-http28080 = {
-                priority = 100
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "pp-onr-bods-http28080"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-            }
-          })
-        })
-      })
+    # DO NOT DEPLOY YET AS OTHER THINGS AREN'T READY
+    # lbs = {
+    #   public = merge(local.lbs.public, {
+    #     instance_target_groups = {
+    #       pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
+    #         attachments = [
+    #           { ec2_instance_name = "pp-onr-bods-1" },
+    #         ]
+    #       })
+    #     }
+    #     listeners = merge(local.lbs.public.listeners, {
+    #       https = merge(local.lbs.public.listeners.https, {
+    #         alarm_target_group_names = []
+    #         rules = {
+    #           pp-onr-bods-http28080 = {
+    #             priority = 100
+    #             actions = [{
+    #               type              = "forward"
+    #               target_group_name = "pp-onr-bods-http28080"
+    #             }]
+    #             conditions = [{
+    #               host_header = {
+    #                 values = [
+    #                   "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
+    #                 ]
+    #               }
+    #             }]
+    #           }
+    #         }
+    #       })
+    #     })
+    #   })
 
       # No web instances built yet, not in use
       # private = {

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -176,110 +176,110 @@ locals {
     #     })
     #   })
 
-      # No web instances built yet, not in use
-      # private = {
-      #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
-      #   enable_cross_zone_load_balancing = true
-      #   enable_delete_protection         = false
-      #   idle_timeout                     = 3600
-      #   internal_lb                      = true
-      #   load_balancer_type               = "application"
-      #   security_groups                  = ["lb"]
-      #   subnets                          = module.environment.subnets["private"].ids
+    # No web instances built yet, not in use
+    # private = {
+    #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
+    #   enable_cross_zone_load_balancing = true
+    #   enable_delete_protection         = false
+    #   idle_timeout                     = 3600
+    #   internal_lb                      = true
+    #   load_balancer_type               = "application"
+    #   security_groups                  = ["lb"]
+    #   subnets                          = module.environment.subnets["private"].ids
 
-      #   instance_target_groups = {
-      #     pp-onr-web-1-a = {
-      #       port     = 7777
-      #       protocol = "HTTP"
-      #       health_check = {
-      #         enabled             = true
-      #         healthy_threshold   = 3
-      #         interval            = 30
-      #         matcher             = "200-399"
-      #         path                = "/"
-      #         port                = 7777
-      #         timeout             = 5
-      #         unhealthy_threshold = 5
-      #       }
-      #       stickiness = {
-      #         enabled = true
-      #         type    = "lb_cookie"
-      #       }
-      #       attachments = [
-      #         { ec2_instance_name = "pp-onr-web-1-a" },
-      #       ]
-      #     }
-      #   }
+    #   instance_target_groups = {
+    #     pp-onr-web-1-a = {
+    #       port     = 7777
+    #       protocol = "HTTP"
+    #       health_check = {
+    #         enabled             = true
+    #         healthy_threshold   = 3
+    #         interval            = 30
+    #         matcher             = "200-399"
+    #         path                = "/"
+    #         port                = 7777
+    #         timeout             = 5
+    #         unhealthy_threshold = 5
+    #       }
+    #       stickiness = {
+    #         enabled = true
+    #         type    = "lb_cookie"
+    #       }
+    #       attachments = [
+    #         { ec2_instance_name = "pp-onr-web-1-a" },
+    #       ]
+    #     }
+    #   }
 
-      #   listeners = {
-      #     http = {
-      #       port     = 7777
-      #       protocol = "HTTP"
+    #   listeners = {
+    #     http = {
+    #       port     = 7777
+    #       protocol = "HTTP"
 
-      #       default_action = {
-      #         type = "fixed-response"
-      #         fixed_response = {
-      #           content_type = "text/plain"
-      #           message_body = "Not implemented"
-      #           status_code  = "501"
-      #         }
-      #       }
-      #       rules = {
-      #         pp-onr-web-1-a = {
-      #           priority = 4000
+    #       default_action = {
+    #         type = "fixed-response"
+    #         fixed_response = {
+    #           content_type = "text/plain"
+    #           message_body = "Not implemented"
+    #           status_code  = "501"
+    #         }
+    #       }
+    #       rules = {
+    #         pp-onr-web-1-a = {
+    #           priority = 4000
 
-      #           actions = [{
-      #             type              = "forward"
-      #             target_group_name = "pp-onr-web-1-a"
-      #           }]
+    #           actions = [{
+    #             type              = "forward"
+    #             target_group_name = "pp-onr-web-1-a"
+    #           }]
 
-      #           conditions = [{
-      #             host_header = {
-      #               values = [
-      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
-      #               ]
-      #             }
-      #           }]
-      #         }
-      #       }
-      #     }
-      #     https = {
-      #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
-      #       port                      = 443
-      #       protocol                  = "HTTPS"
-      #       ssl_policy                = "ELBSecurityPolicy-2016-08"
+    #           conditions = [{
+    #             host_header = {
+    #               values = [
+    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
+    #               ]
+    #             }
+    #           }]
+    #         }
+    #       }
+    #     }
+    #     https = {
+    #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
+    #       port                      = 443
+    #       protocol                  = "HTTPS"
+    #       ssl_policy                = "ELBSecurityPolicy-2016-08"
 
-      #       default_action = {
-      #         type = "fixed-response"
-      #         fixed_response = {
-      #           content_type = "text/plain"
-      #           message_body = "Not implemented"
-      #           status_code  = "501"
-      #         }
-      #       }
+    #       default_action = {
+    #         type = "fixed-response"
+    #         fixed_response = {
+    #           content_type = "text/plain"
+    #           message_body = "Not implemented"
+    #           status_code  = "501"
+    #         }
+    #       }
 
-      #       rules = {
-      #         pp-onr-web-1-a = {
-      #           priority = 4580
+    #       rules = {
+    #         pp-onr-web-1-a = {
+    #           priority = 4580
 
-      #           actions = [{
-      #             type              = "forward"
-      #             target_group_name = "pp-onr-web-1-a"
-      #           }]
+    #           actions = [{
+    #             type              = "forward"
+    #             target_group_name = "pp-onr-web-1-a"
+    #           }]
 
-      #           conditions = [{
-      #             host_header = {
-      #               values = [
-      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
-      #               ]
-      #             }
-      #           }]
-      #         }
-      #       }
-      #     }
-      #   }
-      # }
-    }
+    #           conditions = [{
+    #             host_header = {
+    #               values = [
+    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
+    #               ]
+    #             }
+    #           }]
+    #         }
+    #       }
+    #     }
+    #   }
+    # }
+    # }
 
     route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -73,13 +73,12 @@ locals {
     #   bods = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 1 instance, reduced RAM as Azure usage doesn't warrant higher RAM
     # }
     ec2_instances = {
-      pp-onr-bods-1-b = merge(local.ec2_instances.bods, {
+      pp-onr-bods-1 = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
+          availability_zone = "eu-west-2a"
           user_data_raw = base64encode(templatefile(
             "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch      = "main"
-              newhostname = "pp-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+              branch = "main"
             }
           ))
           instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
@@ -98,13 +97,12 @@ locals {
       })
 
       # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
-      # pp-onr-bods-2-a = merge(local.ec2_instances.bods, {
+      # pp-onr-bods-2 = merge(local.ec2_instances.bods, {
       #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2a"
+      #     availability_zone = "eu-west-2b"
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
       #         branch   = "main"
-      #         newhostname = "pp-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
       #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
@@ -128,7 +126,7 @@ locals {
         instance_target_groups = {
           pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
             attachments = [
-              { ec2_instance_name = "pp-onr-bods-1-b" },
+              { ec2_instance_name = "pp-onr-bods-1" },
             ]
           })
         }

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -150,7 +150,7 @@ locals {
         instance_target_groups = {
           pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
             attachments = [
-              {},
+              { ec2_instance_name = "" },
               # { ec2_instance_name = "pp-onr-bods-1" },
             ]
           })

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -31,6 +31,41 @@ locals {
       }
     }
 
+    efs = {
+      pp-onr-sap-share = {
+        access_points = {
+          root = {
+            posix_user = {
+              gid = 1201 # binstall
+              uid = 1201 # bobj
+            }
+            root_directory = {
+              path = "/"
+              creation_info = {
+                owner_gid   = 1201 # binstall
+                owner_uid   = 1201 # bobj
+                permissions = "0777"
+              }
+            }
+          }
+        }
+        file_system = {
+          availability_zone_name = "eu-west-2a"
+          lifecycle_policy = {
+            transition_to_ia = "AFTER_30_DAYS"
+          }
+        }
+        mount_targets = [{
+          subnet_name        = "private"
+          availability_zones = ["eu-west-2a"]
+          security_groups    = ["boe"]
+        }]
+        tags = {
+          backup = "false"
+        }
+      }
+    }
+
     # Instance Type Defaults for preproduction
     # instance_type_defaults = {
     #   web = "m6i.xlarge" # 4 vCPUs, 16GB RAM x 2 instances
@@ -38,27 +73,208 @@ locals {
     #   bods = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 1 instance, reduced RAM as Azure usage doesn't warrant higher RAM
     # }
     ec2_instances = {
-      pp-onr-bods-1-a = merge(local.ec2_instances.bods, {
+      pp-onr-bods-1-b = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
-          ami_name          = "hmpps_windows_server_2019_release_2024-07-02T00-00-37.755Z"
-          ami_owner         = "self" # remove this if this is ever rebuilt, you can reference AMI direct from core-shared-services-production
-          availability_zone = "eu-west-2a"
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch      = "main"
+              newhostname = "pp-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
         })
         instance = merge(local.ec2_instances.bods.instance, {
           instance_type = "m6i.2xlarge"
         })
-        # volumes are a direct copy of BODS in NCR
-        ebs_volumes = merge(local.ec2_instances.bods.ebs_volumes, {
-          "/dev/sda1" = { type = "gp3", size = 100 }
-          "/dev/sdb"  = { type = "gp3", size = 100 }
-          "/dev/sdc"  = { type = "gp3", size = 100 }
-          "/dev/sds"  = { type = "gp3", size = 100 }
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "pp"
+          domain-name                          = "azure.hmpp.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
+
+      # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
+      # pp-onr-bods-2-a = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2a"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch   = "main"
+      #         newhostname = "pp-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m6i.2xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "pp"
+      #     domain-name = "azure.hmpp.root"
+      #   })
+      # cloudwatch_metric_alarms = {}
+      # })
+    }
+
+    lbs = {
+      public = merge(local.lbs.public, {
+        instance_target_groups = {
+          pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
+            attachments = [
+              { ec2_instance_name = "pp-onr-bods-1-b" },
+            ]
+          })
+        }
+        listeners = merge(local.lbs.public.listeners, {
+          https = merge(local.lbs.public.listeners.https, {
+            alarm_target_group_names = []
+            rules = {
+              pp-onr-bods-http28080 = {
+                priority = 100
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "pp-onr-bods-http28080"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+            }
+          })
         })
       })
+
+      # No web instances built yet, not in use
+      # private = {
+      #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
+      #   enable_cross_zone_load_balancing = true
+      #   enable_delete_protection         = false
+      #   idle_timeout                     = 3600
+      #   internal_lb                      = true
+      #   load_balancer_type               = "application"
+      #   security_groups                  = ["lb"]
+      #   subnets                          = module.environment.subnets["private"].ids
+
+      #   instance_target_groups = {
+      #     pp-onr-web-1-a = {
+      #       port     = 7777
+      #       protocol = "HTTP"
+      #       health_check = {
+      #         enabled             = true
+      #         healthy_threshold   = 3
+      #         interval            = 30
+      #         matcher             = "200-399"
+      #         path                = "/"
+      #         port                = 7777
+      #         timeout             = 5
+      #         unhealthy_threshold = 5
+      #       }
+      #       stickiness = {
+      #         enabled = true
+      #         type    = "lb_cookie"
+      #       }
+      #       attachments = [
+      #         { ec2_instance_name = "pp-onr-web-1-a" },
+      #       ]
+      #     }
+      #   }
+
+      #   listeners = {
+      #     http = {
+      #       port     = 7777
+      #       protocol = "HTTP"
+
+      #       default_action = {
+      #         type = "fixed-response"
+      #         fixed_response = {
+      #           content_type = "text/plain"
+      #           message_body = "Not implemented"
+      #           status_code  = "501"
+      #         }
+      #       }
+      #       rules = {
+      #         pp-onr-web-1-a = {
+      #           priority = 4000
+
+      #           actions = [{
+      #             type              = "forward"
+      #             target_group_name = "pp-onr-web-1-a"
+      #           }]
+
+      #           conditions = [{
+      #             host_header = {
+      #               values = [
+      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
+      #               ]
+      #             }
+      #           }]
+      #         }
+      #       }
+      #     }
+      #     https = {
+      #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
+      #       port                      = 443
+      #       protocol                  = "HTTPS"
+      #       ssl_policy                = "ELBSecurityPolicy-2016-08"
+
+      #       default_action = {
+      #         type = "fixed-response"
+      #         fixed_response = {
+      #           content_type = "text/plain"
+      #           message_body = "Not implemented"
+      #           status_code  = "501"
+      #         }
+      #       }
+
+      #       rules = {
+      #         pp-onr-web-1-a = {
+      #           priority = 4580
+
+      #           actions = [{
+      #             type              = "forward"
+      #             target_group_name = "pp-onr-web-1-a"
+      #           }]
+
+      #           conditions = [{
+      #             host_header = {
+      #               values = [
+      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
+      #               ]
+      #             }
+      #           }]
+      #         }
+      #       }
+      #     }
+      #   }
+      # }
     }
 
     route53_zones = {
-      "preproduction.reporting.oasys.service.justice.gov.uk" = {}
+      "preproduction.reporting.oasys.service.justice.gov.uk" = {
+        lb_alias_records = [
+          { name = "pp-bods", type = "A", lbs_map_key = "public" }
+        ],
+      }
+    }
+
+    # TODO: THESE ARE NOT FINALIZED
+    secretsmanager_secrets = {
+      "/ec2/onr-bods/pp"         = local.secretsmanager_secrets.bods
+      "/ec2/onr-boe/pp"          = local.secretsmanager_secrets.boe_app
+      "/ec2/onr-web/pp"          = local.secretsmanager_secrets.boe_web
+      "/oracle/database/PPBOSYS" = local.secretsmanager_secrets.db
+      "/oracle/database/PPBOAUD" = local.secretsmanager_secrets.db
     }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -283,9 +283,10 @@ locals {
 
     route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {
-        lb_alias_records = [
-          { name = "pp-bods", type = "A", lbs_map_key = "public" }
-        ],
+        # TODO: need to put this back
+        # lb_alias_records = [
+        #   { name = "pp-bods", type = "A", lbs_map_key = "public" }
+        # ],
       }
     }
 

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -73,28 +73,29 @@ locals {
     #   bods = "m6i.2xlarge" # 8 vCPUs, 32GB RAM x 1 instance, reduced RAM as Azure usage doesn't warrant higher RAM
     # }
     ec2_instances = {
-      pp-onr-bods-1 = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2a"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "main"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m6i.2xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "pp"
-          domain-name                          = "azure.hmpp.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # DO NOT DEPLOY THESE YET AS THE REST OF THE THINGS AREN'T READY
+      # pp-onr-bods-1 = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2a"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "main"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m6i.2xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "pp"
+      #     domain-name                          = "azure.hmpp.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
       # pp-onr-bods-2 = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -121,6 +121,27 @@ locals {
       # })
     }
 
+    iam_policies = {
+      Ec2SecretPolicy = {
+        description = "Permissions required for secret value access by instances"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-boe/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-bods/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-web/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*",
+            ]
+          }
+        ]
+      }
+    }
+
     lbs = {
       public = merge(local.lbs.public, {
         instance_target_groups = {

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -145,149 +145,148 @@ locals {
     }
 
     # DO NOT DEPLOY YET AS OTHER THINGS AREN'T READY
-    lbs = {
-      public = merge(local.lbs.public, {
-        instance_target_groups = {
-          pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
-            attachments = [
-              { ec2_instance_name = "" },
-              # { ec2_instance_name = "pp-onr-bods-1" },
-            ]
-          })
-        }
-        listeners = merge(local.lbs.public.listeners, {
-          https = merge(local.lbs.public.listeners.https, {
-            alarm_target_group_names = []
-            rules = {
-              pp-onr-bods-http28080 = {
-                priority = 100
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "pp-onr-bods-http28080"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-            }
-          })
-        })
-      })
+    # lbs = {
+    #   public = merge(local.lbs.public, {
+    #     instance_target_groups = {
+    #       pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
+    #         attachments = [
+    #           { ec2_instance_name = "pp-onr-bods-1" },
+    #         ]
+    #       })
+    #     }
+    #     listeners = merge(local.lbs.public.listeners, {
+    #       https = merge(local.lbs.public.listeners.https, {
+    #         alarm_target_group_names = []
+    #         rules = {
+    #           pp-onr-bods-http28080 = {
+    #             priority = 100
+    #             actions = [{
+    #               type              = "forward"
+    #               target_group_name = "pp-onr-bods-http28080"
+    #             }]
+    #             conditions = [{
+    #               host_header = {
+    #                 values = [
+    #                   "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
+    #                 ]
+    #               }
+    #             }]
+    #           }
+    #         }
+    #       })
+    #     })
+    #   })
 
-      # No web instances built yet, not in use
-      # private = {
-      #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
-      #   enable_cross_zone_load_balancing = true
-      #   enable_delete_protection         = false
-      #   idle_timeout                     = 3600
-      #   internal_lb                      = true
-      #   load_balancer_type               = "application"
-      #   security_groups                  = ["lb"]
-      #   subnets                          = module.environment.subnets["private"].ids
+    # No web instances built yet, not in use
+    # private = {
+    #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
+    #   enable_cross_zone_load_balancing = true
+    #   enable_delete_protection         = false
+    #   idle_timeout                     = 3600
+    #   internal_lb                      = true
+    #   load_balancer_type               = "application"
+    #   security_groups                  = ["lb"]
+    #   subnets                          = module.environment.subnets["private"].ids
 
-      #   instance_target_groups = {
-      #     pp-onr-web-1-a = {
-      #       port     = 7777
-      #       protocol = "HTTP"
-      #       health_check = {
-      #         enabled             = true
-      #         healthy_threshold   = 3
-      #         interval            = 30
-      #         matcher             = "200-399"
-      #         path                = "/"
-      #         port                = 7777
-      #         timeout             = 5
-      #         unhealthy_threshold = 5
-      #       }
-      #       stickiness = {
-      #         enabled = true
-      #         type    = "lb_cookie"
-      #       }
-      #       attachments = [
-      #         { ec2_instance_name = "pp-onr-web-1-a" },
-      #       ]
-      #     }
-      #   }
+    #   instance_target_groups = {
+    #     pp-onr-web-1-a = {
+    #       port     = 7777
+    #       protocol = "HTTP"
+    #       health_check = {
+    #         enabled             = true
+    #         healthy_threshold   = 3
+    #         interval            = 30
+    #         matcher             = "200-399"
+    #         path                = "/"
+    #         port                = 7777
+    #         timeout             = 5
+    #         unhealthy_threshold = 5
+    #       }
+    #       stickiness = {
+    #         enabled = true
+    #         type    = "lb_cookie"
+    #       }
+    #       attachments = [
+    #         { ec2_instance_name = "pp-onr-web-1-a" },
+    #       ]
+    #     }
+    #   }
 
-      #   listeners = {
-      #     http = {
-      #       port     = 7777
-      #       protocol = "HTTP"
+    #   listeners = {
+    #     http = {
+    #       port     = 7777
+    #       protocol = "HTTP"
 
-      #       default_action = {
-      #         type = "fixed-response"
-      #         fixed_response = {
-      #           content_type = "text/plain"
-      #           message_body = "Not implemented"
-      #           status_code  = "501"
-      #         }
-      #       }
-      #       rules = {
-      #         pp-onr-web-1-a = {
-      #           priority = 4000
+    #       default_action = {
+    #         type = "fixed-response"
+    #         fixed_response = {
+    #           content_type = "text/plain"
+    #           message_body = "Not implemented"
+    #           status_code  = "501"
+    #         }
+    #       }
+    #       rules = {
+    #         pp-onr-web-1-a = {
+    #           priority = 4000
 
-      #           actions = [{
-      #             type              = "forward"
-      #             target_group_name = "pp-onr-web-1-a"
-      #           }]
+    #           actions = [{
+    #             type              = "forward"
+    #             target_group_name = "pp-onr-web-1-a"
+    #           }]
 
-      #           conditions = [{
-      #             host_header = {
-      #               values = [
-      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
-      #               ]
-      #             }
-      #           }]
-      #         }
-      #       }
-      #     }
-      #     https = {
-      #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
-      #       port                      = 443
-      #       protocol                  = "HTTPS"
-      #       ssl_policy                = "ELBSecurityPolicy-2016-08"
+    #           conditions = [{
+    #             host_header = {
+    #               values = [
+    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
+    #               ]
+    #             }
+    #           }]
+    #         }
+    #       }
+    #     }
+    #     https = {
+    #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
+    #       port                      = 443
+    #       protocol                  = "HTTPS"
+    #       ssl_policy                = "ELBSecurityPolicy-2016-08"
 
-      #       default_action = {
-      #         type = "fixed-response"
-      #         fixed_response = {
-      #           content_type = "text/plain"
-      #           message_body = "Not implemented"
-      #           status_code  = "501"
-      #         }
-      #       }
+    #       default_action = {
+    #         type = "fixed-response"
+    #         fixed_response = {
+    #           content_type = "text/plain"
+    #           message_body = "Not implemented"
+    #           status_code  = "501"
+    #         }
+    #       }
 
-      #       rules = {
-      #         pp-onr-web-1-a = {
-      #           priority = 4580
+    #       rules = {
+    #         pp-onr-web-1-a = {
+    #           priority = 4580
 
-      #           actions = [{
-      #             type              = "forward"
-      #             target_group_name = "pp-onr-web-1-a"
-      #           }]
+    #           actions = [{
+    #             type              = "forward"
+    #             target_group_name = "pp-onr-web-1-a"
+    #           }]
 
-      #           conditions = [{
-      #             host_header = {
-      #               values = [
-      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
-      #               ]
-      #             }
-      #           }]
-      #         }
-      #       }
-      #     }
-      #   }
-      # }
-    }
+    #           conditions = [{
+    #             host_header = {
+    #               values = [
+    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
+    #               ]
+    #             }
+    #           }]
+    #         }
+    #       }
+    #     }
+    #   }
+    # }
+    # }
 
     route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {
-        lb_alias_records = [
-          { name = "pp-bods", type = "A", lbs_map_key = "public" }
-        ],
+        # lb_alias_records = [
+        #   { name = "pp-bods", type = "A", lbs_map_key = "public" }
+        # ],
       }
     }
 

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -31,40 +31,41 @@ locals {
       }
     }
 
-    efs = {
-      pp-onr-sap-share = {
-        access_points = {
-          root = {
-            posix_user = {
-              gid = 1201 # binstall
-              uid = 1201 # bobj
-            }
-            root_directory = {
-              path = "/"
-              creation_info = {
-                owner_gid   = 1201 # binstall
-                owner_uid   = 1201 # bobj
-                permissions = "0777"
-              }
-            }
-          }
-        }
-        file_system = {
-          availability_zone_name = "eu-west-2a"
-          lifecycle_policy = {
-            transition_to_ia = "AFTER_30_DAYS"
-          }
-        }
-        mount_targets = [{
-          subnet_name        = "private"
-          availability_zones = ["eu-west-2a"]
-          security_groups    = ["boe"]
-        }]
-        tags = {
-          backup = "false"
-        }
-      }
-    }
+    # DO NOT DEPLOY THIS - MOVING TO HMPPS-DOMAIN-SERVICES Account
+    # efs = {
+    #   pp-onr-sap-share = {
+    #     access_points = {
+    #       root = {
+    #         posix_user = {
+    #           gid = 1201 # binstall
+    #           uid = 1201 # bobj
+    #         }
+    #         root_directory = {
+    #           path = "/"
+    #           creation_info = {
+    #             owner_gid   = 1201 # binstall
+    #             owner_uid   = 1201 # bobj
+    #             permissions = "0777"
+    #           }
+    #         }
+    #       }
+    #     }
+    #     file_system = {
+    #       availability_zone_name = "eu-west-2a"
+    #       lifecycle_policy = {
+    #         transition_to_ia = "AFTER_30_DAYS"
+    #       }
+    #     }
+    #     mount_targets = [{
+    #       subnet_name        = "private"
+    #       availability_zones = ["eu-west-2a"]
+    #       security_groups    = ["boe"]
+    #     }]
+    #     tags = {
+    #       backup = "false"
+    #     }
+    #   }
+    # }
 
     # Instance Type Defaults for preproduction
     # instance_type_defaults = {
@@ -133,9 +134,9 @@ locals {
               "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-boe/pp/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-bods/pp/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-web/pp/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/bods/pp/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/bip/pp/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/web/pp/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*",
             ]
           }
@@ -144,159 +145,158 @@ locals {
     }
 
     # DO NOT DEPLOY YET AS OTHER THINGS AREN'T READY
-    # lbs = {
-    #   public = merge(local.lbs.public, {
-    #     instance_target_groups = {
-    #       pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
-    #         attachments = [
-    #           { ec2_instance_name = "pp-onr-bods-1" },
-    #         ]
-    #       })
-    #     }
-    #     listeners = merge(local.lbs.public.listeners, {
-    #       https = merge(local.lbs.public.listeners.https, {
-    #         alarm_target_group_names = []
-    #         rules = {
-    #           pp-onr-bods-http28080 = {
-    #             priority = 100
-    #             actions = [{
-    #               type              = "forward"
-    #               target_group_name = "pp-onr-bods-http28080"
-    #             }]
-    #             conditions = [{
-    #               host_header = {
-    #                 values = [
-    #                   "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
-    #                 ]
-    #               }
-    #             }]
-    #           }
-    #         }
-    #       })
-    #     })
-    #   })
+    lbs = {
+      public = merge(local.lbs.public, {
+        instance_target_groups = {
+          pp-onr-bods-http28080 = merge(local.lbs.public.instance_target_groups.http28080, {
+            attachments = [
+              {},
+              # { ec2_instance_name = "pp-onr-bods-1" },
+            ]
+          })
+        }
+        listeners = merge(local.lbs.public.listeners, {
+          https = merge(local.lbs.public.listeners.https, {
+            alarm_target_group_names = []
+            rules = {
+              pp-onr-bods-http28080 = {
+                priority = 100
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "pp-onr-bods-http28080"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "pp-bods.preproduction.reporting.oasys.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
+            }
+          })
+        })
+      })
 
-    # No web instances built yet, not in use
-    # private = {
-    #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
-    #   enable_cross_zone_load_balancing = true
-    #   enable_delete_protection         = false
-    #   idle_timeout                     = 3600
-    #   internal_lb                      = true
-    #   load_balancer_type               = "application"
-    #   security_groups                  = ["lb"]
-    #   subnets                          = module.environment.subnets["private"].ids
+      # No web instances built yet, not in use
+      # private = {
+      #   drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
+      #   enable_cross_zone_load_balancing = true
+      #   enable_delete_protection         = false
+      #   idle_timeout                     = 3600
+      #   internal_lb                      = true
+      #   load_balancer_type               = "application"
+      #   security_groups                  = ["lb"]
+      #   subnets                          = module.environment.subnets["private"].ids
 
-    #   instance_target_groups = {
-    #     pp-onr-web-1-a = {
-    #       port     = 7777
-    #       protocol = "HTTP"
-    #       health_check = {
-    #         enabled             = true
-    #         healthy_threshold   = 3
-    #         interval            = 30
-    #         matcher             = "200-399"
-    #         path                = "/"
-    #         port                = 7777
-    #         timeout             = 5
-    #         unhealthy_threshold = 5
-    #       }
-    #       stickiness = {
-    #         enabled = true
-    #         type    = "lb_cookie"
-    #       }
-    #       attachments = [
-    #         { ec2_instance_name = "pp-onr-web-1-a" },
-    #       ]
-    #     }
-    #   }
+      #   instance_target_groups = {
+      #     pp-onr-web-1-a = {
+      #       port     = 7777
+      #       protocol = "HTTP"
+      #       health_check = {
+      #         enabled             = true
+      #         healthy_threshold   = 3
+      #         interval            = 30
+      #         matcher             = "200-399"
+      #         path                = "/"
+      #         port                = 7777
+      #         timeout             = 5
+      #         unhealthy_threshold = 5
+      #       }
+      #       stickiness = {
+      #         enabled = true
+      #         type    = "lb_cookie"
+      #       }
+      #       attachments = [
+      #         { ec2_instance_name = "pp-onr-web-1-a" },
+      #       ]
+      #     }
+      #   }
 
-    #   listeners = {
-    #     http = {
-    #       port     = 7777
-    #       protocol = "HTTP"
+      #   listeners = {
+      #     http = {
+      #       port     = 7777
+      #       protocol = "HTTP"
 
-    #       default_action = {
-    #         type = "fixed-response"
-    #         fixed_response = {
-    #           content_type = "text/plain"
-    #           message_body = "Not implemented"
-    #           status_code  = "501"
-    #         }
-    #       }
-    #       rules = {
-    #         pp-onr-web-1-a = {
-    #           priority = 4000
+      #       default_action = {
+      #         type = "fixed-response"
+      #         fixed_response = {
+      #           content_type = "text/plain"
+      #           message_body = "Not implemented"
+      #           status_code  = "501"
+      #         }
+      #       }
+      #       rules = {
+      #         pp-onr-web-1-a = {
+      #           priority = 4000
 
-    #           actions = [{
-    #             type              = "forward"
-    #             target_group_name = "pp-onr-web-1-a"
-    #           }]
+      #           actions = [{
+      #             type              = "forward"
+      #             target_group_name = "pp-onr-web-1-a"
+      #           }]
 
-    #           conditions = [{
-    #             host_header = {
-    #               values = [
-    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
-    #               ]
-    #             }
-    #           }]
-    #         }
-    #       }
-    #     }
-    #     https = {
-    #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
-    #       port                      = 443
-    #       protocol                  = "HTTPS"
-    #       ssl_policy                = "ELBSecurityPolicy-2016-08"
+      #           conditions = [{
+      #             host_header = {
+      #               values = [
+      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-test.modernisation-platform.service.justice.gov.uk",
+      #               ]
+      #             }
+      #           }]
+      #         }
+      #       }
+      #     }
+      #     https = {
+      #       certificate_names_or_arns = ["oasys_national_reporting_wildcard_cert"]
+      #       port                      = 443
+      #       protocol                  = "HTTPS"
+      #       ssl_policy                = "ELBSecurityPolicy-2016-08"
 
-    #       default_action = {
-    #         type = "fixed-response"
-    #         fixed_response = {
-    #           content_type = "text/plain"
-    #           message_body = "Not implemented"
-    #           status_code  = "501"
-    #         }
-    #       }
+      #       default_action = {
+      #         type = "fixed-response"
+      #         fixed_response = {
+      #           content_type = "text/plain"
+      #           message_body = "Not implemented"
+      #           status_code  = "501"
+      #         }
+      #       }
 
-    #       rules = {
-    #         pp-onr-web-1-a = {
-    #           priority = 4580
+      #       rules = {
+      #         pp-onr-web-1-a = {
+      #           priority = 4580
 
-    #           actions = [{
-    #             type              = "forward"
-    #             target_group_name = "pp-onr-web-1-a"
-    #           }]
+      #           actions = [{
+      #             type              = "forward"
+      #             target_group_name = "pp-onr-web-1-a"
+      #           }]
 
-    #           conditions = [{
-    #             host_header = {
-    #               values = [
-    #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
-    #               ]
-    #             }
-    #           }]
-    #         }
-    #       }
-    #     }
-    #   }
-    # }
-    # }
+      #           conditions = [{
+      #             host_header = {
+      #               values = [
+      #                 "pp-onr-web-1-a.oasys-national-reporting.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
+      #               ]
+      #             }
+      #           }]
+      #         }
+      #       }
+      #     }
+      #   }
+      # }
+    }
 
     route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {
-        # TODO: need to put this back
-        # lb_alias_records = [
-        #   { name = "pp-bods", type = "A", lbs_map_key = "public" }
-        # ],
+        lb_alias_records = [
+          { name = "pp-bods", type = "A", lbs_map_key = "public" }
+        ],
       }
     }
 
-    # TODO: THESE ARE NOT FINALIZED
-    # secretsmanager_secrets = {
-    #   "/ec2/onr-bods/pp"         = local.secretsmanager_secrets.bods
-    #   "/ec2/onr-boe/pp"          = local.secretsmanager_secrets.boe_app
-    #   "/ec2/onr-web/pp"          = local.secretsmanager_secrets.boe_web
-    #   "/oracle/database/PPBOSYS" = local.secretsmanager_secrets.db
-    #   "/oracle/database/PPBOAUD" = local.secretsmanager_secrets.db
-    # }
+    secretsmanager_secrets = {
+      "/sap/bods/pp"             = local.secretsmanager_secrets.bods
+      "/sap/bip/pp"              = local.secretsmanager_secrets.bip
+      "/sap/web/pp"              = local.secretsmanager_secrets.web
+      "/oracle/database/PPBOSYS" = local.secretsmanager_secrets.db
+      "/oracle/database/PPBOAUD" = local.secretsmanager_secrets.db
+    }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -132,9 +132,9 @@ locals {
               "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-boe/t2/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-bods/t2/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-web/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-boe/pp/*",
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-bods/pp/*",
+              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-web/pp/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*",
             ]
           }
@@ -288,12 +288,12 @@ locals {
     }
 
     # TODO: THESE ARE NOT FINALIZED
-    secretsmanager_secrets = {
-      "/ec2/onr-bods/pp"         = local.secretsmanager_secrets.bods
-      "/ec2/onr-boe/pp"          = local.secretsmanager_secrets.boe_app
-      "/ec2/onr-web/pp"          = local.secretsmanager_secrets.boe_web
-      "/oracle/database/PPBOSYS" = local.secretsmanager_secrets.db
-      "/oracle/database/PPBOAUD" = local.secretsmanager_secrets.db
-    }
+    # secretsmanager_secrets = {
+    #   "/ec2/onr-bods/pp"         = local.secretsmanager_secrets.bods
+    #   "/ec2/onr-boe/pp"          = local.secretsmanager_secrets.boe_app
+    #   "/ec2/onr-web/pp"          = local.secretsmanager_secrets.boe_web
+    #   "/oracle/database/PPBOSYS" = local.secretsmanager_secrets.db
+    #   "/oracle/database/PPBOAUD" = local.secretsmanager_secrets.db
+    # }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_secretsmanager.tf
+++ b/terraform/environments/oasys-national-reporting/locals_secretsmanager.tf
@@ -7,15 +7,15 @@ locals {
       }
     }
 
-    boe_web = {
+    web = {
       secrets = {
         passwords = { description = "Web Passwords" }
       }
     }
 
-    boe_app = {
+    bip = {
       secrets = {
-        passwords = { description = "BOE Passwords" }
+        passwords = { description = "BIP Passwords" }
       }
     }
 

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -148,34 +148,33 @@ locals {
         })
       })
 
-      # t2-onr-bods-1-b = merge(local.ec2_instances.bods, {
-      #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-      #         branch = "main"
-      #         newhostname = "t2-onr-bods-1-b" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy",
-      #     ])
-      #   })
-      #   instance = merge(local.ec2_instances.bods.instance, {
-      #     instance_type = "m4.xlarge"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      #   tags = merge(local.ec2_instances.bods.tags, {
-      #     oasys-national-reporting-environment = "t2"
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-onr-bods-1 = merge(local.ec2_instances.bods, {
+        config = merge(local.ec2_instances.bods.config, {
+          availability_zone = "eu-west-2a"
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/onr-preprod-bods"
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+        })
+        instance = merge(local.ec2_instances.bods.instance, {
+          instance_type = "m4.xlarge"
+        })
+        cloudwatch_metric_alarms = null
+        tags = merge(local.ec2_instances.bods.tags, {
+          oasys-national-reporting-environment = "t2"
+          domain-name                          = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
-      # t2-onr-bods-2-a = merge(local.ec2_instances.bods, {
+      # t2-onr-bods-2 = merge(local.ec2_instances.bods, {
       #   config = merge(local.ec2_instances.bods.config, {
-      #     availability_zone = "eu-west-2a"
+      #     availability_zone = "eu-west-2b"
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
       #         branch   = "main"

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -148,28 +148,28 @@ locals {
         })
       })
 
-      t2-onr-bods-1 = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2a"
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
-              branch = "TM/onr-preprod-bods"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name                          = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-onr-bods-1 = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2a"
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+      #         branch = "main"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name                          = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo
       # t2-onr-bods-2 = merge(local.ec2_instances.bods, {
@@ -178,7 +178,6 @@ locals {
       #     user_data_raw = base64encode(templatefile(
       #       "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
       #         branch   = "main"
-      #         # hostname = "t2-onr-bods-2-a" # 15 characters max, only alphanumeric characters and hyphens, must not be just numbers.
       #       }
       #     ))
       #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -250,9 +250,9 @@ locals {
               "secretsmanager:PutSecretValue",
             ]
             resources = [
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-boe/t2/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-bods/t2/*",
-              "arn:aws:secretsmanager:*:*:secret:/ec2/onr-web/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/bods/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/bip/t2/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/web/t2/*",
               "arn:aws:secretsmanager:*:*:secret:/oracle/database/*",
             ]
           }
@@ -405,9 +405,9 @@ locals {
     }
 
     secretsmanager_secrets = {
-      "/ec2/onr-bods/t2"         = local.secretsmanager_secrets.bods
-      "/ec2/onr-boe/t2"          = local.secretsmanager_secrets.boe_app
-      "/ec2/onr-web/t2"          = local.secretsmanager_secrets.boe_web
+      "/sap/bods/t2"             = local.secretsmanager_secrets.bods
+      "/sap/bip/t2"              = local.secretsmanager_secrets.bip
+      "/sap/web/t2"              = local.secretsmanager_secrets.web
       "/oracle/database/T2BOSYS" = local.secretsmanager_secrets.db
       "/oracle/database/T2BOAUD" = local.secretsmanager_secrets.db
     }

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh.yaml.tftpl
@@ -4,10 +4,6 @@
 # See C:\Windows\System32\config\systemprofile\AppData\Local\Temp\EC2Launch* for script output
 version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
-  - task: setHostName
-    inputs:
-        hostName: "${newhostname}"
-        reboot: true
   - task: initializeVolume
     inputs:
         initialize: all


### PR DESCRIPTION
- Remove change hostname from user-data script

TEST env
- rename secrets /sap/<instance-type>/<env>
 
PREPROD
- delete ppr-onr-bods-1-a instance, was deployed manually
- create secrets with new naming
- added pp-onr-bods-1 and -2 but commented out for now
- comment out efs for preproduction, will be moved elsewhere
- deploy LB later