### PR TITLE
delete bucket - mojap-compute-derived-tables-replication

### DIFF
--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -50,6 +50,10 @@ module "mojap_derived_tables_replication_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.2.1"
 
+  providers = {
+    aws = aws.analytical-platform-compute-eu-west-1
+  }
+
   bucket = "mojap-compute-${local.environment}-derived-tables-replication"
 
   force_destroy = true

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -22,68 +22,68 @@ module "mlflow_bucket" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "s3_replication_policy" {
-  #checkov:skip=CKV_AWS_356:resource "*" being applied to replication iam role only
-  statement {
-    sid    = "AllowLakeFormationPrincipalsReplication"
-    effect = "Allow"
-    actions = [
-      "s3:ReplicateTags",
-      "s3:ReplicateDelete",
-      "s3:ReplicateObject"
-    ]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::525294151996:role/service-role/s3replicate_role_for_lf-antfmoj-test",
-        "arn:aws:iam::525294151996:role/service-role/s3crr_role_for_lf-antfmoj-test_1"
-      ]
-    }
-    resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication/*"]
-  }
-}
+# data "aws_iam_policy_document" "s3_replication_policy" {
+#   #checkov:skip=CKV_AWS_356:resource "*" being applied to replication iam role only
+#   statement {
+#     sid    = "AllowLakeFormationPrincipalsReplication"
+#     effect = "Allow"
+#     actions = [
+#       "s3:ReplicateTags",
+#       "s3:ReplicateDelete",
+#       "s3:ReplicateObject"
+#     ]
+#     principals {
+#       type = "AWS"
+#       identifiers = [
+#         "arn:aws:iam::525294151996:role/service-role/s3replicate_role_for_lf-antfmoj-test",
+#         "arn:aws:iam::525294151996:role/service-role/s3crr_role_for_lf-antfmoj-test_1"
+#       ]
+#     }
+#     resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication/*"]
+#   }
+# }
 
-module "mojap_derived_tables_replication_bucket" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+# module "mojap_derived_tables_replication_bucket" {
+#   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+#   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.2.1"
+#   source  = "terraform-aws-modules/s3-bucket/aws"
+#   version = "4.2.1"
 
-  providers = {
-    aws = aws.analytical-platform-compute-eu-west-1
-  }
+#   providers = {
+#     aws = aws.analytical-platform-compute-eu-west-1
+#   }
 
-  bucket = "mojap-compute-${local.environment}-derived-tables-replication"
+#   bucket = "mojap-compute-${local.environment}-derived-tables-replication"
 
-  force_destroy = true
+#   force_destroy = true
 
-  attach_policy = true
-  policy        = data.aws_iam_policy_document.s3_replication_policy.json
+#   attach_policy = true
+#   policy        = data.aws_iam_policy_document.s3_replication_policy.json
 
-  object_lock_enabled = false
+#   object_lock_enabled = false
 
-  versioning = {
-    status = "Enabled"
-  }
+#   versioning = {
+#     status = "Enabled"
+#   }
 
-  server_side_encryption_configuration = {
-    rule = {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.mojap_derived_tables_replication_s3_kms.key_arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
+#   server_side_encryption_configuration = {
+#     rule = {
+#       bucket_key_enabled = true
+#       apply_server_side_encryption_by_default = {
+#         kms_master_key_id = module.mojap_derived_tables_replication_s3_kms.key_arn
+#         sse_algorithm     = "aws:kms"
+#       }
+#     }
+#   }
 
-  logging = {
-    target_bucket = module.mojap_compute_logs_bucket.s3_bucket_id
-    target_prefix = "mojap-derived-tables-replication/"
-  }
+#   logging = {
+#     target_bucket = module.mojap_compute_logs_bucket.s3_bucket_id
+#     target_prefix = "mojap-derived-tables-replication/"
+#   }
 
-  tags = local.tags
-}
+#   tags = local.tags
+# }
 
 data "aws_iam_policy_document" "s3_server_access_logs_policy" {
   #checkov:skip=CKV_AWS_356:resource "*" limited by condition


### PR DESCRIPTION
This pull request:

- contributes to [this ticket](https://github.com/ministryofjustice/analytical-platform/issues/5599)
- deletes the mojap-compute-derived-tables-replication bucket region in `eu-west-2`, to be created in `eu-west-1` in separate PR

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>