### PR TITLE
Bucket policy now points to actual security role

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/ext-user-2024.tf
+++ b/terraform/environments/analytical-platform-ingestion/ext-user-2024.tf
@@ -45,7 +45,7 @@ module "s3_ext_2024_egress_kms" {
       principals = [
         {
           type        = "AWS"
-          identifiers = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/read-only"] # placeholder -- will change
+          identifiers = ["arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/security-read-only"]
         }
       ]
     }


### PR DESCRIPTION
Closes https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/26

Updated the role in the bucket policy for the test bucket.