### PR TITLE
Revert temporary fixes due to issues with aws provider 5.71.0

### DIFF
--- a/terraform/environments/electronic-monitoring-data/platform_versions.tf
+++ b/terraform/environments/electronic-monitoring-data/platform_versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
+      version = "~> 5.0"
       source  = "hashicorp/aws"
-      version = "~> 5.0, != 5.71.0"
     }
     http = {
       version = "~> 3.0"

--- a/terraform/environments/ppud/platform_versions.tf
+++ b/terraform/environments/ppud/platform_versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
+      version = "~> 5.0"
       source  = "hashicorp/aws"
-      version = "~> 5.0, != 5.71.0"
     }
     http = {
       version = "~> 3.0"

--- a/terraform/environments/sprinkler/platform_versions.tf
+++ b/terraform/environments/sprinkler/platform_versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
+      version = "~> 5.0"
       source  = "hashicorp/aws"
-      version = "~> 5.0, != 5.71.0"
     }
     http = {
       version = "~> 3.0"


### PR DESCRIPTION
Reverts temporary fixes to avoid issues with aws provider 5.71.0 that have now been resolved.

See bug https://github.com/hashicorp/terraform-provider-aws/issues/39676 for further information.