### PR TITLE
DPR2-1316: Shorten dps-incident-reporting

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -94,7 +94,7 @@
       "setup_sonatype_secrets": true,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting", "dps-csip"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-inc-reporting", "dps-csip"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -270,7 +270,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting", "dps-csip"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-inc-reporting", "dps-csip"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -448,7 +448,7 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "enable_redshift_health_check": true,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting", "dps-csip"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-inc-reporting", "dps-csip"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {
@@ -642,7 +642,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": false,
       "setup_redshift_schedule": false,
-      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-incident-reporting", "dps-csip"],
+      "dps_domains": ["dps-activities", "dps-case-notes", "dps-basm", "dps-inc-reporting", "dps-csip"],
       "alarms": {
         "setup_cw_alarms": true,
         "redshift": {


### PR DESCRIPTION
- Unfortunately 'dps-incident-reporting' is too long for our platform naming conventions
- 17 characters seems to be the longest allowed domain name otherwise we see errors when creating IAM roles

For example:
```
│ Error: expected length of name to be in the range (1 - 64), got dpr-create-reload-diff-dps-incident-reporting-development-glue-role
│ 
│   with module.ingestion-jobs["dps-incident-reporting"].module.create_reload_diff_job.aws_iam_role.glue-service-role[0],
│   on .terraform/modules/ingestion-jobs/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf line 66, in resource "aws_iam_role" "glue-service-role":
│   66:   name  = "${var.name}-glue-role"
│ 
╵
╷
│ Error: expected length of name to be in the range (1 - 64), got dpr-reporting-hub-cdc-dps-incident-reporting-development-glue-role
│ 
│   with module.ingestion-jobs["dps-incident-reporting"].module.glue_reporting_hub_cdc_job.aws_iam_role.glue-service-role[0],
│   on .terraform/modules/ingestion-jobs/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf line 66, in resource "aws_iam_role" "glue-service-role":
│   66:   name  = "${var.name}-glue-role"
│ 
╵
╷
│ Error: expected length of name to be in the range (1 - 64), got unprocessed-files-check-dps-incident-reporting-development-glue-role
│ 
│   with module.ingestion-jobs["dps-incident-reporting"].module.unprocessed_raw_files_check_job.aws_iam_role.glue-service-role[0],
│   on .terraform/modules/ingestion-jobs/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf line 66, in resource "aws_iam_role" "glue-service-role":
│   66:   name  = "${var.name}-glue-role"
│ 
```