### PR TITLE
Removed import block for ppud

### DIFF
--- a/terraform/environments/ppud/shield.tf
+++ b/terraform/environments/ppud/shield.tf
@@ -20,9 +20,3 @@ module "shield" {
     }
   }
 }
-
-import {
-  for_each = local.is-production ? { "build" = true } : {}
-  id       = "60a72081-57ea-4a38-b04a-778796012304/FMManagedWebACLV2-shield_advanced_auto_remediate-1649415357278/REGIONAL"
-  to       = module.shield["build"].aws_wafv2_web_acl.main
-}


### PR DESCRIPTION
Import block is only required once - removing as this seems to be causing some issues in terraform 1.10 and is not longer required.