### PR TITLE
TM-500: oem: endpoint monitoring

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -21,6 +21,7 @@ locals {
   baseline_presets_all_environments = {
     options = {
       cloudwatch_dashboard_default_widget_groups = [
+        "ec2_instance_endpoint_monitoring",
         "custom",
         "network_lb",
         "lb",

--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -1,54 +1,56 @@
 locals {
 
+  endpoint_down_alarm = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"]
+
   # these should match the alarms configured in ansible collectd-endpoint-monitoring role on the given EC2
   cloudwatch_metric_alarms_endpoint_status_environment_specific = {
     "development" = {
     }
 
     "test" = {
-      "endpoint-down-nomis-t1" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-nomis-t1" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "c-t1.test.nomis.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-nomis-t2" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-nomis-t2" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "c-t2.test.nomis.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-nomis-t3" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-nomis-t3" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "c-t3.test.nomis.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-oasys-t1" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-oasys-t1" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "t1-int.oasys.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-oasys-t2" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-oasys-t2" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "t2-int.oasys.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-offloc-stage" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-offloc-stage" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "stage.offloc.service.justice.gov.uk"
         }
       })
 
-      "endpoint-down-hmppgw1-rdgateway" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-hmppgw1-rdgateway" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "hmppgw1.justice.gov.uk"
@@ -57,73 +59,84 @@ locals {
     }
 
     "preproduction" = {
-      "endpoint-down-nomis-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+      "endpoint-down-nomis-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "c.pp-nomis.az.justice.gov.uk"
         }
       })
-      "endpoint-down-nomis-lsast" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-nomis-lsast" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "c.lsast-nomis.az.justice.gov.uk"
         }
       })
-      "endpoint-down-oasys-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-oasys-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "pp-oasys.az.justice.gov.uk"
         }
       })
-      "endpoint-down-onr-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-onr-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "onr.pp-oasys.az.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r1-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r1-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r1.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r2-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r2-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r2.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r3-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r3-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r3.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r4-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r4-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r4.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r5-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r5-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r5.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-r6-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-r6-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "r6.pp.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-csr-traina" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-csr-traina" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "traina.csr.service.justice.gov.uk"
         }
       })
-      "endpoint-down-cafmwebx-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-cafmwebx-pp" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "cafmwebx.pp.planetfm.service.justice.gov.uk"
@@ -131,7 +144,8 @@ locals {
         alarm_actions = [] # TODO: remove when IP allow listing fixed
         ok_actions    = []
       })
-      "endpoint-down-hpa-preprod" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+
+      "endpoint-down-hpa-preprod" = merge(local.endpoint_down_alarm, {
         dimensions = {
           type          = "exitcode"
           type_instance = "hpa-preprod.service.hmpps.dsd.io"
@@ -141,7 +155,141 @@ locals {
       })
     }
 
+
     "production" = {
+      "endpoint-down-nomis" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c.nomis.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-nomis-reporting" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "reporting.nomis.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-oasys" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "oasys.az.justice.gov.uk"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
+
+      "endpoint-down-oasys-training" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "training.oasys.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-oasys-practice" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "practice.oasys.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-bridge-oasys" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "bridge-oasys.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-onr" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "onr.oasys.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r1" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r1.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r2" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r2.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r3" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r3.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r4" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r4.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r5" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r5.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-csr-r6" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r6.csr.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-cafmwebx2" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "cafmwebx2.az.justice.gov.uk"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
+
+      "endpoint-down-cafmtrainweb" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "cafmtrainweb.az.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-offloc" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "www.offloc.service.justice.gov.uk"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
+
+      "endpoint-down-hpa" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "hpa.service.hmpps.dsd.io"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
+
+      "endpoint-down-hmpps-az-gw1-rdgateway" = merge(local.endpoint_down_alarm, {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "hmpps-az-gw1.justice.gov.uk"
+        }
+      })
     }
   }
 

--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -57,6 +57,88 @@ locals {
     }
 
     "preproduction" = {
+      "endpoint-down-nomis-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c.pp-nomis.az.justice.gov.uk"
+        }
+      })
+      "endpoint-down-nomis-lsast" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c.lsast-nomis.az.justice.gov.uk"
+        }
+      })
+      "endpoint-down-oasys-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "pp-oasys.az.justice.gov.uk"
+        }
+      })
+      "endpoint-down-onr-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "onr.pp-oasys.az.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r1-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r1.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r2-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r2.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r3-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r3.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r4-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r4.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r5-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r5.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-r6-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "r6.pp.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-csr-traina" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "traina.csr.service.justice.gov.uk"
+        }
+      })
+      "endpoint-down-cafmwebx-pp" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "cafmwebx.pp.planetfm.service.justice.gov.uk"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
+      "endpoint-down-hpa-preprod" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "hpa-preprod.service.hmpps.dsd.io"
+        }
+        alarm_actions = [] # TODO: remove when IP allow listing fixed
+        ok_actions    = []
+      })
     }
 
     "production" = {

--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -1,0 +1,71 @@
+locals {
+
+  # these should match the alarms configured in ansible collectd-endpoint-monitoring role on the given EC2
+  cloudwatch_metric_alarms_endpoint_status_environment_specific = {
+    "development" = {
+    }
+
+    "test" = {
+      "endpoint-down-nomis-t1" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c-t1.test.nomis.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-nomis-t2" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c-t2.test.nomis.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-nomis-t3" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "c-t3.test.nomis.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-oasys-t1" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "t1-int.oasys.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-oasys-t2" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "t2-int.oasys.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-offloc-stage" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "stage.offloc.service.justice.gov.uk"
+        }
+      })
+
+      "endpoint-down-hmppgw1-rdgateway" = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+        dimensions = {
+          type          = "exitcode"
+          type_instance = "hmppgw1.justice.gov.uk"
+        }
+      })
+    }
+
+    "preproduction" = {
+    }
+
+    "production" = {
+    }
+  }
+
+  cloudwatch_metric_alarms_endpoint_monitoring = merge(
+    local.cloudwatch_metric_alarms_endpoint_status_environment_specific[local.environment], {
+      "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-cert-expires-soon"]
+    }
+  )
+}

--- a/terraform/environments/hmpps-oem/locals_development.tf
+++ b/terraform/environments/hmpps-oem/locals_development.tf
@@ -66,6 +66,10 @@ locals {
 
     ec2_instances = {
       dev-oem-a = merge(local.ec2_instances.oem, {
+        cloudwatch_metric_alarms = merge(
+          local.ec2_instances.oem.cloudwatch_metric_alarms,
+          local.cloudwatch_metric_alarms_endpoint_monitoring
+        )
         config = merge(local.ec2_instances.oem.config, {
           ami_name          = "hmpps_ol_8_5_oracledb_19c_release_2023-12-07T12-10-49.620Z"
           availability_zone = "eu-west-2a"

--- a/terraform/environments/hmpps-oem/locals_preproduction.tf
+++ b/terraform/environments/hmpps-oem/locals_preproduction.tf
@@ -18,6 +18,10 @@ locals {
     ec2_instances = {
 
       preprod-oem-a = merge(local.ec2_instances.oem, {
+        cloudwatch_metric_alarms = merge(
+          local.ec2_instances.oem.cloudwatch_metric_alarms,
+          local.cloudwatch_metric_alarms_endpoint_monitoring
+        )
         config = merge(local.ec2_instances.oem.config, {
           availability_zone = "eu-west-2a"
         })

--- a/terraform/environments/hmpps-oem/locals_production.tf
+++ b/terraform/environments/hmpps-oem/locals_production.tf
@@ -15,6 +15,10 @@ locals {
 
     ec2_instances = {
       prod-oem-a = merge(local.ec2_instances.oem, {
+        cloudwatch_metric_alarms = merge(
+          local.ec2_instances.oem.cloudwatch_metric_alarms,
+          local.cloudwatch_metric_alarms_endpoint_monitoring
+        )
         config = merge(local.ec2_instances.oem.config, {
           availability_zone = "eu-west-2a"
         })

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -6,7 +6,8 @@ locals {
 
       sns_topics = {
         pagerduty_integrations = {
-          pagerduty = "hmpps-oem-test"
+          pagerduty = "hmpps-oem-test",
+          nomis     = "nomis-test",
         }
       }
     }
@@ -36,21 +37,13 @@ locals {
           availability_zone = "eu-west-2a"
         })
         cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
-          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = {
-            comparison_operator = "GreaterThanOrEqualToThreshold"
-            evaluation_periods  = "1"
-            datapoints_to_alarm = "1"
-            metric_name         = "collectd_endpoint_status_value"
-            namespace           = "CWAgent"
-            period              = "60"
-            statistic           = "Maximum"
-            threshold           = "1"
-            alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
+          "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-cert-expires-soon
+          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["nomis"].ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint_down, {
             dimensions = {
               type          = "exitcode"
               type_instance = "c-t3.test.nomis.service.justice.gov.uk"
             }
-          }
+          })
         })
         instance = merge(local.ec2_instances.oem.instance, {
           disable_api_termination = true

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -38,7 +38,7 @@ locals {
         })
         cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
           "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-cert-expires-soon"]
-          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
+          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["nomis"].ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
             dimensions = {
               type          = "exitcode"
               type_instance = "c-t3.test.nomis.service.justice.gov.uk"

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -6,8 +6,7 @@ locals {
 
       sns_topics = {
         pagerduty_integrations = {
-          pagerduty = "hmpps-oem-test",
-          nomis     = "nomis-test",
+          pagerduty = "hmpps-oem-test"
         }
       }
     }
@@ -36,15 +35,10 @@ locals {
         config = merge(local.ec2_instances.oem.config, {
           availability_zone = "eu-west-2a"
         })
-        cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
-          "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-cert-expires-soon"]
-          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["nomis"].ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
-            dimensions = {
-              type          = "exitcode"
-              type_instance = "c-t3.test.nomis.service.justice.gov.uk"
-            }
-          })
-        })
+        cloudwatch_metric_alarms = merge(
+          local.ec2_instances.oem.cloudwatch_metric_alarms,
+          local.cloudwatch_metric_alarms_endpoint_monitoring
+        )
         instance = merge(local.ec2_instances.oem.instance, {
           disable_api_termination = true
         })

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -38,7 +38,7 @@ locals {
         })
         cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
           "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-cert-expires-soon
-          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["nomis"].ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint_down, {
+          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint_down, {
             dimensions = {
               type          = "exitcode"
               type_instance = "c-t3.test.nomis.service.justice.gov.uk"

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -35,6 +35,23 @@ locals {
         config = merge(local.ec2_instances.oem.config, {
           availability_zone = "eu-west-2a"
         })
+        cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
+          endpoint-status = {
+            comparison_operator = "GreaterThanOrEqualToThreshold"
+            evaluation_periods  = "1"
+            datapoints_to_alarm = "1"
+            metric_name         = "collectd_endpoint_status_value"
+            namespace           = "CWAgent"
+            period              = "60"
+            statistic           = "Maximum"
+            threshold           = "1"
+            alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
+            split_by_dimension  = {
+              dimension_name   = type_instance
+              dimension_values = ["c-t3.test.nomis.service.justice.gov.uk"]
+            }
+          }
+        })
         instance = merge(local.ec2_instances.oem.instance, {
           disable_api_termination = true
         })

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -46,8 +46,8 @@ locals {
             statistic           = "Maximum"
             threshold           = "1"
             alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
-            split_by_dimension  = {
-              dimension_name   = type_instance
+            split_by_dimension = {
+              dimension_name   = "type_instance"
               dimension_values = ["c-t3.test.nomis.service.justice.gov.uk"]
             }
           }

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -47,6 +47,7 @@ locals {
             threshold           = "1"
             alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
             dimensions = {
+              type          = "exitcode"
               type_instance = "c-t3.test.nomis.service.justice.gov.uk"
             }
           }

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -37,8 +37,8 @@ locals {
           availability_zone = "eu-west-2a"
         })
         cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
-          "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-cert-expires-soon
-          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint_down, {
+          "endpoint-cert-expires-soon" = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-cert-expires-soon"]
+          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = merge(module.baseline_presets.cloudwatch_metric_alarms_by_sns_topic["pagerduty"].ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"], {
             dimensions = {
               type          = "exitcode"
               type_instance = "c-t3.test.nomis.service.justice.gov.uk"

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -32,13 +32,13 @@ locals {
 
     ec2_instances = {
       test-oem-a = merge(local.ec2_instances.oem, {
-        config = merge(local.ec2_instances.oem.config, {
-          availability_zone = "eu-west-2a"
-        })
         cloudwatch_metric_alarms = merge(
           local.ec2_instances.oem.cloudwatch_metric_alarms,
           local.cloudwatch_metric_alarms_endpoint_monitoring
         )
+        config = merge(local.ec2_instances.oem.config, {
+          availability_zone = "eu-west-2a"
+        })
         instance = merge(local.ec2_instances.oem.instance, {
           disable_api_termination = true
         })

--- a/terraform/environments/hmpps-oem/locals_test.tf
+++ b/terraform/environments/hmpps-oem/locals_test.tf
@@ -36,7 +36,7 @@ locals {
           availability_zone = "eu-west-2a"
         })
         cloudwatch_metric_alarms = merge(local.ec2_instances.oem.cloudwatch_metric_alarms, {
-          endpoint-status = {
+          "endpoint-down_c-t3.test.nomis.service.justice.gov.uk" = {
             comparison_operator = "GreaterThanOrEqualToThreshold"
             evaluation_periods  = "1"
             datapoints_to_alarm = "1"
@@ -46,9 +46,8 @@ locals {
             statistic           = "Maximum"
             threshold           = "1"
             alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
-            split_by_dimension = {
-              dimension_name   = "type_instance"
-              dimension_values = ["c-t3.test.nomis.service.justice.gov.uk"]
+            dimensions = {
+              type_instance = "c-t3.test.nomis.service.justice.gov.uk"
             }
           }
         })

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -921,8 +921,8 @@ locals {
       width           = 8
       height          = 8
       widgets = [
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.endpoint-down,
-        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.endpoint-cert-expires-soon,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-down,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-cert-expires-soon,
       ]
     }
 

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -441,6 +441,45 @@ locals {
       }
     }
 
+    ec2_instance_cwagent_collectd_endpoint_monitoring = {
+      endpoint-down = {
+        type            = "metric"
+        alarm_threshold = 1
+        expression      = "SORT(SEARCH('{CWAgent,InstanceId,type,type_instance} MetricName=\"collectd_endpoint_status_value\"','Maximum'),MAX,DESC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "EC2 Endpoint Monitoring endpoint-down"
+          stat    = "Maximum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "exitcode"
+            }
+          }
+        }
+      }
+      endpoint-cert-expires-soon = {
+        type            = "metric"
+        alarm_threshold = local.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring.endpoint-cert-expires-soon.threshold
+        expression      = "SORT(SEARCH('{CWAgent,InstanceId,type,type_instance} MetricName=\"collectd_endpoint_cert_expiry_value\"','Minimum'),MIN,ASC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "EC2 Endpoint Monitoring endpoint-cert-expires-soon"
+          stat    = "Maximum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "days"
+            }
+          }
+        }
+      }
+    }
+
     lb = {
       load-balancer-requests = {
         type       = "metric"
@@ -875,6 +914,15 @@ locals {
       widgets = [
         local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.filesystems-check-error,
         local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.filesystems-check-metric-not-updated,
+      ]
+    }
+    ec2_instance_endpoint_monitoring = {
+      header_markdown = "## Endpoint Monitoring via EC2 collectd"
+      width           = 8
+      height          = 8
+      widgets = [
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.endpoint-down,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_filesystems_check.endpoint-cert-expires-soon,
       ]
     }
 

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -328,6 +328,34 @@ locals {
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
         ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
       }
+      ec2_instance_cwagent_collectd_endpoint_monitoring = {
+        "endpoint-down" = {
+          comparison_operator = "GreaterThanOrEqualToThreshold"
+          evaluation_periods  = "1"
+          datapoints_to_alarm = "1"
+          metric_name         = "collectd_endpoint_status_value"
+          namespace           = "CWAgent"
+          period              = "60"
+          statistic           = "Maximum"
+          threshold           = "1"
+          alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
+          alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+          ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
+        }
+        "endpoint-cert-expires-soon" = {
+          comparison_operator = "LessThanThreshold"
+          evaluation_periods  = "1"
+          datapoints_to_alarm = "1"
+          metric_name         = "collectd_endpoint_cert_expiry_value"
+          namespace           = "AWS/CertificateManager"
+          period              = "86400"
+          statistic           = "Minimum"
+          threshold           = "14"
+          alarm_description   = "Triggers if collectd-endpoint-monitoring detects an endpoint with a certificate due to expire shortly. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4615340266"
+          alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+          ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
+        }
+      }
     }
     lb = {
       unhealthy-load-balancer-host = {

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -348,7 +348,7 @@ locals {
         evaluation_periods  = "1"
         datapoints_to_alarm = "1"
         metric_name         = "collectd_endpoint_cert_expiry_value"
-        namespace           = "AWS/CertificateManager"
+        namespace           = "CWAgent"
         period              = "86400"
         statistic           = "Minimum"
         threshold           = "14"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -328,35 +328,36 @@ locals {
         alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
         ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
       }
-      ec2_instance_cwagent_collectd_endpoint_monitoring = {
-        "endpoint-down" = {
-          comparison_operator = "GreaterThanOrEqualToThreshold"
-          evaluation_periods  = "1"
-          datapoints_to_alarm = "1"
-          metric_name         = "collectd_endpoint_status_value"
-          namespace           = "CWAgent"
-          period              = "60"
-          statistic           = "Maximum"
-          threshold           = "1"
-          alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
-          alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-          ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
-        }
-        "endpoint-cert-expires-soon" = {
-          comparison_operator = "LessThanThreshold"
-          evaluation_periods  = "1"
-          datapoints_to_alarm = "1"
-          metric_name         = "collectd_endpoint_cert_expiry_value"
-          namespace           = "AWS/CertificateManager"
-          period              = "86400"
-          statistic           = "Minimum"
-          threshold           = "14"
-          alarm_description   = "Triggers if collectd-endpoint-monitoring detects an endpoint with a certificate due to expire shortly. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4615340266"
-          alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
-          ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
-        }
+    }
+    ec2_instance_cwagent_collectd_endpoint_monitoring = {
+      "endpoint-down" = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
+        metric_name         = "collectd_endpoint_status_value"
+        namespace           = "CWAgent"
+        period              = "60"
+        statistic           = "Maximum"
+        threshold           = "1"
+        alarm_description   = "Triggers if curl returns error for given endpoint from this EC2"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
+      }
+      "endpoint-cert-expires-soon" = {
+        comparison_operator = "LessThanThreshold"
+        evaluation_periods  = "1"
+        datapoints_to_alarm = "1"
+        metric_name         = "collectd_endpoint_cert_expiry_value"
+        namespace           = "AWS/CertificateManager"
+        period              = "86400"
+        statistic           = "Minimum"
+        threshold           = "14"
+        alarm_description   = "Triggers if collectd-endpoint-monitoring detects an endpoint with a certificate due to expire shortly. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4615340266"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
+
     lb = {
       unhealthy-load-balancer-host = {
         comparison_operator = "GreaterThanOrEqualToThreshold"


### PR DESCRIPTION
Add endpoint monitoring into OEM account - to replace Grafana:
- adds alarms for endpoint status and certificate expiry
- adds dashboard widgets for same
- relies upon metrics being collected via collectd on OEM servers configured via ansible (separate PR)
