### PR TITLE
Update WAF rule and alb actions from "Count" to "Block" for better protection against DDOS attacks

### DIFF
--- a/terraform/environments/equip/shield.tf
+++ b/terraform/environments/equip/shield.tf
@@ -16,7 +16,7 @@ module "shield" {
       "action"    = "block",
       "name"      = "equip-count-rule",
       "priority"  = 0,
-      "threshold" = "100"
+      "threshold" = "1000"
     }
   }
 }

--- a/terraform/environments/equip/shield.tf
+++ b/terraform/environments/equip/shield.tf
@@ -7,13 +7,13 @@ module "shield" {
   application_name = local.application_name
   resources = {
     citrix_alb = {
-      action = "count"
+      action = "block"
       arn    = aws_lb.citrix_alb.arn
     }
   }
   waf_acl_rules = {
     example = {
-      "action"    = "count",
+      "action"    = "block",
       "name"      = "equip-count-rule",
       "priority"  = 0,
       "threshold" = "100"


### PR DESCRIPTION
Tracked as part of ticket [#7975](https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=80386408) 

- These changes are intended to enhance the security posture by proactively blocking unwanted or malicious traffic.
- No Count Action Triggered: Looking at the CloudWatch metrics, the "count" action did not trigger after increasing the rate limit which suggests the traffic patterns have not reached the defined threshold, and it is safe to move to blocking action.