### PR TITLE
feat/AP 5859 add cross region lakeformation role

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -1,6 +1,4 @@
 locals {
-  ap_data_prod_s3_kms_key_id = "df8888e3-4080-4c2b-a71e-1425e72f98e4"
-
   environment_configurations = {
     development = {
       /* VPC */

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -1,5 +1,5 @@
 locals {
-  ap_data_prod_account_id = local.environment_management.account_ids["analytical-platform-data-production"]
+  ap_data_prod_s3_kms_key_id = "df8888e3-4080-4c2b-a71e-1425e72f98e4"
 
   environment_configurations = {
     development = {
@@ -39,7 +39,7 @@ locals {
       }
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-dev-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-dev-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-development"
@@ -93,7 +93,7 @@ locals {
       observability_platform = "development"
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-dev-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-dev-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-test"
@@ -140,7 +140,7 @@ locals {
       }
 
       /* Data Engineering Airflow */
-      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.ap_data_prod_account_id}:role/airflow-prod-execution-role"
+      data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-prod-execution-role"
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow"

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -316,7 +316,6 @@ data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_format
     effect = "Allow"
     actions = [
       "s3:ListBucket",
-      "s3:GetBucketLocation",
     ]
     resources = ["arn:aws:s3:::mojap-derived-tables"]
   }

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -320,18 +320,6 @@ data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_format
     resources = ["arn:aws:s3:::mojap-derived-tables"]
   }
   statement {
-    sid = "AwsSseS3KmsSourceAccount"
-    effect = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey"
-    ]
-    resources = ["arn:aws:kms:eu-west-1:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/${local.ap_data_prod_s3_kms_key_id}"]
-  }
-  statement {
     sid = "AllowLakeFormationCloudWatchLogs"
     effect = "Allow"
     actions = [

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -339,7 +339,7 @@ module "data_production_mojap_derived_bucket_lake_formation_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.46.0"
+  version = "5.48.0"
 
   name_prefix = "analytical-platform-data-bucket-lake-formation-policy"
 

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -263,6 +263,8 @@ module "analytical_platform_lake_formation_share_policy" {
   name_prefix = "analytical-platform-lake-formation-sharing-policy"
 
   policy = data.aws_iam_policy_document.analytical_platform_share_policy.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "quicksight_vpc_connection" {
@@ -344,4 +346,6 @@ module "data_production_mojap_derived_bucket_lake_formation_policy" {
   name_prefix = "analytical-platform-data-bucket-lake-formation-policy"
 
   policy = data.aws_iam_policy_document.data_production_mojap_derived_bucket_lake_formation_policy.json
+
+  tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -299,11 +299,11 @@ module "quicksight_vpc_connection_iam_policy" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "data_account_mojap_derived_bucket_lake_formation_policy" {
+data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_formation_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   statement {
-    sid    = "AllowS3ReadWriteAPDataProdDerivedTables"
+    sid = "AllowS3ReadWriteAPDataProdDerivedTables"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -312,7 +312,7 @@ data "aws_iam_policy_document" "data_account_mojap_derived_bucket_lake_formation
     resources = ["arn:aws:s3:::mojap-derived-tables/prod/*"]
   }
   statement {
-    sid    = "AllowS3AccessAPDataProdDerivedTablesBucket"
+    sid = "AllowS3AccessAPDataProdDerivedTablesBucket"
     effect = "Allow"
     actions = [
       "s3:ListBucket",
@@ -321,7 +321,7 @@ data "aws_iam_policy_document" "data_account_mojap_derived_bucket_lake_formation
     resources = ["arn:aws:s3:::mojap-derived-tables"]
   }
   statement {
-    sid    = "AwsSseS3KmsSourceAccount"
+    sid = "AwsSseS3KmsSourceAccount"
     effect = "Allow"
     actions = [
       "kms:Encrypt",
@@ -333,7 +333,7 @@ data "aws_iam_policy_document" "data_account_mojap_derived_bucket_lake_formation
     resources = ["arn:aws:kms:eu-west-1:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/${local.ap_data_prod_s3_kms_key_id}"]
   }
   statement {
-    sid    = "AllowLakeFormationCloudWatchLogs"
+    sid = "AllowLakeFormationCloudWatchLogs"
     effect = "Allow"
     actions = [
       "logs:CreateLogStream",
@@ -347,7 +347,7 @@ data "aws_iam_policy_document" "data_account_mojap_derived_bucket_lake_formation
   }
 }
 
-module "data_account_mojap_derived_bucket_lake_formation_policy" {
+module "data_production_mojap_derived_bucket_lake_formation_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
@@ -356,5 +356,5 @@ module "data_account_mojap_derived_bucket_lake_formation_policy" {
 
   name_prefix = "analytical-platform-data-bucket-lake-formation-policy"
 
-  policy = data.aws_iam_policy_document.data_account_mojap_derived_bucket_lake_formation_policy.json
+  policy = data.aws_iam_policy_document.data_production_mojap_derived_bucket_lake_formation_policy.json
 }

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -303,7 +303,7 @@ data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_format
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   statement {
-    sid = "AllowS3ReadWriteAPDataProdDerivedTables"
+    sid    = "AllowS3ReadWriteAPDataProdDerivedTables"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -312,7 +312,7 @@ data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_format
     resources = ["arn:aws:s3:::mojap-derived-tables/prod/*"]
   }
   statement {
-    sid = "AllowS3AccessAPDataProdDerivedTablesBucket"
+    sid    = "AllowS3AccessAPDataProdDerivedTablesBucket"
     effect = "Allow"
     actions = [
       "s3:ListBucket",
@@ -320,7 +320,7 @@ data "aws_iam_policy_document" "data_production_mojap_derived_bucket_lake_format
     resources = ["arn:aws:s3:::mojap-derived-tables"]
   }
   statement {
-    sid = "AllowLakeFormationCloudWatchLogs"
+    sid    = "AllowLakeFormationCloudWatchLogs"
     effect = "Allow"
     actions = [
       "logs:CreateLogStream",

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -353,7 +353,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   create_role       = true
   role_requires_mfa = false
 
-  role_name_prefix = "lake-formation-data-prod-mojap-derived-"
+  role_name_prefix = "lakeformation-data-prod-mojap-derived-"
 
   # number_of_custom_role_policy_arns = 1
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -353,7 +353,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   create_role       = true
   role_requires_mfa = false
 
-  role_name_prefix = "lakeformation-data-prod-mojap-derived-"
+  role_name = "lake-formation-data-production-data-access"
 
   # number_of_custom_role_policy_arns = 1
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -353,7 +353,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   create_role       = true
   role_requires_mfa = false
 
-  role_name_prefix = "lf-data-prod-mojap-derived"
+  role_name_prefix = "lf-data-prod-mojap-derived-"
 
   # number_of_custom_role_policy_arns = 1
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -353,7 +353,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   create_role       = true
   role_requires_mfa = false
 
-  role_name_prefix = "lake-formation-data-production-mojap-derived"
+  role_name_prefix = "lf-data-prod-mojap-derived"
 
   # number_of_custom_role_policy_arns = 1
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -348,12 +348,12 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.46.0"
+  version = "5.48.0"
 
   create_role       = true
   role_requires_mfa = false
 
-  role_name_prefix = "lf-data-prod-mojap-derived-"
+  role_name_prefix = "lake-formation-data-prod-mojap-derived-"
 
   # number_of_custom_role_policy_arns = 1
 
@@ -361,25 +361,15 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
     module.data_production_mojap_derived_bucket_lake_formation_policy.arn,
   ]
 
-  create_custom_role_trust_policy = true
-  custom_role_trust_policy        = data.aws_iam_policy_document.custom_lake_formation_trust_policy.json
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:SetContext"
+  ]
+
+  trusted_role_services = [
+    "glue.amazonaws.com",
+    "lakeformation.amazonaws.com"
+  ]
 
   tags = local.tags
-}
-
-data "aws_iam_policy_document" "custom_lake_formation_trust_policy" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-      "sts:SetContext"
-    ]
-    principals {
-      type = "Service"
-      identifiers = [
-        "glue.amazonaws.com",
-        "lakeformation.amazonaws.com"
-      ]
-    }
-  }
 }

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -375,7 +375,7 @@ data "aws_iam_policy_document" "custom_lake_formation_trust_policy" {
       "sts:SetContext"
     ]
     principals {
-      type = "AWS"
+      type = "Service"
       identifiers = [
         "glue.amazonaws.com",
         "lakeformation.amazonaws.com"

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -342,3 +342,44 @@ module "quicksight_vpc_connection_iam_role" {
 
   tags = local.tags
 }
+
+module "lake_formation_to_data_production_mojap_derived_tables_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.46.0"
+
+  create_role       = true
+  role_requires_mfa = false
+
+  role_name_prefix = "lake-formation-data-production-mojap-derived"
+
+  # number_of_custom_role_policy_arns = 1
+
+  custom_role_policy_arns = [
+    module.data_production_mojap_derived_bucket_lake_formation_policy.arn,
+  ]
+
+  create_custom_role_trust_policy = true
+  custom_role_trust_policy        = data.aws_iam_policy_document.custom_lake_formation_trust_policy.json
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "custom_lake_formation_trust_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:SetContext"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "glue.amazonaws.com",
+        "lakeformation.amazonaws.com"
+      ]
+    }
+  }
+}

--- a/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
@@ -4,7 +4,8 @@ resource "aws_lakeformation_data_lake_settings" "london" {
     module.lake_formation_share_role.iam_role_arn,
     module.analytical_platform_ui_service_role.iam_role_arn,
     module.analytical_platform_data_eng_dba_service_role.iam_role_arn,
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_sso_role.names)}"
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_sso_role.names)}",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.eks_sso_access_role.names)}"
   ]
 }
 
@@ -15,6 +16,7 @@ resource "aws_lakeformation_data_lake_settings" "ireland" {
     module.lake_formation_share_role.iam_role_arn,
     module.analytical_platform_ui_service_role.iam_role_arn,
     module.analytical_platform_data_eng_dba_service_role.iam_role_arn,
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_sso_role.names)}"
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_sso_role.names)}",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.eks_sso_access_role.names)}"
   ]
 }

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "s3_replication_policy" {
       identifiers = [
         "arn:aws:iam::525294151996:role/service-role/s3replicate_role_for_lf-antfmoj-test",
         "arn:aws:iam::525294151996:role/service-role/s3crr_role_for_lf-antfmoj-test_1",
-        "arn:aws:iam::${local.ap_data_prod_account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
+        "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-cadet-to-apc-production-replication",
       ]
     }
     resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication/*"]
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "s3_replication_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.ap_data_prod_account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
+        "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-cadet-to-apc-production-replication",
       ]
     }
     resources = ["arn:aws:s3:::mojap-compute-${local.environment}-derived-tables-replication"]


### PR DESCRIPTION
This PR relates to ministryofjustice/analytical-platform#5859.

The PR adds a role for use in lake formation to share the `mojap-derived-tables` CaDeT bucket from the data-production account to APC. The role should have the minimum permissions necessary to do so.
- **feat: add cross-region lake formation (lf) role for adding `mojap-derived-tables` to lf**
- **fix: uncommitted changes from previous commit**
