### PR TITLE
Update_101024_3

### DIFF
--- a/terraform/environments/ppud/endpointservice.tf
+++ b/terraform/environments/ppud/endpointservice.tf
@@ -20,8 +20,8 @@ resource "aws_lb" "ppud_internal_nlb" {
   load_balancer_type         = "network"
   subnets                    = [data.aws_subnet.private_subnets_b.id, data.aws_subnet.private_subnets_c.id]
   security_groups            = [aws_security_group.PPUD-ALB.id]
-  enable_deletion_protection = false # change it to true
-
+  enable_deletion_protection = true
+  
   tags = {
     Name = "${var.networking[0].business-unit}-${local.environment}"
   }

--- a/terraform/environments/ppud/iam.tf
+++ b/terraform/environments/ppud/iam.tf
@@ -159,7 +159,9 @@ resource "aws_iam_policy" "iam_policy_for_lambda" {
        "logs:CreateLogStream",
        "logs:PutLogEvents"
      ],
-     "Resource": "arn:aws:logs:*:*:*"
+     "Resource": [
+         "arn:aws:logs:eu-west-2:817985104434:*"
+     ]
     },
    {
      "Effect": "Allow",
@@ -167,7 +169,9 @@ resource "aws_iam_policy" "iam_policy_for_lambda" {
         "ec2:Start*",
         "ec2:Stop*"
       ],
-      "Resource": "*"
+      "Resource": [
+          "arn:aws:ec2:eu-west-2:817985104434:*"
+      ]
    },
    {
      "Effect": "Allow",
@@ -236,7 +240,9 @@ resource "aws_iam_policy" "iam_policy_for_lambda_alarm_suppression" {
        "logs:CreateLogStream",
        "logs:PutLogEvents"
      ],
-     "Resource": "arn:aws:logs:*:*:*"
+     "Resource": [
+         "arn:aws:logs:eu-west-2:817985104434:*"
+     ]
     },
    {
      "Effect": "Allow",
@@ -574,19 +580,25 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_dev" {
                 "acm:ListCertificates",
                 "acm:ListTagsForCertificate"
             ],
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:acm:eu-west-2:075585660276:certificate:*"
+            ]
         },
         {
             "Sid":"LambdaCertificateExpiryPolicy4",
             "Effect": "Allow",
             "Action": "SNS:Publish",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:sns:eu-west-2:075585660276:*"
+            ]
         },
                {
             "Sid": "LambdaCertificateExpiryPolicy5",
             "Effect": "Allow",
             "Action": "cloudwatch:ListMetrics",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:cloudwatch:eu-west-2:075585660276:*"
+            ]
         },
                {
             "Sid": "LambdaCertificateExpiryPolicy6",
@@ -675,19 +687,25 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_uat" {
                 "acm:ListCertificates",
                 "acm:ListTagsForCertificate"
             ],
-            "Resource": "*"
+            "Resource": [
+                 "arn:aws:acm:eu-west-2:172753231260:certificate:*"
+            ]
         },
         {
             "Sid":"LambdaCertificateExpiryPolicy4",
             "Effect": "Allow",
             "Action": "SNS:Publish",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:sns:eu-west-2:172753231260:*"
+            ]
         },
                {
             "Sid": "LambdaCertificateExpiryPolicy5",
             "Effect": "Allow",
             "Action": "cloudwatch:ListMetrics",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:cloudwatch:eu-west-2:172753231260:*"
+            ]
         },
            {
             "Sid": "LambdaCertificateExpiryPolicy6",
@@ -776,19 +794,25 @@ resource "aws_iam_policy" "iam_policy_for_lambda_certificate_expiry_prod" {
                 "acm:ListCertificates",
                 "acm:ListTagsForCertificate"
             ],
-            "Resource": "*"
+            "Resource": [
+                 "arn:aws:acm:eu-west-2:817985104434:certificate:*"
+            ]
         },
         {
             "Sid":"LambdaCertificateExpiryPolicy4",
             "Effect": "Allow",
             "Action": "SNS:Publish",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:sns:eu-west-2:817985104434:*"
+            ]
         },
                {
             "Sid": "LambdaCertificateExpiryPolicy5",
             "Effect": "Allow",
             "Action": "cloudwatch:ListMetrics",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:cloudwatch:eu-west-2:817985104434:*"
+            ]
         },
            {
             "Sid": "LambdaCertificateExpiryPolicy6",
@@ -997,7 +1021,10 @@ resource "aws_iam_policy" "aws_signer_policy_prod" {
           "signer:GetSigningProfile",
           "signer:ListSigningJobs"
         ],
-        Resource = "*"
+        Resource = [
+          "arn:aws:signer:eu-west-2:817985104434:/signing-profiles/0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni20241008100713396700000002",
+          "arn:aws:signer:eu-west-2:817985104434:/signing-profiles/0r1ihd4swpgdxsjmfe1ibqhvdpm3zg05le4uni20241008100713396700000002/HzoPedNoUr"
+        ]
       }
     ]
   })
@@ -1055,7 +1082,10 @@ resource "aws_iam_policy" "aws_signer_policy_uat" {
           "signer:GetSigningProfile",
           "signer:ListSigningJobs"
         ],
-        Resource = "*"
+        Resource = [
+          "arn:aws:signer:eu-west-2:172753231260:/signing-profiles/ucjvuurx21fa91xmhktdde5ognhxig1vahls8z20241008084937718900000002",
+          "arn:aws:signer:eu-west-2:172753231260:/signing-profiles/ucjvuurx21fa91xmhktdde5ognhxig1vahls8z20241008084937718900000002/ZYACVFPo1R"
+        ]
       }
     ]
   })
@@ -1113,7 +1143,10 @@ resource "aws_iam_policy" "aws_signer_policy_dev" {
           "signer:GetSigningProfile",
           "signer:ListSigningJobs"
         ],
-        Resource = "*"
+        Resource = [
+          "arn:aws:signer:eu-west-2:075585660276:/signing-profiles/grw77tzk96phtwcrceot5xlbt9veqixuyck04420241008100655411100000002",
+          "arn:aws:signer:eu-west-2:075585660276:/signing-profiles/grw77tzk96phtwcrceot5xlbt9veqixuyck04420241008100655411100000002/AHvOa02ifI"
+        ]
       }
     ]
   })

--- a/terraform/environments/ppud/lambda.tf
+++ b/terraform/environments/ppud/lambda.tf
@@ -20,6 +20,7 @@ data "archive_file" "zip_the_stop_instance_code" {
 # Lambda Function for Stop and Start of Instance
 #################################################
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_stop" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/stop-instance/StopEC2Instances.zip"
@@ -38,6 +39,7 @@ resource "aws_lambda_function" "terraform_lambda_func_stop" {
   }
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_start" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/start-instance/StartEC2Instances.zip"
@@ -187,6 +189,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_enable_cpu_alarm" {
 
 # Disable CPU Alarm
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_disable_cpu_alarm" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/disable_cpu_alarm.zip"
@@ -207,6 +210,7 @@ resource "aws_lambda_function" "terraform_lambda_disable_cpu_alarm" {
 
 # Enable CPU Alarm
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_enable_cpu_alarm" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/enable_cpu_alarm.zip"
@@ -238,6 +242,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_
   source_arn    = "arn:aws:cloudwatch:eu-west-2:075585660276:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_terminate_cpu_process_dev" {
   count         = local.is-development == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/terminate_cpu_process_dev.zip"
@@ -279,6 +284,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_
   source_arn    = "arn:aws:cloudwatch:eu-west-2:172753231260:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_terminate_cpu_process_uat" {
   count         = local.is-preproduction == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/terminate_cpu_process_uat.zip"
@@ -320,6 +326,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_terminate_cpu_
   source_arn    = "arn:aws:cloudwatch:eu-west-2:817985104434:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_terminate_cpu_process_prod" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/terminate_cpu_process_prod.zip"
@@ -361,6 +368,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_send_cpu_notif
   source_arn    = "arn:aws:cloudwatch:eu-west-2:075585660276:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_dev" {
   count         = local.is-development == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/send_cpu_notification_dev.zip"
@@ -406,6 +414,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_send_cpu_notif
   source_arn    = "arn:aws:cloudwatch:eu-west-2:172753231260:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_uat" {
   count         = local.is-preproduction == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/send_cpu_notification_uat.zip"
@@ -451,6 +460,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_send_cpu_notif
   source_arn    = "arn:aws:cloudwatch:eu-west-2:817985104434:alarm:*"
 }
 
+#trivy:ignore:CKV_AWS_117: "PPUD Lambda functions do not require VPC access and can run in no-VPC mode"
 resource "aws_lambda_function" "terraform_lambda_func_send_cpu_notification_prod" {
   count         = local.is-production == true ? 1 : 0
   filename      = "${path.module}/lambda_scripts/send_cpu_notification_prod.zip"


### PR DESCRIPTION
Configured all Lambda functions to skip the Trivy scan check for being inside a VPC. Enabled deletion protection on internal NLB.
Further Locked down IAM permissions by removing access without constraints