### PR TITLE
🤫 Add secret for APC Self-Hosted Runners GitHub App

### DIFF
--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -117,3 +117,28 @@ module "ui_azure_tenant_secret" {
 
   tags = local.tags
 }
+
+module "actions_runners_github_app_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name        = "actions-runners/github-app"
+  description = "https://github.com/organizations/moj-analytical-services/settings/apps/apc-self-hosted-runners"
+
+  secret_string = jsonencode({
+    "change-me" = "CHANGEME"
+  })
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    {
+      "expiry-date" = "2025-07-31"
+    }
+  )
+}

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -129,16 +129,12 @@ module "actions_runners_github_app_secret" {
 
   name        = "actions-runners/github-app"
   description = "https://github.com/organizations/moj-analytical-services/settings/apps/apc-self-hosted-runners"
+  kms_key_id  = module.common_secrets_manager_kms.key_arn
 
   secret_string = jsonencode({
     "change-me" = "CHANGEME"
   })
   ignore_secret_changes = true
 
-  tags = merge(
-    local.tags,
-    {
-      "expiry-date" = "2025-07-31"
-    }
-  )
+  tags = local.tags
 }


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5784
- Adds a secret for the GitHub App credentials

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 