### PR TITLE
TM-679: ssm command widgets

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -32,6 +32,7 @@ locals {
         "ec2_instance_oracle_db_with_backup",
         "ec2_instance_textfile_monitoring",
         "ec2_windows",
+        "ssm_command",
       ]
       cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       enable_backup_plan_daily_and_weekly         = true
@@ -105,6 +106,7 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_windows,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }
       "nomis-combined-reporting-${local.environment}" = {

--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -48,6 +48,7 @@ locals {
       enable_resource_explorer = true
     }
 
-    security_groups = local.security_groups
+    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.ssm
+    security_groups          = local.security_groups
   }
 }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -41,6 +41,7 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
           local.cloudwatch_dashboard_widget_groups.db,
           local.cloudwatch_dashboard_widget_groups.syscon,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }
     }

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -49,6 +49,7 @@ locals {
           local.cloudwatch_dashboard_widget_groups.db,
           local.cloudwatch_dashboard_widget_groups.xtag,
           local.cloudwatch_dashboard_widget_groups.asg,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }
     }

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -51,6 +51,7 @@ locals {
           local.cloudwatch_dashboard_widget_groups.db,
           local.cloudwatch_dashboard_widget_groups.xtag,
           local.cloudwatch_dashboard_widget_groups.asg,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }
       "prod-nomis-db-1-a" = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -45,6 +45,7 @@ locals {
           local.cloudwatch_dashboard_widget_groups.db,
           local.cloudwatch_dashboard_widget_groups.xtag,
           local.cloudwatch_dashboard_widget_groups.asg,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }
     }

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -800,7 +800,7 @@ locals {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
-          title   = "SSM command-faileds-count"
+          title   = "SSM command-failed-count"
           stat    = "Sum"
           yAxis = {
             left = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -776,6 +776,58 @@ locals {
       }
     }
     ssm = {
+      ssm-command-success-count = {
+        type       = "metric"
+        expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandSuccessCount\"','Sum'),SUM,DESC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "SSM command-success-count"
+          stat    = "Sum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "count"
+            }
+          }
+        }
+      }
+      ssm-command-failed-count = {
+        type       = "metric"
+        expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandFailedCount\"','Sum'),SUM,DESC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "SSM command-faileds-count"
+          stat    = "Sum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "count"
+            }
+          }
+        }
+      }
+      ssm-command-ignore-count = {
+        type       = "metric"
+        expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandIgnoreCount\"','Sum'),SUM,DESC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "SSM command-ignore-count"
+          stat    = "Sum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "count"
+            }
+          }
+        }
+      }
+
       ssm-command-invocation-status = {
         type = "metric"
         properties = {
@@ -956,6 +1008,16 @@ locals {
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-bytes,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-packets,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-peak-packets-per-second,
+      ]
+    }
+    ssm_command = {
+      header_markdown = "## SSM Command Metrics"
+      width           = 8
+      height          = 8
+      widgets = [
+        local.cloudwatch_dashboard_widgets.ssm.ssm-command-success-count,
+        local.cloudwatch_dashboard_widgets.ssm.ssm-command-failed-count,
+        local.cloudwatch_dashboard_widgets.ssm.ssm-command-ignore-count,
       ]
     }
     custom = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -466,6 +466,7 @@ locals {
         expression      = "SORT(SEARCH('{CWAgent,InstanceId,type,type_instance} MetricName=\"collectd_endpoint_cert_expiry_value\"','Minimum'),MIN,ASC)"
         properties = {
           view    = "bar"
+          period  = 3600
           stacked = false
           region  = "eu-west-2"
           title   = "endpoint-cert-days-to-expiry"
@@ -781,6 +782,7 @@ locals {
         expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandSuccessCount\"','Sum'),SUM,DESC)"
         properties = {
           view    = "timeSeries"
+          period  = 3600
           stacked = true
           region  = "eu-west-2"
           title   = "SSM command-success-count"
@@ -798,6 +800,7 @@ locals {
         expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandFailedCount\"','Sum'),SUM,DESC)"
         properties = {
           view    = "timeSeries"
+          period  = 3600
           stacked = true
           region  = "eu-west-2"
           title   = "SSM command-failed-count"
@@ -815,6 +818,7 @@ locals {
         expression = "SORT(SEARCH('{CustomMetrics, DocumentName} MetricName=\"SSMCommandIgnoreCount\"','Sum'),SUM,DESC)"
         properties = {
           view    = "timeSeries"
+          period  = 3600
           stacked = true
           region  = "eu-west-2"
           title   = "SSM command-ignore-count"

--- a/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_metric_alarms.tf
@@ -388,5 +388,21 @@ locals {
         ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
       }
     }
+
+    ssm = {
+      failed-ssm-command = {
+        comparison_operator = "GreaterThanOrEqualToThreshold"
+        evaluation_periods  = "24"
+        datapoints_to_alarm = "1"
+        metric_name         = "SSMCommandFailedCount"
+        namespace           = "CustomMetrics"
+        period              = "3600"
+        statistic           = "Maximum"
+        threshold           = "1"
+        alarm_description   = "Triggers if there has been a failed scheduled SSM command. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/5291475023"
+        alarm_actions       = var.options.cloudwatch_metric_alarms_default_actions
+        ok_actions          = var.options.cloudwatch_metric_alarms_default_actions
+      }
+    }
   }
 }


### PR DESCRIPTION
Add scheduled SSM command run monitoring - alarm and dashboard widgets. Alarm just added to nomis-test for now to see if OK.