### PR TITLE
DPR2-1435: Add DPS Case Notes service secrets and glue connections.

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -94,7 +94,10 @@
       "setup_sonatype_secrets": true,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities"],
+      "dps_domains": [
+        "dps-activities",
+        "dps-case-notes"
+      ],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -269,7 +272,10 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities"],
+      "dps_domains": [
+        "dps-activities",
+        "dps-case-notes"
+      ],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -446,7 +452,10 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "enable_redshift_health_check": true,
-      "dps_domains": ["dps-activities"],
+      "dps_domains": [
+        "dps-activities",
+        "dps-case-notes"
+      ],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -639,7 +648,10 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": false,
       "setup_redshift_schedule": false,
-      "dps_domains": ["dps-activities"],
+      "dps_domains": [
+        "dps-activities",
+        "dps-case-notes"
+      ],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {


### PR DESCRIPTION
* Add dps-case-notes to the list of dps_domains
* This will create a secret manager secret and a glue connection for dps-case-notes
* Note that the secret will contain placeholder values and so the glue connection will start off with placeholder connection details
* The pipeline will need reapplying once the secret has been populated with the genuine details