### PR TITLE
feat: add athena query buckets (london) for compute environments

### DIFF
--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -282,7 +282,7 @@ module "mojap_compute_athena_s3_kms_eu_west_2" {
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.1"
 
-  aliases               = ["s3/mlflow"]
+  aliases               = ["s3/mojap-compute-athena-query-results-eu-west-2"]
   description           = "Mojap Athena query bucket S3 KMS key for eu-west-2"
   enable_default_policy = true
 

--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -275,6 +275,22 @@ module "mlflow_s3_kms" {
   tags = local.tags
 }
 
+module "mojap_compute_athena_s3_kms_eu_west_2" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["s3/mlflow"]
+  description           = "Mojap Athena query bucket S3 KMS key for eu-west-2"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}
+
 module "mojap_compute_logs_s3_kms_eu_west_2" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -168,7 +168,7 @@ module "mojap_compute_athena_query_results_bucket_eu_west_2" {
 
   bucket = "mojap-compute-${local.environment}-athena-query-results-eu-west-2"
 
-  force_destroy = false
+  force_destroy = true
 
   attach_policy = true
   policy        = data.aws_iam_policy_document.athena_query_results_policy_eu_west_2.json

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -189,5 +189,8 @@ module "mojap_compute_athena_query_results_bucket_eu_west_2" {
     }
   }
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    { "backup" = "false" }
+  )
 }

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -136,28 +136,58 @@ module "mojap_compute_logs_bucket_eu_west_1" {
   )
 }
 
-moved {
-  from = module.mojap_compute_logs_bucket.aws_s3_bucket.this[0]
-  to   = module.mojap_compute_logs_bucket_eu_west_2.aws_s3_bucket.this[0]
-}
-moved {
-  from = module.mojap_compute_logs_bucket.aws_s3_bucket_policy.this[0]
-  to   = module.mojap_compute_logs_bucket_eu_west_2.aws_s3_bucket_policy.this[0]
-}
-moved {
-  from = module.mojap_compute_logs_bucket.aws_s3_bucket_public_access_block.this[0]
-  to   = module.mojap_compute_logs_bucket_eu_west_2.aws_s3_bucket_public_access_block.this[0]
-}
-moved {
-  from = module.mojap_compute_logs_bucket.aws_s3_bucket_server_side_encryption_configuration.this[0]
-  to   = module.mojap_compute_logs_bucket_eu_west_2.aws_s3_bucket_server_side_encryption_configuration.this[0]
-}
-moved {
-  from = module.mojap_compute_logs_bucket.aws_s3_bucket_versioning.this[0]
-  to   = module.mojap_compute_logs_bucket_eu_west_2.aws_s3_bucket_versioning.this[0]
+
+data "aws_iam_policy_document" "athena_query_results_policy_eu_west_2" {
+  #checkov:skip=CKV_AWS_356:resource "*" limited by condition
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::mojap-compute-${local.environment}-athena-query-results-eu-west-2/*",
+      "arn:aws:s3:::mojap-compute-${local.environment}-athena-query-results-eu-west-2"
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
-moved {
-  from = aws_iam_policy_document.s3_server_access_logs_policy
-  to   = aws_iam_policy_document.s3_server_access_logs_eu_west_2_policy
+module "mojap_compute_athena_query_results_bucket_eu_west_2" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.2.2"
+
+  bucket = "mojap-compute-${local.environment}-athena-query-results-eu-west-2"
+
+  force_destroy = false
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.athena_query_results_policy_eu_west_2.json
+
+  object_lock_enabled = false
+
+  versioning = {
+    status = "Disabled"
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = true
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.mojap_compute_athena_s3_kms_eu_west_2.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  tags = local.tags
 }


### PR DESCRIPTION
feat: add athena query buckets (london) for environments, kms encrypted with bucket keys