### PR TITLE
🔒 Add External Secret for GitHub App

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -16,9 +16,9 @@
       "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8",
-      "integrity": "sha256:34eb8c510a11fc44abb8173519215fcb6b82715b94e647c69089ee23773c6dc8"
+      "version": "1.2.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c",
+      "integrity": "sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c"
     }
   }
 }

--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -308,8 +308,8 @@ module "mojap_compute_logs_s3_kms" {
 
   key_statements = [
     {
-      sid = "AllowS3Logging"
-      effect = "Allow" 
+      sid    = "AllowS3Logging"
+      effect = "Allow"
       actions = [
         "kms:Encrypt",
         "kms:Decrypt",

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -59,3 +59,56 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
     }
   }
 }
+
+resource "kubernetes_manifest" "actions_runners_github_app_secret" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "actions-runner-github-app"
+      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+    }
+    "spec" = {
+      "refreshInterval" = "1m"
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "actions-runner-github-app"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_github_app_secret[0].secret_id
+            "property" = "app_id"
+          }
+          "secretKey" = "app-id"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_github_app_secret[0].secret_id
+            "property" = "app_key"
+          }
+          "secretKey" = "app-key"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_github_app_secret[0].secret_id
+            "property" = "client_id"
+          }
+          "secretKey" = "client-id"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_github_app_secret[0].secret_id
+            "property" = "installation_id"
+          }
+          "secretKey" = "installation_id-id"
+        },
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5784
- Adds a new ExternalSecret `actions-runner-github-app`
- Updates `ghcr.io/ministryofjustice/devcontainer-feature/terraform` to `1.2.0`
- Runs a `terraform fmt` on APC

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 