### PR TITLE
Fixing trust policy to point to the correct account

### DIFF
--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -21,8 +21,14 @@ locals {
 
   /* Mapping Analytical Platform Environments to Modernisation Platform */
 
-  analytical_platform_environment = format("analytical-platform-%s", local.environment == "test" ? "development" : local.environment)
-
+  environment_map = {
+    "test"       = "development",
+    "production" = "data-production"
+  }
+  analytical_platform_environment = format(
+    "analytical-platform-%s",
+    lookup(local.environment_map, local.environment, local.environment)
+  )
   /* Environment Configuration */
   environment_configuration = local.environment_configurations[local.environment]
 


### PR DESCRIPTION
Fixing the trust policy for the Control Panel service role to allow it to be assumed from within Analytical Platform Data Production account.