### PR TITLE
🔀 Switch to central fine-grained token

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -67,7 +67,7 @@ resource "kubernetes_manifest" "actions_runners_github_app_secret" {
     "apiVersion" = "external-secrets.io/v1beta1"
     "kind"       = "ExternalSecret"
     "metadata" = {
-      "name"      = "actions-runner-github-app"
+      "name"      = "actions-runners-token-apc-self-hosted-runners"
       "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
     }
     "spec" = {
@@ -77,36 +77,14 @@ resource "kubernetes_manifest" "actions_runners_github_app_secret" {
         "name" = "aws-secretsmanager"
       }
       "target" = {
-        "name" = "actions-runner-github-app"
+        "name" = "actions-runners-token-apc-self-hosted-runners"
       }
       "data" = [
         {
           "remoteRef" = {
-            "key"      = module.actions_runners_github_app_secret[0].secret_id
-            "property" = "app_id"
+            "key" = module.actions_runners_token_apc_self_hosted_runners_secret[0].secret_id
           }
-          "secretKey" = "app-id"
-        },
-        {
-          "remoteRef" = {
-            "key"      = module.actions_runners_github_app_secret[0].secret_id
-            "property" = "app_key"
-          }
-          "secretKey" = "app-key"
-        },
-        {
-          "remoteRef" = {
-            "key"      = module.actions_runners_github_app_secret[0].secret_id
-            "property" = "client_id"
-          }
-          "secretKey" = "client-id"
-        },
-        {
-          "remoteRef" = {
-            "key"      = module.actions_runners_github_app_secret[0].secret_id
-            "property" = "installation_id"
-          }
-          "secretKey" = "installation_id-id"
+          "secretKey" = "token"
         },
       ]
     }

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -118,7 +118,7 @@ module "ui_azure_tenant_secret" {
   tags = local.tags
 }
 
-module "actions_runners_github_app_secret" {
+module "actions_runners_token_apc_self_hosted_runners_secret" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
@@ -127,14 +127,17 @@ module "actions_runners_github_app_secret" {
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "1.3.1"
 
-  name        = "actions-runners/github-app"
-  description = "https://github.com/organizations/moj-analytical-services/settings/apps/apc-self-hosted-runners"
+  name        = "actions-runners/token/apc-self-hosted-runners"
+  description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/2208432"
   kms_key_id  = module.common_secrets_manager_kms.key_arn
 
-  secret_string = jsonencode({
-    "change-me" = "CHANGEME"
-  })
+  secret_string         = "CHANGEME"
   ignore_secret_changes = true
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    {
+      "expiry-date" = "2025-10-24"
+    }
+  )
 }


### PR DESCRIPTION
This pull request:

- Switches new secret to token again because while KEDA supports GitHub App auth, the runner software does not 😭 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 