### PR TITLE
Add DE role permissions to lakeformation_database_share module

### DIFF
--- a/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
+++ b/terraform/environments/electronic-monitoring-data/analytical_platform_share.tf
@@ -435,18 +435,11 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
   }
 }
 
-module "share_dbs_with_de_role" {
-  count                   = local.is-production ? 1 : 0
-  source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = local.dbs_to_grant
-  data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
-  role_arn                = try(one(data.aws_iam_roles.data_engineering_roles.arns))
-}
-
-module "share_dbs_with_cadt_role" {
+module "share_dbs_with_roles" {
   count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
   dbs_to_grant            = local.dbs_to_grant
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.dataapi_cross_role.arn
+  de_role_arn             = try(one(data.aws_iam_roles.data_engineering_roles.arns))
 }

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -12,7 +12,7 @@ resource "aws_lakeformation_permissions" "s3_bucket_permissions" {
 
 
 resource "aws_lakeformation_permissions" "grant_cadt_databases" {
-  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.name }
   principal   = var.role_arn
   permissions = ["ALL"]
   database {
@@ -21,7 +21,7 @@ resource "aws_lakeformation_permissions" "grant_cadt_databases" {
 }
 
 resource "aws_lakeformation_permissions" "grant_cadt_tables" {
-  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.name }
   principal   = var.role_arn
   permissions = ["ALL"]
   table {
@@ -42,7 +42,7 @@ resource "aws_lakeformation_permissions" "s3_bucket_permissions_de" {
 
 
 resource "aws_lakeformation_permissions" "grant_cadt_databases_de" {
-  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.name }
   principal   = var.de_role_arn
   permissions = ["ALL"]
   database {
@@ -51,7 +51,7 @@ resource "aws_lakeformation_permissions" "grant_cadt_databases_de" {
 }
 
 resource "aws_lakeformation_permissions" "grant_cadt_tables_de" {
-  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.name }
   principal   = var.de_role_arn
   permissions = ["ALL"]
   table {

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -30,6 +30,36 @@ resource "aws_lakeformation_permissions" "grant_cadt_tables" {
   }
 }
 
+resource "aws_lakeformation_permissions" "s3_bucket_permissions_de" {
+  principal = var.de_role_arn
+
+  permissions = ["DATA_LOCATION_ACCESS"]
+
+  data_location {
+    arn = var.data_bucket_lf_resource
+  }
+}
+
+
+resource "aws_lakeformation_permissions" "grant_cadt_databases_de" {
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  principal   = var.de_role_arn
+  permissions = ["ALL"]
+  database {
+    name = each.value
+  }
+}
+
+resource "aws_lakeformation_permissions" "grant_cadt_tables_de" {
+  for_each    = { for k, v in aws_glue_catalog_database.cadt_databases : k => v.id }
+  principal   = var.de_role_arn
+  permissions = ["ALL"]
+  table {
+    database_name = each.value
+    wildcard      = true
+  }
+}
+
 resource "aws_glue_catalog_database" "cadt_databases" {
   for_each = var.dbs_to_grant
 

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/variables.tf
@@ -13,3 +13,8 @@ variable "role_arn" {
   description = "Role to grant permissions to"
   type        = string
 }
+
+variable "de_role_arn" {
+  description = "DE Role to grant permissions to"
+  type        = string
+}


### PR DESCRIPTION
Introduce permissions for the DE role in the lakeformation_database_share module, allowing it to access data locations and databases. Update the module to accept a DE role ARN for permission grants.