### PR TITLE
Revert "Add zip files to LFS through `.gitattributes`"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 terraform/environments/nomis/templates/jumpserver-user-data.yaml.tftpl linguist-language=YAML
-*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform-environments#8706

This caused us some outside issues such as here: https://github.com/ministryofjustice/modernisation-platform/actions/runs/11912296203/job/33195577979?pr=8529#step:9:112

This PR is more of a stopgap before implementing a better approach to storing binaries in Git so we'll revert this for now.