### PR TITLE
deploy a test bods instance

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
@@ -212,10 +212,10 @@ locals {
         ))
       }
       ebs_volumes = {
-        "/dev/sda1" = { type = "gp3", size = 100 }
-        "/dev/sdb"  = { type = "gp3", size = 100 }
-        "/dev/sdc"  = { type = "gp3", size = 100 }
-        "/dev/sds"  = { type = "gp3", size = 100 }
+        "/dev/sda1" = { type = "gp3", size = 100 } # root volume
+        "xvdd"      = { type = "gp3", size = 100 } # D:/ Temp
+        "xvde"      = { type = "gp3", size = 100 } # E:/ App
+        "xvdf"      = { type = "gp3", size = 100 } # F:/ Storage
       }
       instance = {
         disable_api_termination = false
@@ -231,7 +231,7 @@ locals {
         backup                 = "false"
         instance-access-policy = "full"
         os-type                = "Windows"
-        server-type            = "NcrBods"
+        server-type            = "Bods"
         update-ssm-agent       = "patchgroup1"
       }
     }

--- a/terraform/environments/oasys-national-reporting/locals_development.tf
+++ b/terraform/environments/oasys-national-reporting/locals_development.tf
@@ -65,6 +65,7 @@ locals {
         tags = merge(local.ec2_autoscaling_groups.bods.tags, {
           oasys-national-reporting-environment = "t3"
           domain-name                          = "azure.noms.root"
+          server-type                          = "Bods"
         })
         cloudwatch_metric_alarms = null
       })

--- a/terraform/environments/oasys-national-reporting/locals_development.tf
+++ b/terraform/environments/oasys-national-reporting/locals_development.tf
@@ -46,14 +46,25 @@ locals {
         cloudwatch_metric_alarms = null
       })
 
-      dev-bods-asg = merge(local.ec2_autoscaling_groups.bods, {
+      dev-onr-bods-1 = merge(local.ec2_autoscaling_groups.bods, {
         autoscaling_group = merge(local.ec2_autoscaling_groups.bods.autoscaling_group, {
           desired_capacity = 0
         })
         config = merge(local.ec2_autoscaling_groups.bods.config, {
+          instance_profile_policies = concat(local.ec2_autoscaling_groups.bods.config.instance_profile_policies, [
+            "Ec2SecretPolicy",
+          ])
+          user_data_raw = base64encode(templatefile(
+            "./templates/user-data-onr-bods-pwsh.yaml.tftpl", {
+              branch = "TM/combine-bods-installers"
+          }))
         })
         instance = merge(local.ec2_autoscaling_groups.bods.instance, {
           instance_type = "t3.large"
+        })
+        tags = merge(local.ec2_autoscaling_groups.bods.tags, {
+          oasys-national-reporting-environment = "t3"
+          domain-name                          = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null
       })

--- a/terraform/environments/oasys-national-reporting/locals_development.tf
+++ b/terraform/environments/oasys-national-reporting/locals_development.tf
@@ -63,7 +63,7 @@ locals {
           instance_type = "t3.large"
         })
         tags = merge(local.ec2_autoscaling_groups.bods.tags, {
-          oasys-national-reporting-environment = "t3"
+          oasys-national-reporting-environment = "dev"
           domain-name                          = "azure.noms.root"
           server-type                          = "Bods"
         })
@@ -74,8 +74,35 @@ locals {
     ec2_instances = {
     }
 
+    iam_policies = {
+      Ec2SecretPolicy = {
+        description = "Permissions required for secret value access by instances"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/sap/bods/dev/*",
+              "arn:aws:secretsmanager:*:*:secret:/sap/bip/dev/*",
+              "arn:aws:secretsmanager:*:*:secret:/oracle/database/*",
+            ]
+          }
+        ]
+      }
+    }
+
     route53_zones = {
       "development.reporting.oasys.service.justice.gov.uk" = {}
+    }
+
+    secretsmanager_secrets = {
+      "/sap/bods/dev"            = local.secretsmanager_secrets.bods
+      "/sap/bip/dev"             = local.secretsmanager_secrets.bip
+      "/oracle/database/TESTSYS" = local.secretsmanager_secrets.db
+      "/oracle/database/TESTAUD" = local.secretsmanager_secrets.db
     }
   }
 }

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -46,7 +46,7 @@ locals {
         backup           = "false"
         component        = "onr_bods"
         os-type          = "Windows"
-        server-type      = "OnrBods"
+        server-type      = "Bods"
         update-ssm-agent = "patchgroup1"
       }
       cloudwatch_metric_alarms = merge(


### PR DESCRIPTION
- use correct Windows drive letters for EBS in nomis-combined-reporting EC2 instance BODS default
- change to Bods `server-type` tag in both NCR and ONR EC2 instance BODS default

- modify the bods asg instance in the ONR development environment to test the 'get-config' function works 
  - will be used for testing only anyway
