### PR TITLE
DPR2-1316: Add incident reporting service glue connections and secrets.

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -94,7 +94,7 @@
       "setup_sonatype_secrets": true,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -270,7 +270,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -448,7 +448,7 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "enable_redshift_health_check": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -642,7 +642,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": false,
       "setup_redshift_schedule": false,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {


### PR DESCRIPTION
- Add dps-incident-reporting to the list of dps_domains
- This will create a secret manager secret and a glue connection for dps-incident-reporting