### PR TITLE
style: AP-6133 clearer role and policy names for APDP metadata-copy-to-compute assumable role & add `lakeformation:*LFTag*` perms

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -431,7 +431,7 @@ module "copy_apdp_cadet_metadata_to_compute_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "5.48.0"
 
-  name_prefix = "copy-ap-cadet-metadata-to-compute-"
+  name_prefix = "copy-apdp-cadet-metadata-to-compute-"
 
   policy = data.aws_iam_policy_document.copy_apdp_cadet_metadata_to_compute_policy.json
 

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -422,6 +422,21 @@ data "aws_iam_policy_document" "copy_apdp_cadet_metadata_to_compute_policy" {
       "${module.mojap_compute_athena_query_results_bucket_eu_west_2.s3_bucket_arn}/*"
     ]
   }
+  statement {
+    sid    = "AlterLFTags"
+    effect = "Allow"
+    actions = [
+      "lakeformation:AddLFTagsToResource",
+      "lakeformation:RemoveLFTagsFromResource",
+      "lakeformation:GetResourceLFTags",
+      "lakeformation:ListLFTags",
+      "lakeformation:GetLFTag",
+      "lakeformation:SearchTablesByLFTags",
+      "lakeformation:SearchDatabasesByLFTags",
+    ]
+    resources = ["*"]
+  }
+
 }
 
 module "copy_apdp_cadet_metadata_to_compute_policy" {

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -350,7 +350,7 @@ module "data_production_mojap_derived_bucket_lake_formation_policy" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "analytical_platform_cadet_runner_compute_policy" {
+data "aws_iam_policy_document" "copy_apdp_cadet_metadata_to_compute_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   statement {
@@ -424,16 +424,16 @@ data "aws_iam_policy_document" "analytical_platform_cadet_runner_compute_policy"
   }
 }
 
-module "analytical_platform_cadet_runner_compute_policy" {
+module "copy_apdp_cadet_metadata_to_compute_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "5.48.0"
 
-  name_prefix = "analytical-platform-cadet-runner-compute-policy"
+  name_prefix = "copy-ap-cadet-metadata-to-compute-"
 
-  policy = data.aws_iam_policy_document.analytical_platform_cadet_runner_compute_policy.json
+  policy = data.aws_iam_policy_document.copy_apdp_cadet_metadata_to_compute_policy.json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -384,7 +384,7 @@ module "copy_apdp_cadet_metadata_to_compute_assumable_role" {
   trusted_role_arns      = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/create-a-derived-table"]
   create_role            = true
   role_requires_mfa      = false
-  role_name              = "copy-ap-cadet-metadata-to-compute"
+  role_name              = "copy-apdp-cadet-metadata-to-compute"
 
   custom_role_policy_arns = [module.copy_apdp_cadet_metadata_to_compute_policy.arn]
   # number_of_custom_role_policy_arns = 1

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -374,7 +374,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   tags = local.tags
 }
 
-module "analytical_platform_cadet_runner" {
+module "copy_apdp_cadet_metadata_to_compute_assumable_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
@@ -384,9 +384,13 @@ module "analytical_platform_cadet_runner" {
   trusted_role_arns      = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/create-a-derived-table"]
   create_role            = true
   role_requires_mfa      = false
-  role_name              = "analytical-platform-cadet-runner-assumable"
+  role_name              = "copy-ap-cadet-metadata-to-compute"
 
-  custom_role_policy_arns = [module.analytical_platform_cadet_runner_compute_policy.arn]
+  custom_role_policy_arns = [module.copy_apdp_cadet_metadata_to_compute_policy.arn]
   # number_of_custom_role_policy_arns = 1
+}
 
+moved {
+  from = module.analytical_platform_cadet_runner
+  to   = module.copy_apdp_cadet_metadata_to_compute_assumable_role
 }


### PR DESCRIPTION
This PR is tracked as part of ministryofjustice/analytical-platform#6133.

This PR makes the role name for the metadata-copy role clearer and more precise. It also adds [`lakeformation:*LFTag*` permissions required to create and update LFTags](https://docs.aws.amazon.com/lake-formation/latest/dg/permissions-reference.html#persona-engineer) (assuming the tag was added by this role).

>As tag creator , the principal gets Alter permission on this LF-Tag and can update or remove any tag value from this LF-Tag. The LF-Tag creator principal can also grant Alter permission to another principal to update and remove tag values on this LF-Tag.

[docs](https://docs.aws.amazon.com/lake-formation/latest/dg/TBAC-creating-tags.html)

It needs to be coordinated with the merging of ministryofjustice/analytical-platform#6181