### PR TITLE
🏷️ Enable pod labelling in kube-state-metrics

### DIFF
--- a/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/amazon-prometheus-proxy/values.yml.tftpl
@@ -14,6 +14,10 @@ alertmanager:
 grafana:
   enabled: false
 
+kube-state-metrics:
+  extraArgs:
+    - --metric-labels-allowlist=pods=[*]
+
 prometheus:
   agentMode: true
   serviceAccount:


### PR DESCRIPTION
This pull request:

- Enables kube-state-metrics to include labels

<img width="1920" alt="Screenshot 2024-11-28 at 16 32 40" src="https://github.com/user-attachments/assets/541bf4b8-c640-461f-9fec-f8a51664a73b">


Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 