### PR TITLE
DPR2-1642: Include part-*.snappy.parquet in batch job during ingestio…

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/pipeline.tf
@@ -166,6 +166,7 @@ module "replay_pipeline" {
           "Parameters" : {
             "JobName" : var.glue_reporting_hub_batch_jobname,
             "Arguments" : {
+              "--dpr.batch.load.fileglobpattern" : "{part-*.snappy.parquet,LOAD*parquet}",
               "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
               "--dpr.config.key" : var.domain
             }


### PR DESCRIPTION
The batch job of the replay pipeline does not process diff files created by the reload pipeline. This is because the batch job looks for files matching the name pattern `LOAD*.parquet` whereas the reload diff files have the name pattern `part-*.snappy.parquet`.

Steps to reproduce:
- Run the ingestion pipeline if there is no already ingested data
- Run the reload pipeline. This generates the reload diff files
- Run the replay pipeline. The batch job would fail to read the reload diff files

To fix this, an extra argument will be supplied to the batch job invocation during the replay pipeline:
`--dpr.batch.load.fileglobpattern : {part-*.snappy.parquet,LOAD*parquet}`