### PR TITLE
TM-720: endpoint monitoring improvements

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -664,32 +664,24 @@ locals {
             }
           })
           http-7770 = merge(local.lbs.rxy.listeners.http-7770, {
-            alarm_target_group_names = ["pp-csr-w-34-7770"]
-            cloudwatch_metric_alarms = {}
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7770"
             }
           })
           http-7771 = merge(local.lbs.rxy.listeners.http-7771, {
-            alarm_target_group_names = ["pp-csr-w-34-7771"]
-            cloudwatch_metric_alarms = {}
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7771"
             }
           })
           http-7780 = merge(local.lbs.rxy.listeners.http-7780, {
-            alarm_target_group_names = ["pp-csr-w-34-7780"]
-            cloudwatch_metric_alarms = {}
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7780"
             }
           })
           http-7781 = merge(local.lbs.rxy.listeners.http-7781, {
-            alarm_target_group_names = ["pp-csr-w-34-7781"]
-            cloudwatch_metric_alarms = {}
             default_action = {
               type              = "forward"
               target_group_name = "pp-csr-w-34-7781"

--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -3,57 +3,95 @@ locals {
   # these should match the alarms configured in ansible collectd-endpoint-monitoring role on the given EC2
   # format for each dict item is: alarm-postfix = [metric-dimension, is_https, sns_topic]
   endpoint_alarms = {
+
     development = {
     }
+
     test = {
-      hmppgw1-rdgateway = ["hmppgw1.justice.gov.uk", true, "azure-fixngo-pagerduty"]
-      nomis-t1          = ["c-t1.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
-      nomis-t2          = ["c-t2.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
-      nomis-t3          = ["c-t3.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
-      oasys-t1          = ["t1-int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
-      oasys-t2          = ["t2-int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+      # az-noms-dev-test-environments
       offloc-stage      = ["stage.offloc.service.justice.gov.uk", true, "azure-fixngo-pagerduty"]
-      rdgateway         = ["rdgateway1.test.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+      hmppgw1-rdgateway = ["hmppgw1.justice.gov.uk", true, "azure-fixngo-pagerduty"]
+
+      # hmpps-domain-services
+      rdgateway = ["rdgateway1.test.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+
+      # nomis
+      nomis-t1 = ["c-t1.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
+      nomis-t2 = ["c-t2.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
+      nomis-t3 = ["c-t3.test.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
+
+      # oasys
+      oasys-t1 = ["t1-int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+      oasys-t2 = ["t2-int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
     }
+
     preproduction = {
-      cafmtx-pp          = ["cafmtx.pp.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
-      cafmwebx-pp        = ["cafmwebx.pp.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
-      csr-traina         = ["traina.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r1-pp          = ["r1.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r2-pp          = ["r2.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r3-pp          = ["r3.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r4-pp          = ["r4.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r5-pp          = ["r5.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r6-pp          = ["r6.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      nomis-lsast        = ["c.lsast-nomis.az.justice.gov.uk", true, "nomis-pagerduty"]
-      nomis-pp           = ["c.pp-nomis.az.justice.gov.uk", true, "nomis-pagerduty"]
+      # corporate-staff-rostering
+      csr-r1-pp  = ["r1.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r2-pp  = ["r2.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r3-pp  = ["r3.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r4-pp  = ["r4.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r5-pp  = ["r5.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r6-pp  = ["r6.pp.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-traina = ["traina.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+
+      # hmpps-domain-services
+      rdgateway = ["rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+
+      # nomis
+      nomis-lsast = ["c-lsast.preproduction.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
+      nomis-pp    = ["c.preproduction.nomis.service.justice.gov.uk", true, "nomis-pagerduty"]
+
+      # nomis-combined-reporting
       nomis-reporting-pp = ["reporting.pp-nomis.az.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
-      oasys-pp           = ["pp-oasys.az.justice.gov.uk", true, "oasys-pagerduty"]
-      onr-pp             = ["onr.pp-oasys.az.justice.gov.uk", true, "oasys-national-reporting-pagerduty"]
-      rdgateway          = ["rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+
+      # oasys
+      oasys-pp = ["pp.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+
+      # oasys-national-reporting
+      onr-pp = ["onr.pp-oasys.az.justice.gov.uk", true, "oasys-national-reporting-pagerduty"]
+
+      # planetfm
+      cafmtx-pp   = ["cafmtx.pp.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
+      cafmwebx-pp = ["cafmwebx.pp.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
     }
 
     production = {
-      bridge-oasys           = ["bridge-oasys.az.justice.gov.uk", true, "oasys-pagerduty"]
-      cafmtrainweb           = ["cafmtrainweb.az.justice.gov.uk", true, "planetfm-pagerduty"]
-      cafmtx                 = ["cafmtx.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
-      cafmwebx2              = ["cafmwebx2.az.justice.gov.uk", true, "planetfm-pagerduty"]
-      csr-r1                 = ["r1.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r2                 = ["r2.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r3                 = ["r3.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r4                 = ["r4.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r5                 = ["r5.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      csr-r6                 = ["r6.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
-      hpa                    = ["hpa.service.hmpps.dsd.io", true, "azure-fixngo-pagerduty"]
+      # az-noms-production-1
       hmpps-az-gw1-rdgateway = ["hmpps-az-gw1.justice.gov.uk", true, "azure-fixngo-pagerduty"]
-      nomis                  = ["c.nomis.az.justice.gov.uk", true, "nomis-pagerduty"]
-      nomis-reporting        = ["reporting.nomis.az.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
-      oasys                  = ["oasys.az.justice.gov.uk", true, "oasys-pagerduty"]
-      oasys-practice         = ["practice.oasys.az.justice.gov.uk", true, "oasys-pagerduty"]
-      oasys-training         = ["training.oasys.az.justice.gov.uk", true, "oasys-pagerduty"]
+      hpa                    = ["hpa.service.hmpps.dsd.io", true, "azure-fixngo-pagerduty"]
       offloc                 = ["www.offloc.service.justice.gov.uk", true, "azure-fixngo-pagerduty"]
-      onr                    = ["onr.oasys.az.justice.gov.uk", true, "oasys-national-reporting-pagerduty"]
-      rdgateway              = ["rdgateway1.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+
+      # corporate-staff-rostering
+      csr-r1 = ["r1.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r2 = ["r2.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r3 = ["r3.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r4 = ["r4.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r5 = ["r5.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+      csr-r6 = ["r6.csr.service.justice.gov.uk", false, "corporate-staff-rostering-pagerduty"]
+
+      # hmpps-domain-services
+      rdgateway = ["rdgateway1.hmpps-domain.service.justice.gov.uk", true, "hmpps-domain-services-pagerduty"]
+
+      # nomis
+      nomis = ["c.nomis.az.justice.gov.uk", true, "nomis-pagerduty"]
+
+      # nomis-combined-reporting
+      nomis-reporting = ["reporting.nomis.az.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
+
+      # oasys
+      oasys          = ["oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+      oasys-int      = ["int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+      oasys-practice = ["practice.int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+      oasys-training = ["training.int.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
+
+      # oasys-national-reporting
+      onr = ["onr.oasys.az.justice.gov.uk", true, "oasys-national-reporting-pagerduty"]
+
+      # planetfm
+      cafmtrainweb = ["cafmtrainweb.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
+      cafmtx       = ["cafmtx.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
+      cafmwebx2    = ["cafmwebx2.planetfm.service.justice.gov.uk", true, "planetfm-pagerduty"]
     }
   }
 


### PR DESCRIPTION
More tidy up:
- remove CSR preprod LB alerts as endpoint alarms cover this
- group alarms by services and use AWS URLs wherever possible