### PR TITLE
🚚 Update APC Transit Gateway routing

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -13,11 +13,7 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = [
-        "10.26.0.0/15", # modernisation-platform
-        "10.40.0.0/18", # noms-live-vnet
-        "10.205.0.0/20" # laa-lz-prod
-      ]
+      transit_gateway_routes = ["10.0.0.0/8"]
 
       /* Route53 */
       route53_zone = "compute.development.analytical-platform.service.justice.gov.uk"
@@ -64,11 +60,7 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = [
-        "10.26.0.0/15", # modernisation-platform
-        "10.40.0.0/18", # noms-live-vnet
-        "10.205.0.0/20" # laa-lz-prod
-      ]
+      transit_gateway_routes = ["10.0.0.0/8"]
 
       /* Route53 */
       route53_zone = "compute.test.analytical-platform.service.justice.gov.uk"
@@ -115,10 +107,7 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = [
-        "10.26.0.0/15", # modernisation-platform
-        "10.40.0.0/18"  # noms-live-vnet
-      ]
+      transit_gateway_routes = ["10.0.0.0/8"]
 
       /* Route53 */
       route53_zone = "compute.analytical-platform.service.justice.gov.uk"


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4490
- Sends all 10.0.0.0/8 traffic to MoJO TGW that isn't destined for VPC

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 