### PR TITLE
DPR2-1435: Configure DMS to send deletes to the raw zone

### DIFF
--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -79,6 +79,7 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 resource "aws_security_group" "glue_job_connection_sg" {
   #checkov:skip=CKV2_AWS_5
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
   name        = "${local.project}-glue-connection_sg"
   description = "Security group for glue jobs when using Glue Connections"
   vpc_id      = data.aws_vpc.shared.id

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1230,7 +1230,7 @@ module "dms_nomis_ingestor" {
   dms_target_name              = "kinesis"
   short_name                   = "nomis"
   migration_type               = "full-load-and-cdc"
-  replication_instance_version = "3.4.7" # Upgrade
+  replication_instance_version = "3.5.2"
   replication_instance_class   = "dms.t3.medium"
   subnet_ids = [
     data.aws_subnet.data_subnets_a.id, data.aws_subnet.data_subnets_b.id, data.aws_subnet.data_subnets_c.id

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1299,10 +1299,6 @@ module "dms_nomis_to_s3_ingestor" {
 
   bucket_name = module.s3_raw_bucket.bucket_id
 
-  availability_zones = {
-    0 = "eu-west-2a"
-  }
-
   depends_on = [
     module.s3_raw_bucket.bucket_id
   ]

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1248,10 +1248,6 @@ module "dms_nomis_ingestor" {
     "kinesis_target_stream"          = "arn:aws:kinesis:eu-west-2:${data.aws_caller_identity.current.account_id}:stream/${local.kinesis_stream_ingestor}"
   }
 
-  availability_zones = {
-    0 = "eu-west-2a"
-  }
-
   tags = merge(
     local.all_tags,
     {

--- a/terraform/environments/digital-prison-reporting/modules/dms/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/main.tf
@@ -104,7 +104,6 @@ resource "aws_dms_s3_endpoint" "dms-s3-target-endpoint" {
 
   max_file_size           = 120000
   cdc_max_batch_interval  = 10
-  cdc_inserts_and_updates = true
 
   depends_on = [aws_iam_policy.dms-s3-target-policy, aws_iam_policy.dms-operator-s3-policy]
 

--- a/terraform/environments/digital-prison-reporting/modules/dms/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/main.tf
@@ -125,6 +125,7 @@ resource "aws_dms_replication_subnet_group" "dms-s3-target-subnet-group" {
 resource "aws_security_group" "dms_s3_target_sec_group" {
   #checkov:skip=CKV2_AWS_5
   #checkov:skip=CKV_AWS_23: "Ensure every security group and rule has a description"
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
 
   count = var.setup_dms_instance ? 1 : 0
 

--- a/terraform/environments/digital-prison-reporting/modules/dms/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/variables.tf
@@ -1,4 +1,5 @@
 variable "name" {
+  type        = string
   description = "DMS Replication name."
 }
 
@@ -56,14 +57,6 @@ variable "migration_type" {
   description = "DMS Migration Type"
 }
 
-variable "availability_zones" {
-  default = [
-    {
-      0 = "eu-west-2a"
-    }
-  ]
-}
-
 variable "rename_rule_source_schema" {
   description = "The source schema we will rename to a target output 'space'"
   type        = string
@@ -81,19 +74,26 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "source_address" {}
+variable "source_address" {
+  type = string
+}
 
-variable "vpc" {}
+variable "vpc" {
+  type = string
+}
 
 variable "availability_zone" {
+  type    = string
   default = null
 }
 
 variable "create" {
+  type    = bool
   default = true
 }
 
 variable "create_iam_roles" {
+  type    = bool
   default = true
 }
 
@@ -106,11 +106,13 @@ variable "iam_role_permissions_boundary" {
 # Used in tagginga and naming the resources
 
 variable "stack_name" {
+  type        = string
   description = "The name of our application"
   default     = "dblink"
 }
 
 variable "owner" {
+  type        = string
   description = "A group email address to be used in tags"
   default     = "autobots@ga.gov.au"
 }
@@ -120,6 +122,7 @@ variable "owner" {
 #--------------------------------------------------------------
 
 variable "identifier" {
+  type        = string
   default     = "rds"
   description = "Name of the database in the RDS"
 }
@@ -129,49 +132,40 @@ variable "identifier" {
 #--------------------------------------------------------------
 
 variable "target_backup_retention_period" {
+  type        = string
   # Days
   default     = "30"
   description = "Retention of RDS backups"
 }
 
 variable "target_backup_window" {
+  type        = string
   default     = "14:00-17:00"
   description = "RDS backup window"
 }
 
 variable "target_db_port" {
+  type        = number
   description = "The port the Application Server will access the database on"
   default     = 5432
 }
 
 variable "target_engine_version" {
+  type        = string
   description = "Engine version"
   default     = "9.3.14"
 }
 
 variable "target_instance_class" {
+  type        = string
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "target_maintenance_window" {
+  type        = string
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
-}
-
-variable "target_rds_is_multi_az" {
-  description = "Create backup database in separate availability zone"
-  default     = "false"
-}
-
-variable "target_storage" {
-  default     = "10"
-  description = "Storage size in GB"
-}
-
-variable "target_storage_encrypted" {
-  description = "Encrypt storage or leave unencrypted"
-  default     = false
 }
 
 #variable "target_username" {
@@ -183,81 +177,78 @@ variable "target_storage_encrypted" {
 #--------------------------------------------------------------
 
 variable "source_app_password" {
+  type        = string
   description = "Password for the endpoint to access the source database"
 }
 
 variable "source_app_username" {
+  type        = string
   description = "Username for the endpoint to access the source database"
 }
 
-variable "source_backup_retention_period" {
-  # Days
-  default     = "1"
-  description = "Retention of RDS backups"
-}
-
 variable "source_backup_window" {
+  type        = string
   # 12:00AM-03:00AM AEST
   default     = "14:00-17:00"
   description = "RDS backup window"
 }
 
 variable "source_db_name" {
+  type        = string
   description = "Name of the target database"
   default     = "oracle"
 }
 
 variable "source_db_port" {
+  type        = number
   description = "The port the Application Server will access the database on"
   default     = null
 }
 
 variable "source_engine" {
+  type        = string
   default     = "oracle-se2"
   description = "Engine type, example values mysql, postgres"
 }
 
 variable "source_engine_name" {
+  type        = string
   default     = ""
   description = "Engine name for DMS"
 }
 
 variable "source_engine_version" {
+  type        = string
   description = "Engine version"
   default     = "12.1.0.2.v8"
 }
 
 variable "source_instance_class" {
+  type        = string
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "source_maintenance_window" {
+  type        = string
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
 }
 
 variable "source_password" {
+  type        = string
   description = "Password of the source database"
   default     = ""
 }
 
-variable "source_rds_is_multi_az" {
-  description = "Create backup database in separate availability zone"
-  default     = "false"
-}
-
-variable "source_storage" {
-  default     = "10"
-  description = "Storage size in GB"
-}
-
 variable "source_storage_encrypted" {
+  type        = bool
   description = "Encrypt storage or leave unencrypted"
   default     = false
 }
 
 variable "source_username" {
+  type        = string
   description = "Username to access the source database"
   default     = ""
 }
@@ -267,21 +258,25 @@ variable "source_username" {
 #--------------------------------------------------------------
 
 variable "replication_instance_maintenance_window" {
+  type        = string
   description = "Maintenance window for the replication instance"
   default     = "sun:10:30-sun:14:30"
 }
 
 variable "replication_instance_storage" {
+  type        = number
   description = "Size of the replication instance in GB"
-  default     = "10"
+  default     = 10
 }
 
 variable "replication_instance_version" {
+  type        = string
   description = "Engine version of the replication instance"
   default     = "3.4.6"
 }
 
 variable "replication_instance_class" {
+  type        = string
   description = "Instance class of replication instance"
   default     = "dms.t2.micro"
 }
@@ -297,6 +292,7 @@ variable "allow_major_version_upgrade" {
 #--------------------------------------------------------------
 
 variable "database_subnet_cidr" {
+  type        = list(string)
   default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
   description = "List of subnets to be used for databases"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/main.tf
@@ -135,6 +135,7 @@ resource "aws_dms_replication_subnet_group" "dms" {
 resource "aws_security_group" "dms_sec_group" {
 
   #checkov:skip=CKV_AWS_23: "Ensure every security group and rule has a description"
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
   count = var.setup_dms_instance ? 1 : 0
 
   name   = "${var.project_id}-dms-${var.short_name}-${var.dms_source_name}-${var.dms_target_name}-security-group"

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
@@ -1,5 +1,5 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "DMS Replication name."
 }
 
@@ -60,19 +60,19 @@ variable "subnet_ids" {
 }
 
 variable "source_address" {
-  type = "string"
+  type = string
 }
 
 variable "vpc" {
-  type = "string"
+  type = string
 }
 
 variable "kinesis_stream_policy" {
-  type = "string"
+  type = string
 }
 
 variable "availability_zone" {
-  type    = "string"
+  type    = string
   default = null
 }
 
@@ -95,13 +95,13 @@ variable "iam_role_permissions_boundary" {
 # Used in tagginga and naming the resources
 
 variable "stack_name" {
-  type        = "string"
+  type        = string
   description = "The name of our application"
   default     = "dblink"
 }
 
 variable "owner" {
-  type        = "string"
+  type        = string
   description = "A group email address to be used in tags"
   default     = "autobots@ga.gov.au"
 }
@@ -111,7 +111,7 @@ variable "owner" {
 #--------------------------------------------------------------
 
 variable "identifier" {
-  type        = "string"
+  type        = string
   default     = "rds"
   description = "Name of the database in the RDS"
 }
@@ -121,7 +121,7 @@ variable "identifier" {
 #--------------------------------------------------------------
 
 variable "target_backup_window" {
-  type        = "string"
+  type        = string
   # 12:00AM-03:00AM AEST
   default     = "14:00-17:00"
   description = "RDS backup window"
@@ -138,25 +138,25 @@ variable "target_db_port" {
 }
 
 variable "target_engine" {
-  type        = "string"
+  type        = string
   default     = "kinesis"
   description = "Engine type, example values mysql, postgres"
 }
 
 variable "target_engine_version" {
-  type        = "string"
+  type        = string
   description = "Engine version"
   default     = "9.3.14"
 }
 
 variable "target_instance_class" {
-  type        = "string"
+  type        = string
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "target_maintenance_window" {
-  type        = "string"
+  type        = string
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
 }
@@ -179,24 +179,24 @@ variable "kinesis_settings" {
 #--------------------------------------------------------------
 
 variable "source_app_password" {
-  type        = "string"
+  type        = string
   description = "Password for the endpoint to access the source database"
 }
 
 variable "source_app_username" {
-  type        = "string"
+  type        = string
   description = "Username for the endpoint to access the source database"
 }
 
 variable "source_backup_window" {
-  type        = "string"
+  type        = string
   # 12:00AM-03:00AM AEST
   default     = "14:00-17:00"
   description = "RDS backup window"
 }
 
 variable "source_db_name" {
-  type        = "string"
+  type        = string
   description = "Name of the target database"
   default     = "oracle"
 }
@@ -208,37 +208,37 @@ variable "source_db_port" {
 }
 
 variable "source_engine" {
-  type        = "string"
+  type        = string
   default     = "oracle-se2"
   description = "Engine type, example values mysql, postgres"
 }
 
 variable "source_engine_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Engine name for DMS"
 }
 
 variable "source_engine_version" {
-  type        = "string"
+  type        = string
   description = "Engine version"
   default     = "12.1.0.2.v8"
 }
 
 variable "source_instance_class" {
-  type        = "string"
+  type        = string
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "source_maintenance_window" {
-  type        = "string"
+  type        = string
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
 }
 
 variable "source_password" {
-  type        = "string"
+  type        = string
   description = "Password of the source database"
   default     = ""
 }
@@ -250,7 +250,7 @@ variable "source_storage_encrypted" {
 }
 
 variable "source_username" {
-  type        = "string"
+  type        = string
   description = "Username to access the source database"
   default     = ""
 }
@@ -260,7 +260,7 @@ variable "source_username" {
 #--------------------------------------------------------------
 
 variable "replication_instance_maintenance_window" {
-  type        = "string"
+  type        = string
   description = "Maintenance window for the replication instance"
   default     = "sun:10:30-sun:14:30"
 }
@@ -272,13 +272,13 @@ variable "replication_instance_storage" {
 }
 
 variable "replication_instance_version" {
-  type        = "string"
+  type        = string
   description = "Engine version of the replication instance"
   default     = "3.4.6"
 }
 
 variable "replication_instance_class" {
-  type        = "string"
+  type        = string
   description = "Instance class of replication instance"
   default     = "dms.t2.micro"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
@@ -1,4 +1,5 @@
 variable "name" {
+  type        = "string"
   description = "DMS Replication name."
 }
 
@@ -52,38 +53,36 @@ variable "migration_type" {
   description = "DMS Migration Type"
 }
 
-variable "availability_zones" {
-  default = [
-    {
-      0 = "eu-west-2a"
-      1 = "eu-west-2b"
-      2 = "eu-west-2c"
-    }
-  ]
-}
-
-
 variable "subnet_ids" {
   description = "An List of VPC subnet IDs to use in the subnet group"
   type        = list(string)
   default     = []
 }
 
-variable "source_address" {}
+variable "source_address" {
+  type = "string"
+}
 
-variable "vpc" {}
+variable "vpc" {
+  type = "string"
+}
 
-variable "kinesis_stream_policy" {}
+variable "kinesis_stream_policy" {
+  type = "string"
+}
 
 variable "availability_zone" {
+  type    = "string"
   default = null
 }
 
 variable "create" {
+  type    = bool
   default = true
 }
 
 variable "create_iam_roles" {
+  type    = bool
   default = true
 }
 
@@ -96,11 +95,13 @@ variable "iam_role_permissions_boundary" {
 # Used in tagginga and naming the resources
 
 variable "stack_name" {
+  type        = "string"
   description = "The name of our application"
   default     = "dblink"
 }
 
 variable "owner" {
+  type        = "string"
   description = "A group email address to be used in tags"
   default     = "autobots@ga.gov.au"
 }
@@ -110,6 +111,7 @@ variable "owner" {
 #--------------------------------------------------------------
 
 variable "identifier" {
+  type        = "string"
   default     = "rds"
   description = "Name of the database in the RDS"
 }
@@ -118,13 +120,8 @@ variable "identifier" {
 # DMS target config
 #--------------------------------------------------------------
 
-variable "target_backup_retention_period" {
-  # Days
-  default     = "30"
-  description = "Retention of RDS backups"
-}
-
 variable "target_backup_window" {
+  type        = "string"
   # 12:00AM-03:00AM AEST
   default     = "14:00-17:00"
   description = "RDS backup window"
@@ -135,26 +132,31 @@ variable "target_backup_window" {
 #}
 
 variable "target_db_port" {
+  type        = number
   description = "The port the Application Server will access the database on"
   default     = 5432
 }
 
 variable "target_engine" {
+  type        = "string"
   default     = "kinesis"
   description = "Engine type, example values mysql, postgres"
 }
 
 variable "target_engine_version" {
+  type        = "string"
   description = "Engine version"
   default     = "9.3.14"
 }
 
 variable "target_instance_class" {
+  type        = "string"
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "target_maintenance_window" {
+  type        = "string"
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
 }
@@ -162,21 +164,6 @@ variable "target_maintenance_window" {
 #variable "target_password" {
 #  description = "Password of the target database"
 #}
-
-variable "target_rds_is_multi_az" {
-  description = "Create backup database in separate availability zone"
-  default     = "false"
-}
-
-variable "target_storage" {
-  default     = "10"
-  description = "Storage size in GB"
-}
-
-variable "target_storage_encrypted" {
-  description = "Encrypt storage or leave unencrypted"
-  default     = false
-}
 
 #variable "target_username" {
 #  description = "Username to access the target database"
@@ -192,81 +179,78 @@ variable "kinesis_settings" {
 #--------------------------------------------------------------
 
 variable "source_app_password" {
+  type        = "string"
   description = "Password for the endpoint to access the source database"
 }
 
 variable "source_app_username" {
+  type        = "string"
   description = "Username for the endpoint to access the source database"
 }
 
-variable "source_backup_retention_period" {
-  # Days
-  default     = "1"
-  description = "Retention of RDS backups"
-}
-
 variable "source_backup_window" {
+  type        = "string"
   # 12:00AM-03:00AM AEST
   default     = "14:00-17:00"
   description = "RDS backup window"
 }
 
 variable "source_db_name" {
+  type        = "string"
   description = "Name of the target database"
   default     = "oracle"
 }
 
 variable "source_db_port" {
+  type        = number
   description = "The port the Application Server will access the database on"
   default     = null
 }
 
 variable "source_engine" {
+  type        = "string"
   default     = "oracle-se2"
   description = "Engine type, example values mysql, postgres"
 }
 
 variable "source_engine_name" {
+  type        = "string"
   default     = ""
   description = "Engine name for DMS"
 }
 
 variable "source_engine_version" {
+  type        = "string"
   description = "Engine version"
   default     = "12.1.0.2.v8"
 }
 
 variable "source_instance_class" {
+  type        = "string"
   default     = "db.t2.micro"
   description = "Instance class"
 }
 
 variable "source_maintenance_window" {
+  type        = "string"
   default     = "Mon:00:00-Mon:03:00"
   description = "RDS maintenance window"
 }
 
 variable "source_password" {
+  type        = "string"
   description = "Password of the source database"
   default     = ""
 }
 
-variable "source_rds_is_multi_az" {
-  description = "Create backup database in separate availability zone"
-  default     = "false"
-}
-
-variable "source_storage" {
-  default     = "10"
-  description = "Storage size in GB"
-}
-
 variable "source_storage_encrypted" {
+  type        = bool
   description = "Encrypt storage or leave unencrypted"
   default     = false
 }
 
 variable "source_username" {
+  type        = "string"
   description = "Username to access the source database"
   default     = ""
 }
@@ -276,21 +260,25 @@ variable "source_username" {
 #--------------------------------------------------------------
 
 variable "replication_instance_maintenance_window" {
+  type        = "string"
   description = "Maintenance window for the replication instance"
   default     = "sun:10:30-sun:14:30"
 }
 
 variable "replication_instance_storage" {
+  type        = number
   description = "Size of the replication instance in GB"
-  default     = "10"
+  default     = 10
 }
 
 variable "replication_instance_version" {
+  type        = "string"
   description = "Engine version of the replication instance"
   default     = "3.4.6"
 }
 
 variable "replication_instance_class" {
+  type        = "string"
   description = "Instance class of replication instance"
   default     = "dms.t2.micro"
 }
@@ -300,6 +288,7 @@ variable "replication_instance_class" {
 #--------------------------------------------------------------
 
 variable "database_subnet_cidr" {
+  type        = list(string)
   default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
   description = "List of subnets to be used for databases"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
+
+  }
+  required_version = "~> 1.0"
+}

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -169,7 +169,6 @@ resource "aws_dms_s3_endpoint" "dms-s3-target-endpoint" {
 
   max_file_size           = 120000
   cdc_max_batch_interval  = 10
-  cdc_inserts_and_updates = true
 
   tags = merge(
     var.tags,

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
@@ -37,6 +37,7 @@ resource "aws_security_group_rule" "rule" {
 }
 
 resource "aws_security_group_rule" "rds_allow_all" {
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
   count = var.enable_rds ? 1 : 0
 
   type              = "egress"

--- a/terraform/environments/digital-prison-reporting/sg.tf
+++ b/terraform/environments/digital-prison-reporting/sg.tf
@@ -40,6 +40,7 @@ resource "aws_security_group_rule" "lambda_ingress_generic" {
 }
 
 resource "aws_security_group_rule" "lambda_egress_generic" {
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
   count = local.enable_generic_lambda_sg ? 1 : 0
 
   type              = "egress"
@@ -88,6 +89,7 @@ resource "aws_security_group_rule" "serverless_gw_ingress" {
 }
 
 resource "aws_security_group_rule" "serverless_gw_egress" {
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
   count = local.enable_dbuilder_serverless_gw ? 1 : 0
 
   type              = "egress"
@@ -102,6 +104,7 @@ resource "aws_security_group_rule" "serverless_gw_egress" {
 # VPC Gateway Endpoint SG
 resource "aws_security_group" "gateway_endpoint_sg" {
   #checkov:skip=CKV_AWS_23: "Ensure every security group and rule has a description"
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
 
   count = local.include_dbuilder_gw_vpclink ? 1 : 0
 


### PR DESCRIPTION
Configure DMS to send all inserts, updates and deletes to the Raw zone rather than just inserts and updates by removing the `cdc_inserts_and_updates = true` setting.

The `cdc_inserts_and_updates` setting configures DMS to only propagate inserts and updates to the S3 sink. This means we are missing deletes in the raw zone.

You can see this in the DMS logs:
```2024-11-29T13:57:07 [TARGET_APPLY    ]W:  Updates/Deletes will be ignored because cdcInsertsOnly or cdcInsertsAndUpdates is set by customer  (file_apply.c:1212)```