### PR TITLE
deploy single az to T2

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -231,35 +231,35 @@ locals {
     }
 
     fsx_windows = {
-      # switch to using SINGLE_AZ_1 in T2 (cheaper), change settings in T2 servers then remove this
-      t2-bods-windows-share = {
-        preferred_availability_zone = "eu-west-2a"
-        deployment_type             = "MULTI_AZ_1"
-        security_groups             = ["bods"]
-        skip_final_backup           = true
-        storage_capacity            = 128
-        throughput_capacity         = 8
+      # retain commented out as a version of this (MULTI_AZ_1) fsx_share will be needed in production account
+      # t2-bods-windows-share = {
+      #   preferred_availability_zone = "eu-west-2a"
+      #   deployment_type             = "MULTI_AZ_1"
+      #   security_groups             = ["bods"]
+      #   skip_final_backup           = true
+      #   storage_capacity            = 128
+      #   throughput_capacity         = 8
 
-        subnets = [
-          {
-            name               = "private"
-            availability_zones = ["eu-west-2a", "eu-west-2b"]
-          }
-        ]
+      #   subnets = [
+      #     {
+      #       name               = "private"
+      #       availability_zones = ["eu-west-2a", "eu-west-2b"]
+      #     }
+      #   ]
 
-        self_managed_active_directory = {
-          dns_ips = [
-            module.ip_addresses.mp_ip.ad-azure-dc-a,
-            module.ip_addresses.mp_ip.ad-azure-dc-b,
-          ]
-          domain_name          = "azure.noms.root"
-          username             = "svc_join_domain"
-          password_secret_name = "/sap/bods/t2/passwords"
-        }
-        tags = {
-          backup = true
-        }
-      }
+      #   self_managed_active_directory = {
+      #     dns_ips = [
+      #       module.ip_addresses.mp_ip.ad-azure-dc-a,
+      #       module.ip_addresses.mp_ip.ad-azure-dc-b,
+      #     ]
+      #     domain_name          = "azure.noms.root"
+      #     username             = "svc_join_domain"
+      #     password_secret_name = "/sap/bods/t2/passwords"
+      #   }
+      #   tags = {
+      #     backup = true
+      #   }
+      # }
       t2-bods-win-share = {
         deployment_type     = "SINGLE_AZ_1"
         security_groups     = ["bods"]

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -151,39 +151,39 @@ locals {
 
     ec2_instances = {
 
-      t2-onr-bods-1 = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2a"
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name                          = "azure.noms.root"
-        })
-      })
+      # t2-onr-bods-1 = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2a"
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name                          = "azure.noms.root"
+      #   })
+      # })
 
-      t2-onr-bods-2 = merge(local.ec2_instances.bods, {
-        config = merge(local.ec2_instances.bods.config, {
-          availability_zone = "eu-west-2b"
-          instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-        })
-        instance = merge(local.ec2_instances.bods.instance, {
-          instance_type = "m4.xlarge"
-        })
-        cloudwatch_metric_alarms = null
-        tags = merge(local.ec2_instances.bods.tags, {
-          oasys-national-reporting-environment = "t2"
-          domain-name                          = "azure.noms.root"
-        })
-      })
+      # t2-onr-bods-2 = merge(local.ec2_instances.bods, {
+      #   config = merge(local.ec2_instances.bods.config, {
+      #     availability_zone = "eu-west-2b"
+      #     instance_profile_policies = concat(local.ec2_instances.bods.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #   })
+      #   instance = merge(local.ec2_instances.bods.instance, {
+      #     instance_type = "m4.xlarge"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      #   tags = merge(local.ec2_instances.bods.tags, {
+      #     oasys-national-reporting-environment = "t2"
+      #     domain-name                          = "azure.noms.root"
+      #   })
+      # })
 
       # NOTE: These are all BOE 3.1 instances and are not currently needed
       # t2-onr-boe-1-a = merge(local.ec2_instances.boe_app, {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -266,7 +266,13 @@ locals {
         skip_final_backup   = true
         storage_capacity    = 128
         throughput_capacity = 8
-        subnet_ids          = [data.aws_subnet.private_subnets_a.id]
+
+        subnets = [
+          {
+            name               = "private"
+            availability_zones = ["eu-west-2a"]
+          }
+        ]
 
         self_managed_active_directory = {
           dns_ips = [

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -231,6 +231,7 @@ locals {
     }
 
     fsx_windows = {
+      # switch to using SINGLE_AZ_1 in T2 (cheaper), change settings in T2 servers then remove this
       t2-bods-windows-share = {
         preferred_availability_zone = "eu-west-2a"
         deployment_type             = "MULTI_AZ_1"
@@ -245,6 +246,27 @@ locals {
             availability_zones = ["eu-west-2a", "eu-west-2b"]
           }
         ]
+
+        self_managed_active_directory = {
+          dns_ips = [
+            module.ip_addresses.mp_ip.ad-azure-dc-a,
+            module.ip_addresses.mp_ip.ad-azure-dc-b,
+          ]
+          domain_name          = "azure.noms.root"
+          username             = "svc_join_domain"
+          password_secret_name = "/sap/bods/t2/passwords"
+        }
+        tags = {
+          backup = true
+        }
+      }
+      t2-bods-win-share = {
+        deployment_type     = "SINGLE_AZ_1"
+        security_groups     = ["bods"]
+        skip_final_backup   = true
+        storage_capacity    = 128
+        throughput_capacity = 8
+        subnet_ids          = [data.aws_subnet.private_subnets_a.id]
 
         self_managed_active_directory = {
           dns_ips = [

--- a/terraform/environments/oasys-national-reporting/versions.tf
+++ b/terraform/environments/oasys-national-reporting/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "5.53.0" # hardcoded from "~> 5.0" as currently broken, fix expected in 5.57.0 - change back when this is released
+      version = "~> 5.8"
       source  = "hashicorp/aws"
     }
     http = {
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.5"
 }

--- a/terraform/modules/baseline/versions.tf
+++ b/terraform/modules/baseline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version               = "~> 5.0"
+      version               = "~> 5.8"
       source                = "hashicorp/aws"
       configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.us-east-1]
     }


### PR DESCRIPTION
- replace (more expensive) multiple AZ with single_az_1 version
- unfortunately, having used the test environment to test removing the deprecated feature the only way to recover this is to blow away t2-onr-bods-1 and t2-onr-bods-2 and start again 😢 
- also update provider versions to address issues with other module code