### PR TITLE
TM-776: nomis: ebs bandwidth tweaks

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -344,7 +344,7 @@ locals {
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
           data  = { total_size = 4000, iops = 9000, throughput = 300 }
-          flash = { total_size = 1000, iops = 3000, throughput = 150 }
+          flash = { total_size = 1000, iops = 3000, throughput = 200 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -376,7 +376,7 @@ locals {
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
           data  = { total_size = 4000, iops = 9000, throughput = 300 }
-          flash = { total_size = 1000, iops = 3000, throughput = 150 }
+          flash = { total_size = 1000, iops = 3000, throughput = 200 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -409,7 +409,7 @@ locals {
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
           data  = { total_size = 6000, iops = 9000, throughput = 300 }
-          flash = { total_size = 1000, iops = 3000, throughput = 150 }
+          flash = { total_size = 1000, iops = 3000, throughput = 200 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -445,7 +445,7 @@ locals {
           data  = { total_size = 6000, iops = 3000, throughput = 125 }
           flash = { total_size = 1000, iops = 3000, throughput = 125 }
           # data  = { total_size = 6000, iops = 9000, throughput = 300 } # replace above with this on failover
-          # flash = { total_size = 1000, iops = 3000, throughput = 150 } # replace above with this on failover
+          # flash = { total_size = 1000, iops = 3000, throughput = 200 } # replace above with this on failover
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -343,8 +343,8 @@ locals {
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 4000, iops = 9000, throughput = 500 }
-          flash = { total_size = 1000, iops = 3000, throughput = 250 }
+          data  = { total_size = 4000, iops = 9000, throughput = 300 }
+          flash = { total_size = 1000, iops = 3000, throughput = 150 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -375,8 +375,8 @@ locals {
           "/dev/sdc" = { label = "app", size = 500 }
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 4000, iops = 9000, throughput = 250 }
-          flash = { total_size = 1000, iops = 3000, throughput = 125 }
+          data  = { total_size = 4000, iops = 9000, throughput = 300 }
+          flash = { total_size = 1000, iops = 3000, throughput = 150 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -408,8 +408,8 @@ locals {
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 6000, iops = 9000, throughput = 250 }
-          flash = { total_size = 1000, iops = 3000, throughput = 250 }
+          data  = { total_size = 6000, iops = 9000, throughput = 300 }
+          flash = { total_size = 1000, iops = 3000, throughput = 150 }
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
@@ -444,8 +444,8 @@ locals {
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
           data  = { total_size = 6000, iops = 3000, throughput = 125 }
           flash = { total_size = 1000, iops = 3000, throughput = 125 }
-          # data  = { total_size = 6000, iops = 9000, throughput = 250 } # replace above with this on failover
-          # flash = { total_size = 1000, iops = 3000, throughput = 250 } # replace above with this on failover
+          # data  = { total_size = 6000, iops = 9000, throughput = 300 } # replace above with this on failover
+          # flash = { total_size = 1000, iops = 3000, throughput = 150 } # replace above with this on failover
         })
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true


### PR DESCRIPTION
Update nomis iops / bandwidth:
- flash: make consistent across all DBs. Widgets show 200 still leaves plenty of headroom
- db-1-a data: drop back down to 300 (was increased to 500 following incident but subsequently shown to be not needed)
- db-1-b data: align with db-1-a to make failover easier
- db-2-a data: increase to 300 (widgets show we are hitting 250 at some points) 