### PR TITLE
feat: AP-5599 add ap-data-prod replication role permissions on replication destination bucket

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -1,4 +1,6 @@
 locals {
+  ap_data_prod_account_id = local.environment_management.account_ids["analytical-platform-data-production"]
+  
   environment_configurations = {
     development = {
       /* VPC */
@@ -37,7 +39,7 @@ locals {
       }
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::593291632749:role/airflow-dev-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-dev-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-development"
@@ -91,7 +93,7 @@ locals {
       observability_platform = "development"
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::593291632749:role/airflow-dev-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-dev-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-test"
@@ -138,7 +140,7 @@ locals {
       }
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::593291632749:role/airflow-prod-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-prod-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow"

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -25,7 +25,7 @@ module "mlflow_bucket" {
 data "aws_iam_policy_document" "s3_replication_policy" {
   #checkov:skip=CKV_AWS_356:resource "*" being applied to replication iam role only
   statement {
-    sid    = "AllowLakeFormationPrincipalsReplication"
+    sid    = "AllowReplicateObjectsInDestinationBucket"
     effect = "Allow"
     actions = [
       "s3:ReplicateTags",
@@ -36,10 +36,27 @@ data "aws_iam_policy_document" "s3_replication_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::525294151996:role/service-role/s3replicate_role_for_lf-antfmoj-test",
-        "arn:aws:iam::525294151996:role/service-role/s3crr_role_for_lf-antfmoj-test_1"
+        "arn:aws:iam::525294151996:role/service-role/s3crr_role_for_lf-antfmoj-test_1",
+        "arn:aws:iam::${local.ap_data_prod_account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
       ]
     }
     resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication/*"]
+  }
+  statement {
+    sid    = "AllowReplicateWithinDestinationBucket"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetBucketVersioning",
+      "s3:PutBucketVersioning"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.ap_data_prod_account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
+      ]
+    }
+    resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication"]
   }
 }
 


### PR DESCRIPTION
relates to ministryofjustice/analytical-platform#5599

- adds ap-data-prod replication role permissions on replication destination bucket
- obfuscates account number