### PR TITLE
Update dependabot script to use `directories:` key

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -9,20 +9,16 @@ dependabot_file=.github/dependabot.yml
 
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
-all_env_test_folders=`find . -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 echo
 echo "All TF folders"
 echo $all_tf_folders
-echo
-echo "All environment test folders"
-echo $all_env_test_folders
 
 echo "Writing dependabot.yml file"
-# Creates a dependabot file to avoid having to manually add each new TF folder or go.mod file
+# Creates a dependabot file to avoid having to manually add each new TF folder
 # Add any additional fixed entries in this top section
   cat > $dependabot_file << EOL
 # This file is auto-generated here, do not manually amend.
-# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
+# scripts/generate-dependabot.sh
 
 version: 2
 

--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -4,18 +4,25 @@ set -euo pipefail
 
 dependabot_file=.github/dependabot.yml
 
+# Clear the dependabot file
+> $dependabot_file
+
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+all_env_test_folders=`find . -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 echo
 echo "All TF folders"
 echo $all_tf_folders
+echo
+echo "All environment test folders"
+echo $all_env_test_folders
 
 echo "Writing dependabot.yml file"
-# Creates a dependabot file to avoid having to manually add each new TF folder
+# Creates a dependabot file to avoid having to manually add each new TF folder or go.mod file
 # Add any additional fixed entries in this top section
   cat > $dependabot_file << EOL
-# This file is auto-generated here, do not manually amend. 
-# scripts/generate-dependabot.sh
+# This file is auto-generated here, do not manually amend.
+# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
 
 version: 2
 
@@ -24,22 +31,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "ministryofjustice/devcontainer-community"
-  # Dependabot doesn't currently support wildcard or multiple directory declarations within
-  # a dependabot configuration, so we need to add all directories individually
-  # See: github.com/dependabot/dependabot-core/issues/2178
 EOL
 
-for folder in $all_tf_folders
-do
-echo "Generating entry for ${folder}"
+echo "Generating entry for Terraform ecosystem"
 echo "  - package-ecosystem: \"terraform\"" >> $dependabot_file
-echo "    directory: \"/${folder}\"" >> $dependabot_file
+echo "    directories:" >> $dependabot_file
+for folder in $all_tf_folders; do
+  echo "      - \"/$folder\"" >> $dependabot_file
+done
 echo "    schedule:" >> $dependabot_file
 echo "      interval: \"daily\"" >> $dependabot_file
-done


### PR DESCRIPTION
Tracked upstream by [#7503](https://github.com/ministryofjustice/modernisation-platform/issues/7053).

This PR replaces the use of multiple `directory` keys with a single `directories`.