### PR TITLE
Update_101024_1

### DIFF
--- a/terraform/environments/ppud/cloudwatch_alarms_windows.tf
+++ b/terraform/environments/ppud/cloudwatch_alarms_windows.tf
@@ -1,8 +1,9 @@
-# =====================
-# Alerts - EC2 Windows
-# =====================
+###############################################################
+# Data Sources and CloudWatch Alarms for EC2 Instances Windows
+###############################################################
 
 # Create a data source to fetch the tags of each instance
+
 data "aws_instances" "windows_tagged_instances" {
   filter {
     name   = "tag:patch_group"
@@ -11,6 +12,7 @@ data "aws_instances" "windows_tagged_instances" {
 }
 
 # Data source for ImageId and InstanceType for each instance
+
 data "aws_instance" "windows_instance_details" {
   for_each    = toset(data.aws_instances.windows_tagged_instances.ids)
   instance_id = each.value
@@ -300,8 +302,8 @@ resource "aws_cloudwatch_metric_alarm" "Memory_percentage_Committed_Bytes_In_Use
   }
 }
 
-
 # High CPU IOwait Alarm
+
 resource "aws_cloudwatch_metric_alarm" "cpu_usage_iowait" {
   for_each            = toset(data.aws_instances.windows_tagged_instances.ids)
   alarm_name          = "CPU-Usage-IOWait-${each.key}"
@@ -321,7 +323,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu_usage_iowait" {
   }
 }
 
-# CPU Utilization Alarm
+# High CPU Utilization Alarm
+
 resource "aws_cloudwatch_metric_alarm" "cpu" {
   for_each            = toset(data.aws_instances.windows_tagged_instances.ids)
   alarm_name          = "CPU-Utilisation-High-${each.key}"          # name of the alarm
@@ -345,7 +348,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
 # EC2 Instance Statuses
 # ======================
 
-# Instance Health Alarm
+# EC2 Instance Health Alarm
+
 resource "aws_cloudwatch_metric_alarm" "instance_health_check" {
   for_each            = toset(data.aws_instances.windows_tagged_instances.ids)
   alarm_name          = "Instance-Health-Check-Failed-${each.key}"
@@ -365,7 +369,8 @@ resource "aws_cloudwatch_metric_alarm" "instance_health_check" {
   }
 }
 
-# Status Check Alarm
+# EC2 Status Check Alarm
+
 resource "aws_cloudwatch_metric_alarm" "system_health_check" {
   for_each            = toset(data.aws_instances.windows_tagged_instances.ids)
   alarm_name          = "System-Health-Check-Failed-${each.key}"
@@ -385,15 +390,15 @@ resource "aws_cloudwatch_metric_alarm" "system_health_check" {
   }
 }
 
-
 # ====================
 # IIS and Event Logs
 # ====================
 
 # Status Check Alarm
+
 resource "aws_cloudwatch_metric_alarm" "Windows_IIS_check" {
   for_each            = toset(data.aws_instances.windows_tagged_instances.ids)
-  alarm_name          = "IIS-failure-${each.key}"
+  alarm_name          = "IIS-Failure-${each.key}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   datapoints_to_alarm = "2"
@@ -407,291 +412,5 @@ resource "aws_cloudwatch_metric_alarm" "Windows_IIS_check" {
   alarm_actions       = [aws_sns_topic.cw_alerts[0].arn]
   dimensions = {
     InstanceId = each.key
-  }
-}
-
-#Log Groups
-
-resource "aws_cloudwatch_log_group" "IIS-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "IIS-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "System-Event-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "System-Event-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "Application-Event-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "Application-Event-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "Windows-Services-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "Windows-Services-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "Network-Connectivity-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "Network-Connectivity-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "SQL-Server-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "SQL-Server-Logs"
-  retention_in_days = 365
-}
-
-resource "aws_cloudwatch_log_group" "Windows-Defender-Logs" {
-  count             = local.is-production == true ? 1 : 0
-  name              = "Windows-Defender-Logs"
-  retention_in_days = 365
-}
-
-#Metric Filters
-
-resource "aws_cloudwatch_log_metric_filter" "ServiceStatus-Running" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "ServiceStatus-Running"
-  log_group_name = aws_cloudwatch_log_group.Windows-Services-Logs[count.index].name
-  pattern        = "[date, time, Instance, Service, status=Running]"
-  metric_transformation {
-    name      = "IsRunning"
-    namespace = "ServiceStatus"
-    value     = "1"
-    dimensions = {
-      Instance = "$Instance"
-      Service  = "$Service"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "ServiceStatus-NotRunning" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "ServiceStatus-NotRunning"
-  log_group_name = aws_cloudwatch_log_group.Windows-Services-Logs[count.index].name
-  pattern        = "[date, time, Instance, Service, status!=Running]"
-  metric_transformation {
-    name      = "IsRunning"
-    namespace = "ServiceStatus"
-    value     = "0"
-    dimensions = {
-      Instance = "$Instance"
-      Service  = "$Service"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "PortStatus-True" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "PortStatus-True"
-  log_group_name = aws_cloudwatch_log_group.Network-Connectivity-Logs[count.index].name
-  pattern        = "[date, time, Instance, Port, status=True]"
-  metric_transformation {
-    name      = "True"
-    namespace = "PortStatus"
-    value     = "1"
-    dimensions = {
-      Instance = "$Instance"
-      Port     = "$Port"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "PortStatus-False" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "PortStatus-False"
-  log_group_name = aws_cloudwatch_log_group.Network-Connectivity-Logs[count.index].name
-  pattern        = "[date, time, Instance, Port, status=False]"
-  metric_transformation {
-    name      = "False"
-    namespace = "PortStatus"
-    value     = "0"
-    dimensions = {
-      Instance = "$Instance"
-      Port     = "$Port"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "SQLBackupStatus-Successful" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "SQLBackupStatus-Successful"
-  log_group_name = aws_cloudwatch_log_group.SQL-Server-Logs[count.index].name
-  pattern        = "[date, time, Instance, SQLBackup, status=Successful]"
-  metric_transformation {
-    name      = "Successful"
-    namespace = "SQLBackupStatus"
-    value     = "1"
-    dimensions = {
-      Instance = "$Instance"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "SQLBackupStatus-Failed" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "SQLBackupStatus-Failed"
-  log_group_name = aws_cloudwatch_log_group.SQL-Server-Logs[count.index].name
-  pattern        = "[date, time, Instance, SQLBackup, status=Failed]"
-  metric_transformation {
-    name      = "Failed"
-    namespace = "SQLBackupStatus"
-    value     = "0"
-    dimensions = {
-      Instance = "$Instance"
-    }
-  }
-}
-
-# Windows Defender Event Metrics
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareScanStarted" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareScanStarted"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareScanStarted, status=1000]"
-  metric_transformation {
-    name      = "MalwareScanStarted"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance           = "$Instance"
-      MalwareScanStarted = "$MalwareScanStarted"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareScanFinished" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareScanFinished"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareScanFinished, status=1001]"
-  metric_transformation {
-    name      = "MalwareScanFinished"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance            = "$Instance"
-      MalwareScanFinished = "$MalwareScanFinished"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareScanStopped" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareScanStopped"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareScanStopped, status=1002]"
-  metric_transformation {
-    name      = "MalwareScanStopped"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance           = "$Instance"
-      MalwareScanStopped = "$MalwareScanStopped"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareScanFailed" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareScanFailed"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareScanFailed, status=1005]"
-  metric_transformation {
-    name      = "MalwareScanFailed"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance          = "$Instance"
-      MalwareScanFailed = "$MalwareScanFailed"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareBehaviorDetected" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareBehaviorDetected"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareBehaviorDetected, status=1015]"
-  metric_transformation {
-    name      = "MalwareBehaviorDetected"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance                = "$Instance"
-      MalwareBehaviorDetected = "$MalwareBehaviorDetected"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareStateDetected" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareStateDetected"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareStateDetected, status=1116]"
-  metric_transformation {
-    name      = "MalwareStateDetected"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance             = "$Instance"
-      MalwareStateDetected = "$MalwareStateDetected"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareSignatureFailed" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareSignatureFailed"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareSignatureFailed, status=2001]"
-  metric_transformation {
-    name      = "MalwareSignatureFailed"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance               = "$Instance"
-      MalwareSignatureFailed = "$MalwareSignatureFailed"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareEngineFailed" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareEngineFailed"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareEngineFailed, status=2003]"
-  metric_transformation {
-    name      = "MalwareEngineFailed"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance            = "$Instance"
-      MalwareEngineFailed = "$MalwareEngineFailed"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "MalwareEngineOutofDate" {
-  count          = local.is-production == true ? 1 : 0
-  name           = "MalwareEngineOutofDate"
-  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
-  pattern        = "[date, time, Instance, MalwareEngineOutofDate, status=2005]"
-  metric_transformation {
-    name      = "MalwareEngineOutofDate"
-    namespace = "WindowsDefender"
-    value     = "1"
-    dimensions = {
-      Instance               = "$Instance"
-      MalwareEngineOutofDate = "$MalwareEngineOutofDate"
-    }
   }
 }

--- a/terraform/environments/ppud/cloudwatch_filters_groups_linux.tf
+++ b/terraform/environments/ppud/cloudwatch_filters_groups_linux.tf
@@ -1,0 +1,45 @@
+##################################################################
+# CloudWatch Metric Filters and Log Groups for EC2 Instances Linux
+##################################################################
+
+# Linux Log Groups
+
+resource "aws_cloudwatch_log_group" "Linux-Services-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "Linux-Services-Logs"
+  retention_in_days = 365
+}
+
+# Linux Services Metric Filters
+
+resource "aws_cloudwatch_log_metric_filter" "Linux-ServiceStatus-Running" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "Linux-ServiceStatus-Running"
+  log_group_name = aws_cloudwatch_log_group.Linux-Services-Logs[count.index].name
+  pattern        = "[date, time, Instance, Service, status=Running]"
+  metric_transformation {
+    name      = "IsRunning"
+    namespace = "ServiceStatus"
+    value     = "1"
+    dimensions = {
+      Instance = "$Instance"
+      Service  = "$Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "Linux-ServiceStatus-NotRunning" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "Linux-ServiceStatus-NotRunning"
+  log_group_name = aws_cloudwatch_log_group.Linux-Services-Logs[count.index].name
+  pattern        = "[date, time, Instance, Service, status!=Running]"
+  metric_transformation {
+    name      = "IsRunning"
+    namespace = "ServiceStatus"
+    value     = "0"
+    dimensions = {
+      Instance = "$Instance"
+      Service  = "$Service"
+    }
+  }
+}

--- a/terraform/environments/ppud/cloudwatch_filters_groups_windows.tf
+++ b/terraform/environments/ppud/cloudwatch_filters_groups_windows.tf
@@ -1,0 +1,293 @@
+####################################################################
+# CloudWatch Metric Filters and Log Groups for EC2 Instances Windows
+####################################################################
+
+# Windows Log Groups
+
+resource "aws_cloudwatch_log_group" "IIS-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "IIS-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "System-Event-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "System-Event-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "Application-Event-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "Application-Event-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "Windows-Services-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "Windows-Services-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "Network-Connectivity-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "Network-Connectivity-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "SQL-Server-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "SQL-Server-Logs"
+  retention_in_days = 365
+}
+
+resource "aws_cloudwatch_log_group" "Windows-Defender-Logs" {
+  count             = local.is-production == true ? 1 : 0
+  name              = "Windows-Defender-Logs"
+  retention_in_days = 365
+}
+
+# Windows Services Metric Filters
+
+resource "aws_cloudwatch_log_metric_filter" "ServiceStatus-Running" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "ServiceStatus-Running"
+  log_group_name = aws_cloudwatch_log_group.Windows-Services-Logs[count.index].name
+  pattern        = "[date, time, Instance, Service, status=Running]"
+  metric_transformation {
+    name      = "IsRunning"
+    namespace = "ServiceStatus"
+    value     = "1"
+    dimensions = {
+      Instance = "$Instance"
+      Service  = "$Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ServiceStatus-NotRunning" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "ServiceStatus-NotRunning"
+  log_group_name = aws_cloudwatch_log_group.Windows-Services-Logs[count.index].name
+  pattern        = "[date, time, Instance, Service, status!=Running]"
+  metric_transformation {
+    name      = "IsRunning"
+    namespace = "ServiceStatus"
+    value     = "0"
+    dimensions = {
+      Instance = "$Instance"
+      Service  = "$Service"
+    }
+  }
+}
+
+# SMTP Port 25 Metric Filters
+
+resource "aws_cloudwatch_log_metric_filter" "PortStatus-True" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "PortStatus-True"
+  log_group_name = aws_cloudwatch_log_group.Network-Connectivity-Logs[count.index].name
+  pattern        = "[date, time, Instance, Port, status=True]"
+  metric_transformation {
+    name      = "True"
+    namespace = "PortStatus"
+    value     = "1"
+    dimensions = {
+      Instance = "$Instance"
+      Port     = "$Port"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "PortStatus-False" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "PortStatus-False"
+  log_group_name = aws_cloudwatch_log_group.Network-Connectivity-Logs[count.index].name
+  pattern        = "[date, time, Instance, Port, status=False]"
+  metric_transformation {
+    name      = "False"
+    namespace = "PortStatus"
+    value     = "0"
+    dimensions = {
+      Instance = "$Instance"
+      Port     = "$Port"
+    }
+  }
+}
+
+# SQL Server Metric Filters
+
+resource "aws_cloudwatch_log_metric_filter" "SQLBackupStatus-Successful" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "SQLBackupStatus-Successful"
+  log_group_name = aws_cloudwatch_log_group.SQL-Server-Logs[count.index].name
+  pattern        = "[date, time, Instance, SQLBackup, status=Successful]"
+  metric_transformation {
+    name      = "Successful"
+    namespace = "SQLBackupStatus"
+    value     = "1"
+    dimensions = {
+      Instance = "$Instance"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "SQLBackupStatus-Failed" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "SQLBackupStatus-Failed"
+  log_group_name = aws_cloudwatch_log_group.SQL-Server-Logs[count.index].name
+  pattern        = "[date, time, Instance, SQLBackup, status=Failed]"
+  metric_transformation {
+    name      = "Failed"
+    namespace = "SQLBackupStatus"
+    value     = "0"
+    dimensions = {
+      Instance = "$Instance"
+    }
+  }
+}
+
+# Windows Defender Event Metric Filters
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareScanStarted" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareScanStarted"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareScanStarted, status=1000]"
+  metric_transformation {
+    name      = "MalwareScanStarted"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance           = "$Instance"
+      MalwareScanStarted = "$MalwareScanStarted"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareScanFinished" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareScanFinished"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareScanFinished, status=1001]"
+  metric_transformation {
+    name      = "MalwareScanFinished"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance            = "$Instance"
+      MalwareScanFinished = "$MalwareScanFinished"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareScanStopped" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareScanStopped"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareScanStopped, status=1002]"
+  metric_transformation {
+    name      = "MalwareScanStopped"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance           = "$Instance"
+      MalwareScanStopped = "$MalwareScanStopped"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareScanFailed" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareScanFailed"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareScanFailed, status=1005]"
+  metric_transformation {
+    name      = "MalwareScanFailed"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance          = "$Instance"
+      MalwareScanFailed = "$MalwareScanFailed"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareBehaviorDetected" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareBehaviorDetected"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareBehaviorDetected, status=1015]"
+  metric_transformation {
+    name      = "MalwareBehaviorDetected"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance                = "$Instance"
+      MalwareBehaviorDetected = "$MalwareBehaviorDetected"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareStateDetected" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareStateDetected"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareStateDetected, status=1116]"
+  metric_transformation {
+    name      = "MalwareStateDetected"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance             = "$Instance"
+      MalwareStateDetected = "$MalwareStateDetected"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareSignatureFailed" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareSignatureFailed"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareSignatureFailed, status=2001]"
+  metric_transformation {
+    name      = "MalwareSignatureFailed"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance               = "$Instance"
+      MalwareSignatureFailed = "$MalwareSignatureFailed"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareEngineFailed" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareEngineFailed"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareEngineFailed, status=2003]"
+  metric_transformation {
+    name      = "MalwareEngineFailed"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance            = "$Instance"
+      MalwareEngineFailed = "$MalwareEngineFailed"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "MalwareEngineOutofDate" {
+  count          = local.is-production == true ? 1 : 0
+  name           = "MalwareEngineOutofDate"
+  log_group_name = aws_cloudwatch_log_group.Windows-Defender-Logs[count.index].name
+  pattern        = "[date, time, Instance, MalwareEngineOutofDate, status=2005]"
+  metric_transformation {
+    name      = "MalwareEngineOutofDate"
+    namespace = "WindowsDefender"
+    value     = "1"
+    dimensions = {
+      Instance               = "$Instance"
+      MalwareEngineOutofDate = "$MalwareEngineOutofDate"
+    }
+  }
+}

--- a/terraform/environments/ppud/iam.tf
+++ b/terraform/environments/ppud/iam.tf
@@ -585,7 +585,10 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_dev" {
                 "sqs:ReceiveMessage",
                 "sqs:SendMessage"
               ],
-            "Resource": "*"
+            "Resource": [
+            "arn:aws:sqs:eu-west-2:075585660276:Lambda-Queue-DEV",
+            "arn:aws:sqs:eu-west-2:075585660276:Lambda-Deadletter-Queue-DEV"
+            ]
         }
     ]
 }
@@ -683,7 +686,10 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_uat" {
                 "sqs:ReceiveMessage",
                 "sqs:SendMessage"
               ],
-            "Resource": "*"
+            "Resource": [
+            "arn:aws:sqs:eu-west-2:172753231260:Lambda-Queue-UAT",
+            "arn:aws:sqs:eu-west-2:172753231260:Lambda-Deadletter-Queue-UAT"
+            ]
         }
     ]
 }
@@ -781,7 +787,10 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_prod" {
                 "sqs:ReceiveMessage",
                 "sqs:SendMessage"
               ],
-            "Resource": "*"
+            "Resource": [
+            "arn:aws:sqs:eu-west-2:817985104434:Lambda-Queue-Production",
+            "arn:aws:sqs:eu-west-2:817985104434:Lambda-Deadletter-Queue-Production"
+            ]
         }
     ]
 }

--- a/terraform/environments/ppud/lambda.tf
+++ b/terraform/environments/ppud/lambda.tf
@@ -372,6 +372,10 @@ resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_dev"
   depends_on    = [aws_iam_role_policy_attachment.attach_lambda_policy_cloudwatch_invoke_lambda_to_lambda_role_cloudwatch_invoke_lambda_dev]
   reserved_concurrent_executions = 5
   code_signing_config_arn = "arn:aws:lambda:eu-west-2:075585660276:code-signing-config:csc-0c7136ccff2de748f"
+#    vpc_config {
+#    subnet_ids         = var.vpc_private_subnet_ids_dev
+#    security_group_ids = var.vpc_security_group_ids_dev
+#  }
   dead_letter_config {
    target_arn = aws_sqs_queue.lambda_queue_dev[0].arn
   }
@@ -413,6 +417,10 @@ resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_uat"
   depends_on    = [aws_iam_role_policy_attachment.attach_lambda_policy_cloudwatch_invoke_lambda_to_lambda_role_cloudwatch_invoke_lambda_uat]
   reserved_concurrent_executions = 5
   code_signing_config_arn = "arn:aws:lambda:eu-west-2:172753231260:code-signing-config:csc-0db408c5170a8eba6" 
+#  vpc_config {
+#    subnet_ids         = var.vpc_private_subnet_ids_uat
+#    security_group_ids = var.vpc_security_group_ids_uat
+#  }
   dead_letter_config {
    target_arn = aws_sqs_queue.lambda_queue_uat[0].arn
   }
@@ -454,6 +462,10 @@ resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_prod
   depends_on    = [aws_iam_role_policy_attachment.attach_lambda_policy_cloudwatch_invoke_lambda_to_lambda_role_cloudwatch_invoke_lambda_prod]
   reserved_concurrent_executions = 5
   code_signing_config_arn = "arn:aws:lambda:eu-west-2:817985104434:code-signing-config:csc-0bafee04a642a41c1"
+#  vpc_config {
+#    subnet_ids         = var.vpc_private_subnet_ids_prod
+#    security_group_ids = var.vpc_security_group_ids_prod
+#  }
   dead_letter_config {
    target_arn = aws_sqs_queue.lambda_queue_prod[0].arn
   }
@@ -470,87 +482,3 @@ data "archive_file" "zip_the_send_cpu_notification_code_prod" {
   source_dir  = "${path.module}/lambda_scripts/"
   output_path = "${path.module}/lambda_scripts/send_cpu_notification_prod.zip"
 }
-
-
-#################################################
-# Lambda Code Signing Configuration (CSC)
-#################################################
-
-# Development
-
-resource "aws_signer_signing_profile" "lambda_signing_profile_dev" {
-  count       = local.is-development == true ? 1 : 0
-  name_prefix = "grw77tzk96phtwcrceot5xlbt9veqixuyck044"
-  platform_id = "AWSLambda-SHA384-ECDSA"
-  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_dev]
-  signature_validity_period {
-    value = 10
-    type  = "YEARS"
-  }
-}
-
-resource "aws_lambda_code_signing_config" "lambda_csc_dev" {
-  count       = local.is-development == true ? 1 : 0
-  description = "Lambda code signing configuration for development environment"
-  allowed_publishers {
-    signing_profile_version_arns = [
-      "arn:aws:signer:eu-west-2:075585660276:/signing-profiles/grw77tzk96phtwcrceot5xlbt9veqixuyck04420241008100655411100000002/AHvOa02ifI"
-    ]
-  }
-  policies {
-    untrusted_artifact_on_deployment = "Warn"
-  }
-}
-
-# UAT
-
-resource "aws_signer_signing_profile" "lambda_signing_profile_uat" {
-  count       = local.is-preproduction == true ? 1 : 0
-  name_prefix = "ucjvuurx21fa91xmhktdde5ognhxig1vahls8z"
-  platform_id = "AWSLambda-SHA384-ECDSA"
-  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_uat]
-  signature_validity_period {
-    value = 10
-    type  = "YEARS"
-  }
-}
-
-resource "aws_lambda_code_signing_config" "lambda_csc_uat" {
-  count       = local.is-preproduction == true ? 1 : 0
-  description = "Lambda code signing configuration for uat environment"
-  allowed_publishers {
-    signing_profile_version_arns = [ 
-      "arn:aws:signer:eu-west-2:172753231260:/signing-profiles/ucjvuurx21fa91xmhktdde5ognhxig1vahls8z20241008084937718900000002/ZYACVFPo1R"
-    ]
-  }
-  policies {
-    untrusted_artifact_on_deployment = "Warn"
-  }
-}
-
-# Production
-
-resource "aws_signer_signing_profile" "lambda_signing_profile_prod" {
-  count       = local.is-production == true ? 1 : 0
-  name_prefix = "0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni"
-  platform_id = "AWSLambda-SHA384-ECDSA"
-  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_prod]
-  signature_validity_period {
-    value = 10
-    type  = "YEARS"
-  }
-}
-
-resource "aws_lambda_code_signing_config" "lambda_csc_prod" {
-  count       = local.is-production == true ? 1 : 0
-  description = "Lambda code signing configuration for production environment"
-  allowed_publishers {
-    signing_profile_version_arns = [
-      "arn:aws:signer:eu-west-2:817985104434:/signing-profiles/0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni20241008100713396700000002/HzoPedNoUr"
-    ]
-  }
-  policies {
-    untrusted_artifact_on_deployment = "Warn"
-  }
-}
-

--- a/terraform/environments/ppud/lambda_csc_signing_profile.tf
+++ b/terraform/environments/ppud/lambda_csc_signing_profile.tf
@@ -1,0 +1,81 @@
+##############################################################
+# Signing Profiles and Lambda Code Signing Configuration (CSC)
+##############################################################
+
+# Development signing profile and lambda signing configuration
+
+resource "aws_signer_signing_profile" "lambda_signing_profile_dev" {
+  count       = local.is-development == true ? 1 : 0
+  name_prefix = "grw77tzk96phtwcrceot5xlbt9veqixuyck044"
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_dev]
+  signature_validity_period {
+    value = 10
+    type  = "YEARS"
+  }
+}
+
+resource "aws_lambda_code_signing_config" "lambda_csc_dev" {
+  count       = local.is-development == true ? 1 : 0
+  description = "Lambda code signing configuration for development environment"
+  allowed_publishers {
+    signing_profile_version_arns = [
+      "arn:aws:signer:eu-west-2:075585660276:/signing-profiles/grw77tzk96phtwcrceot5xlbt9veqixuyck04420241008100655411100000002/AHvOa02ifI"
+    ]
+  }
+  policies {
+    untrusted_artifact_on_deployment = "Warn"
+  }
+}
+
+# UAT signing profile and lambda signing configuration
+
+resource "aws_signer_signing_profile" "lambda_signing_profile_uat" {
+  count       = local.is-preproduction == true ? 1 : 0
+  name_prefix = "ucjvuurx21fa91xmhktdde5ognhxig1vahls8z"
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_uat]
+  signature_validity_period {
+    value = 10
+    type  = "YEARS"
+  }
+}
+
+resource "aws_lambda_code_signing_config" "lambda_csc_uat" {
+  count       = local.is-preproduction == true ? 1 : 0
+  description = "Lambda code signing configuration for uat environment"
+  allowed_publishers {
+    signing_profile_version_arns = [ 
+      "arn:aws:signer:eu-west-2:172753231260:/signing-profiles/ucjvuurx21fa91xmhktdde5ognhxig1vahls8z20241008084937718900000002/ZYACVFPo1R"
+    ]
+  }
+  policies {
+    untrusted_artifact_on_deployment = "Warn"
+  }
+}
+
+# Production signing profile and lambda signing configuration
+
+resource "aws_signer_signing_profile" "lambda_signing_profile_prod" {
+  count       = local.is-production == true ? 1 : 0
+  name_prefix = "0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni"
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  depends_on  = [aws_iam_role_policy_attachment.attach_aws_signer_policy_to_aws_signer_role_prod]
+  signature_validity_period {
+    value = 10
+    type  = "YEARS"
+  }
+}
+
+resource "aws_lambda_code_signing_config" "lambda_csc_prod" {
+  count       = local.is-production == true ? 1 : 0
+  description = "Lambda code signing configuration for production environment"
+  allowed_publishers {
+    signing_profile_version_arns = [
+      "arn:aws:signer:eu-west-2:817985104434:/signing-profiles/0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni20241008100713396700000002/HzoPedNoUr"
+    ]
+  }
+  policies {
+    untrusted_artifact_on_deployment = "Warn"
+  }
+}


### PR DESCRIPTION
Split CloudWatch Alarms and Groups & Filters into separate files. Removed some redundant alarms. AWS signing profile and lambda signing configs spun into a separate file. Updated IAM policy to lock down SQS permissions to the queues. Updated lambda functions with VPC configs - to be enabled later.