### PR TITLE
TM-776: align csr db primary and secondary iops

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -109,7 +109,7 @@ locals {
           "/dev/sdc"  = { label = "app", size = 500 } # /u02
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 1500, iops = 6000 }
+          data  = { total_size = 1500 }
           flash = { total_size = 500 }
         })
         instance = merge(local.ec2_instances.db.instance, {


### PR DESCRIPTION
Drop CSR iops back to default - same as DR. We're not getting close to the default 3000, never mind 6000.