### PR TITLE
feat: AP-6133 add cadet assumable role for apdp->apc-prod metadata copy

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -349,3 +349,73 @@ module "data_production_mojap_derived_bucket_lake_formation_policy" {
 
   tags = local.tags
 }
+
+data "aws_iam_policy_document" "analytical_platform_cadet_runner_compute_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  statement {
+    sid    = "AthenaAccess"
+    effect = "Allow"
+    actions = [
+      "athena:List*",
+      "athena:Get*",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution"
+    ]
+    resources = [
+      "arn:aws:athena:eu-west-2:${data.aws_caller_identity.current.account_id}:datacatalog/*",
+      "arn:aws:athena:eu-west-2:${data.aws_caller_identity.current.account_id}:workgroup/*"
+    ]
+  }
+  statement {
+    sid    = "GlueAccess"
+    effect = "Allow"
+    actions = [
+      "glue:Get*",
+      "glue:DeleteTable",
+      "glue:DeleteTableVersion",
+      "glue:DeleteSchema",
+      "glue:DeletePartition",
+      "glue:DeleteDatabase",
+      "glue:UpdateTable",
+      "glue:UpdateSchema",
+      "glue:UpdatePartition",
+      "glue:UpdateDatabase",
+      "glue:CreateTable",
+      "glue:CreateSchema",
+      "glue:CreatePartition",
+      "glue:CreatePartitionIndex",
+      "glue:BatchCreatePartition",
+      "glue:CreateDatabase"
+    ]
+    resources = [
+      "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:schema/*",
+      "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:database/*",
+      "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:table/*/*",
+      "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:catalog"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "glue:GetTable",
+      "glue:GetDatabase",
+      "glue:GetPartition"
+    ]
+    resources = ["arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:*"]
+  }
+}
+
+module "analytical_platform_cadet_runner_compute_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.48.0"
+
+  name_prefix = "analytical-platform-cadet-runner-compute-policy"
+
+  policy = data.aws_iam_policy_document.analytical_platform_cadet_runner_compute_policy.json
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -373,3 +373,23 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
 
   tags = local.tags
 }
+
+module "analytical_platform_cadet_runner" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.48.0"
+
+  allow_self_assume_role = false
+  trusted_role_arns      = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-management-production"]}:role/create-a-derived-table"]
+  create_role            = true
+  role_requires_mfa      = false
+  role_name              = "analytical-platform-cadet-runner-assumable"
+
+  custom_role_policy_arns = [
+    module.analytical_platform_lake_formation_share_policy.arn,
+    "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
+  ]
+  number_of_custom_role_policy_arns = 2
+
+}

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -386,10 +386,7 @@ module "analytical_platform_cadet_runner" {
   role_requires_mfa      = false
   role_name              = "analytical-platform-cadet-runner-assumable"
 
-  custom_role_policy_arns = [
-    module.analytical_platform_lake_formation_share_policy.arn,
-    "arn:aws:iam::aws:policy/AWSLakeFormationCrossAccountManager"
-  ]
-  number_of_custom_role_policy_arns = 2
+  custom_role_policy_arns = [module.analytical_platform_cadet_runner_compute_policy.arn]
+  # number_of_custom_role_policy_arns = 1
 
 }


### PR DESCRIPTION
This PR contributes to ministryofjustice/analytical-platform#6133.

This PR adds a role assumable by [the CaDeT GitHub runner role ](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf#L107). This assumable role is used by [this workflow](https://github.com/moj-analytical-services/create-a-derived-table/pull/2465/files) to add tables to the glue catalog copied from `analytical-platform-data-production` `eu-west-1`, and then run `MSCK REPAIR TABLES` on hive tables to ensure the partitions are up to date.