### PR TITLE
TM-720: fix schedule alarms

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -154,7 +154,6 @@ locals {
     }
 
     schedule_alarms_lambda = {
-      function_name = "schedule-alarms"
       alarm_patterns = [
         "public-https-*-unhealthy-load-balancer-host",
       ]

--- a/terraform/modules/baseline/outputs.tf
+++ b/terraform/modules/baseline/outputs.tf
@@ -146,9 +146,24 @@ output "security_groups" {
   value       = aws_security_group.this
 }
 
+output "schedule_alarms_lambda" {
+  description = "schedule alarms lambda output"
+  value       = module.schedule_alarms_lambda
+}
+
 output "sns_topics" {
   description = "map of aws_sns_topic resources corresponding to var.sns_topics"
   value       = aws_sns_topic.this
+}
+
+output "ssm_associations" {
+  description = "map of aws_ssm_association resources corresponding to var.ssm_association"
+  value       = aws_ssm_association.this
+}
+
+output "ssm_documents" {
+  description = "map of aws_ssm_document resources corresponding to var.ssm_documents"
+  value       = aws_ssm_document.this
 }
 
 output "ssm_parameters" {

--- a/terraform/modules/baseline/schedule_alarms_lambda.tf
+++ b/terraform/modules/baseline/schedule_alarms_lambda.tf
@@ -6,7 +6,7 @@ module "schedule_alarms_lambda" {
     length(var.schedule_alarms_lambda.alarm_patterns) > 0
   ) ? 1 : 0
 
-  lambda_function_name = var.schedule_alarms_lambda.function_name
+  lambda_function_name = "schedule-alarms"
   lambda_log_level     = var.schedule_alarms_lambda.lambda_log_level
 
   alarm_list     = var.schedule_alarms_lambda.alarm_list

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -922,7 +922,7 @@ variable "schedule_alarms_lambda" {
     alarm_list       = optional(list(string), [])
     alarm_patterns   = optional(list(string), [])
     disable_weekend  = optional(bool, true)
-    start_time       = optional(string, "19:45") # when to disable alarm
+    start_time       = optional(string, "20:45") # when to disable alarm
     end_time         = optional(string, "06:15") # when to re-enable alarm
     tags             = optional(map(string), {})
   })

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -918,13 +918,12 @@ variable "s3_buckets" {
 variable "schedule_alarms_lambda" {
   description = ""
   type = object({
-    function_name    = optional(string, null)
     lambda_log_level = optional(string, "INFO")
     alarm_list       = optional(list(string), [])
     alarm_patterns   = optional(list(string), [])
     disable_weekend  = optional(bool, true)
-    start_time       = optional(string, "06:15")
-    end_time         = optional(string, "20:45")
+    start_time       = optional(string, "19:45") # when to disable alarm
+    end_time         = optional(string, "06:15") # when to re-enable alarm
     tags             = optional(map(string), {})
   })
   default = {}


### PR DESCRIPTION
Fix + tidy up of schedule alarms
- start/end time were wrong way round
- add module output to baseline outputs (plus ssm stuff that was missing as well)
- hardcode function name so it is consistent. There is only one instance of module so may as well hardcode the name.