### PR TITLE
TM-776: add csr iops dashboards

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -20,14 +20,6 @@ locals {
 
   baseline_presets_all_environments = {
     options = {
-      cloudwatch_dashboard_default_widget_groups = [
-        "network_lb",
-        "ec2",
-        "ec2_linux",
-        "ec2_instance_linux",
-        "ec2_instance_oracle_db_with_backup",
-        "ssm_command",
-      ]
       cloudwatch_metric_alarms_default_actions    = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters  = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                 = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
@@ -1,0 +1,69 @@
+locals {
+
+  cloudwatch_dashboard_widget_groups = {
+    app = {
+      header_markdown = "## EC2 App Tier"
+      width           = 8
+      height          = 8
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "app" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        # CloudWatch agent not running, monitored by Glenn Bot instead
+      ]
+    }
+
+    db = {
+      header_markdown = "## EC2 Oracle Database"
+      width           = 8
+      height          = 8
+      add_ebs_widgets = {
+        iops       = true
+        throughput = true
+      }
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "data" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_linux.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-error,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run,
+      ]
+    }
+
+    web = {
+      header_markdown = "## EC2 Web Tier"
+      width           = 8
+      height          = 8
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "web" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        # CloudWatch agent not running, monitored by Glenn Bot instead
+      ]
+    }
+
+  }
+}
+

--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -13,6 +13,20 @@ locals {
   # please keep resources in alphabetical order
   baseline_preproduction = {
 
+    cloudwatch_dashboards = {
+      "CloudWatch-Default" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
+          local.cloudwatch_dashboard_widget_groups.db,
+          local.cloudwatch_dashboard_widget_groups.app,
+          local.cloudwatch_dashboard_widget_groups.web,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
+        ]
+      }
+    }
+
     ec2_instances = {
       pp-csr-db-a = merge(local.ec2_instances.db, {
         config = merge(local.ec2_instances.db.config, {

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -14,6 +14,86 @@ locals {
   # please keep resources in alphabetical order
   baseline_production = {
 
+    cloudwatch_dashboards = {
+      "CloudWatch-Default" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
+          local.cloudwatch_dashboard_widget_groups.db,
+          local.cloudwatch_dashboard_widget_groups.app,
+          local.cloudwatch_dashboard_widget_groups.web,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
+        ]
+      }
+      "pd-csr-db-a" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          {
+            width         = 8
+            height        = 8
+            search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-a" }] }
+            widgets = [
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_linux.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-error,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_backup.oracle-db-rman-backup-did-not-run,
+            ]
+          },
+          {
+            header_markdown = "## EBS PERFORMANCE"
+            width           = 8
+            height          = 8
+            add_ebs_widgets = { iops = true, throughput = true }
+            search_filter   = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-a" }] }
+            widgets         = []
+          }
+        ]
+      }
+      "pd-csr-db-b" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          {
+            width         = 8
+            height        = 8
+            search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-b" }] }
+            widgets = [
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_linux.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_os.service-status-error-os-layer,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_service_status_app.service-status-error-app-layer,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_collectd_oracle_db_connected.oracle-db-disconnected,
+              null,
+              null,
+            ]
+          },
+          {
+            header_markdown = "## EBS PERFORMANCE"
+            width           = 8
+            height          = 8
+            add_ebs_widgets = { iops = true, throughput = true }
+            search_filter   = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-b" }] }
+            widgets         = []
+          }
+        ]
+      }
+    }
+
     ec2_instances = {
       pd-csr-db-a = merge(local.ec2_instances.db, {
         config = merge(local.ec2_instances.db.config, {
@@ -38,6 +118,7 @@ locals {
           ami           = "base_ol_8_5"
           description   = "PD CSR Oracle primary DB server"
           pre-migration = "PDCDL00013"
+          oracle-sids   = "PIWFM"
         })
       })
 
@@ -68,6 +149,7 @@ locals {
           ami           = "base_ol_8_5"
           description   = "PD CSR Oracle secondary DB server"
           pre-migration = "PDCDL00014"
+          oracle-sids   = "DIWFM"
         })
       })
 


### PR DESCRIPTION
Improved dashboards for CSR:
- remove dev/test as the accounts are empty
- split out dashboard by db,app,web tier
- include DB specific dashboards with IOPS/bandwidth widgets
- add missing tag for DB connected monitoring