### PR TITLE
Adding Control Panel service role to Ananlytical Platform Compute

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -1,26 +1,4 @@
 locals {
-  /* VPC */
-  our_vpc_name                                        = "${local.application_name}-${local.environment}"
-  vpc_flow_log_cloudwatch_log_group_name_prefix       = "/aws/vpc-flow-log/"
-  vpc_flow_log_cloudwatch_log_group_name_suffix       = local.our_vpc_name
-  vpc_flow_log_cloudwatch_log_group_retention_in_days = 400
-  vpc_flow_log_max_aggregation_interval               = 60
-
-  /* AMP */
-  amp_workspace_alias                        = "${local.application_name}-${local.environment}"
-  amp_cloudwatch_log_group_name              = "/aws/amp/${local.amp_workspace_alias}"
-  amp_cloudwatch_log_group_retention_in_days = 400
-
-  /* EKS */
-  eks_cluster_name                           = "${local.application_name}-${local.environment}"
-  eks_cloudwatch_log_group_name              = "/aws/eks/${local.eks_cluster_name}/logs"
-  eks_cloudwatch_log_group_retention_in_days = 400
-
-  /* Kube Prometheus Stack */
-  prometheus_operator_crd_version = "v0.76.1"
-
-  /* Environment Configuration */
-  environment_configuration = local.environment_configurations[local.environment]
   environment_configurations = {
     development = {
       /* VPC */

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -295,9 +295,9 @@ module "analytical_platform_control_panel_service_role" {
     format("arn:aws:iam::%s:root", local.environment_management.account_ids[local.analytical_platform_environment])
 
   ]
-  create_role = true
+  create_role       = true
   role_requires_mfa = false
-  role_name   = "analytical-platform-control-panel"
+  role_name         = "analytical-platform-control-panel"
 
   custom_role_policy_arns = [
     module.analytical_platform_lake_formation_share_policy.arn,

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -283,3 +283,24 @@ module "analytical_platform_ui_service_role" {
   }
   tags = local.tags
 }
+
+module "analytical_platform_control_panel_service_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.46.0"
+
+  allow_self_assume_role = true
+  trusted_role_arns = [
+    format("arn:aws:iam::%s:root", local.environment_management.account_ids["analytical-platform-${local.environment}"])
+  ]
+  create_role = true
+  role_name   = "analytical-platform-control-panel"
+
+  cutom_role_policy_arns = {
+    "lake_formation_and_quicksight"      = module.analytical_platform_lake_formation_share_policy.arn
+    "lake_formation_cross_account_share" = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+  }
+  number_of_custom_role_policy_arns = 2
+
+}

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -292,12 +292,12 @@ module "analytical_platform_control_panel_service_role" {
 
   allow_self_assume_role = true
   trusted_role_arns = [
-    format("arn:aws:iam::%s:root", local.environment_management.account_ids["analytical-platform-${local.environment}"])
+    format("arn:aws:iam::%s:root", local.environment_management.account_ids["analytical-platform-${local.analytical_platform_environment}"])
   ]
   create_role = true
   role_name   = "analytical-platform-control-panel"
 
-  cutom_role_policy_arns = {
+  custom_role_policy_arns = {
     "lake_formation_and_quicksight"      = module.analytical_platform_lake_formation_share_policy.arn
     "lake_formation_cross_account_share" = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
   }

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -292,7 +292,8 @@ module "analytical_platform_control_panel_service_role" {
 
   allow_self_assume_role = true
   trusted_role_arns = [
-    format("arn:aws:iam::%s:root", local.environment_management.account_ids["analytical-platform-${local.analytical_platform_environment}"])
+    format("arn:aws:iam::%s:root", local.environment_management.account_ids[local.analytical_platform_environment])
+
   ]
   create_role = true
   role_name   = "analytical-platform-control-panel"

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -296,6 +296,7 @@ module "analytical_platform_control_panel_service_role" {
 
   ]
   create_role = true
+  role_requires_mfa = false
   role_name   = "analytical-platform-control-panel"
 
   custom_role_policy_arns = [

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -297,10 +297,10 @@ module "analytical_platform_control_panel_service_role" {
   create_role = true
   role_name   = "analytical-platform-control-panel"
 
-  custom_role_policy_arns = {
-    "lake_formation_and_quicksight"      = module.analytical_platform_lake_formation_share_policy.arn
-    "lake_formation_cross_account_share" = "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
-  }
+  custom_role_policy_arns = [
+    module.analytical_platform_lake_formation_share_policy.arn,
+    "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+  ]
   number_of_custom_role_policy_arns = 2
 
 }

--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -1,0 +1,29 @@
+locals {
+  /* VPC */
+  our_vpc_name                                        = "${local.application_name}-${local.environment}"
+  vpc_flow_log_cloudwatch_log_group_name_prefix       = "/aws/vpc-flow-log/"
+  vpc_flow_log_cloudwatch_log_group_name_suffix       = local.our_vpc_name
+  vpc_flow_log_cloudwatch_log_group_retention_in_days = 400
+  vpc_flow_log_max_aggregation_interval               = 60
+
+  /* AMP */
+  amp_workspace_alias                        = "${local.application_name}-${local.environment}"
+  amp_cloudwatch_log_group_name              = "/aws/amp/${local.amp_workspace_alias}"
+  amp_cloudwatch_log_group_retention_in_days = 400
+
+  /* EKS */
+  eks_cluster_name                           = "${local.application_name}-${local.environment}"
+  eks_cloudwatch_log_group_name              = "/aws/eks/${local.eks_cluster_name}/logs"
+  eks_cloudwatch_log_group_retention_in_days = 400
+
+  /* Kube Prometheus Stack */
+  prometheus_operator_crd_version = "v0.76.1"
+
+  /* Mapping Analytical Platform Environments to Modernisation Platform */
+
+  analytical_platform_environment = format("analytical-platform-%s", local.environment == "test" ? "development" : local.environment)
+
+  /* Environment Configuration */
+  environment_configuration = local.environment_configurations[local.environment]
+
+}


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/5532

Adding a role assumable from Analytical Platform Dev/Prod to allow Control Panel to access and manage QuickSight.