### PR TITLE
fix the file path to the parquet data for Atrium unstructured

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -25,7 +25,7 @@ module "load_unstructured_atrium_database" {
   name               = "unstructured-atrium-database"
   environment        = local.environment
   database_name      = "g4s-atrium-unstructured"
-  path_to_data       = "/g4s/atrium_unstructured"
+  path_to_data       = "/load/g4s_atrium_unstructured/structure"
   source_data_bucket = module.s3-json-directory-structure-bucket.bucket
   secret_code        = jsondecode(data.aws_secretsmanager_secret_version.airflow_secret.secret_string)["oidc_cluster_identifier"]
   oidc_arn           = aws_iam_openid_connect_provider.analytical_platform_compute.arn


### PR DESCRIPTION
@matt-heery @pricemg Does this look more correct?

See our S3 buckets:
Before: s3://emds-prod-json-directory-structure-20240918073115968100000008/g4s/atrium_unstructured/
After: s3://emds-prod-json-directory-structure-20240918073115968100000008/load/g4s_atrium_unstructured/structure/