### PR TITLE
Fixed case for condition test

### DIFF
--- a/terraform/environments/long-term-storage/data.tf
+++ b/terraform/environments/long-term-storage/data.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "aws_transfer_assume_role_policy" {
     }
     actions = ["sts:AssumeRole"]
     condition {
-      test     = "stringEquals"
+      test     = "StringEquals"
       values   = [data.aws_caller_identity.current.account_id]
       variable = "aws:SourceAccount"
     }


### PR DESCRIPTION
Condition tests in IAM policies are case sensitive:

> │ Error: creating IAM Role (call-centre-migration-logging*): operation error IAM: CreateRole, https response error StatusCode: 400, RequestID: 4d280e66-9a95-490f-9c97-b77049144e43, MalformedPolicyDocument: Invalid Condition type : stringEquals