### PR TITLE
oasys: TM-749: remove unused IPs in oasys whitelist

### DIFF
--- a/terraform/environments/oasys/locals_security_groups.tf
+++ b/terraform/environments/oasys/locals_security_groups.tf
@@ -12,9 +12,7 @@ locals {
     https_external = flatten([
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
-      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
       module.ip_addresses.external_cidrs.cloud_platform,
-      module.ip_addresses.azure_studio_hosting_public.devtest,
     ])
     https_external_monitoring = flatten([
       module.ip_addresses.mp_cidrs.non_live_eu_west_nat,
@@ -46,8 +44,6 @@ locals {
       module.ip_addresses.moj_cidr.vodafone_dia_networks,
       module.ip_addresses.moj_cidr.palo_alto_primsa_access_corporate,
       module.ip_addresses.external_cidrs.cloud_platform,
-      module.ip_addresses.azure_studio_hosting_public.prod,
-      "35.177.125.252/32", "35.177.137.160/32", # infra_ip.j5_phones - probably not needed
       module.ip_addresses.external_cidrs.sodeco,
       module.ip_addresses.external_cidrs.interserve,
       module.ip_addresses.external_cidrs.meganexus,
@@ -88,14 +84,14 @@ locals {
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
     ])
+    # NOTE: this is at the limit for the number of rules in a single SG
+    # Always test changes in preproduction first
     https_external = flatten([
       module.ip_addresses.azure_fixngo_cidrs.internet_egress,
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
       module.ip_addresses.moj_cidr.vodafone_dia_networks,
       module.ip_addresses.moj_cidr.palo_alto_primsa_access_corporate,
       module.ip_addresses.external_cidrs.cloud_platform,
-      module.ip_addresses.azure_studio_hosting_public.prod,
-      "35.177.125.252/32", "35.177.137.160/32", # infra_ip.j5_phones - probably not needed
       module.ip_addresses.external_cidrs.sodeco,
       module.ip_addresses.external_cidrs.interserve,
       module.ip_addresses.external_cidrs.meganexus,


### PR DESCRIPTION
Previous PR failed due to breaching maximum number of rules in a single SG.
Remove some old rules to make space:
- studio hosting, this is about to be decommissioned
- J5, checked the flow logs and there is no traffic from these IPs