### PR TITLE
planetfm: remove unused acm cert

### DIFF
--- a/terraform/environments/planetfm/locals_lbs.tf
+++ b/terraform/environments/planetfm/locals_lbs.tf
@@ -2,70 +2,7 @@ locals {
 
   lbs = {
 
-    private = {
-      enable_cross_zone_load_balancing = true
-      enable_delete_protection         = false
-      force_destroy_bucket             = true
-      idle_timeout                     = 3600
-      load_balancer_type               = "application"
-      internal_lb                      = true
-      security_groups                  = ["loadbalancer"]
-      subnets                          = module.environment.subnets["private"].ids
-
-      instance_target_groups = {
-        web-80 = {
-          health_check = {
-            enabled             = true
-            healthy_threshold   = 3
-            interval            = 30
-            matcher             = "200-399"
-            path                = "/"
-            port                = 80
-            timeout             = 5
-            unhealthy_threshold = 5
-          }
-          port     = 80
-          protocol = "HTTP"
-          stickiness = {
-            enabled = true
-            type    = "lb_cookie"
-          }
-        }
-      }
-
-      listeners = {
-        http = {
-          port     = 80
-          protocol = "HTTP"
-
-          default_action = {
-            type = "redirect"
-            redirect = {
-              port        = 443
-              protocol    = "HTTPS"
-              status_code = "HTTP_301"
-            }
-          }
-        }
-        https = {
-          cloudwatch_metric_alarms  = module.baseline_presets.cloudwatch_metric_alarms.lb
-          certificate_names_or_arns = ["planetfm_wildcard_cert"]
-          port                      = 443
-          protocol                  = "HTTPS"
-          ssl_policy                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-
-          default_action = {
-            type = "fixed-response"
-            fixed_response = {
-              content_type = "text/plain"
-              message_body = "Not implemented"
-              status_code  = "501"
-            }
-          }
-        }
-      }
-    }
-
+    # NOTE: NTLM auth doesn't support application load balancer
     web = {
       access_logs                      = false
       enable_cross_zone_load_balancing = true

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -13,22 +13,6 @@ locals {
   # please keep resources in alphabetical order
   baseline_preproduction = {
 
-    acm_certificates = {
-      planetfm_wildcard_cert = {
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
-        domain_name                         = "modernisation-platform.service.justice.gov.uk"
-        external_validation_records_created = true
-        subject_alternate_names = [
-          "*.pp.planetfm.service.justice.gov.uk",
-          "pp-cafmwebx.az.justice.gov.uk",
-          "pp-cafmtx.az.justice.gov.uk",
-        ]
-        tags = {
-          description = "wildcard cert for planetfm preproduction domains"
-        }
-      }
-    }
-
     ec2_instances = {
 
       # app servers

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -13,24 +13,6 @@ locals {
   # please keep resources in alphabetical order
   baseline_production = {
 
-    acm_certificates = {
-      planetfm_wildcard_cert = {
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
-        domain_name                         = "modernisation-platform.service.justice.gov.uk"
-        external_validation_records_created = true
-        subject_alternate_names = [
-          "*.planetfm.service.justice.gov.uk",
-          "cafmwebx.az.justice.gov.uk",
-          "cafmwebx2.az.justice.gov.uk",
-          "cafmtx.az.justice.gov.uk",
-          "cafmtrainweb.az.justice.gov.uk",
-        ]
-        tags = {
-          description = "wildcard cert for planetfm production domains"
-        }
-      }
-    }
-
     ec2_instances = {
       # app servers
       pd-cafm-a-10-b = merge(local.ec2_instances.app, {


### PR DESCRIPTION
The ACM cert is not used. Removing as it is triggering a cert expiry alarm.