### PR TITLE
Nomis: clean up old observability platform code

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -7,7 +7,6 @@ locals {
 
   baseline_presets_test = {
     options = {
-      enable_observability_platform_monitoring = true
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "nomis-test"

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -3,7 +3,6 @@ locals {
   baseline_presets_test = {
     options = {
 
-      enable_observability_platform_monitoring = true
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "oasys-test"

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -5,7 +5,6 @@ locals {
     var.options.enable_ec2_delius_dba_secrets_access ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
     var.options.enable_image_builder ? ["EC2ImageBuilderDistributionCrossAccountRole"] : [],
     var.options.enable_ec2_oracle_enterprise_managed_server ? ["EC2OracleEnterpriseManagementSecretsRole"] : [],
-    var.options.enable_observability_platform_monitoring ? ["observability-platform"] : [],
     try(length(var.options.cloudwatch_metric_oam_links), 0) != 0 ? ["CloudWatch-CrossAccountSharingRole"] : [],
     var.options.enable_vmimport ? ["vmimport"] : [],
   ]))
@@ -89,21 +88,6 @@ locals {
         "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
         "arn:aws:iam::aws:policy/CloudWatchAutomaticDashboardsAccess",
         "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
-      ]
-    }
-
-    # allow Observability Plaform read-only access to Cloudwatch metrics
-    observability-platform = {
-      assume_role_policy = [{
-        effect  = "Allow"
-        actions = ["sts:AssumeRole"]
-        principals = {
-          type        = "AWS"
-          identifiers = ["observability-platform-development"]
-        }
-      }]
-      policy_attachments = [
-        "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
       ]
     }
 

--- a/terraform/modules/baseline_presets/variables.tf
+++ b/terraform/modules/baseline_presets/variables.tf
@@ -37,7 +37,6 @@ variable "options" {
     enable_ec2_session_manager_cloudwatch_logs   = optional(bool, false)           # create SSM doc and log group for session manager logs
     enable_ec2_ssm_agent_update                  = optional(bool, false)           # create SSM association for auto-update of SSM agent. update-ssm-agent tag needs to be set on EC2s also
     enable_ec2_user_keypair                      = optional(bool, false)           # create secret and key-pair for ec2-user
-    enable_observability_platform_monitoring     = optional(bool, false)           # create role for observability platform monitroing
     enable_s3_bucket                             = optional(bool, false)           # create s3-bucket S3 bucket for general use
     enable_s3_db_backup_bucket                   = optional(bool, false)           # create db-backup S3 buckets
     enable_s3_shared_bucket                      = optional(bool, false)           # create devtest and preprodprod S3 bucket for sharing between accounts


### PR DESCRIPTION
Delete old observability platform code since Cloudwatch/Pagerduty is sufficient for us.