### PR TITLE
Add AWS Glue catalog database resource for database access grants

### DIFF
--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -438,7 +438,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 module "share_dbs_with_de_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = local.dbs_to_grant
+  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].name
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
 }
@@ -446,7 +446,7 @@ module "share_dbs_with_de_role" {
 module "share_dbs_with_cadt_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = local.dbs_to_grant
+  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].name
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
 }

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -441,7 +441,6 @@ module "share_dbs_with_de_role" {
   dbs_to_grant            = local.dbs_to_grant
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
-  depends_on              = [aws_glue_catalog_database.cadt_databases]
 }
 
 module "share_dbs_with_cadt_role" {
@@ -450,5 +449,4 @@ module "share_dbs_with_cadt_role" {
   dbs_to_grant            = local.dbs_to_grant
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
-  depends_on              = [aws_glue_catalog_database.cadt_databases]
 }

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -438,7 +438,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 module "share_dbs_with_de_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = [for db in aws_glue_catalog_database.cadt_databases : db.id]
+  dbs_to_grant            = [for name, db in aws_glue_catalog_database.cadt_databases : db.id]
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
 }
@@ -446,7 +446,7 @@ module "share_dbs_with_de_role" {
 module "share_dbs_with_cadt_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = [for db in aws_glue_catalog_database.cadt_databases : db.id]
+  dbs_to_grant            = [for name, db in aws_glue_catalog_database.cadt_databases : db.id]
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
 }

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -8,7 +8,7 @@ locals {
   suffix            = local.is-production ? "" : "-test"
   prod_dbs_to_grant = local.is-production ? ["am_stg", "cap_dw_stg", "emd_historic_int", "historic_api_mart", "historic_api_mart_mock"] : []
   dev_dbs_to_grant  = local.is-production ? [for db in local.prod_dbs_to_grant : "${db}_historic_dev_dbt"] : []
-  dbs_to_grant      = toset(flatten([local.prod_dbs_to_grant, local.dev_dbs_to_grant]))
+  dbs_to_grant      = flatten([local.prod_dbs_to_grant, local.dev_dbs_to_grant])
 }
 
 # Source Analytics DBT Secrets

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -438,7 +438,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 module "share_dbs_with_de_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].name
+  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].id
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
 }
@@ -446,7 +446,7 @@ module "share_dbs_with_de_role" {
 module "share_dbs_with_cadt_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].name
+  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].id
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
 }

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -438,7 +438,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 module "share_dbs_with_de_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].id
+  dbs_to_grant            = [for db in aws_glue_catalog_database.cadt_databases : db.id]
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
 }
@@ -446,7 +446,7 @@ module "share_dbs_with_de_role" {
 module "share_dbs_with_cadt_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = aws_glue_catalog_database.cadt_databases[*].id
+  dbs_to_grant            = [for db in aws_glue_catalog_database.cadt_databases : db.id]
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
 }

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -438,17 +438,19 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 module "share_dbs_with_de_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = [for name, db in aws_glue_catalog_database.cadt_databases : db.id]
+  dbs_to_grant            = toset([for name, db in aws_glue_catalog_database.cadt_databases : db.id])
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
+  depends_on              = [aws_glue_catalog_database.cadt_databases]
 }
 
 module "share_dbs_with_cadt_role" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = [for name, db in aws_glue_catalog_database.cadt_databases : db.id]
+  dbs_to_grant            = toset([for name, db in aws_glue_catalog_database.cadt_databases : db.id])
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
+  depends_on              = [aws_glue_catalog_database.cadt_databases]
 }
 
 resource "aws_glue_catalog_database" "cadt_databases" {

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -450,3 +450,9 @@ module "share_dbs_with_cadt_role" {
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
 }
+
+resource "aws_glue_catalog_database" "cadt_databases" {
+  count = length(local.dbs_to_grant)
+
+  name = local.dbs_to_grant[count.index]
+}

--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -452,7 +452,7 @@ module "share_dbs_with_cadt_role" {
 }
 
 resource "aws_glue_catalog_database" "cadt_databases" {
-  count = length(local.dbs_to_grant)
+  for_each = toset(local.dbs_to_grant)
 
-  name = local.dbs_to_grant[count.index]
+  name = each.value
 }

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -12,7 +12,7 @@ resource "aws_lakeformation_permissions" "s3_bucket_permissions" {
 
 
 resource "aws_lakeformation_permissions" "grant_cadt_databases" {
-  for_each    = aws_glue_catalog_database.cadt_databases[*].id
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
   principal   = var.role_arn
   permissions = ["ALL"]
   database {
@@ -21,7 +21,7 @@ resource "aws_lakeformation_permissions" "grant_cadt_databases" {
 }
 
 resource "aws_lakeformation_permissions" "grant_cadt_tables" {
-  for_each    = aws_glue_catalog_database.cadt_databases[*].id
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
   principal   = var.role_arn
   permissions = ["ALL"]
   table {

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -12,7 +12,7 @@ resource "aws_lakeformation_permissions" "s3_bucket_permissions" {
 
 
 resource "aws_lakeformation_permissions" "grant_cadt_databases" {
-  for_each    = var.dbs_to_grant
+  for_each    = aws_glue_catalog_database.cadt_databases[*].id
   principal   = var.role_arn
   permissions = ["ALL"]
   database {
@@ -21,11 +21,17 @@ resource "aws_lakeformation_permissions" "grant_cadt_databases" {
 }
 
 resource "aws_lakeformation_permissions" "grant_cadt_tables" {
-  for_each    = var.dbs_to_grant
+  for_each    = aws_glue_catalog_database.cadt_databases[*].id
   principal   = var.role_arn
   permissions = ["ALL"]
   table {
     database_name = each.value
     wildcard      = true
   }
+}
+
+resource "aws_glue_catalog_database" "cadt_databases" {
+  for_each = var.dbs_to_grant
+
+  name = each.value
 }


### PR DESCRIPTION
Introduce a resource for AWS Glue catalog databases to facilitate granting access to specified databases.