### PR TITLE
get checkov to shut up

### DIFF
--- a/terraform/modules/schedule_alarms_lambda/main.tf
+++ b/terraform/modules/schedule_alarms_lambda/main.tf
@@ -6,6 +6,15 @@ data "archive_file" "lambda_function_payload" {
 }
 
 resource "aws_lambda_function" "alarm_scheduler" {
+  #checkov:skip=CKV_AWS_50: "X-Ray tracing is enabled for Lambda", could be implemented but not required
+  #checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit", seems unnecessary for this module, could be added as reserved_concurrent_executions = 100 or similar (smaller) number.
+  #checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)", not required 
+  #checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC", irrelevant for this module
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
+  #checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable", Not required
+  #checkov:skip=CKV_AWS_272: "Ensure AWS Lambda function is configured to validate code-signing", code signing is not implemented
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year", add retention_in_days = 365
+
   filename         = "${path.module}/lambda/alarm_scheduler.zip"
   function_name    = var.lambda_function_name
   architectures    = ["arm64"]

--- a/terraform/modules/schedule_alarms_lambda/main.tf
+++ b/terraform/modules/schedule_alarms_lambda/main.tf
@@ -6,14 +6,14 @@ data "archive_file" "lambda_function_payload" {
 }
 
 resource "aws_lambda_function" "alarm_scheduler" {
-  #checkov:skip=CKV_AWS_50: "X-Ray tracing is enabled for Lambda", could be implemented but not required
-  #checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit", seems unnecessary for this module, could be added as reserved_concurrent_executions = 100 or similar (smaller) number.
-  #checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)", not required 
-  #checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC", irrelevant for this module
-  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
-  #checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable", Not required
-  #checkov:skip=CKV_AWS_272: "Ensure AWS Lambda function is configured to validate code-signing", code signing is not implemented
-  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year", add retention_in_days = 365
+  #checkov:skip=CKV_AWS_50: "X-Ray tracing is enabled for Lambda" - could be implemented but not required
+  #checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit" - seems unnecessary for this module, could be added as reserved_concurrent_executions = 100 or similar (smaller) number.
+  #checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)" - not required 
+  #checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC" - irrelevant for this module
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS" - not required
+  #checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable" - not required
+  #checkov:skip=CKV_AWS_272: "Ensure AWS Lambda function is configured to validate code-signing" - code signing is not implemented
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year" - only 7 days required, see execution_logs below
 
   filename         = "${path.module}/lambda/alarm_scheduler.zip"
   function_name    = var.lambda_function_name
@@ -36,6 +36,8 @@ resource "aws_lambda_function" "alarm_scheduler" {
 }
 
 resource "aws_cloudwatch_log_group" "execution_logs" {
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS" - not required
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year" - only 7 days required, see below
   name              = format("/aws/lambda/%s", var.lambda_function_name)
   retention_in_days = 7
 


### PR DESCRIPTION
- BE QUIET!!

Okay, joking aside I did actually review what checkov was shouting about and there are notes in the skip=ckv_aws_ comments but I can't see that any of these are needed, maybe the concurrency limit one but also 🤷 

Trivy doesn't run in this environment so that particular set of checks fails in here BUT it will pass everywhere else now.

I just want to avoid seeing red crosses as per my un-related PR here https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/12162819398/job/33920666092?pr=8902