### PR TITLE
DPR2-1435: Explicitly set DMS Postgres source heartbeat frequency

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
@@ -82,7 +82,6 @@ resource "aws_dms_endpoint" "source" {
   extra_connection_attributes = var.extra_attributes
 
   postgres_settings {
-    map_boolean_as_boolean = true
     heartbeat_enable       = true
     heartbeat_frequency    = 5
   }

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
@@ -81,6 +81,12 @@ resource "aws_dms_endpoint" "source" {
 
   extra_connection_attributes = var.extra_attributes
 
+  postgres_settings {
+    map_boolean_as_boolean = true
+    heartbeat_enable       = true
+    heartbeat_frequency    = 5
+  }
+
   tags = var.tags
 
   depends_on = [

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
@@ -4,12 +4,6 @@ terraform {
       version = ">= 5.77.0, < 6.0.0"
       source  = "hashicorp/aws"
     }
-
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2"
-    }
-
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -137,6 +137,7 @@ resource "aws_dms_endpoint" "dms-s3-target-source" {
   postgres_settings {
     map_boolean_as_boolean = true
     heartbeat_enable       = true
+    heartbeat_frequency    = var.postgres_source_heartbeat_frequency
   }
 
   extra_connection_attributes = var.extra_attributes

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
@@ -205,6 +205,12 @@ variable "dms_target_endpoint" {
   default = ""
 }
 
+variable "postgres_source_heartbeat_frequency" {
+  description = "(Optional) Sets the WAL heartbeat frequency (in minutes). Default value is 5."
+  type    = number
+  default = 5
+}
+
 #--------------------------------------------------------------
 # DMS Endpoint
 #--------------------------------------------------------------

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
@@ -207,8 +207,8 @@ variable "dms_target_endpoint" {
 
 variable "postgres_source_heartbeat_frequency" {
   description = "(Optional) Sets the WAL heartbeat frequency (in minutes). Default value is 5."
-  type    = number
-  default = 5
+  type        = number
+  default     = 5
 }
 
 #--------------------------------------------------------------

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = ">= 5.31.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 5.31.0"
+      version = ">= 5.31.0, < 6.0.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/endpoints.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/endpoints.tf
@@ -2,24 +2,25 @@
 module "dms_endpoints" {
   source = "../../dms_s3_v2"
 
-  setup_dms_endpoints       = var.setup_dms_endpoints
-  setup_dms_iam             = var.setup_dms_iam
-  setup_dms_source_endpoint = var.setup_dms_source_endpoint
-  setup_dms_s3_endpoint     = var.setup_dms_s3_endpoint
-  source_engine_name        = var.source_engine_name
-  dms_source_name           = var.dms_source_name
-  dms_target_name           = var.dms_target_name
-  project_id                = var.project_id
-  env                       = var.env # common
-  short_name                = var.short_name
-  source_db_name            = var.source_db_name
-  source_app_username       = var.source_app_username
-  source_app_password       = var.source_app_password
-  source_address            = var.source_address
-  source_ssl_mode           = var.source_ssl_mode
-  source_db_port            = var.source_db_port
-  extra_attributes          = var.extra_attributes
-  bucket_name               = var.bucket_name
+  setup_dms_endpoints                 = var.setup_dms_endpoints
+  setup_dms_iam                       = var.setup_dms_iam
+  setup_dms_source_endpoint           = var.setup_dms_source_endpoint
+  setup_dms_s3_endpoint               = var.setup_dms_s3_endpoint
+  source_engine_name                  = var.source_engine_name
+  dms_source_name                     = var.dms_source_name
+  dms_target_name                     = var.dms_target_name
+  project_id                          = var.project_id
+  env                                 = var.env # common
+  short_name                          = var.short_name
+  source_db_name                      = var.source_db_name
+  source_app_username                 = var.source_app_username
+  source_app_password                 = var.source_app_password
+  source_address                      = var.source_address
+  source_ssl_mode                     = var.source_ssl_mode
+  source_db_port                      = var.source_db_port
+  postgres_source_heartbeat_frequency = var.postgres_source_heartbeat_frequency
+  extra_attributes                    = var.extra_attributes
+  bucket_name                         = var.bucket_name
 
   tags = var.tags
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
@@ -233,6 +233,6 @@ variable "source_username" {
 
 variable "postgres_source_heartbeat_frequency" {
   description = "(Optional) Sets the WAL heartbeat frequency (in minutes). Default value is 5."
-  type    = number
-  default = 5
+  type        = number
+  default     = 5
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
@@ -230,3 +230,9 @@ variable "source_username" {
   description = "Username to access the source database"
   default     = ""
 }
+
+variable "postgres_source_heartbeat_frequency" {
+  description = "(Optional) Sets the WAL heartbeat frequency (in minutes). Default value is 5."
+  type    = number
+  default = 5
+}


### PR DESCRIPTION
The DMS Postgres source heartbeat frequency is supposed to default to 5 minutes according to the AWS docs but it seems that it actually defaults to zero and runs in a tight loop.

![image](https://github.com/user-attachments/assets/7a36970d-ee10-472d-9b2d-4355904af8b9)
![image](https://github.com/user-attachments/assets/a3358369-1a64-44fc-a08c-9d58ac8385cb)
![image](https://github.com/user-attachments/assets/71ebfd36-094b-4a4d-a9ec-ebc174ca8afc)



