### PR TITLE
🚚 Migrate Analytical Platform to Observability Platform Production

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -38,9 +38,6 @@ locals {
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-development"
 
-      /* Observability Platform */
-      observability_platform = "development"
-
       /* QuickSight */
       quicksight_notification_email = "analytical-platform@digital.justice.gov.uk"
 
@@ -78,9 +75,6 @@ locals {
         eks_pod_identity_agent = "v1.3.2-eksbuild.2"
         vpc_cni                = "v1.19.0-eksbuild.1"
       }
-
-      /* Observability Platform */
-      observability_platform = "development"
 
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-dev-execution-role"
@@ -131,9 +125,6 @@ locals {
 
       /* MLFlow */
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow"
-
-      /* Observability Platform */
-      observability_platform = "production"
 
       /* QuickSight */
       quicksight_notification_email = "analytical-platform@digital.justice.gov.uk"

--- a/terraform/environments/analytical-platform-compute/observability-platform.tf
+++ b/terraform/environments/analytical-platform-compute/observability-platform.tf
@@ -5,7 +5,7 @@ module "observability_platform_tenant" {
   source  = "ministryofjustice/observability-platform-tenant/aws"
   version = "1.2.0"
 
-  observability_platform_account_id = local.environment_management.account_ids["observability-platform-${local.environment_configuration.observability_platform}"]
+  observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
   enable_prometheus                 = true
   enable_xray                       = true
   additional_policies = {

--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -19,9 +19,6 @@ locals {
         "10.0.0.0/8"
       ]
 
-      /* Observability Platform */
-      observability_platform = "development"
-
       /* Image Versions */
       scan_image_version     = "0.1.3"
       transfer_image_version = "0.0.18"
@@ -66,9 +63,6 @@ locals {
         /* Send all traffic not destined for local down to the transit gateway */
         "10.0.0.0/8"
       ]
-
-      /* Observability Platform */
-      observability_platform = "production"
 
       /* Image Versions */
       scan_image_version     = "0.1.3"

--- a/terraform/environments/analytical-platform-ingestion/observability-platform.tf
+++ b/terraform/environments/analytical-platform-ingestion/observability-platform.tf
@@ -4,7 +4,7 @@ module "observability_platform_tenant" {
   source  = "ministryofjustice/observability-platform-tenant/aws"
   version = "1.2.0"
 
-  observability_platform_account_id = local.environment_management.account_ids["observability-platform-${local.environment_configuration.observability_platform}"]
+  observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
   enable_xray                       = true
 
   tags = local.tags


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/observability-platform/issues/148
- Sets OP module to `observability-platform-production`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 