### PR TITLE
Reinstate missing ecosystem for devcontainers

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -27,6 +27,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "ministryofjustice/devcontainer-community"
 EOL
 
 echo "Generating entry for Terraform ecosystem"


### PR DESCRIPTION
Tracked upstream by [#7503](https://github.com/ministryofjustice/modernisation-platform/issues/7053).

This PR reinstates an unintentional deletion from the dependabot creation script.