### PR TITLE
:wrench: Correct data source type

### DIFF
--- a/terraform/environments/observability-platform/modules/grafana/athena-source/main.tf
+++ b/terraform/environments/observability-platform/modules/grafana/athena-source/main.tf
@@ -8,7 +8,7 @@ data "grafana_data_source" "this" {
 }
 
 resource "grafana_data_source" "this" {
-  type = "Amazon Athena"
+  type = "grafana-athena-datasource"
   name = "${var.athena_workgroup}-${var.athena_database}"
   json_data_encoded = jsonencode({
     defaultRegion = "eu-west-2"


### PR DESCRIPTION
Looked at `https://<url>/api/datasources/` and compared to existing data sources. 