### PR TITLE
Add GuardDuty S3 malware protection for specified S3 buckets

### DIFF
--- a/terraform/environments/example/s3_malware_protection.tf
+++ b/terraform/environments/example/s3_malware_protection.tf
@@ -1,0 +1,44 @@
+# Variable to allow bucket selection
+variable "buckets_to_protect" {
+  description = <<EOF
+    Enter the pre-existing bucket names you want to enable malware protection for.
+    Bucket names must be separated by commas (e.g., bucket1,bucket2,bucket3).
+    To enable for all buckets, list all bucket names here.
+  EOF
+  type        = string
+  default     = "tests3malwarescanning,tests3malwarekf"
+}
+
+# Define the list of buckets to protect
+locals {
+  bucket_list = toset(split(",", replace(trimspace(var.buckets_to_protect), " ", "")))
+}
+
+# GuardDuty Malware Protection Plan
+resource "aws_guardduty_malware_protection_plan" "malware_protection_plan" {
+  for_each = local.bucket_list
+
+  role = data.aws_iam_role.member_access.arn
+
+  protected_resource {
+    s3_bucket {
+      bucket_name = each.key
+    }
+  }
+
+  actions {
+    tagging {
+      status = "ENABLED"
+    }
+  }
+
+  tags = {
+    "Name" = "GuardDutyMalwareProtectionPlan-${each.key}" # Unique tag for each bucket
+  }
+}
+
+
+# Data source for the member-access IAM role
+data "aws_iam_role" "member_access" {
+  name = "MemberInfrastructureAccess"
+}


### PR DESCRIPTION
This PR introduces GuardDuty S3 malware protection for specified S3 buckets to improve security and protect against threats. It includes a flexible configuration allowing users to specify the S3 buckets for which protection should be applied, along with necessary role associations and tagging.