### PR TITLE
Add `states:StartExecution` to eventbridge role

### DIFF
--- a/terraform/modules/fargate_graceful_retirement/eventbridge.tf
+++ b/terraform/modules/fargate_graceful_retirement/eventbridge.tf
@@ -74,6 +74,15 @@ data "aws_iam_policy_document" "all_health_events" {
       variable = "aws:SourceArn"
     }
   }
+  statement {
+    effect = "Allow"
+    actions = [
+      "states:StartExecution"
+    ]
+    resources = [
+      aws_sfn_state_machine.ecs_restart_state_machine.arn
+    ]
+  }
 }
 
 resource "aws_cloudwatch_log_resource_policy" "all_health_events" {


### PR DESCRIPTION
This pull request includes a change to the `terraform/modules/fargate_graceful_retirement/eventbridge.tf` file to enhance the IAM policy document for handling health events. The most important change is the addition of a new statement to allow starting executions of a specific state machine.

Enhancements to IAM policy document:

* [`terraform/modules/fargate_graceful_retirement/eventbridge.tf`](diffhunk://#diff-af31f80a5e202ea1dcbb3f244e11fdee796abe47fc5cdf0202a4d09f39bb0da4R77-R85): Added a new statement to the `aws_iam_policy_document` to allow the action `states:StartExecution` on the specified state machine resource.