### PR TITLE
check array length instead of comparing `[]`

### DIFF
--- a/terraform/modules/baseline/schedule_alarms_lambda.tf
+++ b/terraform/modules/baseline/schedule_alarms_lambda.tf
@@ -2,8 +2,8 @@ module "schedule_alarms_lambda" {
   source = "../schedule_alarms_lambda"
 
   count = (
-    var.schedule_alarms_lambda.alarm_list != [] ||
-    var.schedule_alarms_lambda.alarm_patterns != []
+    length(var.schedule_alarms_lambda.alarm_list) > 0 ||
+    length(var.schedule_alarms_lambda.alarm_patterns) > 0
   ) ? 1 : 0
 
   lambda_function_name = var.schedule_alarms_lambda.function_name


### PR DESCRIPTION
This previously didn't work as intended. I've tested this new method with a local plan and it's now working as expected.