### PR TITLE
🌐 Allow tenants to set AMP region

### DIFF
--- a/terraform/environments/observability-platform/environment-configurations.tf
+++ b/terraform/environments/observability-platform/environment-configurations.tf
@@ -173,12 +173,13 @@ locals {
               athena_enabled                  = false
             }
             "analytical-platform-production" = {
-              cloudwatch_enabled              = true
-              prometheus_push_enabled         = false
-              amazon_prometheus_query_enabled = true
-              amazon_prometheus_workspace_id  = "ws-a7b353be-244a-47e7-8054-436b41c050d932"
-              xray_enabled                    = false
-              athena_enabled                  = false
+              cloudwatch_enabled                 = true
+              prometheus_push_enabled            = false
+              amazon_prometheus_query_enabled    = true
+              amazon_prometheus_workspace_region = "eu-west-1"
+              amazon_prometheus_workspace_id     = "ws-a7b353be-244a-47e7-8054-436b41c050d932"
+              xray_enabled                       = false
+              athena_enabled                     = false
             },
             "analytical-platform-data-development" = {
               cloudwatch_enabled              = true

--- a/terraform/environments/observability-platform/modules/grafana/amazon-prometheus-query-source/main.tf
+++ b/terraform/environments/observability-platform/modules/grafana/amazon-prometheus-query-source/main.tf
@@ -13,7 +13,7 @@ resource "grafana_data_source" "this" {
     sigV4Auth          = true
     sigV4AuthType      = "ec2_iam_role"
     sigV4AssumeRoleArn = "arn:aws:iam::${var.account_id}:role/observability-platform"
-    sigV4Region        = "eu-west-2"
+    sigV4Region        = var.amazon_prometheus_workspace_region
     sigV4ExternalId    = var.name
   })
 }

--- a/terraform/environments/observability-platform/modules/grafana/amazon-prometheus-query-source/variables.tf
+++ b/terraform/environments/observability-platform/modules/grafana/amazon-prometheus-query-source/variables.tf
@@ -6,6 +6,10 @@ variable "account_id" {
   type = string
 }
 
+variable "amazon_prometheus_workspace_region" {
+  type = string
+}
+
 variable "amazon_prometheus_workspace_id" {
   type = string
 }

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/main.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/main.tf
@@ -31,9 +31,10 @@ module "amazon_prometheus_query_source" {
 
   source = "../../grafana/amazon-prometheus-query-source"
 
-  name                           = each.key
-  account_id                     = var.environment_management.account_ids[each.key]
-  amazon_prometheus_workspace_id = each.value.amazon_prometheus_workspace_id
+  name                               = each.key
+  account_id                         = var.environment_management.account_ids[each.key]
+  amazon_prometheus_workspace_region = try(each.value.amazon_prometheus_workspace_region, "eu-west-2")
+  amazon_prometheus_workspace_id     = each.value.amazon_prometheus_workspace_id
 }
 
 locals {

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/variables.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/variables.tf
@@ -12,13 +12,14 @@ variable "identity_centre_team" {
 
 variable "aws_accounts" {
   type = map(object({
-    cloudwatch_enabled              = optional(bool)
-    cloudwatch_custom_namespaces    = optional(string)
-    prometheus_push_enabled         = optional(bool)
-    amazon_prometheus_query_enabled = optional(bool)
-    amazon_prometheus_workspace_id  = optional(string)
-    xray_enabled                    = optional(bool)
-    athena_enabled                  = optional(bool)
+    cloudwatch_enabled                 = optional(bool)
+    cloudwatch_custom_namespaces       = optional(string)
+    prometheus_push_enabled            = optional(bool)
+    amazon_prometheus_query_enabled    = optional(bool)
+    amazon_prometheus_workspace_region = optional(string)
+    amazon_prometheus_workspace_id     = optional(string)
+    xray_enabled                       = optional(bool)
+    athena_enabled                     = optional(bool)
     athena_config = optional(map(object({
       database  = string
       workgroup = string


### PR DESCRIPTION
This pull request:

- Allows tenants to set a region for their AMP workspace with `amazon_prometheus_workspace_region` - This is for Analytical Platform as their infrastructure runs in `eu-west-1`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 