### PR TITLE
feat: AP-6133 add cadet metadata copy assumable role as lf admin in eu-west-2

### DIFF
--- a/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-data-lake-settings.tf
@@ -5,7 +5,8 @@ resource "aws_lakeformation_data_lake_settings" "london" {
     module.analytical_platform_ui_service_role.iam_role_arn,
     module.analytical_platform_data_eng_dba_service_role.iam_role_arn,
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_sso_role.names)}",
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.eks_sso_access_role.names)}"
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.eks_sso_access_role.names)}",
+    module.copy_apdp_cadet_metadata_to_compute_assumable_role.iam_role_arn
   ]
 }
 


### PR DESCRIPTION
This PR contributes to ministryofjustice/analytical-platform#6133.

The metadata copy assumable role requires sufficient LF permissions (`Alter`) on CaDeT LF tables it touches in order to update them. This permission is automatically granted to a role that creates a resource (table, database), or a Lake Formation Admin. After swapping the role name for a more accurate name, the new role no longer has permission to update tables from previous runs of the metadata copy workflow. Adding the new role as a Lake Formation in `eu-west-2` will resolve this issue without needing to add the permissions to the role one at a time.