### PR TITLE
Remove production database permissions from Lake Formation settings

### DIFF
--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -8,7 +8,7 @@ locals {
   suffix            = local.is-production ? "" : "-test"
   prod_dbs_to_grant = local.is-production ? ["am_stg", "cap_dw_stg", "emd_historic_int", "historic_api_mart", "historic_api_mart_mock"] : []
   dev_dbs_to_grant  = local.is-production ? [for db in local.prod_dbs_to_grant : "${db}_historic_dev_dbt"] : []
-  dbs_to_grant      = toset(flatten([local.prod_dbs_to_grant, local.dev_dbs_to_grant]))
+  dbs_to_grant      = toset(flatten([local.dev_dbs_to_grant]))
 }
 
 # Source Analytics DBT Secrets
@@ -423,17 +423,6 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 
   # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
   # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
-  create_database_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = ["ALL"]
-    principal   = "IAM_ALLOWED_PRINCIPALS"
-  }
-
-  create_table_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = ["ALL"]
-    principal   = "IAM_ALLOWED_PRINCIPALS"
-  }
 }
 
 resource "aws_lakeformation_permissions" "grant_cadt_databases" {


### PR DESCRIPTION
Eliminate unnecessary production database permissions in Lake Formation settings to enhance security and simplify configuration.