### PR TITLE
fix missing defaults in baseline module

### DIFF
--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -920,8 +920,8 @@ variable "schedule_alarms_lambda" {
   type = object({
     function_name    = string,
     lambda_log_level = optional(string, "INFO")
-    alarm_list       = optional(list(string))
-    alarm_patterns   = optional(list(string))
+    alarm_list       = optional(list(string), [])
+    alarm_patterns   = optional(list(string), [])
     disable_weekend  = optional(bool, true)
     start_time       = optional(string, "06:15")
     end_time         = optional(string, "22:45")


### PR DESCRIPTION
Fixes issue in #8629. This caused [the hmpps-domain-services workflow to fail](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/11782749900/job/32818469556#step:11:511).