### PR TITLE
🤔 Add decoding strategy for fetching private key from Secrets Manager

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -134,8 +134,9 @@ resource "kubernetes_manifest" "actions_runners_github_app_apc_self_hosted_runne
         },
         {
           "remoteRef" = {
-            "key"      = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
-            "property" = "private_key"
+            "key"              = module.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_id
+            "property"         = "private_key"
+            "decodingStrategy" = "base64"
           }
           "secretKey" = "private-key"
         },

--- a/terraform/environments/analytical-platform-compute/kubernetes-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-secrets.tf
@@ -70,5 +70,3 @@ resource "kubernetes_secret" "ui_app_secrets" {
     secret_key  = random_password.ui_app_secrets.result
   }
 }
-
-


### PR DESCRIPTION
This pull request:

- Adds the missing `decodingStrategy` to `private_key` so it renders as expected

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 