### PR TITLE
🪟 Add KMS key and secret for DOM1 credentials

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -213,3 +213,16 @@ module "ec2_ebs_kms" {
 
   deletion_window_in_days = 7
 }
+
+module "datasync_credentials_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  aliases               = ["datasync/credentials"]
+  description           = "DataSync Credentials KMS Key"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+}

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -31,7 +31,7 @@ module "datasync_dom1_secret" {
   kms_key_id  = module.datasync_credentials_kms.key_arn
 
   ignore_secret_changes = true
-  secret_json           = jsonencode({
+  secret_string = jsonencode({
     username = "CHANGEME"
     password = "CHANGEME"
   })

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -19,3 +19,22 @@ resource "aws_secretsmanager_secret" "slack_token" {
   name       = "ingestion/slack-token"
   kms_key_id = module.slack_token_kms.key_arn
 }
+
+module "datasync_dom1_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name        = "datasync/dom1"
+  kms_key_id  = module.datasync_credentials_kms.key_arn
+
+  ignore_secret_changes = true
+  secret_json           = jsonencode({
+    username = "CHANGEME"
+    password = "CHANGEME"
+  })
+
+  tags = local.tags
+}


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5175
- Adds a new KMS key and Secrets Manager secret for storing our DOM1 credential to be consumed by Terraform when configuring DataSync location/task

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 