### PR TITLE
ELM-2785 add virus scanning

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-event-rules.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-event-rules.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_event_rule" "definition_update" {
+  name                = "definition-update"
+  schedule_expression = "cron(15 6 * * ? *)" # 06:15 every day
+}

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-event-targets.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-event-targets.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_event_target" "definition_update" {
+  rule      = aws_cloudwatch_event_rule.definition_update.name
+  target_id = "definition-update"
+  arn       = module.virus_scan_definition_upload.lambda_function_arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -696,8 +696,8 @@ data "aws_iam_policy_document" "virus_scan_definition_upload_policy_document" {
     sid    = "AllowS3"
     effect = "Allow"
     actions = [
-        "s3:GetObject",
-        "s3:PutObject"
+      "s3:GetObject",
+      "s3:PutObject"
     ]
     resources = "${module.s3-clamav-definitions-bucket.bucket.arn}/*"
   }
@@ -712,4 +712,50 @@ resource "aws_iam_policy" "virus_scan_definition_upload" {
 resource "aws_iam_role_policy_attachment" "virus_scan_definition_upload_policy_attachment" {
   role       = aws_iam_role.virus_scan_definition_upload.name
   policy_arn = aws_iam_policy.virus_scan_definition_upload.arn
+}
+
+#-----------------------------------------------------------------------------------
+# Virus scanning - file scanning
+#-----------------------------------------------------------------------------------
+
+resource "aws_iam_role" "virus_scan_file" {
+  name               = "virus_scan_file"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "virus_scan_file_policy_document" {
+  statement {
+    sid    = "S3PermissionsForReceivedBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:CopyObject",
+      "s3:DeleteObject",
+    ]
+    resources = "${module.s3-received-files-bucket.bucket.arn}/*"
+  }
+  statement {
+    sid    = "S3PermissionsForQuarantineAndProcessedBucket"
+    effect = "Allow"
+    actions = [
+      "s3:CopyObject",
+      "s3:PutObject",
+      "s3:PutObjectTagging"
+    ]
+    resources = [
+      "${module.s3-quarantined-files-bucket.bucket.arn}/*",
+      "${module.s3-data-bucket.bucket.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "virus_scan_file" {
+  name        = "virus-scan-file-policy"
+  description = "Policy for Lambda to virus scan and move files"
+  policy      = data.aws_iam_policy_document.virus_scan_file_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "virus_scan_file_policy_attachment" {
+  role       = aws_iam_role.virus_scan_file.name
+  policy_arn = aws_iam_policy.virus_scan_file.arn
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -728,9 +728,10 @@ data "aws_iam_policy_document" "virus_scan_file_policy_document" {
     sid    = "S3PermissionsForReceivedBucket"
     effect = "Allow"
     actions = [
-      "s3:GetObject",
       "s3:CopyObject",
       "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
     ]
     resources = ["${module.s3-received-files-bucket.bucket.arn}/*"]
   }

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -681,3 +681,35 @@ resource "aws_iam_role_policy_attachment" "process_landing_bucket_files_s3_polic
   role       = aws_iam_role.process_landing_bucket_files.name
   policy_arn = aws_iam_policy.process_landing_bucket_files_s3.arn
 }
+
+#-----------------------------------------------------------------------------------
+# Virus scanning - definition upload
+#-----------------------------------------------------------------------------------
+
+resource "aws_iam_role" "virus_scan_definition_upload" {
+  name               = "virus_scan_definition_upload"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "virus_scan_definition_upload_policy_document" {
+  statement {
+    sid    = "AllowS3"
+    effect = "Allow"
+    actions = [
+        "s3:GetObject",
+        "s3:PutObject"
+    ]
+    resources = "${module.s3-clamav-definitions-bucket.bucket.arn}/*"
+  }
+}
+
+resource "aws_iam_policy" "virus_scan_definition_upload" {
+  name        = "virus-scan-definitions-upload-policy"
+  description = "Policy for Lambda to get and upload latest clamav virus definitions"
+  policy      = data.aws_iam_policy_document.virus_scan_definition_upload_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "virus_scan_definition_upload_policy_attachment" {
+  role       = aws_iam_role.virus_scan_definition_upload.name
+  policy_arn = aws_iam_policy.virus_scan_definition_upload.arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -699,7 +699,7 @@ data "aws_iam_policy_document" "virus_scan_definition_upload_policy_document" {
       "s3:GetObject",
       "s3:PutObject"
     ]
-    resources = "${module.s3-clamav-definitions-bucket.bucket.arn}/*"
+    resources = ["${module.s3-clamav-definitions-bucket.bucket.arn}/*"]
   }
 }
 
@@ -732,7 +732,7 @@ data "aws_iam_policy_document" "virus_scan_file_policy_document" {
       "s3:CopyObject",
       "s3:DeleteObject",
     ]
-    resources = "${module.s3-received-files-bucket.bucket.arn}/*"
+    resources = ["${module.s3-received-files-bucket.bucket.arn}/*"]
   }
   statement {
     sid    = "S3PermissionsForQuarantineAndProcessedBucket"
@@ -743,7 +743,7 @@ data "aws_iam_policy_document" "virus_scan_file_policy_document" {
       "s3:PutObjectTagging"
     ]
     resources = [
-      "${module.s3-quarantined-files-bucket.bucket.arn}/*",
+      "${module.s3-quarantine-files-bucket.bucket.arn}/*",
       "${module.s3-data-bucket.bucket.arn}/*",
     ]
   }

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -367,3 +367,28 @@ module "virus_scan_definition_upload" {
     CLAMAV_DEFINITON_BUCKET_NAME = module.s3-clamav-definitions-bucket.bucket.id
   }
 }
+
+#-----------------------------------------------------------------------------------
+# Virus scanning - file scan
+#-----------------------------------------------------------------------------------
+
+module "virus_scan_file" {
+  source                  = "./modules/lambdas"
+  function_name           = "scan"
+  is_image                = true
+  ecr_repo_name           = "analytical-platform-ingestion-scan"
+  function_tag            = "0.0.9"
+  role_name               = aws_iam_role.virus_scan_file.name
+  role_arn                = aws_iam_role.virus_scan_file.arn
+  ephemeral_storage_size  = 10240
+  memory_size             = 2048
+  timeout                 = 900
+  core_shared_services_id = local.environment_management.account_ids["core-shared-services-production"]
+  environment_variables = {
+    MODE                         = "scan",
+    CLAMAV_DEFINITON_BUCKET_NAME = module.s3-clamav-definitions-bucket.bucket.id
+    LANDING_BUCKET_NAME          = module.s3-received-files-bucket.bucket.id
+    QUARANTINE_BUCKET_NAME       = module.s3-quarantine-files-bucket.bucket.id
+    PROCESSED_BUCKET_NAME        = module.s3-data-bucket.bucket.id
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -346,3 +346,24 @@ module "process_landing_bucket_files" {
     DESTINATION_BUCKET = module.s3-received-files-bucket.bucket.id
   }
 }
+
+#-----------------------------------------------------------------------------------
+# Virus scanning - definition upload
+#-----------------------------------------------------------------------------------
+
+module "virus_scan_definition_upload" {
+  source                  = "./modules/lambdas"
+  function_name           = "definition-upload"
+  is_image                = true
+  ecr_repo_name           = "analytical-platform-ingestion-scan"
+  function_tag            = "0.0.9"
+  role_name               = aws_iam_role.virus_scan_definition_upload.name
+  role_arn                = aws_iam_role.virus_scan_definition_upload.arn
+  memory_size             = 2048
+  timeout                 = 900
+  core_shared_services_id = local.environment_management.account_ids["core-shared-services-production"]
+  environment_variables = {
+    MODE                         = "definition-upload",
+    CLAMAV_DEFINITON_BUCKET_NAME = module.s3-clamav-definitions-bucket.bucket.id
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -356,7 +356,7 @@ module "virus_scan_definition_upload" {
   function_name           = "definition-upload"
   is_image                = true
   ecr_repo_name           = "analytical-platform-ingestion-scan"
-  function_tag            = "0.0.9"
+  function_tag            = "0.1.0"
   role_name               = aws_iam_role.virus_scan_definition_upload.name
   role_arn                = aws_iam_role.virus_scan_definition_upload.arn
   memory_size             = 2048
@@ -377,7 +377,7 @@ module "virus_scan_file" {
   function_name           = "scan"
   is_image                = true
   ecr_repo_name           = "analytical-platform-ingestion-scan"
-  function_tag            = "0.0.9"
+  function_tag            = "0.1.0"
   role_name               = aws_iam_role.virus_scan_file.name
   role_arn                = aws_iam_role.virus_scan_file.arn
   ephemeral_storage_size  = 10240

--- a/terraform/environments/electronic-monitoring-data/modules/lambdas/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lambdas/main.tf
@@ -159,6 +159,10 @@ resource "aws_lambda_function" "this" {
   timeout       = var.timeout
   memory_size   = var.memory_size
 
+  ephemeral_storage {
+    size = var.ephemeral_storage_size # Min 512 MB and the Max 10240 MB
+  }
+
   dynamic "vpc_config" {
     for_each = local.use_vpc_config ? [1] : []
     content {

--- a/terraform/environments/electronic-monitoring-data/modules/lambdas/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lambdas/variables.tf
@@ -120,3 +120,9 @@ variable "function_tag" {
   nullable    = true
   default     = null
 }
+
+variable "ephemeral_storage_size" {
+  description = "Size in MB of lambda ephemeral storage"
+  type        = number
+  default     = 512
+}

--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -696,6 +696,25 @@ module "s3-received-files-bucket" {
   tags = local.tags
 }
 
+resource "aws_lambda_permission" "scan_received_files" {
+  statement_id  = "AllowExecutionFromReceivedFilesS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = module.virus_scan_file.lambda_function_arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = module.s3-received-files-bucket.bucket.arn
+}
+
+resource "aws_s3_bucket_notification" "scan_received_files" {
+  bucket = module.s3-received-files-bucket.bucket.id
+
+  lambda_function {
+    lambda_function_arn = module.virus_scan_file.lambda_function_arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+
+  depends_on = [aws_lambda_permission.scan_received_files]
+}
+
 module "s3-quarantine-files-bucket" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=f759060"
 


### PR DESCRIPTION
<img width="526" alt="image" src="https://github.com/user-attachments/assets/87dba493-9d34-4195-8049-9ab86ba4fc1d">


This PR implements
* lambdas for updating the virus definitions and scanning files
* permissions for the lambdas to access the required s3 buckets (see attached picture for architecture
* cloudwatch trigger for updating the definitions daily
* updated the lambda module so `ephemeral_storage` can be changed, default variable value is the terraform default.