### PR TITLE
Add s3:GetObjectTagging permission to IAM policy for data access

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -378,6 +378,8 @@ data "aws_iam_policy_document" "format_json_fms_data_policy_document" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
+      "s3:GetObjectTagging",
+
     ]
     resources = ["${module.s3-data-bucket.bucket.arn}/*"]
   }


### PR DESCRIPTION
Include the s3:GetObjectTagging permission in the IAM policy to enhance data access capabilities.