### PR TITLE
use v3.0.0 release of ec2_instance and ec2_asg modules

### DIFF
--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -15,7 +15,7 @@ module "ec2_autoscaling_group" {
 
   for_each = var.ec2_autoscaling_groups
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v3.0.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -3,7 +3,7 @@ module "ec2_instance" {
 
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v3.0.0"
 
   providers = {
     aws.core-vpc = aws.core-vpc


### PR DESCRIPTION
**IMPORTANT NOTE**: Updating these module versions is a one-way only change!! 

IF there is an issue with using the v3.0.0 module version your choices are to destroy/rebuild or fix forwards! 

* Destroy what you've deployed, revert this PR and re-deploy what you've deployed FROM SCRATCH is possible... 
  * HOWEVER this will only work if no-one else has deployed anything using the new v3.0.0 module version already!
  * Just trying to revert to use an earlier module version for resources which have already been deployed against the new v3.0.0. tag of these modules won't work

The recommended solution is to fix forward whatever the issue is in the v3.0.0 release of the ec2_instance and ec2_autoscaling_group modules. We're replacing the deprecated parameter with a new one which should behave in exactly the same way so no changes in functionality should be seen.

ec2_instance module changes are [here](https://github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance/pull/556/files)

ec2_autoscaling_group module changes are [here](https://github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group/commit/cddbb56d7acf529f08beea23a8bdb807c0b7ba0d)