### PR TITLE
📌 APC Patching 16/10/24

### DIFF
--- a/terraform/environments/analytical-platform-compute/cloudwatch-log-groups.tf
+++ b/terraform/environments/analytical-platform-compute/cloudwatch-log-groups.tf
@@ -3,7 +3,7 @@ module "eks_log_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.6.1"
 
   name              = local.eks_cloudwatch_log_group_name
   kms_key_id        = module.eks_cluster_logs_kms.key_arn
@@ -17,7 +17,7 @@ module "managed_prometheus_log_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.6.1"
 
   name              = local.amp_cloudwatch_log_group_name
   kms_key_id        = module.managed_prometheus_logs_kms.key_arn

--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -104,13 +104,13 @@ module "eks" {
       min_size       = 1
       max_size       = 10
       desired_size   = 3
-      instance_types = ["t3.xlarge"]
+      instance_types = ["m6a.xlarge"]
     }
     airflow-high-memory = {
       min_size       = 0
       max_size       = 1
       desired_size   = 0
-      instance_types = ["r6i.8xlarge"]
+      instance_types = ["r7i.8xlarge"]
       labels = {
         high-memory = "true"
       }

--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -6,7 +6,7 @@ module "eks" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks/aws"
-  version = "20.24.2"
+  version = "20.26.0"
 
   cluster_name    = local.eks_cluster_name
   cluster_version = local.environment_configuration.eks_cluster_version
@@ -172,7 +172,7 @@ module "karpenter" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "20.24.2"
+  version = "20.26.0"
 
   cluster_name = module.eks.cluster_name
 

--- a/terraform/environments/analytical-platform-compute/eks-pod-identities.tf
+++ b/terraform/environments/analytical-platform-compute/eks-pod-identities.tf
@@ -7,7 +7,7 @@ module "aws_cloudwatch_metrics_pod_identity" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.4.2"
+  version = "1.5.0"
 
   name = "aws-cloudwatch-metrics"
 

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -24,16 +24,16 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
-      eks_cluster_version = "1.30"
-      eks_node_version    = "1.23.0-74970be4"
+      eks_cluster_version = "1.31"
+      eks_node_version    = "1.25.0-388e1050"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.3-eksbuild.1"
-        kube_proxy             = "v1.30.3-eksbuild.5"
+        kube_proxy             = "v1.31.0-eksbuild.5"
         aws_ebs_csi_driver     = "v1.35.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.7-eksbuild.1"
         aws_guardduty_agent    = "v1.7.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.2-eksbuild.2"
-        vpc_cni                = "v1.18.3-eksbuild.3"
+        vpc_cni                = "v1.18.5-eksbuild.1"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -75,16 +75,16 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.30"
-      eks_node_version    = "1.23.0-74970be4"
+      eks_cluster_version = "1.31"
+      eks_node_version    = "1.25.0-388e1050"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.3-eksbuild.1"
-        kube_proxy             = "v1.30.3-eksbuild.5"
+        kube_proxy             = "v1.31.0-eksbuild.5"
         aws_ebs_csi_driver     = "v1.35.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.7-eksbuild.1"
         aws_guardduty_agent    = "v1.7.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.2-eksbuild.2"
-        vpc_cni                = "v1.18.3-eksbuild.3"
+        vpc_cni                = "v1.18.5-eksbuild.1"
       }
 
       /* Observability Platform */
@@ -125,16 +125,16 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.30"
-      eks_node_version    = "1.23.0-74970be4"
+      eks_cluster_version = "1.31"
+      eks_node_version    = "1.25.0-388e1050"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.3-eksbuild.1"
-        kube_proxy             = "v1.30.3-eksbuild.5"
+        kube_proxy             = "v1.31.0-eksbuild.5"
         aws_ebs_csi_driver     = "v1.35.0-eksbuild.1"
         aws_efs_csi_driver     = "v2.0.7-eksbuild.1"
         aws_guardduty_agent    = "v1.7.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.2-eksbuild.2"
-        vpc_cni                = "v1.18.3-eksbuild.3"
+        vpc_cni                = "v1.18.5-eksbuild.1"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -4,7 +4,7 @@ resource "helm_release" "kyverno" {
   name       = "kyverno"
   repository = "https://kyverno.github.io/kyverno"
   chart      = "kyverno"
-  version    = "3.2.6"
+  version    = "3.2.7"
   namespace  = kubernetes_namespace.kyverno.metadata[0].name
   values = [
     templatefile(
@@ -71,7 +71,7 @@ resource "helm_release" "amazon_prometheus_proxy" {
   name       = "amazon-prometheus-proxy"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  version    = "62.7.0"
+  version    = "65.2.0"
   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
   values = [
     templatefile(
@@ -96,7 +96,7 @@ resource "helm_release" "cluster_autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.40.0"
+  version    = "9.43.0"
   namespace  = kubernetes_namespace.cluster_autoscaler.metadata[0].name
 
   values = [
@@ -119,7 +119,7 @@ resource "helm_release" "karpenter_crd" {
   name       = "karpenter-crd"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter-crd"
-  version    = "1.0.3"
+  version    = "1.0.6"
   namespace  = kubernetes_namespace.karpenter.metadata[0].name
 
   values = [
@@ -141,7 +141,7 @@ resource "helm_release" "karpenter" {
   name       = "karpenter"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
-  version    = "1.0.3"
+  version    = "1.0.6"
   namespace  = kubernetes_namespace.karpenter.metadata[0].name
 
   values = [
@@ -209,7 +209,7 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.15.3"
+  version    = "v1.16.1"
   namespace  = kubernetes_namespace.cert_manager.metadata[0].name
   values = [
     templatefile(
@@ -262,7 +262,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
-  version    = "4.11.2"
+  version    = "4.11.3"
   namespace  = kubernetes_namespace.ingress_nginx.metadata[0].name
   values = [
     templatefile(

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -18,7 +18,7 @@ module "eks_cluster_logs_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "eks-cluster-logs-kms-access"
 
@@ -45,7 +45,7 @@ module "karpenter_sqs_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "karpenter-sqs-kms-access"
 
@@ -71,7 +71,7 @@ module "amazon_prometheus_proxy_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "amazon-prometheus-proxy"
 
@@ -98,7 +98,7 @@ module "managed_prometheus_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "managed-prometheus-kms-access"
 
@@ -147,7 +147,7 @@ module "mlflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "mlflow"
 
@@ -168,7 +168,7 @@ module "gha_mojas_airflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "github-actions-mojas-airflow"
 
@@ -274,7 +274,7 @@ module "analytical_platform_lake_formation_share_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name_prefix = "analytical-platform-lake-formation-sharing-policy"
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -3,7 +3,7 @@ module "vpc_cni_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix      = "vpc-cni"
   attach_vpc_cni_policy = true
@@ -24,7 +24,7 @@ module "ebs_csi_driver_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix      = "ebs-csi-driver"
   attach_ebs_csi_policy = true
@@ -44,7 +44,7 @@ module "efs_csi_driver_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix      = "efs-csi-driver"
   attach_efs_csi_policy = true
@@ -64,7 +64,7 @@ module "aws_for_fluent_bit_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix = "aws-for-fluent-bit"
 
@@ -88,7 +88,7 @@ module "amazon_prometheus_proxy_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix = "amazon-prometheus-proxy"
 
@@ -111,7 +111,7 @@ module "cluster_autoscaler_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix = "cluster-autoscaler"
 
@@ -133,7 +133,7 @@ module "external_dns_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix              = "external-dns"
   attach_external_dns_policy    = true
@@ -154,7 +154,7 @@ module "cert_manager_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix              = "cert-manager"
   attach_cert_manager_policy    = true
@@ -175,7 +175,7 @@ module "external_secrets_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix               = "external-secrets"
   attach_external_secrets_policy = true
@@ -196,7 +196,7 @@ module "mlflow_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   role_name_prefix = "mlflow"
 
@@ -219,7 +219,7 @@ module "gha_mojas_airflow_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.44.1"
+  version = "5.46.0"
 
   name = "github-actions-mojas-airflow"
 
@@ -237,7 +237,7 @@ module "lake_formation_share_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.44.1"
+  version = "5.46.0"
 
   create_role       = true
   role_requires_mfa = false
@@ -265,7 +265,7 @@ module "analytical_platform_ui_service_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.44.1"
+  version = "5.46.0"
 
   create_role = true
 

--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -3,7 +3,7 @@ module "vpc_flow_logs_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases                 = ["vpc/flow-logs"]
   description             = "VPC flow logs KMS key"
@@ -45,7 +45,7 @@ module "managed_prometheus_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases                 = ["amp/default"]
   description             = "AMP KMS key"
@@ -91,7 +91,7 @@ module "managed_prometheus_logs_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases                 = ["amp/logs"]
   description             = "AMP logs KMS key"
@@ -133,7 +133,7 @@ module "eks_cluster_logs_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases                 = ["eks/cluster-logs"]
   description             = "EKS cluster logs KMS key"
@@ -175,7 +175,7 @@ module "eks_ebs_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases                 = ["eks/ebs"]
   description             = "EKS EBS KMS key"
@@ -232,7 +232,7 @@ module "mlflow_auth_rds_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["rds/mlflow-auth"]
   description           = "MLflow Auth RDS KMS key"
@@ -248,7 +248,7 @@ module "mlflow_rds_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["rds/mlflow"]
   description           = "MLflow RDS KMS key"
@@ -264,7 +264,7 @@ module "mlflow_s3_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["s3/mlflow"]
   description           = "MLflow S3 KMS key"
@@ -280,7 +280,7 @@ module "common_secrets_manager_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["secretsmanager/common"]
   description           = "Common Secrets Manager KMS key"
@@ -296,7 +296,7 @@ module "karpenter_sqs_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["sqs/karpenter"]
   description           = "Karpenter SQS KMS key"
@@ -329,7 +329,7 @@ module "ui_rds_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["rds/ui"]
   description           = "UI RDS KMS key"
@@ -347,7 +347,7 @@ module "actions_runner_cache_efs_kms" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
+  version = "3.1.1"
 
   aliases               = ["efs/actions-runner-cache"]
   description           = "Actions Runner Cache EFS KMS key"

--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -17,7 +17,7 @@ locals {
   eks_cloudwatch_log_group_retention_in_days = 400
 
   /* Kube Prometheus Stack */
-  prometheus_operator_crd_version = "v0.76.1"
+  prometheus_operator_crd_version = "v0.77.1"
 
   /* Mapping Analytical Platform Environments to Modernisation Platform */
 

--- a/terraform/environments/analytical-platform-compute/rds.tf
+++ b/terraform/environments/analytical-platform-compute/rds.tf
@@ -3,7 +3,7 @@ module "mlflow_auth_rds" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.9.0"
+  version = "6.10.0"
 
   identifier = "mlflow-auth"
 
@@ -73,7 +73,7 @@ module "mlflow_rds" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.9.0"
+  version = "6.10.0"
 
   identifier = "mlflow"
 
@@ -143,7 +143,7 @@ module "ui_rds" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.9.0"
+  version = "6.10.0"
 
   identifier = "ui"
 

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -3,7 +3,7 @@ module "mlflow_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.1.2"
+  version = "4.2.1"
 
   bucket = "mojap-compute-${local.environment}-mlflow"
 

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -5,7 +5,7 @@ module "actions_runners_create_a_derived_table_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "actions-runners/create-a-derived-table"
   description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/2208432"
@@ -28,7 +28,7 @@ module "actions_runners_airflow_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "actions-runners/airflow"
   description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/3544241"
@@ -51,7 +51,7 @@ module "actions_runners_airflow_create_a_pipeline_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "actions-runners/airflow-create-a-pipeline"
   description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/3733767"
@@ -72,7 +72,7 @@ module "ui_sentry_dsn_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "ui/sentry-dsn"
   description = "Sentry DSN for Analytical Platform UI"
@@ -89,7 +89,7 @@ module "ui_azure_client_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "ui/azure-client"
   description = "Azure client secret for Analytical Platform UI"
@@ -106,7 +106,7 @@ module "ui_azure_tenant_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.0"
+  version = "1.3.1"
 
   name        = "ui/azure-tenant"
   description = "Azure tenant secret for Analytical Platform UI"


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/analytical-platform/issues/5661
- Switches to m6a for general purpose compute
- Switches to r7i for Airflow's high-memory compute

Do not merge until maintenance window at 1500!

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 