### PR TITLE
Revert changes to dependabot script

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -33,13 +33,16 @@ updates:
       interval: "daily"
     reviewers:
       - "ministryofjustice/devcontainer-community"
+  # Dependabot doesn't currently support wildcard or multiple directory declarations within
+  # a dependabot configuration, so we need to add all directories individually
+  # See: github.com/dependabot/dependabot-core/issues/2178
 EOL
 
-echo "Generating entry for Terraform ecosystem"
+for folder in $all_tf_folders
+do
+echo "Generating entry for ${folder}"
 echo "  - package-ecosystem: \"terraform\"" >> $dependabot_file
-echo "    directories:" >> $dependabot_file
-for folder in $all_tf_folders; do
-  echo "      - \"/$folder\"" >> $dependabot_file
-done
+echo "    directory: \"/${folder}\"" >> $dependabot_file
 echo "    schedule:" >> $dependabot_file
 echo "      interval: \"daily\"" >> $dependabot_file
+done


### PR DESCRIPTION
Tracked upstream by [#7053](https://github.com/ministryofjustice/modernisation-platform/issues/7053).

This PR reverts the use of the `directories:` key as this was leading to failed dependabot runs.