### PR TITLE
🎡 Bump Dev Container features

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,14 +1,14 @@
 {
   "features": {
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5",
-      "integrity": "sha256:bb07a76c8e7a6b630a2056ce959addddee436e3f9936c69b9163eff54f58dbd5"
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40",
+      "integrity": "sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
-      "version": "1.0.1",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5",
-      "integrity": "sha256:0ec758e44468ba2a8b70b87613762ab04e50f7bb5eac8f2aea592cff213dbde5"
+      "version": "1.0.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a",
+      "integrity": "sha256:d24f235b7578a71a60fce981d250fa300e9f353911561648c31a7022fd8ded6a"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {
       "version": "1.0.0",


### PR DESCRIPTION
This pull request:

> [!NOTE]
> Code formatting makes changes to `.devcontainer/devcontainer-lock.json` but this file is automatically generated

- Bumps `ghcr.io/ministryofjustice/devcontainer-feature/aws` to `1.0.1`
- Bumps `ghcr.io/ministryofjustice/devcontainer-feature/kubernetes` to `1.0.2`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 