### PR TITLE
Bumped equip waf threshold

### DIFF
--- a/terraform/environments/equip/shield.tf
+++ b/terraform/environments/equip/shield.tf
@@ -16,7 +16,7 @@ module "shield" {
       "action"    = "block",
       "name"      = "equip-count-rule",
       "priority"  = 0,
-      "threshold" = "75"
+      "threshold" = "1000"
     }
   }
 }


### PR DESCRIPTION
In response to [this Slack request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1733735679084179?thread_ts=1733405114.654599&cid=C01A7QK5VM1) the threshold for Equip AWS Shield is being bumped back up to 1000.