### PR TITLE
🔒 Add APC GitHub Self-Hosted Runner ESO

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -60,33 +60,33 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
   }
 }
 
-# resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_secret" {
-#   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_secret" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
-#   manifest = {
-#     "apiVersion" = "external-secrets.io/v1beta1"
-#     "kind"       = "ExternalSecret"
-#     "metadata" = {
-#       "name"      = "actions-runners-token-apc-self-hosted-runners"
-#       "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
-#     }
-#     "spec" = {
-#       "refreshInterval" = "1m"
-#       "secretStoreRef" = {
-#         "kind" = "ClusterSecretStore"
-#         "name" = "aws-secretsmanager"
-#       }
-#       "target" = {
-#         "name" = "actions-runners-token-apc-self-hosted-runners"
-#       }
-#       "data" = [
-#         {
-#           "remoteRef" = {
-#             "key" = module.actions_runners_token_apc_self_hosted_runners_secret[0].secret_id
-#           }
-#           "secretKey" = "token"
-#         }
-#       ]
-#     }
-#   }
-# }
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "actions-runners-token-apc-self-hosted-runners"
+      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+    }
+    "spec" = {
+      "refreshInterval" = "1m"
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "actions-runners-token-apc-self-hosted-runners"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key" = module.actions_runners_token_apc_self_hosted_runners_secret[0].secret_id
+          }
+          "secretKey" = "token"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request:

- Adds the commented secret back in

It will not plan unless the Secrets Manager secret exists

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 