### PR TITLE
DPR2-1213: Make postgres DMS source heartbeat configurable

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -140,8 +140,8 @@ resource "aws_dms_endpoint" "dms-s3-target-source" {
     content {
       map_boolean_as_boolean       = true
       fail_tasks_on_lob_truncation = true
-      heartbeat_enable             = true
-      heartbeat_frequency          = 5
+      heartbeat_enable             = var.source_postgres_heartbeat_enable
+      heartbeat_frequency          = var.source_postgres_heartbeat_frequency
     }
   }
 

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
@@ -270,6 +270,18 @@ variable "source_ssl_mode" {
   type        = string
 }
 
+variable "source_postgres_heartbeat_enable" {
+  default     = true
+  description = "Only used for Postgres sources. The write-ahead log (WAL) heartbeat feature mimics a dummy transaction. By doing this, it prevents idle logical replication slots from holding onto old WAL logs, which can result in storage full situations on the source."
+  type        = bool
+}
+
+variable "source_postgres_heartbeat_frequency" {
+  default     = 5
+  description = "Only used for Postgres sources.  Sets the WAL heartbeat frequency (in minutes)."
+  type        = number
+}
+
 variable "bucket_name" {
   type    = string
   default = ""

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/endpoints.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/endpoints.tf
@@ -2,24 +2,26 @@
 module "dms_endpoints" {
   source = "../../dms_s3_v2"
 
-  setup_dms_endpoints       = var.setup_dms_endpoints
-  setup_dms_iam             = var.setup_dms_iam
-  setup_dms_source_endpoint = var.setup_dms_source_endpoint
-  setup_dms_s3_endpoint     = var.setup_dms_s3_endpoint
-  source_engine_name        = var.source_engine_name
-  dms_source_name           = var.dms_source_name
-  dms_target_name           = var.dms_target_name
-  project_id                = var.project_id
-  env                       = var.env # common
-  short_name                = var.short_name
-  source_db_name            = var.source_db_name
-  source_app_username       = var.source_app_username
-  source_app_password       = var.source_app_password
-  source_address            = var.source_address
-  source_ssl_mode           = var.source_ssl_mode
-  source_db_port            = var.source_db_port
-  extra_attributes          = var.extra_attributes
-  bucket_name               = var.bucket_name
+  setup_dms_endpoints                 = var.setup_dms_endpoints
+  setup_dms_iam                       = var.setup_dms_iam
+  setup_dms_source_endpoint           = var.setup_dms_source_endpoint
+  setup_dms_s3_endpoint               = var.setup_dms_s3_endpoint
+  source_engine_name                  = var.source_engine_name
+  dms_source_name                     = var.dms_source_name
+  dms_target_name                     = var.dms_target_name
+  project_id                          = var.project_id
+  env                                 = var.env # common
+  short_name                          = var.short_name
+  source_db_name                      = var.source_db_name
+  source_app_username                 = var.source_app_username
+  source_app_password                 = var.source_app_password
+  source_address                      = var.source_address
+  source_ssl_mode                     = var.source_ssl_mode
+  source_db_port                      = var.source_db_port
+  extra_attributes                    = var.extra_attributes
+  bucket_name                         = var.bucket_name
+  source_postgres_heartbeat_enable    = var.source_postgres_heartbeat_enable
+  source_postgres_heartbeat_frequency = var.source_postgres_heartbeat_frequency
 
   tags = var.tags
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
@@ -68,6 +68,18 @@ variable "source_ssl_mode" {
   type        = string
 }
 
+variable "source_postgres_heartbeat_enable" {
+  default     = true
+  description = "Only used for Postgres sources. The write-ahead log (WAL) heartbeat feature mimics a dummy transaction. By doing this, it prevents idle logical replication slots from holding onto old WAL logs, which can result in storage full situations on the source."
+  type        = bool
+}
+
+variable "source_postgres_heartbeat_frequency" {
+  default     = 5
+  description = "Only used for Postgres sources.  Sets the WAL heartbeat frequency (in minutes)."
+  type        = number
+}
+
 variable "bucket_name" {
   type = string
 }


### PR DESCRIPTION
- We need to be able to turn heartbeat off for read replicas since DMS cannot create, and insert into, the heartbeat table on an RDS Postgres read replica where only read operations are allowed.