### PR TITLE
Registering CaDeT Bucket + Adding service role to LF Admins

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -306,3 +306,26 @@ module "analytical_platform_control_panel_service_role" {
   number_of_custom_role_policy_arns = 2
 
 }
+
+module "analytical_platform_data_eng_dba_service_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.46.0"
+
+  allow_self_assume_role = false
+  trusted_role_arns = [
+    format("arn:aws:iam::%s:root", local.environment_management.account_ids[local.analytical_platform_environment])
+
+  ]
+  create_role       = true
+  role_requires_mfa = false
+  role_name         = "analytical-platform-data-engineering-database-access"
+
+  custom_role_policy_arns = [
+    module.analytical_platform_lake_formation_share_policy.arn,
+    "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+  ]
+  number_of_custom_role_policy_arns = 2
+
+}

--- a/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
@@ -2,7 +2,8 @@ resource "aws_lakeformation_data_lake_settings" "london" {
   admins = [
     data.aws_iam_session_context.current.issuer_arn,
     module.lake_formation_share_role.iam_role_arn,
-    module.analytical_platform_ui_service_role.iam_role_arn
+    module.analytical_platform_ui_service_role.iam_role_arn,
+    module.analytical_platform_data_eng_dba_service_role.iam_role_arn
   ]
 }
 
@@ -11,6 +12,7 @@ resource "aws_lakeformation_data_lake_settings" "ireland" {
   admins = [
     data.aws_iam_session_context.current.issuer_arn,
     module.lake_formation_share_role.iam_role_arn,
-    module.analytical_platform_ui_service_role.iam_role_arn
+    module.analytical_platform_ui_service_role.iam_role_arn,
+    module.analytical_platform_data_eng_dba_service_role.iam_role_arn
   ]
 }

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -1,0 +1,10 @@
+module "replicated_cadet_bucket" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source         = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation"
+  version        = "0.5.0"
+  data_locations = [module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn]
+  register       = true
+  hybrid_mode    = false # will be managed exclusively in LakeFormation
+
+}

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -10,7 +10,7 @@ module "replicated_cadet_bucket" {
   }]
 
   providers = {
-    aws.source      = aws.eu-west-1
+    aws.source      = aws.analytical-platform-compute-eu-west-1
     aws.destination = aws
   }
 }

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -1,11 +1,13 @@
 module "replicated_cadet_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-  source         = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=0.5.0"
-  data_locations = [module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn]
-  register       = true
-  share          = true
-  hybrid_mode    = false # will be managed exclusively in LakeFormation
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=0.5.0"
+  data_locations = [{
+    data_location = module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn
+    register      = true
+    share         = true
+    hybrid_mode   = false # will be managed exclusively in LakeFormation
+  }]
 
   providers = {
     aws.source      = aws.eu-west-1

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -5,4 +5,9 @@ module "replicated_cadet_bucket" {
   data_locations = [module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn]
   register       = true
   hybrid_mode    = false # will be managed exclusively in LakeFormation
+
+  providers = {
+    aws.source      = aws
+    aws.destination = aws
+  }
 }

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -1,10 +1,8 @@
 module "replicated_cadet_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-  source         = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation"
-  version        = "0.5.0"
+  source         = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=0.5.0"
   data_locations = [module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn]
   register       = true
   hybrid_mode    = false # will be managed exclusively in LakeFormation
-
 }

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -4,10 +4,11 @@ module "replicated_cadet_bucket" {
   source         = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=0.5.0"
   data_locations = [module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn]
   register       = true
+  share          = true
   hybrid_mode    = false # will be managed exclusively in LakeFormation
 
   providers = {
-    aws.source      = aws
+    aws.source      = aws.eu-west-1
     aws.destination = aws
   }
 }

--- a/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-registrations.tf
@@ -3,7 +3,7 @@ module "replicated_cadet_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=0.5.0"
   data_locations = [{
-    data_location = module.mojap_compute_logs_bucket_eu_west_1.s3_bucket_arn
+    data_location = module.mojap_derived_tables_replication_bucket.s3_bucket_arn
     register      = true
     share         = true
     hybrid_mode   = false # will be managed exclusively in LakeFormation


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/5600

This registers the bucket location in LakeFormation so we can begin adding data location permissions from within the Data Engineering Database Access Repository.

Additionally, this creates a service role for the GithubActions service role in Data Engineering Database Access to assume to carry out permissions changes.

