### PR TITLE
DPR2-1447: Add S3 retry configs to pipelines

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -104,7 +104,9 @@ module "data_ingestion_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -192,7 +194,9 @@ module "data_ingestion_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.allowed.s3.file.extensions" : ".parquet",
               "--dpr.config.key" : var.domain

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
@@ -229,6 +229,21 @@ variable "retention_curated_num_workers" {
   }
 }
 
+variable "glue_s3_max_attempts" {
+  description = "The maximum number of attempts when making requests to S3"
+  type        = number
+}
+
+variable "glue_s3_retry_min_wait_millis" {
+  description = "The minimum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
+variable "glue_s3_retry_max_wait_millis" {
+  description = "The maximum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/pipeline.tf
@@ -30,7 +30,10 @@ module "maintenance_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_unprocessed_raw_files_check_job,
             "Arguments" : {
-              "--dpr.orchestration.wait.interval.seconds" : "60"
+              "--dpr.orchestration.wait.interval.seconds" : "60",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis)
             }
           },
           "Next" : "Stop Glue Streaming Job"

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
@@ -157,6 +157,21 @@ variable "retention_curated_num_workers" {
   }
 }
 
+variable "glue_s3_max_attempts" {
+  description = "The maximum number of attempts when making requests to S3"
+  type        = number
+}
+
+variable "glue_s3_retry_min_wait_millis" {
+  description = "The minimum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
+variable "glue_s3_retry_max_wait_millis" {
+  description = "The maximum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
 variable "tags" {
   description = "(Optional) Key-value map of resource tags."
   type        = map(string)

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -78,7 +78,9 @@ module "reload_pipeline" {
               "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -119,7 +121,9 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -229,7 +233,9 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -247,7 +253,9 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -265,7 +273,9 @@ module "reload_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -238,6 +238,21 @@ variable "retention_curated_num_workers" {
   }
 }
 
+variable "glue_s3_max_attempts" {
+  description = "The maximum number of attempts when making requests to S3"
+  type        = number
+}
+
+variable "glue_s3_retry_min_wait_millis" {
+  description = "The minimum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
+variable "glue_s3_retry_max_wait_millis" {
+  description = "The maximum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
@@ -89,7 +89,9 @@ module "replay_pipeline" {
               "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
               "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
               "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -129,7 +131,9 @@ module "replay_pipeline" {
               "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
               "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }
@@ -146,7 +150,9 @@ module "replay_pipeline" {
               "--dpr.file.transfer.destination.bucket" : var.s3_raw_bucket_id,
               "--dpr.file.transfer.retention.period.amount" : "0",
               "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : "3",
+              "--dpr.datastorage.retry.maxAttempts"   : tostring(var.glue_s3_max_attempts),
+              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }

--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/variables.tf
@@ -235,6 +235,21 @@ variable "retention_curated_num_workers" {
   }
 }
 
+variable "glue_s3_max_attempts" {
+  description = "The maximum number of attempts when making requests to S3"
+  type        = number
+}
+
+variable "glue_s3_retry_min_wait_millis" {
+  description = "The minimum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
+variable "glue_s3_retry_max_wait_millis" {
+  description = "The maximum wait duration in millis before a request to S3 is retried"
+  type        = number
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
This PR passes the retry arguments to the ingestion, reload, replay and maintenance pipelines so they can be used to retry S3 failures while listing files.