### PR TITLE
TM-720: remove ssm command monitoring from nomis

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -48,7 +48,6 @@ locals {
       enable_resource_explorer = true
     }
 
-    cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.ssm
-    security_groups          = local.security_groups
+    security_groups = local.security_groups
   }
 }


### PR DESCRIPTION
Removing this monitoring - going to add via baseline across all accounts