### PR TITLE
Filter OpenSearch Packages causing aws-nuke failures

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -109,6 +109,12 @@ presets:
         - property: PackageName
           type: regex
           value: "^(opensearch-)?analysis-.+$"
+        - property: PackageName
+          type: glob
+          value: "titaniam-lockbox*"
+        - property: PackageName
+          type: glob
+          value: "rni*"
       S3Bucket:
         - property: tag:component
           value: "secure-baselines"


### PR DESCRIPTION
## What/Why?
The scheduled AWS Nuke workflow has been [failing](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/12105218464/job/33749552820) with a common issue in the logs related to OpenSearch packages.

e.g.
```
eu-west-2 - OSPackage - pkg-59fc48a9d14d467ac47dcd5269e6446955f885f1 - [CreatedTime: "2024-11-07T10:55:14Z", PackageID: "pkg-59fc48a9d14d467ac47dcd5269e6446955f885f1", PackageName: "titaniam-lockbox"] - failed
eu-west-2 - OSPackage - pkg-ef5a4cd1f0ed1bfb5cce31d3a108c9e24cdb346d - [CreatedTime: "2024-11-11T19:26:05Z", PackageID: "pkg-ef5a4cd1f0ed1bfb5cce31d3a108c9e24cdb346d", PackageName: "rni"] - failed
``` 

## Changes Made

I've added more filters to the Nuke config to ignore these packages. As far as I can tell these aren't specific resources that are created by users as they occur in all of the accounts being nuked.

## Testing
I've carried out a dry-run of the nuke and can see the packages are being filtered [here](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/12198243043/job/34029559573#step:8:59) - Will have to wait over the weekend to see if it works for sure