### PR TITLE
Bump github-actions to `v18.6.0`

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/terraform-static-analysis@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/terraform-static-analysis@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -81,7 +81,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
+        uses: ministryofjustice/github-actions/terraform-static-analysis@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## A reference to the issue / Description of it

Updating `ministryofjustice/github-actions` to `v18.6.0`

## How does this PR fix the problem?

This version pins the trivy version to `v0.57.1` as the latest version has been causing us some errors.