### PR TITLE
DPR2-1136: Add new reconciliation job parameters

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -637,6 +637,8 @@ module "glue_data_reconciliation_job" {
     "--dpr.reconciliation.datasource.glue.connection.name"        = aws_glue_connection.glue_nomis_connection[0].name
     "--dpr.reconciliation.datasource.source.schema.name"          = "OMS_OWNER"
     "--dpr.reconciliation.datasource.should.uppercase.tablenames" = "true"
+    "--dpr.reconciliation.fail.job.if.checks.fail"                = "true"
+    "--dpr.reconciliation.report.results.to.cloudwatch"           = "false"
   })
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/main.tf
@@ -160,6 +160,7 @@ resource "aws_rds_cluster" "this" {
 ################################################################################
 
 resource "aws_rds_cluster_instance" "this" {
+  #checkov:skip=CKV_AWS_118: "Ensure that enhanced monitoring is enabled for Amazon RDS instances"
   for_each = { for k, v in var.instances : k => v if local.create && !local.is_serverless }
 
   apply_immediately                     = try(each.value.apply_immediately, var.apply_immediately)
@@ -419,6 +420,7 @@ resource "aws_db_parameter_group" "this" {
 # Log groups will not be created if using a cluster identifier prefix
 resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS, Skipping for Timebeing in view of Cost Savings”
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
 
   for_each = toset([for log in var.enabled_cloudwatch_logs_exports : log if local.create && var.create_cloudwatch_log_group && !var.cluster_use_name_prefix])
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/main.tf
@@ -39,6 +39,7 @@ resource "aws_db_subnet_group" "this" {
 resource "aws_rds_cluster" "this" {
   #checkov:skip=CKV2_AWS_8: "Ignore - Ensure that RDS clusters has backup plan of AWS Backup"
   #checkov:skip=CKV2_AWS_27: "Ignore - Ensure Postgres RDS as aws_rds_cluster has Query Logging enabled"
+  #checkov:skip=CKV_AWS_324: "Ensure that RDS Cluster log capture is enabled"
   count = local.create ? 1 : 0
 
   allocated_storage                   = var.allocated_storage
@@ -453,6 +454,7 @@ resource "aws_rds_cluster_activity_stream" "this" {
 ################################################################################
 
 resource "aws_secretsmanager_secret_rotation" "this" {
+  #checkov:skip=CKV_AWS_304: "Ensure Secrets Manager secrets should be rotated within 90 days"
   count = local.create && var.manage_master_user_password && var.manage_master_user_password_rotation ? 1 : 0
 
   secret_id          = aws_rds_cluster.this[0].master_user_secret[0].secret_arn

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/main.tf
@@ -1,5 +1,6 @@
 resource "aws_secretsmanager_secret" "password" {
   #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
+  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
 
   name = "${var.name}-password"
 }
@@ -39,6 +40,13 @@ resource "aws_db_instance" "default" {
   #checkov:skip=CKV2_AWS_30:”Query Logging is not required"
   #checkov:skip=CKV2_AWS_60: “Ignore -Ensure RDS instance with copy tags to snapshots is enabled"
   #checkov:skip=CKV_AWS_129: "Ensure that respective logs of Amazon Relational Database Service (Amazon RDS) are enabled"
+  #checkov:skip=CKV_AWS_161: "Ensure RDS database has IAM authentication enabled"
+  #checkov:skip=CKV_AWS_354: "Ensure RDS Performance Insights are encrypted using KMS CMKs"
+  #checkov:skip=CKV_AWS_157: "Ensure that RDS instances have Multi-AZ enabled"
+  #checkov:skip=CKV_AWS_118: "Ensure that enhanced monitoring is enabled for Amazon RDS instances"
+  #checkov:skip=CKV_AWS_353: "Ensure that RDS instances have performance insights enabled"
+  #checkov:skip=CKV_AWS_226: "Ensure DB instance gets all minor upgrades automatically"
+  #checkov:skip=CKV_AWS_293: "Ensure that AWS database instances have deletion protection enabled"
 
   count                   = var.enable_rds ? 1 : 0
   identifier              = var.name

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+    random = {
+      version = ">= 3.0.0"
+      source  = "hashicorp/random"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/digital-prison-reporting/modules/redshift/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/main.tf
@@ -13,6 +13,8 @@ resource "aws_redshift_cluster" "this" {
   count = var.create_redshift_cluster ? 1 : 0
 
   #checkov:skip=CKV_AWS_105: "Ensure Redshift uses SSL"
+  #checkov:skip=CKV_AWS_71: "Ensure Redshift Cluster logging is enabled"
+  #checkov:skip=CKV_AWS_321: "Ensure Redshift clusters use enhanced VPC routing"
 
   cluster_identifier                   = var.name
   allow_version_upgrade                = var.allow_version_upgrade

--- a/terraform/environments/digital-prison-reporting/modules/redshift/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/secrets.tf
@@ -17,6 +17,7 @@ resource "random_string" "unique_suffix" {
 
 resource "aws_secretsmanager_secret" "redshift_connection" {
   #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
+  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
 
   description = "Redshift connect details"
   name        = "${var.project_id}-redshift-secret-${var.env}"

--- a/terraform/environments/digital-prison-reporting/modules/redshift/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/variables.tf
@@ -1,4 +1,6 @@
-variable "vpc" {}
+variable "vpc" {
+  type = string
+}
 
 variable "project_id" {
   type        = string
@@ -18,6 +20,7 @@ variable "cidr" {
 
 variable "redshift_ingress_sec_rules" {
   description = "A Map of map of security group Rules to associate with"
+  type        = map(object)
   default = {
     "redshift-tcp" = {
       "from_port" = 5439,

--- a/terraform/environments/digital-prison-reporting/modules/redshift/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/variables.tf
@@ -20,7 +20,7 @@ variable "cidr" {
 
 variable "redshift_ingress_sec_rules" {
   description = "A Map of map of security group Rules to associate with"
-  type        = map(object)
+  type        = map(map(any))
   default = {
     "redshift-tcp" = {
       "from_port" = 5439,

--- a/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+    random = {
+      version = ">= 3.0.0"
+      source  = "hashicorp/random"
+    }
+
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
Configure non-domain reconciliation job to:

- fail job if reconciliation fails
- not write cloudwatch metrics

This is because this job is generally used to manually check reconciliation where we want the job to fail to indicate failure rather than cloudwatch metrics.

Also includes a bunch of checkov, linting, etc. changes