### PR TITLE
PI-2526 SageMaker resources to support Probation Search

### DIFF
--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -465,3 +465,19 @@ module "actions_runner_cache_efs_kms" {
 
   tags = local.tags
 }
+
+module "sagemaker_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["sagemaker"]
+  description           = "KMS key for SageMaker encryption-at-rest"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -1,0 +1,119 @@
+# ------------------------------------------------------------------------------
+# Cloud Platform namespace mapping
+# ------------------------------------------------------------------------------
+locals {
+  probation_search_environments = {
+    analytical-platform-compute-development = {
+      hmpps-probation-search-dev = {
+        namespace     = "hmpps-probation-search-dev"
+        instance_type = "ml.t2.medium"
+      }
+    }
+    analytical-platform-compute-production = {
+      hmpps-probation-search-preprod = {
+        namespace     = "hmpps-probation-search-preprod"
+        instance_type = "ml.t2.medium"
+      },
+      hmpps-probation-search-prod = {
+        namespace     = "hmpps-probation-search-prod"
+        instance_type = "ml.g6.xlarge"
+      }
+    }
+  }
+  probation_search_environment = lookup(local.probation_search_environments, terraform.workspace, {})
+}
+
+# ------------------------------------------------------------------------------
+# SageMaker
+# ------------------------------------------------------------------------------
+resource "aws_sagemaker_model" "probation_search_huggingface_embedding_model" {
+  #checkov:skip=CKV_AWS_370:Network isolation must be disabled to enable us to pull the model from Huggingface
+  for_each           = tomap(local.probation_search_environment)
+  name               = "${each.value.namespace}-sagemaker-hf-model"
+  execution_role_arn = aws_iam_role.probation_search_sagemaker_execution_role[each.key].arn
+  primary_container {
+    image = "764974769150.dkr.ecr.eu-west-2.amazonaws.com/tei:2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
+    environment = {
+      HF_MODEL_ID = "mixedbread-ai/mxbai-embed-large-v1"
+    }
+  }
+}
+
+resource "aws_sagemaker_endpoint_configuration" "probation_search_config" {
+  for_each    = tomap(local.probation_search_environment)
+  name        = "${each.value.namespace}-sagemaker-endpoint-config"
+  kms_key_arn = module.sagemaker_kms.key_arn
+  production_variants {
+    variant_name           = "AllTraffic"
+    model_name             = aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key].name
+    initial_instance_count = 1
+    instance_type          = each.value.instance_type
+  }
+}
+
+resource "aws_sagemaker_endpoint" "probation_search_endpoint" {
+  for_each             = tomap(local.probation_search_environment)
+  name                 = "${each.value.namespace}-sagemaker-endpoint"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.probation_search_config[each.key].name
+}
+
+
+# ------------------------------------------------------------------------------
+# IAM Permissions
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "probation_search_sagemaker_invoke_role" {
+  for_each = tomap(local.probation_search_environment)
+  name     = "${each.value.namespace}-sagemaker-role"
+
+  ## Allow role in Account A (MOJ Cloud Platform account) to assume this role and invoke SageMaker in Account B (Analytical Platform Compute account on MOJ Modernisation Platform)
+  ## See https://github.com/opensearch-project/ml-commons/blob/f741f71fff0d2ef6df7a3a62729cc1cb0953a37c/docs/tutorials/aws/semantic_search_with_bedrock_titan_embedding_model_in_another_account.md
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AssumeFromCloudPlatform"
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = "arn:aws:iam::754256621582:role/${each.value.namespace}-xa-opensearch-to-sagemaker"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "probation_search_sagemaker_invoke_policy" {
+  for_each = tomap(local.probation_search_environment)
+  role     = aws_iam_role.probation_search_sagemaker_invoke_role[each.key].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sagemaker:InvokeEndpointAsync",
+          "sagemaker:InvokeEndpoint"
+        ]
+        Resource = aws_sagemaker_endpoint.probation_search_endpoint[each.key].arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "probation_search_sagemaker_execution_role" {
+  for_each = tomap(local.probation_search_environment)
+  name     = "${each.value.namespace}-sagemaker-exec-policy"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
Creates a SageMaker endpoint in the analytical-platform-compute account, with an IAM role that can be assumed from an OpenSearch connector in Cloud Platform.  This is to explore using SageMaker in Analytical Platform / Modernisation Platform to support semantic search for probation data.

Initially using a very basic configuration with a publicly available model and image, to prove the end-to-end process.

Related changes:
* IAM role - https://github.com/ministryofjustice/cloud-platform-environments/pull/28893
* OpenSearch configuration - https://github.com/ministryofjustice/hmpps-probation-integration-services/pull/4541