### PR TITLE
Removed import block from cdpt

### DIFF
--- a/terraform/environments/cdpt-chaps/shield.tf
+++ b/terraform/environments/cdpt-chaps/shield.tf
@@ -20,9 +20,3 @@ module "shield" {
     }
   }
 }
-
-import {
-  for_each = local.is-production ? { "build" = true } : {}
-  id       = "10320dab-b3d2-426f-a02c-4a4a6a554be0/FMManagedWebACLV2-shield_advanced_auto_remediate-1700749032578/REGIONAL"
-  to       = module.shield["build"].aws_wafv2_web_acl.main
-}

--- a/terraform/environments/cdpt-ifs/shield.tf
+++ b/terraform/environments/cdpt-ifs/shield.tf
@@ -20,9 +20,3 @@ module "shield" {
     }
   }
 }
-
-import {
-  for_each = local.is-production ? { "build" = true } : {}
-  id       = "1302dec0-8c83-45ba-a371-0b1599aac5ed/FMManagedWebACLV2-shield_advanced_auto_remediate-1701773787672/REGIONAL"
-  to       = module.shield["build"].aws_wafv2_web_acl.main
-}


### PR DESCRIPTION
Import block is only required once - removing as this seems to be causing some issues in terraform 1.10 and is not longer required.