### PR TITLE
DPR2-1435: Default Postgres DMS source heartbeat frequency to 5 minutes.

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1262,56 +1262,6 @@ module "dms_nomis_ingestor" {
   )
 }
 
-module "dms_fake_data_ingestor" {
-  source                       = "./modules/dms_dps"
-  setup_dms_instance           = local.setup_fake_data_dms_instance
-  enable_replication_task      = local.enable_fake_data_replication_task # Disable Replication Task
-  name                         = "${local.project}-dms-fake-data-ingestor-${local.env}"
-  vpc_cidr                     = [data.aws_vpc.shared.cidr_block]
-  source_engine_name           = "postgres"
-  source_db_name               = "db59b5cf9e5de6b794"
-  source_app_username          = "cp9Zr5bLim"
-  source_app_password          = "whkthrI65zpcFEe5"
-  source_address               = "cloud-platform-59b5cf9e5de6b794.cdwm328dlye6.eu-west-2.rds.amazonaws.com"
-  source_db_port               = 5432
-  vpc                          = data.aws_vpc.shared.id
-  kinesis_stream_policy        = module.kinesis_stream_ingestor.kinesis_stream_iam_policy_admin_arn
-  project_id                   = local.project
-  env                          = local.environment
-  dms_source_name              = "postgres"
-  dms_target_name              = "kinesis"
-  short_name                   = "fake-data"
-  migration_type               = "full-load-and-cdc"
-  replication_instance_version = "3.4.7" # Rollback
-  replication_instance_class   = "dms.t3.medium"
-  subnet_ids = [
-    data.aws_subnet.data_subnets_a.id, data.aws_subnet.data_subnets_b.id, data.aws_subnet.data_subnets_c.id
-  ]
-
-  vpc_role_dependency        = [aws_iam_role.dmsvpcrole]
-  cloudwatch_role_dependency = [aws_iam_role.dms_cloudwatch_logs_role]
-
-  kinesis_settings = {
-    "include_null_and_empty"         = "true"
-    "partition_include_schema_table" = "true"
-    "include_partition_value"        = "true"
-    "kinesis_target_stream"          = "arn:aws:kinesis:eu-west-2:${data.aws_caller_identity.current.account_id}:stream/${local.kinesis_stream_ingestor}"
-  }
-
-  availability_zones = {
-    0 = "eu-west-2a"
-  }
-
-  tags = merge(
-    local.all_tags,
-    {
-      Name            = "${local.project}-dms-fake-data-ingestor-${local.env}"
-      Resource_Type   = "DMS Replication"
-      Postgres_Source = "DPS"
-    }
-  )
-}
-
 # DMS Nomis Data Collector
 module "dms_nomis_to_s3_ingestor" {
   source                       = "./modules/dms"

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -137,6 +137,7 @@ resource "aws_dms_endpoint" "dms-s3-target-source" {
   postgres_settings {
     map_boolean_as_boolean = true
     heartbeat_enable       = true
+    heartbeat_frequency    = 5
   }
 
   extra_connection_attributes = var.extra_attributes

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/main.tf
@@ -33,6 +33,7 @@ resource "aws_s3_bucket_public_access_block" "storage" {
 
 # Resource to define S3 bucket lifecycle configuration
 resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
+  #checkov:skip=CKV_AWS_300: "Ensure S3 lifecycle configuration sets period for aborting failed uploads"
   # Enable the lifecycle configuration only if the variable `enable_lifecycle` is true
   count  = var.enable_lifecycle ? 1 : 0
   bucket = aws_s3_bucket.storage[0].id

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/variables.tf
@@ -1,5 +1,6 @@
 
 variable "name" {
+  type        = string
   description = "Name of the Bucket"
   default     = ""
 }
@@ -23,11 +24,13 @@ variable "cloudtrail_access_policy" {
 }
 
 variable "s3_notification_name" {
+  type        = string
   description = "S3 Notification Event Name"
   default     = "s3-notification-event"
 }
 
 variable "create_s3" {
+  type        = bool
   description = "Setup S3 Buckets"
   default     = false
 }
@@ -39,21 +42,25 @@ variable "custom_kms_key" {
 }
 
 variable "create_notification_queue" {
+  type        = bool
   description = "Setup Notification Queue"
   default     = false
 }
 
 variable "sqs_msg_retention_seconds" {
+  type        = number
   description = "SQS Message Retention"
   default     = 86400
 }
 
 variable "filter_prefix" {
+  type        = string
   description = "S3 Notification Filter Prefix"
   default     = null
 }
 
 variable "enable_lifecycle" {
+  type        = bool
   description = "Enabled Lifecycle for S3 Storage, Default is False"
   default     = false
 }
@@ -74,16 +81,19 @@ variable "enable_lifecycle" {
 #}
 
 variable "enable_versioning_config" {
+  type        = string
   description = "Enable Versioning Config for S3 Storage, Default is Disabled"
   default     = "Disabled"
 }
 
 variable "enable_s3_versioning" {
+  type        = bool
   description = "Enable Versioning for S3 Bucket, Default is false"
   default     = false
 }
 
 variable "enable_notification" {
+  type        = bool
   description = "Enable S3 Bucket Notifications, Default is false"
   default     = false
 }
@@ -111,6 +121,7 @@ variable "dependency_lambda" {
 }
 
 variable "bucket_key" {
+  type        = bool
   description = "If Bucket Key is Enabled or Disabled"
   default     = true
 }
@@ -127,6 +138,7 @@ variable "lifecycle_category" {
 }
 
 variable "enable_lifecycle_expiration" {
+  type        = bool
   description = "Enable item expiration - requires 'enable_lifecycle' and 'override_expiration_rules' to be defined/enabled."
   default     = false
 }

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
The DMS Postgres source heartbeat frequency is supposed to default to 5 minutes according to the AWS docs but it seems that it actually defaults to zero and runs in a tight loop (at least when created using the AWS terraform provider's module).

Also the settings do not update correctly via terraform when you update postgres settings. For example, changing the heartbeat frequency shows up in the terraform plan but does not apply. This means that you have to either delete and recreate the terraform resources or manually update the settings.

See https://github.com/hashicorp/terraform-provider-aws/issues/35834
![image](https://github.com/user-attachments/assets/6034d81e-1734-43f3-955d-636eb8792e6e)

