### PR TITLE
feat: AP-5599 allow replication destination bucket to override object ownership

### DIFF
--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "s3_replication_policy" {
     sid    = "AllowReplicateObjectsInDestinationBucket"
     effect = "Allow"
     actions = [
+      "s3:ObjectOwnerOverrideToBucketOwner",
       "s3:ReplicateTags",
       "s3:ReplicateDelete",
       "s3:ReplicateObject"


### PR DESCRIPTION
see https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-change-owner.html#repl-ownership-accept-ownership-b-policy for an example bucket policy
