### PR TITLE
TM-861: add ec2 throughput to dashboards

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
@@ -12,8 +12,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         # CloudWatch agent not running, monitored by Glenn Bot instead
       ]
     }
@@ -33,8 +36,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -58,8 +64,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         # CloudWatch agent not running, monitored by Glenn Bot instead
       ]
     }

--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -36,8 +36,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-a" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -69,8 +72,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-csr-db-b" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,

--- a/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
@@ -19,8 +19,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
@@ -60,8 +63,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -90,8 +96,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -112,8 +121,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -64,8 +64,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "prod-nomis-db-1-a" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -108,8 +111,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "prod-nomis-db-1-b" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -141,8 +147,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "prod-nomis-db-2-a" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -185,8 +194,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "prod-nomis-db-2-b" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,

--- a/terraform/environments/oasys/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/oasys/locals_cloudwatch_dashboards.tf
@@ -16,8 +16,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
@@ -57,8 +60,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -87,8 +93,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -109,8 +118,11 @@ locals {
       }
       widgets = [
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -63,8 +63,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-oasys-db-a" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,
@@ -107,8 +110,11 @@ locals {
             search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-oasys-db-b" }] }
             widgets = [
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.free-disk-space-low,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.high-memory-usage,
               module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_linux.cpu-iowait-high,

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -33,8 +33,7 @@ locals {
       }
       network-in-bandwidth = {
         type              = "metric"
-        expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')"
-        expression_math   = "SORT(q1/(125000*300),SUM,DESC)"
+        expression        = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')/(125000*300),SUM,DESC)"
         expression_period = 300
         properties = {
           view    = "timeSeries"
@@ -52,8 +51,7 @@ locals {
       }
       network-out-bandwidth = {
         type              = "metric"
-        expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')"
-        expression_math   = "SORT(q1/(125000*300),SUM,DESC)"
+        expression        = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')/(125000*300),SUM,DESC)"
         expression_period = 300
         properties = {
           view    = "timeSeries"

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -34,7 +34,7 @@ locals {
       network-in-bandwidth = {
         type            = "metric"
         expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum'),SUM,DESC)"
-        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1)),SUM,DESC))"
+        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1))),SUM,DESC)"
         properties = {
           view    = "timeSeries"
           stacked = true
@@ -52,7 +52,7 @@ locals {
       network-out-bandwidth = {
         type            = "metric"
         expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum'),SUM,DESC)"
-        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1)),SUM,DESC))"
+        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1))),SUM,DESC)"
         properties = {
           view    = "timeSeries"
           stacked = true

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -32,15 +32,16 @@ locals {
         }
       }
       network-in-bandwidth = {
-        type            = "metric"
-        expression      = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')"
-        expression_math = "(8*q1)/(1000000*DIFF_TIME(IF(AVG(q1) == 0,1,AVG(q1))))"
+        type              = "metric"
+        expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')"
+        expression_math   = "q1/(125000*300)"
+        expression_period = 300
         properties = {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 network-in-bandwidth"
-          stat    = "Sum"
+          stat    = "Average"
           yAxis = {
             left = {
               showUnits = false,
@@ -50,15 +51,16 @@ locals {
         }
       }
       network-out-bandwidth = {
-        type            = "metric"
-        expression      = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')"
-        expression_math = "(8*q1)/(1000000*DIFF_TIME(AVG(q1)))"
+        type              = "metric"
+        expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')"
+        expression_math   = "q1/(125000*60)"
+        expression_period = 60
         properties = {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 network-out-bandwidth"
-          stat    = "Sum"
+          stat    = "Average"
           yAxis = {
             left = {
               showUnits = false,

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -31,6 +31,42 @@ locals {
           }
         }
       }
+      network-in-bandwidth = {
+        type            = "metric"
+        expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum'),SUM,DESC)"
+        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1)),SUM,DESC))"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "EC2 network-in-bandwidth"
+          stat    = "Sum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "Mbps"
+            }
+          }
+        }
+      }
+      network-out-bandwidth = {
+        type            = "metric"
+        expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum'),SUM,DESC)"
+        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1)),SUM,DESC))"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "EC2 network-out-bandwidth"
+          stat    = "Sum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "Mbps"
+            }
+          }
+        }
+      }
       instance-status-check-failed = {
         type            = "metric"
         alarm_threshold = 1
@@ -58,6 +94,24 @@ locals {
           stacked = true
           region  = "eu-west-2"
           title   = "EC2 system-status-check-failed"
+          stat    = "Maximum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "exitcode"
+            }
+          }
+        }
+      }
+      attached-ebs-status-check-failed = {
+        type            = "metric"
+        alarm_threshold = 1
+        expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"StatusCheckFailed_AttachedEBS\"','Maximum'),MAX,DESC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "EC2 attached-ebs-status-check-failed"
           stat    = "Maximum"
           yAxis = {
             left = {
@@ -965,8 +1019,11 @@ locals {
       height          = 8
       widgets = [
         local.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        local.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        local.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
         local.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         local.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        local.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed
       ]
     }
     ec2_windows = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -34,13 +34,13 @@ locals {
       network-in-bandwidth = {
         type              = "metric"
         expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')"
-        expression_math   = "q1/(125000*300)"
+        expression_math   = "SORT(q1/(125000*300),SUM,DESC)"
         expression_period = 300
         properties = {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
-          title   = "EC2 network-in-bandwidth"
+          title   = "EC2 network-in-5min-average"
           stat    = "Average"
           yAxis = {
             left = {
@@ -53,13 +53,13 @@ locals {
       network-out-bandwidth = {
         type              = "metric"
         expression        = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')"
-        expression_math   = "q1/(125000*60)"
-        expression_period = 60
+        expression_math   = "SORT(q1/(125000*300),SUM,DESC)"
+        expression_period = 300
         properties = {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
-          title   = "EC2 network-out-bandwidth"
+          title   = "EC2 network-out-5min-average"
           stat    = "Average"
           yAxis = {
             left = {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -33,8 +33,8 @@ locals {
       }
       network-in-bandwidth = {
         type            = "metric"
-        expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum'),SUM,DESC)"
-        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1))),SUM,DESC)"
+        expression      = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkIn\"','Sum')"
+        expression_math = "(8*q1)/(1000000*DIFF_TIME(IF(AVG(q1) == 0,1,AVG(q1))))"
         properties = {
           view    = "timeSeries"
           stacked = true
@@ -51,8 +51,8 @@ locals {
       }
       network-out-bandwidth = {
         type            = "metric"
-        expression      = "SORT(SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum'),SUM,DESC)"
-        expression_math = "SORT((8*q1)/(1000000*DIFF_TIME(AVG(q1))),SUM,DESC)"
+        expression      = "SEARCH('{AWS/EC2,InstanceId} MetricName=\"NetworkOut\"','Sum')"
+        expression_math = "(8*q1)/(1000000*DIFF_TIME(AVG(q1)))"
         properties = {
           view    = "timeSeries"
           stacked = true

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -706,6 +706,24 @@ locals {
           }
         }
       }
+      load-balancer-processed-bandwidth = {
+        type              = "metric"
+        expression        = "SORT(SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"ProcessedBytes\"','Sum')/(125000*300),SUM,DESC)"
+        expression_period = 300
+        properties = {
+          view    = "timeSeries"
+          stacked = true
+          region  = "eu-west-2"
+          title   = "ALB processed-data-5min-average"
+          stat    = "Average"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "Mbps"
+            }
+          }
+        }
+      }
       unhealthy-load-balancer-host = {
         type            = "metric"
         expression      = "SORT(SEARCH('{AWS/ApplicationELB,LoadBalancer,TargetGroup} MetricName=\"UnHealthyHostCount\"','Maximum'),MAX,DESC)"
@@ -812,19 +830,20 @@ locals {
           }
         }
       }
-      load-balancer-processed-bytes = {
-        type       = "metric"
-        expression = "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"ProcessedBytes\"','Sum'),SUM,DESC)"
+      load-balancer-processed-bandwidth = {
+        type              = "metric"
+        expression        = "SORT(SEARCH('{AWS/NetworkELB,LoadBalancer,LoadBalancer} MetricName=\"ProcessedBytes\"','Sum')/(125000*300),SUM,DESC)"
+        expression_period = 300
         properties = {
           view    = "timeSeries"
           stacked = true
           region  = "eu-west-2"
-          title   = "NLB processed-bytes"
-          stat    = "Sum"
+          title   = "NLB processed-data-5min-average"
+          stat    = "Average"
           yAxis = {
             left = {
               showUnits = false,
-              label     = "processed bytes"
+              label     = "Mbps"
             }
           }
         }
@@ -1129,15 +1148,15 @@ locals {
         local.cloudwatch_dashboard_widgets.lb.load-balancer-requests,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-4XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-http-5XXs,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-processed-bandwidth,
+        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
+        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-requests,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-4XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-group-http-5XXs,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-active-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-new-connections,
         local.cloudwatch_dashboard_widgets.lb.load-balancer-target-connection-errors,
-        local.cloudwatch_dashboard_widgets.lb.unhealthy-load-balancer-host,
-        local.cloudwatch_dashboard_widgets.lb.load-balancer-target-response-time,
-        null,
       ]
     }
     network_lb = {
@@ -1148,7 +1167,7 @@ locals {
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-unhealthy-host-count,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-active-flow-count,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-new-flow-count,
-        local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-bytes,
+        local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-bandwidth,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-processed-packets,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-peak-packets-per-second,
         local.cloudwatch_dashboard_widgets.network_lb.load-balancer-port-allocation-error-count,

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -101,11 +101,19 @@ locals {
       properties = merge(
         widget.properties,
         lookup(widget, "expression", null) == null ? {} : {
-          metrics = [[{
-            expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
-            label      = ""
-            id         = "q1"
-          }]]
+          metrics = [concat(
+            [{
+              expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
+              label      = ""
+              id         = "q1"
+              visible    = lookup(widget, "expression_math", null) == null ? true : false
+            }],
+            lookup(widget, "expression_math", null) == null ? [] : [{
+              expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
+              label      = ""
+              id         = "m1"
+            }]
+          )]
         },
         lookup(widget, "alarm_threshold", null) == null ? {} : {
           # Annotation currently failing with 'Should match exactly one schema in oneOf' error

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -101,19 +101,19 @@ locals {
       properties = merge(
         widget.properties,
         lookup(widget, "expression", null) == null ? {} : {
-          metrics = [concat(
-            [{
+          metrics = concat(
+            [[{
               expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
               label      = ""
               id         = "q1"
-              visible    = lookup(widget, "expression_math", null) == null ? true : false
-            }],
-            lookup(widget, "expression_math", null) == null ? [] : [{
-              expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
+              # visible    = lookup(widget, "expression_math", null) == null ? true : false
+            }]],
+            lookup(widget, "expression_math", null) == null ? [] : [[{
+              expression = widget.expression_math
               label      = ""
               id         = "m1"
-            }]
-          )]
+            }]]
+          )
         },
         lookup(widget, "alarm_threshold", null) == null ? {} : {
           # Annotation currently failing with 'Should match exactly one schema in oneOf' error

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -102,17 +102,27 @@ locals {
         widget.properties,
         lookup(widget, "expression", null) == null ? {} : {
           metrics = concat(
-            [[{
-              expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
-              label      = ""
-              id         = "q1"
-              visible    = lookup(widget, "expression_math", null) == null ? true : false
-            }]],
-            lookup(widget, "expression_math", null) == null ? [] : [[{
-              expression = widget.expression_math
-              label      = ""
-              id         = "m1"
-            }]]
+            [[merge(
+              {
+                expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
+                label      = ""
+                id         = "q1"
+                visible    = lookup(widget, "expression_math", null) == null ? true : false
+              },
+              lookup(widget, "expression_period", null) == null ? {} : {
+                period = widget.expression_period
+              }
+            )]],
+            lookup(widget, "expression_math", null) == null ? [] : [[merge(
+              {
+                expression = widget.expression_math
+                label      = ""
+                id         = "m1"
+              },
+              lookup(widget, "expression_period", null) == null ? {} : {
+                period = widget.expression_period
+              }
+            )]]
           )
         },
         lookup(widget, "alarm_threshold", null) == null ? {} : {

--- a/terraform/modules/cloudwatch_dashboard/main.tf
+++ b/terraform/modules/cloudwatch_dashboard/main.tf
@@ -106,7 +106,7 @@ locals {
               expression = lookup(widget, "search_filter", null) == null ? widget.expression : replace(widget.expression, "MetricName=", "${widget.search_filter} MetricName=")
               label      = ""
               id         = "q1"
-              # visible    = lookup(widget, "expression_math", null) == null ? true : false
+              visible    = lookup(widget, "expression_math", null) == null ? true : false
             }]],
             lookup(widget, "expression_math", null) == null ? [] : [[{
               expression = widget.expression_math

--- a/terraform/modules/cloudwatch_dashboard/variables.tf
+++ b/terraform/modules/cloudwatch_dashboard/variables.tf
@@ -55,6 +55,7 @@ variable "widget_groups" {
   #   widgets         = list(any)            # as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
   #   NOTE: widget can also use following fields for module only
   #     expression      = "" # automatically create metrics[] with expression
+  #     expression_math = "" # if additional maths need to be applied to the expression
   #     search_filter   = "" # additional search filter, e.g. InstanceId=(i-05a8b662eb6a6a5f6 OR i-065e9f701ab8fda22)
   #                                                           NOT InstanceId=(i-05a8b662eb6a6a5f6 OR i-065e9f701ab8fda22)
   #     alarm_threshold = number # automatically create horizontal annotation (if supported)

--- a/terraform/modules/cloudwatch_dashboard/variables.tf
+++ b/terraform/modules/cloudwatch_dashboard/variables.tf
@@ -54,9 +54,10 @@ variable "widget_groups" {
   #   }))
   #   widgets         = list(any)            # as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html
   #   NOTE: widget can also use following fields for module only
-  #     expression      = "" # automatically create metrics[] with expression
-  #     expression_math = "" # if additional maths need to be applied to the expression
-  #     search_filter   = "" # additional search filter, e.g. InstanceId=(i-05a8b662eb6a6a5f6 OR i-065e9f701ab8fda22)
+  #     expression        = string # automatically create metrics[] with expression
+  #     expression_math   = string # if additional maths need to be applied to the expression
+  #     expression_period = number # optionally fix the time period
+  #     search_filter     = string # additional search filter, e.g. InstanceId=(i-05a8b662eb6a6a5f6 OR i-065e9f701ab8fda22)
   #                                                           NOT InstanceId=(i-05a8b662eb6a6a5f6 OR i-065e9f701ab8fda22)
   #     alarm_threshold = number # automatically create horizontal annotation (if supported)
   # }))


### PR DESCRIPTION
On request from Glenn, add additional widget showing network bandwidth (in Megabits / second)
- ec2 network in
- ec2 network out
- ebs attachment status
- alb processed data
Updated nlb processed data to align with the above.

Seems to have worked in nomis-test and hmpps-oem-test