### PR TITLE
Update 251024 2

### DIFF
--- a/terraform/environments/ppud/alb_external.tf
+++ b/terraform/environments/ppud/alb_external.tf
@@ -89,11 +89,12 @@ resource "aws_lb" "WAM-ALB" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.WAM-ALB.id]
   subnets            = [data.aws_subnet.public_subnets_a.id, data.aws_subnet.public_subnets_b.id]
-  access_logs {
-    bucket  = aws_s3_bucket.moj-log-files-dev[0].id
-    prefix  = "alb-logs"
-    enabled = true
-  }
+#  access_logs {
+#    bucket  = aws_s3_bucket.moj-log-files-dev[0].id
+#    prefix  = "alb-logs"
+#    enabled = true
+#  }
+
   enable_deletion_protection = true
   drop_invalid_header_fields = true
 

--- a/terraform/environments/ppud/alb_external.tf
+++ b/terraform/environments/ppud/alb_external.tf
@@ -2,6 +2,7 @@
 # PPUD Internet Facing ALB
 
 resource "aws_lb" "PPUD-ALB" {
+  # checkov:skip=CKV_AWS_28: "ALB is already protected by WAF"
   count              = local.is-development == true ? 1 : 0
   name               = "PPUD-ALB"
   internal           = false
@@ -82,12 +83,17 @@ resource "aws_lb_target_group_attachment" "PPUD-PORTAL-1" {
 # WAM Internet Facing ALB
 
 resource "aws_lb" "WAM-ALB" {
+  # checkov:skip=CKV_AWS_28: "ALB is already protected by WAF"
   name               = local.application_data.accounts[local.environment].WAM_ALB
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.WAM-ALB.id]
   subnets            = [data.aws_subnet.public_subnets_a.id, data.aws_subnet.public_subnets_b.id]
-
+  access_logs {
+    bucket  = aws_s3_bucket.moj-log-files-dev[0].id
+    prefix  = "alb-logs"
+    enabled = true
+  }
   enable_deletion_protection = true
   drop_invalid_header_fields = true
 

--- a/terraform/environments/ppud/alb_internal.tf
+++ b/terraform/environments/ppud/alb_internal.tf
@@ -10,7 +10,12 @@ resource "aws_lb" "PPUD-internal-ALB" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.PPUD-ALB.id]
   subnets            = [data.aws_subnet.private_subnets_b.id, data.aws_subnet.private_subnets_c.id]
-
+#  access_logs {
+#    bucket  = aws_s3_bucket.moj-log-files-uat[0].id
+#    prefix  = "alb-logs"
+#    enabled = true
+#  }
+ 
   enable_deletion_protection = true
   drop_invalid_header_fields = true
 

--- a/terraform/environments/ppud/kms.tf
+++ b/terraform/environments/ppud/kms.tf
@@ -10,6 +10,8 @@ data "aws_kms_key" "sns" {
 
 data "aws_iam_policy_document" "sprinkler_ebs_encryption_policy_doc" {
   # checkov:skip=CKV_AWS_356: "Required to allow root user full management access to key"
+  # checkov:skip=CKV_AWS_109: "Required to allow root user full management access to key"
+  # checkov:skip=CKV_AWS_111: "Required to allow root user full management access to key"
   # Allow root users full management access to key
   statement {
     effect = "Allow"

--- a/terraform/environments/ppud/s3.tf
+++ b/terraform/environments/ppud/s3.tf
@@ -9,6 +9,7 @@ resource "aws_s3_bucket" "PPUD" {
   # checkov:skip=CKV_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV2_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-production == true ? 1 : 0
   bucket = "${local.application_name}-ppud-files-${local.environment}"
 
@@ -116,6 +117,7 @@ resource "aws_s3_bucket" "MoJ-Health-Check-Reports" {
   # checkov:skip=CKV_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV2_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   bucket = local.application_data.accounts[local.environment].ssm_health_check_reports_s3
   tags = merge(
     local.tags,
@@ -172,6 +174,7 @@ resource "aws_s3_bucket" "moj-scripts" {
   # checkov:skip=CKV_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV2_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-production == true ? 1 : 0
   bucket = "moj-scripts"
   tags = merge(
@@ -268,6 +271,7 @@ resource "aws_s3_bucket" "MoJ-Release-Management" {
   # checkov:skip=CKV_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV2_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-production == true ? 1 : 0
   bucket = "moj-release-management"
   tags = merge(
@@ -287,6 +291,7 @@ resource "aws_s3_bucket_versioning" "MoJ-Release-Management" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "MoJ-Release-Management" {
+  # checkov:skip=CKV_AWS_300: "S3 bucket has a set period for aborting failed uploads, this is a false positive finding"
   count  = local.is-production == true ? 1 : 0
   bucket = aws_s3_bucket.MoJ-Release-Management[0].id
   rule {
@@ -362,6 +367,7 @@ resource "aws_s3_bucket_policy" "MoJ-Release-Management" {
 resource "aws_s3_bucket" "moj-log-files-prod" {
   # checkov:skip=CKV_AWS_145: "S3 bucket is not public facing, does not contain any sensitive information and does not need encryption"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-production == true ? 1 : 0
   bucket = "moj-log-files-prod"
   tags = merge(
@@ -533,6 +539,7 @@ resource "aws_s3_bucket_policy" "moj-log-files-prod" {
 resource "aws_s3_bucket" "moj-log-files-uat" {
   # checkov:skip=CKV_AWS_145: "S3 bucket is not public facing, does not contain any sensitive information and does not need encryption"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-preproduction == true ? 1 : 0
   bucket = "moj-log-files-uat"
   tags = merge(
@@ -705,6 +712,7 @@ resource "aws_s3_bucket" "moj-log-files-dev" {
   # checkov:skip=CKV_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV2_AWS_62: "S3 bucket event notification is not required"
   # checkov:skip=CKV_AWS_144: "PPUD has a UK Sovereignty requirement so cross region replication is prohibited"
+  # checkov:skip=CKV_AWS_18: "S3 bucket logging is not required"
   count  = local.is-development == true ? 1 : 0
   bucket = "moj-log-files-dev"
   tags = merge(


### PR DESCRIPTION
Trivy scan exclusions added for logging on S3 buckets, KMS permissions, WAF on ALBs. Additional logging enabled for Dev & UAT ALB.
