### PR TITLE
Enable use_trivy_ecr_database - TOOMANYREQUESTS 🔥

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -39,6 +39,7 @@ jobs:
           tflint_exclude: terraform_unused_declarations
           tflint_call_module_type: none
           tfsec_trivy: trivy
+          use_trivy_ecr_database: true
 
   terraform-static-analysis-full-scan:
     permissions:
@@ -68,6 +69,7 @@ jobs:
           checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
           tflint_exclude: terraform_unused_declarations
           tflint_call_module_type: none
+          use_trivy_ecr_database: true
 
   terraform-static-analysis-scheduled-scan:
     name: Terraform Static Analysis - scheduled scan of all directories
@@ -91,3 +93,4 @@ jobs:
           checkov_exclude: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
           tflint_exclude: terraform_unused_declarations
           tflint_call_module_type: none
+          use_trivy_ecr_database: true


### PR DESCRIPTION
We've all seen / been impacted by the below `TOOMANYREQUEST` error causing our TSCA workflow to fail, well thanks to @jacobwoffenden we now have the option to download the trivy database from ECR 🥳 

available in version https://github.com/ministryofjustice/github-actions/releases/tag/v18.3.0 and upwards.

```
ERROR	[vulndb] Failed to download artifact	repo="ghcr.io/aquasecurity/trivy-db:2" err="oci download error: failed to fetch the layer: GET https://ghcr.io/v2/aquasecurity/trivy-db/blobs/sha256:cae74bde88d988a66b3a4fb824b17b48f38c92258dfecbb748975694233641be: TOOMANYREQUESTS: retry-after: 205.218µs, allowed: 44000/minute"
2024-10-23T15:32:51Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
trivy_exitcode=1
```