### PR TITLE
TM-860: nomis: update number of webservers to 6 using latest release

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -254,7 +254,7 @@ locals {
       # ACTIVE (green deployment)
       prod-nomis-web-b = merge(local.ec2_autoscaling_groups.web, {
         autoscaling_group = merge(local.ec2_autoscaling_groups.web.autoscaling_group, {
-          desired_capacity = 5
+          desired_capacity = 6
           max_size         = 6
 
           initial_lifecycle_hooks = {
@@ -283,7 +283,7 @@ locals {
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.web.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.web.user_data_cloud_init.args, {
             # Comment in instance refresh above if changing branch + want automated instance refresh
-            branch = "86471c5730194674959e03fff043a6b4d2d1a92f" # DSOS-2838 memory fix
+            branch = "753de472568b54954ea0cb8fe6fb8d28ecf33aa3" # 2025-01-14 nomis release
           })
         })
         tags = merge(local.ec2_autoscaling_groups.web.tags, {


### PR DESCRIPTION
Following incident review, increase the number of prod web servers to 6.
Also update pinned branch to the latest. This has been tested in the -a deployment already.