### PR TITLE
disable termination for pp-onr-bods-1 as this is now in use

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -96,6 +96,7 @@ locals {
         }
         instance = merge(local.ec2_instances.bods.instance, {
           instance_type = "r6i.2xlarge"
+          disable_api_termination = true
         })
         cloudwatch_metric_alarms = null
         tags = merge(local.ec2_instances.bods.tags, {


### PR DESCRIPTION
- disable api termination for pp-onr-bods-1 so it can't be killed accidentally