### PR TITLE
Update_151124_5

### DIFF
--- a/terraform/environments/ppud/iam.tf
+++ b/terraform/environments/ppud/iam.tf
@@ -881,8 +881,7 @@ data "aws_iam_policy_document" "sns_topic_policy_ec2cw" {
       "SNS:ListSubscriptions",
       "SNS:ListSubscriptionsByTopic",
       "SNS:ListTopics",
-      "SNS:Publish",
-      "SNS:Receive"
+      "SNS:Publish"
     ]
 
     condition {


### PR DESCRIPTION
Removed invalid (obsolete) SNS permission from IAM policy.