### PR TITLE
Lower Equip AWS Shield threshold

### DIFF
--- a/terraform/environments/equip/shield.tf
+++ b/terraform/environments/equip/shield.tf
@@ -16,7 +16,7 @@ module "shield" {
       "action"    = "block",
       "name"      = "equip-count-rule",
       "priority"  = 0,
-      "threshold" = "1000"
+      "threshold" = "75"
     }
   }
 }


### PR DESCRIPTION
Following some investigation detail in [this Slack thread](https://mojdt.slack.com/archives/C01A7QK5VM1/p1733405114654599) we're reducing the threshold for AWS Shield Advanced WAF rules. These may need to be adjusted back upwards, but this should give sufficient headroom for occasional busy periods.