### PR TITLE
ncr: TM-598: disable instance scheduling in preprod

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -136,6 +136,7 @@ locals {
           ])
         })
         tags = merge(local.ec2_instances.bip_app.tags, {
+          instance-scheduling                  = "skip-scheduling"
           nomis-combined-reporting-environment = "pp"
         })
       })
@@ -148,6 +149,7 @@ locals {
           ])
         })
         tags = merge(local.ec2_instances.bip_cms.tags, {
+          instance-scheduling                  = "skip-scheduling"
           nomis-combined-reporting-environment = "pp"
         })
       })
@@ -160,6 +162,7 @@ locals {
           ])
         })
         tags = merge(local.ec2_instances.bip_cms.tags, {
+          instance-scheduling                  = "skip-scheduling"
           nomis-combined-reporting-environment = "pp"
         })
       })
@@ -192,6 +195,7 @@ locals {
           ])
         })
         tags = merge(local.ec2_instances.bip_webadmin.tags, {
+          instance-scheduling                  = "skip-scheduling"
           nomis-combined-reporting-environment = "pp"
         })
       })
@@ -204,6 +208,7 @@ locals {
           ])
         })
         tags = merge(local.ec2_instances.bip_web.tags, {
+          instance-scheduling                  = "skip-scheduling"
           nomis-combined-reporting-environment = "pp"
         })
       })


### PR DESCRIPTION
Environment needs to be turned off in a more controlled way, i.e. via a pipeline. Disable the mod platform solution.