### PR TITLE
Add S3 ingress and egress rules to lambda security group

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
@@ -11,8 +11,12 @@ resource "aws_security_group" "lambda_generic" {
 
 # get s3 endpoint
 data "aws_vpc_endpoint" "s3" {
+  provider     = aws.core-vpc
   service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
   vpc_id       = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-com.amazonaws.${data.aws_region.current.name}.s3"
+  }
 }
 
 data "aws_prefix_list" "s3" {

--- a/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
@@ -9,6 +9,23 @@ resource "aws_security_group" "lambda_generic" {
   }
 }
 
+# get s3 endpoint
+data "aws_vpc_endpoint" "s3" {
+  filter {
+    name   = "service-name"
+    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+}
+
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
 resource "aws_security_group_rule" "lambda_ingress_generic" {
   cidr_blocks       = [data.aws_vpc.shared.cidr_block, ]
   type              = "ingress"
@@ -19,6 +36,16 @@ resource "aws_security_group_rule" "lambda_ingress_generic" {
   security_group_id = aws_security_group.lambda_generic.id
 }
 
+resource "aws_security_group_rule" "lambda_ingress_s3" {
+  type              = "ingress"
+  description       = "allow s3"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
+  security_group_id = aws_security_group.lambda_generic.id
+}
+
 resource "aws_security_group_rule" "lambda_egress_generic" {
   type              = "egress"
   description       = "allow all"
@@ -26,5 +53,15 @@ resource "aws_security_group_rule" "lambda_egress_generic" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = [data.aws_vpc.shared.cidr_block, ]
+  security_group_id = aws_security_group.lambda_generic.id
+}
+
+resource "aws_security_group_rule" "lambda_egress_s3" {
+  type              = "egress"
+  description       = "allow s3"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
   security_group_id = aws_security_group.lambda_generic.id
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "lambda_generic" {
 
 # get s3 endpoint
 data "aws_vpc_endpoint" "s3" {
-  service_name = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
   vpc_id       = data.aws_vpc.shared.id
 }
 

--- a/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_sg.tf
@@ -11,15 +11,8 @@ resource "aws_security_group" "lambda_generic" {
 
 # get s3 endpoint
 data "aws_vpc_endpoint" "s3" {
-  filter {
-    name   = "service-name"
-    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
-  }
-
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.shared.id]
-  }
+  service_name = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+  vpc_id       = data.aws_vpc.shared.id
 }
 
 data "aws_prefix_list" "s3" {


### PR DESCRIPTION
Introduce security group rules to allow S3 traffic for both ingress and egress in the Lambda security group configuration.