### PR TITLE
✨ Add Audit Log Streaming Infrastructure for GitHub

### DIFF
--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -1,7 +1,21 @@
+data "external" "build_lambdas" {
+  program = [
+    "bash", "-c",
+    <<EOT
+      cd .terraform/modules/github-cloudtrail-auditlog &&
+      make all > /dev/null 2>&1 &&
+      echo '{"status": "success"}'
+    EOT
+  ]
+}
+
 module "github-cloudtrail-auditlog" {
   source                          = "github.com/ministryofjustice/operations-engineering-cloudtrail-lake-github-audit-log-terraform-module?ref=main"
   create_github_auditlog_s3bucket = true
   github_auditlog_s3bucket        = "github-audit-log-landing"
   cloudtrail_lake_channel_arn     = "arn:aws:cloudtrail:eu-west-2:211125434264:channel/810d471f-21e9-4552-b839-9e334f7fbe51"
   github_audit_allow_list         = ".*"
+
+  # Ensure the module waits for Lambdas to be built
+  depends_on = [data.external.build_lambdas]
 }

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -10,7 +10,7 @@ data "external" "build_lambdas" {
 }
 
 module "github-cloudtrail-auditlog" {
-  source                          = "github.com/ministryofjustice/operations-engineering-cloudtrail-lake-github-audit-log-terraform-module?ref=main"
+  source                          = "github.com/ministryofjustice/operations-engineering-cloudtrail-lake-github-audit-log-terraform-module?ref=299e5774acd66d86909e8a77017ee420ff79028e" # v1.0.0
   create_github_auditlog_s3bucket = true
   github_auditlog_s3bucket        = "github-audit-log-landing"
   cloudtrail_lake_channel_arn     = "arn:aws:cloudtrail:eu-west-2:211125434264:channel/810d471f-21e9-4552-b839-9e334f7fbe51"

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -2,27 +2,6 @@ module "github-cloudtrail-auditlog" {
   source                          = "github.com/ministryofjustice/operations-engineering-cloudtrail-lake-github-audit-log-terraform-module?ref=main"
   create_github_auditlog_s3bucket = true
   github_auditlog_s3bucket        = "github-audit-log-landing"
-  cloudtrail_lake_channel_arn     = aws_cloudtrail_channel.github_channel.arn
+  cloudtrail_lake_channel_arn     = "arn:aws:cloudtrail:eu-west-2:211125434264:channel/810d471f-21e9-4552-b839-9e334f7fbe51"
   github_audit_allow_list         = ".*"
-}
-
-resource "aws_cloudtrail_event_data_store" "github_audit_logs" {
-  name                           = "github-audit-logs-store"
-  retention_period               = 90
-  termination_protection_enabled = true
-
-  advanced_event_selector {
-    name = "GitHubAuditLogs"
-    field_selector {
-      field  = "eventSource"
-      equals = ["GitHub"]
-    }
-  }
-}
-
-resource "aws_cloudtrail_channel" "github_channel" {
-  name                    = "github-audit-log-channel"
-  source                  = "Github"
-  destinations            = [aws_cloudtrail_event_data_store.github_audit_logs.arn]
-  advanced_event_selector = aws_cloudtrail_event_data_store.github_audit_logs.advanced_event_selector
 }

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -1,0 +1,28 @@
+module "github-cloudtrail-auditlog" {
+  source                          = "github.com/ministryofjustice/operations-engineering-cloudtrail-lake-github-audit-log-terraform-module?ref=main"
+  create_github_auditlog_s3bucket = true
+  github_auditlog_s3bucket        = "github-audit-log-landing"
+  cloudtrail_lake_channel_arn     = aws_cloudtrail_channel.github_channel.arn
+  github_audit_allow_list         = ".*"
+}
+
+resource "aws_cloudtrail_event_data_store" "github_audit_logs" {
+  name                           = "github-audit-logs-store"
+  retention_period               = 90
+  termination_protection_enabled = true
+
+  advanced_event_selector {
+    name = "GitHubAuditLogs"
+    field_selector {
+      field  = "eventSource"
+      equals = ["GitHub"]
+    }
+  }
+}
+
+resource "aws_cloudtrail_channel" "github_channel" {
+  name                    = "github-audit-log-channel"
+  source                  = "Github"
+  destinations            = [aws_cloudtrail_event_data_store.github_audit_logs.arn]
+  advanced_event_selector = aws_cloudtrail_event_data_store.github_audit_logs.advanced_event_selector
+}

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -1,3 +1,4 @@
+# tflint-ignore: terraform_required_providers
 data "external" "build_lambdas" {
   program = [
     "bash", "-c",


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5127
- To re-create the infrastructure that currently exists in the MoJ Digital Services account to migrate workloads to Modernisation Platform Accounts

## ♻️ What's changed

- Added required infrastructure for GitHub Audit Log Streaming

## 📝 Notes

- Currently doing a like for like migration, optimisations will come later