### PR TITLE
Changed the actions from count to block for better protection against DDOS attacks

### DIFF
--- a/terraform/environments/ppud/shield.tf
+++ b/terraform/environments/ppud/shield.tf
@@ -7,13 +7,13 @@ module "shield" {
   application_name = local.application_name
   resources = {
     WAM-ALB = {
-      action = "count"
+      action = "block"
       arn    = aws_lb.WAM-ALB.arn
     }
   }
   waf_acl_rules = {
     example = {
-      "action"    = "count",
+      "action"    = "block",
       "name"      = "DDoSprotection",
       "priority"  = 0,
       "threshold" = "2000"


### PR DESCRIPTION
Tracked as part of ticket [#7975](https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=80386408) 

- These changes are intended to enhance the security posture by proactively blocking unwanted or malicious traffic.
- No count action triggered after increasing the threshold: Looking at the CloudWatch metrics, the "count" action did not trigger, which suggests the traffic patterns have not reached the defined threshold, and it is safe to move to blocking action.
