### PR TITLE
nomis: disable overnight scale down for dev-nomis-web19c-a

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -121,6 +121,7 @@ locals {
       })
 
       dev-nomis-web19c-a = merge(local.ec2_autoscaling_groups.web19c, {
+        autoscaling_schedules = {} # disable overnight scale down
       })
 
       dev-nomis-web19c-b = merge(local.ec2_autoscaling_groups.web19c, {


### PR DESCRIPTION
On request from DBAs