### PR TITLE
DPR2-1435: Make postgres_settings configuration block conditional on the engine type being postgres

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -134,10 +134,14 @@ resource "aws_dms_endpoint" "dms-s3-target-source" {
   ssl_mode      = var.source_ssl_mode
   username      = var.source_app_username
 
-  postgres_settings {
-    map_boolean_as_boolean = true
-    heartbeat_enable       = true
-    heartbeat_frequency    = 5
+  dynamic postgres_settings {
+    for_each = var.source_engine_name == "postgres" ? [1]: []
+
+    content {
+      map_boolean_as_boolean = true
+      heartbeat_enable       = true
+      heartbeat_frequency    = 5
+    }
   }
 
   extra_connection_attributes = var.extra_attributes

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
@@ -291,7 +291,7 @@ variable "source_engine" {
 variable "source_engine_name" {
   default     = ""
   type        = string
-  description = "Engine name for DMS"
+  description = "Type of engine for the source endpoint. Example valid values are postgres, oracle"
 }
 
 


### PR DESCRIPTION
This avoids the terraform plan being polluted with changes to postgres settings for oracle sources that need reapplying on every terraform run.

![image](https://github.com/user-attachments/assets/7e6aeeec-2d81-4657-b2e7-b845d51e6c99)

