### PR TITLE
Fix missing GITHUB_TOKEN environment variable in workflow

### DIFF
--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -16,7 +16,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   create-and-commit-dependabot-file:

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -17,11 +17,10 @@ defaults:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  create-and-commit-dependabot-file:
-    permissions:
-      pull-requests: write
+  create-and-commit-dependabot-file:    
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Commit changes to GitHub
         run: bash ./scripts/git-setup.sh
       - run: bash ./scripts/git-commit.sh .github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bash ./scripts/git-pull-request.sh dependabot
         env:
           SECRET: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Commit changes to GitHub
         run: bash ./scripts/git-setup.sh
       - run: bash ./scripts/git-commit.sh .github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bash ./scripts/git-pull-request.sh dependabot
         env:
           SECRET: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The script in the workflow is failing because it expects the `$GITHUB_TOKEN` environment variable, but this variable is not defined in the workflow.