### PR TITLE
TM-720: add endpoint dashboard

### DIFF
--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -97,13 +97,34 @@ locals {
         account_name   = null
         periodOverride = "auto"
         start          = "-PT6H"
-        widget_groups = [
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2,
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_linux,
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_linux,
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
-          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_textfile_monitoring,
-        ]
+        widget_groups = [{
+          header_markdown = "## EC2 Oracle Enterprise Management"
+          width           = 8
+          height          = 8
+          add_ebs_widgets = {
+            iops       = true
+            throughput = true
+          }
+          search_filter = {
+            ec2_tag = [
+              { tag_name = "server-type", tag_value = "hmpps-oem" },
+            ]
+          }
+          widgets = [
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_linux.free-disk-space-low,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-error,
+            module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run,
+          ]
+        }]
       }
       "nomis-${local.environment}" = {
         account_name   = "nomis-${local.environment}"

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -94,7 +94,7 @@ locals {
         ]
       }
       "hmpps-oem-${local.environment}" = {
-        account_name   = "self"
+        account_name   = null
         periodOverride = "auto"
         start          = "-PT6H"
         widget_groups = [

--- a/terraform/environments/hmpps-oem/locals.tf
+++ b/terraform/environments/hmpps-oem/locals.tf
@@ -19,6 +19,7 @@ locals {
   baseline_environment_specific = local.baseline_environments_specific[local.environment]
 
   cloudwatch_dashboard_default_widget_groups = [
+    "ec2_instance_endpoint_monitoring",
     "network_lb",
     "lb",
     "ec2",
@@ -72,6 +73,16 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_oracle_db_with_backup,
         ]
       }
+      "endpoints-and-pipelines" = {
+        account_name   = "hmpps-oem-${local.environment}"
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ec2_instance_endpoint_monitoring,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.github_workflows,
+        ]
+      }
       "hmpps-domain-services-${local.environment}" = {
         account_name   = "hmpps-domain-services-${local.environment}"
         periodOverride = "auto"
@@ -83,7 +94,7 @@ locals {
         ]
       }
       "hmpps-oem-${local.environment}" = {
-        account_name   = "hmpps-oem-${local.environment}"
+        account_name   = "self"
         periodOverride = "auto"
         start          = "-PT6H"
         widget_groups = [

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -178,6 +178,11 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "s3_buckets", {}),
   )
 
+  schedule_alarms_lambda = merge(
+    lookup(local.baseline_all_environments, "schedule_alarms", {}),
+    lookup(local.baseline_environment_specific, "schedule_alarms", {}),
+  )
+
   secretsmanager_secrets = merge(
     module.baseline_presets.secretsmanager_secrets,
     lookup(local.baseline_all_environments, "secretsmanager_secrets", {}),

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -31,9 +31,7 @@ module "cloudwatch_dashboard" {
   source = "../../modules/cloudwatch_dashboard"
 
   dashboard_name = each.key
-  accountId = lookup(each.value, "account_name", null) == null ? null : (
-    lookup(each.value, "account_name", null) == "self" ? "self" : var.environment.account_ids[lookup(each.value, "account_name", null)]
-  )
+  accountId      = lookup(each.value, "account_name", null) == null ? null : var.environment.account_ids[lookup(each.value, "account_name", null)]
   ec2_instances  = module.ec2_instance
   periodOverride = lookup(each.value, "periodOverride", null)
   start          = lookup(each.value, "start", null)

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -31,7 +31,9 @@ module "cloudwatch_dashboard" {
   source = "../../modules/cloudwatch_dashboard"
 
   dashboard_name = each.key
-  accountId      = lookup(each.value, "account_name", null) == null ? null : var.environment.account_ids[lookup(each.value, "account_name", null)]
+  accountId = lookup(each.value, "account_name", null) == null ? null : (
+    lookup(each.value, "account_name", null) == "self" ? "self" : var.environment.account_ids[lookup(each.value, "account_name", null)]
+  )
   ec2_instances  = module.ec2_instance
   periodOverride = lookup(each.value, "periodOverride", null)
   start          = lookup(each.value, "start", null)

--- a/terraform/modules/baseline/ssm.tf
+++ b/terraform/modules/baseline/ssm.tf
@@ -59,7 +59,7 @@ resource "aws_ssm_association" "this" {
 
   apply_only_at_cron_interval = each.value.apply_only_at_cron_interval
   association_name            = each.key
-  name                        = each.value.name
+  name                        = try(aws_ssm_document.this[each.value.name].name, each.value.name) # so ssm_doc is created first
   max_concurrency             = each.value.max_concurrency
   max_errors                  = each.value.max_errors
   schedule_expression         = each.value.schedule_expression


### PR DESCRIPTION
Add endpoint monitoring widgets to default OEM dashboard
Add separate dashboard for endpoints and pipelines
Fixed hmpps-oem dashboard so it just shows oem EC2 metrics
Fixed SSM dependency