### PR TITLE
Add additional S3 bucket paths for IAM role permissions in Airflow module

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
@@ -24,6 +24,8 @@ data "aws_iam_policy_document" "load_data" {
       "${var.source_data_bucket.arn}/staging${var.path_to_data}/*",
       "${var.cadt_bucket.arn}/staging/${local.snake-database}/*",
       "${var.cadt_bucket.arn}/staging${var.path_to_data}/*",
+      "${var.cadt_bucket.arn}/staging/${local.snake-database}_pipeline/*",
+      "${var.cadt_bucket.arn}/staging${var.path_to_data}_pipeline/*",
       "${var.athena_dump_bucket.arn}/output/*"
     ]
   }


### PR DESCRIPTION
Include new S3 bucket paths for pipeline data in the IAM role permissions of the Airflow module.