### PR TITLE
✨ Add non-spot runners for CaDeT

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -69,6 +69,32 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   ]
 }
 
+resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
+  name       = "actions-runner-mojas-create-a-derived-table-non-spot"
+  repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
+  version    = "2.320.0-2"
+  chart      = "actions-runner"
+  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
+      {
+        github_organisation  = "moj-analytical-services"
+        github_repository    = "create-a-derived-table"
+        github_runner_labels = "analytical-platform-non-spot"
+        eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
+      }
+    )
+  ]
+  set {
+    name  = "ephemeral.karpenter.nodePool"
+    value = "general-on-demand"
+  }
+}
+
 resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
@@ -113,9 +139,6 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   ]
 }
 
-# ---------------------------------------------------
-# EM test account
-# ---------------------------------------------------
 resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 

--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -16,7 +16,7 @@ resource "helm_release" "actions_runner_mojas_airflow" {
         github_organisation  = "moj-analytical-services"
         github_repository    = "airflow"
         github_runner_labels = "analytical-platform"
-        eks_role_arn         = "arn:aws:iam::593291632749:role/data-iam-creator"
+        eks_role_arn         = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-iam-creator"
       }
     )
   ]
@@ -63,7 +63,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_runner_labels = "analytical-platform"
-        eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
+        eks_role_arn         = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/create-a-derived-table"
       }
     )
   ]
@@ -85,7 +85,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_runner_labels = "analytical-platform-non-spot"
-        eks_role_arn         = "arn:aws:iam::593291632749:role/create-a-derived-table"
+        eks_role_arn         = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/create-a-derived-table"
       }
     )
   ]
@@ -111,7 +111,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_runner_labels = "digital-prison-reporting"
-        eks_role_arn         = "arn:aws:iam::004723187462:role/dpr-data-api-cross-account-role"
+        eks_role_arn         = "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-production"]}:role/dpr-data-api-cross-account-role"
       }
     )
   ]
@@ -133,7 +133,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
         github_organisation  = "moj-analytical-services"
         github_repository    = "create-a-derived-table"
         github_runner_labels = "digital-prison-reporting-pp"
-        eks_role_arn         = "arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role"
+        eks_role_arn         = "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-preproduction"]}:role/dpr-data-api-cross-account-role"
       }
     )
   ]


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/analytical-platform/issues/5666
- Resolves https://github.com/ministryofjustice/analytical-platform/issues/5776
- Adds a new Actions Runner deployment for CaDeT using our general-on-demand Karpeneter fleet
- Parameterises all account numbers

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 