### PR TITLE
Call centre connector IAM role

### DIFF
--- a/terraform/environments/long-term-storage/call-centre-migration.tf
+++ b/terraform/environments/long-term-storage/call-centre-migration.tf
@@ -58,6 +58,24 @@ resource "aws_iam_role" "call_centre_transfer_logging" {
   tags               = local.tags
 }
 
+resource "aws_iam_role" "call_centre_transfer_access" {
+  name_prefix        = "call-centre-access"
+  assume_role_policy = data.aws_iam_policy_document.aws_transfer_assume_role_policy.json
+  tags               = local.tags
+}
+
+resource "aws_iam_policy" "call_centre_transfer_access" {
+  description = "Access policy for AWS Transfer connector."
+  name_prefix = "call-centre-access"
+  policy      = data.aws_iam_policy_document.call_centre_access_policy.json
+  tags        = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "call_centre_transfer_access" {
+  policy_arn = aws_iam_policy.call_centre_transfer_access.arn
+  role       = aws_iam_role.call_centre_transfer_access.name
+}
+
 resource "aws_iam_role_policy_attachments_exclusive" "call_centre_transfer_logging" {
   policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"]
   role_name   = aws_iam_role.call_centre_transfer_logging.name

--- a/terraform/environments/long-term-storage/data.tf
+++ b/terraform/environments/long-term-storage/data.tf
@@ -21,6 +21,44 @@ data "aws_iam_policy_document" "aws_transfer_assume_role_policy" {
   }
 }
 
+data "aws_iam_policy_document" "call_centre_access_policy" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    effect    = "Allow"
+    resources = [aws_s3_bucket.call_centre.arn]
+    sid       = "AllowListingOfBucket"
+  }
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:GetObjectVersion",
+      "s3:GetObjectACL",
+      "s3:PutObjectACL"
+    ]
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.call_centre.arn}/*"]
+    sid       = "AllowAccessToBucketObjects"
+  }
+  statement {
+    actions   = ["kms:*"]
+    effect    = "Allow"
+    resources = [aws_kms_key.call_centre.arn]
+    sid       = "AllowAccessToKMSKey"
+  }
+  statement {
+    actions   = ["secretsmanager:*"]
+    effect    = "Allow"
+    resources = [aws_secretsmanager_secret.call_centre.arn]
+    sid       = "AllowAccessToSecrets"
+  }
+}
+
 data "aws_iam_policy_document" "call_centre_bucket_policy" {
   statement {
     actions = [

--- a/terraform/environments/long-term-storage/data.tf
+++ b/terraform/environments/long-term-storage/data.tf
@@ -52,7 +52,12 @@ data "aws_iam_policy_document" "call_centre_access_policy" {
     sid       = "AllowAccessToKMSKey"
   }
   statement {
-    actions   = ["secretsmanager:*"]
+    actions = [
+      "secretsmanager:BatchGet*",
+      "secretsmanager:Describe*",
+      "secretsmanager:Get*",
+      "secretsmanager:List*"
+    ]
     effect    = "Allow"
     resources = [aws_secretsmanager_secret.call_centre.arn]
     sid       = "AllowAccessToSecrets"


### PR DESCRIPTION
* Creates an IAM role and policy for the call center connector to use.
* KMS permissions are broad as these are also controlled by the KMS policy