### PR TITLE
Update EKS role ARN to production role

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -193,7 +193,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds" {
         github_organisation        = "moj-analytical-services"
         github_repository          = "create-a-derived-table"
         github_runner_labels       = "electronic-monitoring-data"
-        eks_role_arn               = "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/test-data-api-cross-account-role"
+        eks_role_arn               = "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-production"]}:role/prod-data-api-cross-account-role"
       }
     )
   ]


### PR DESCRIPTION
Change the EKS role ARN to reference the production role for the actions runner configuration.