### PR TITLE
🚢  Fix AWS Fluent Bit log shipping for Karpenter nodes

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/values/aws-for-fluent-bit/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/aws-for-fluent-bit/values.yml.tftpl
@@ -12,3 +12,5 @@ serviceAccount:
   name: aws-for-fluent-bit
   annotations:
     eks.amazonaws.com/role-arn: ${eks_role_arn}
+
+priorityClassName: system-node-critical

--- a/terraform/environments/analytical-platform-compute/src/helm/values/aws-for-fluent-bit/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/aws-for-fluent-bit/values.yml.tftpl
@@ -14,3 +14,6 @@ serviceAccount:
     eks.amazonaws.com/role-arn: ${eks_role_arn}
 
 priorityClassName: system-node-critical
+
+tolerations:
+  - operator: Exists


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/analytical-platform/issues/5680
- Sets `priorityClassName` to  `system-node-critical`
- Add `operator: Exists` toleration which allows pod to schedule on any node, including those with `NoSchedule` taint

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 