### PR TITLE
Add lambda permission for cloudwatch event trigger

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -725,6 +725,14 @@ resource "aws_iam_role" "virus_scan_file" {
 
 data "aws_iam_policy_document" "virus_scan_file_policy_document" {
   statement {
+    sid    = "S3PermissionsForScanDefinitionsBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = ["${module.s3-clamav-definitions-bucket.bucket.arn}/*"]
+  }
+  statement {
     sid    = "S3PermissionsForReceivedBucket"
     effect = "Allow"
     actions = [
@@ -741,7 +749,8 @@ data "aws_iam_policy_document" "virus_scan_file_policy_document" {
     actions = [
       "s3:CopyObject",
       "s3:PutObject",
-      "s3:PutObjectTagging"
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
     ]
     resources = [
       "${module.s3-quarantine-files-bucket.bucket.arn}/*",

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -368,6 +368,14 @@ module "virus_scan_definition_upload" {
   }
 }
 
+resource "aws_lambda_permission" "virus_scan_definition_upload_allow_eventbridge" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.virus_scan_definition_upload.lambda_function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.definition_update.arn
+}
+
 #-----------------------------------------------------------------------------------
 # Virus scanning - file scan
 #-----------------------------------------------------------------------------------


### PR DESCRIPTION
As it says on the tin, forgot to include the actual trigger to the lambda for definition updates to run daily.