### PR TITLE
📌 Update all APC GitHub Self-Hosted Runners

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -1,11 +1,5 @@
 /* Airflow */
 
-# data "aws_secretsmanager_secret_version" "actions_runners_airflow" {
-#   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-#   secret_id = module.actions_runners_airflow_secret[0].secret_id
-# }
-
 resource "helm_release" "actions_runner_mojas_airflow" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
@@ -30,19 +24,13 @@ resource "helm_release" "actions_runner_mojas_airflow" {
 
 /* airflow-create-a-pipeline */
 
-data "aws_secretsmanager_secret_version" "actions_runners_airflow_create_a_pipeline" {
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-  secret_id = module.actions_runners_airflow_create_a_pipeline_secret[0].secret_id
-}
-
 resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow-create-a-pipeline"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.320.0-1"
+  version    = "2.320.0-2"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -51,7 +39,6 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
       {
         github_organisation  = "moj-analytical-services"
         github_repository    = "airflow-create-a-pipeline"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_airflow_create_a_pipeline[0].secret_string
         github_runner_labels = "analytical-platform"
       }
     )
@@ -60,19 +47,13 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
 
 /* create-a-derived-table */
 
-data "aws_secretsmanager_secret_version" "actions_runners_create_a_derived_table" {
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
-  secret_id = module.actions_runners_create_a_derived_table_secret[0].secret_id
-}
-
 resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.320.0-1"
+  version    = "2.320.0-2"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -81,7 +62,6 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
       {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
         github_runner_labels = "analytical-platform"
         eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
       }
@@ -95,7 +75,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.320.0-1"
+  version    = "2.320.0-2"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -104,7 +84,6 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
       {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
         github_runner_labels = "digital-prison-reporting"
         eks_role_arn         = "arn:aws:iam::004723187462:role/dpr-data-api-cross-account-role"
       }
@@ -118,7 +97,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.320.0-1"
+  version    = "2.320.0-2"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -127,7 +106,6 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
       {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
         github_runner_labels = "digital-prison-reporting-pp"
         eks_role_arn         = "arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role"
       }
@@ -144,7 +122,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-test"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.320.0-1"
+  version    = "2.320.0-2"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -153,7 +131,6 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
       {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
-        github_token         = data.aws_secretsmanager_secret_version.actions_runners_create_a_derived_table[0].secret_string
         github_runner_labels = "electronic-monitoring-data-test"
         eks_role_arn         = "arn:aws:iam::396913731313:role/emds-test-data-api-cross-account-role"
       }

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl
@@ -2,10 +2,5 @@
 github:
   organisation: ${github_organisation}
   repository: ${github_repository}
-  token: ${github_token}
   runner:
     labels: ${github_runner_labels}
-
-runner:
-  cache:
-    enabled: false

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -2,13 +2,8 @@
 github:
   organisation: ${github_organisation}
   repository: ${github_repository}
-  token: ${github_token}
   runner:
     labels: ${github_runner_labels}
-
-runner:
-  cache:
-    enabled: false
 
 resources:
   requests:


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5784
- Switches all runners to `2.320.0-2

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 