### PR TITLE
use different user-data script for testing

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -134,7 +134,7 @@ locals {
             "Ec2SecretPolicy",
           ])
           user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+            "./templates/user-data-onr-bods-pwsh-drive-init.yaml.tftpl", {
               branch = "TM/TM-584/fix-path"
             }
           ))

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh-drive-init.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bods-pwsh-drive-init.yaml.tftpl
@@ -1,0 +1,99 @@
+# This is an EC2Launch V2 type user-data script
+# https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-settings.html#ec2launch-v2-task-configuration
+# See C:\ProgramData\Amazon\EC2Launch\log for logs
+# See C:\Windows\System32\config\systemprofile\AppData\Local\Temp\EC2Launch* for script output
+version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
+tasks:
+  - task: initializeVolume
+    inputs:
+        initialize: all
+  - task: executeScript
+    inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Install / upgrade chocolatey since the version installed can be very old
+          $ErrorActionPreference = "Stop"
+          if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+            $version=choco --version
+            if ($version -lt "2.2.2") {
+              Write-Output "Upgrading old version of chocolatey $version to 2.2.2"
+              choco upgrade chocolatey --version 2.2.2 -y
+            } else {
+              Write-Output "Chocolatey already installed version $version"
+            }
+          } else {
+            Write-Output "Installing Chocolatey"
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+            Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Install git - it should be in AMI but install if missing
+          $ErrorActionPreference = "Stop"
+          if (Get-Command "git" -ErrorAction SilentlyContinue) {
+            Write-Output "git already installed, skipping choco install"
+          } else {
+            Write-Output "choco upgrade chocolatey-compatibility.extension -y"
+            choco upgrade chocolatey-compatibility.extension -y
+            Write-Output "choco upgrade chocolatey-core.extension -y"
+            choco upgrade chocolatey-core.extension -y
+            Write-Output "choco install git.install -y"
+            choco install git.install -y
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Fallback installation for git
+          $ErrorActionPreference = "Stop"
+          if (Get-Command "git" -ErrorAction SilentlyContinue) {
+            Write-Output "git already installed, skipping fallback install"
+          } else {
+            Set-Location -Path ([System.IO.Path]::GetTempPath())
+            Url="https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/Git-2.44.0-64-bit.exe"
+            Write-Output "Fallback installation for git - downloading from $Url"
+            Invoke-WebRequest $Url -OutFile ".\Git.exe"
+            .\Git.exe /VERYSILENT /NORESTART
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          Write-Output "choco upgrade all -y"
+          choco upgrade all -y
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Install awscli - it should be in AMI but install if missing
+          $ErrorActionPreference = "Stop"
+          if (Get-Command "aws" -ErrorAction SilentlyContinue) {
+            Write-Output "awscli already installed"
+          } else {
+            Write-Output "choco install awscli -y"
+            choco install awscli -y
+          }
+          Start-Sleep -Seconds 1 # helps debugging as logs have different timestamps
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Run UserData powershell from modernisation-platform-configuration-management repo
+          $ErrorActionPreference = "Stop"
+          Write-Output "Downloading and running Run-GitScript.ps1"
+          Set-Location -Path ([System.IO.Path]::GetTempPath())
+          $GitBranch = "${branch}"
+          $Script = "Invoke-UserDataScript.ps1"
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # since powershell 4 uses Tls1 as default
+          Invoke-WebRequest "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-configuration-management/$${GitBranch}/powershell/Scripts/Run-GitScript.ps1" -OutFile "Run-GitScript.ps1"
+          . ./Run-GitScript.ps1 $Script -GitBranch $GitBranch
+          Exit $LASTEXITCODE


### PR DESCRIPTION
- use a different user-data script for testing in -test env
- also want to 'apply' this to get rid of all the critical-national-infra tag updates