### PR TITLE
Updating runner group to use unique label for debugging

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -92,7 +92,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_runner_grou
         github_app_installation_id = jsondecode(data.aws_secretsmanager_secret_version.actions_runners_token_apc_self_hosted_runners_github_app[0].secret_string)["installation_id"]
         github_organisation        = "moj-analytical-services"
         github_repository          = "create-a-derived-table"
-        github_runner_labels       = "analytical-platform"
+        github_runner_labels       = "analytical-platform-prod-deployments"
         eks_role_arn               = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/create-a-derived-table"
       }
     )


### PR DESCRIPTION
A small PR to move our runner group to using a unique label, to make it easier to debug why it doesn't seem to spin up in response to jobs.