### PR TITLE
feat: AP-6133 import `source` LFtag into code into prod account

### DIFF
--- a/terraform/environments/analytical-platform-compute/lakeformation-permissions.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation-permissions.tf
@@ -1,5 +1,12 @@
+resource "aws_lakeformation_lf_tag" "source" {
+  count  = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+  key    = "source"
+  values = ["create-a-derived-table"]
+}
+
 resource "aws_lakeformation_permissions" "cadet_all_data" {
-  for_each = toset(["TABLE", "DATABASE"])
+  for_each = (terraform.workspace == "analytical-platform-compute-production" ?
+  toset(["TABLE", "DATABASE"]) : toset([]))
 
   principal   = module.copy_apdp_cadet_metadata_to_compute_assumable_role.iam_role_arn
   permissions = ["ALL"] # https://docs.aws.amazon.com/lake-formation/latest/dg/lf-permissions-reference.html


### PR DESCRIPTION
This PR relates to ministryofjustice/analytical-platform#6133

add LFTag `source` into terraform in APC production account

Signed off by tom.webber@justice.gov.uk