### PR TITLE
TM-860: nomis: update pinned config management branch part1

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -240,7 +240,7 @@ locals {
         })
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.web.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.web.user_data_cloud_init.args, {
-            branch = "86471c5730194674959e03fff043a6b4d2d1a92f" # DSOS-2838 memory fix
+            branch = "753de472568b54954ea0cb8fe6fb8d28ecf33aa3" # 2025-01-14 nomis release
           })
         })
         tags = merge(local.ec2_autoscaling_groups.web.tags, {


### PR DESCRIPTION
New version of nomis has gone out - test the new branch in the inactive deployment