### PR TITLE
🚑 Allow egress from DataSync VPC endpoint SG

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -109,6 +109,9 @@ module "datasync_vpc_endpoint_security_group" {
 
   vpc_id = module.connected_vpc.vpc_id
 
+  egress_cidr_blocks = [module.connected_vpc.vpc_cidr_block]
+  egress_rules       = ["all-all",]
+
   ingress_with_cidr_blocks = [
     {
       from_port   = 1024


### PR DESCRIPTION
This pull request:

- Allows egress to VPC from DataSync VPC endpoint

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 