### PR TITLE
Add zip files to LFS through `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 terraform/environments/nomis/templates/jumpserver-user-data.yaml.tftpl linguist-language=YAML
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Tracked upstream by [#8393](https://github.com/ministryofjustice/modernisation-platform/issues/8393) in the Modernisation Platform repository.

Implements [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage) for zip archives in this repository.