### PR TITLE
TM-860: nomis: temporarily increase web disk space alarm threshold

### DIFF
--- a/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_metric_alarms.tf
@@ -75,6 +75,15 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
+      local.environment == "production" ? {
+        free-disk-space-low = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["free-disk-space-low"], {
+          threshold = "90"
+        })
+        } : {
+        free-disk-space-low = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["free-disk-space-low"], {
+          threshold = "85"
+        })
+      }
     )
 
     xtag = merge(


### PR DESCRIPTION
Temporarily increase the threshold to 90% to avoid flapping alerts while we fix the issue