### PR TITLE
Increase Athena workgroup bytes scanned cutoff to 1 TB

### DIFF
--- a/terraform/environments/electronic-monitoring-data/athena_main.tf
+++ b/terraform/environments/electronic-monitoring-data/athena_main.tf
@@ -4,7 +4,7 @@ resource "aws_athena_workgroup" "default" {
   state       = "ENABLED"
 
   configuration {
-    bytes_scanned_cutoff_per_query     = 1073741824 # 1 GB
+    bytes_scanned_cutoff_per_query     = 1073741824000 # 1 TB
     enforce_workgroup_configuration    = true
     publish_cloudwatch_metrics_enabled = true
 


### PR DESCRIPTION
Update the Athena workgroup configuration to increase the bytes scanned cutoff per query from 1 GB to 1 TB.