### PR TITLE
🔐 Add external secret for GitHub App

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -90,3 +90,56 @@ resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_se
     }
   }
 }
+
+resource "kubernetes_manifest" "actions_runners_github_app_apc_self_hosted_runners_secret" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "actions-runners-github-app-apc-self-hosted-runners"
+      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+    }
+    "spec" = {
+      "refreshInterval" = "1m"
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "actions-runners-github-app-apc-self-hosted-runners"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
+            "property" = "app_id"
+          }
+          "secretKey" = "app-id"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
+            "property" = "client_id"
+          }
+          "secretKey" = "client-id"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
+            "property" = "installation_id"
+          }
+          "secretKey" = "installation-id"
+        },
+        {
+          "remoteRef" = {
+            "key"      = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
+            "property" = "private_key"
+          }
+          "secretKey" = "private-key"
+        },
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5962
- Adds a new ExternalSecret that consumes the secret from https://github.com/ministryofjustice/modernisation-platform-environments/pull/8639

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 