### PR TITLE
✨ Add Access For GitHub Audit Log Streaming

### DIFF
--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -20,3 +20,13 @@ module "github-cloudtrail-auditlog" {
   # Ensure the module waits for Lambdas to be built
   depends_on = [data.external.build_lambdas]
 }
+
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://oidc-configuration.audit-log.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+}
+

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -29,6 +29,10 @@ resource "aws_iam_openid_connect_provider" "github" {
   ]
 }
 
+data "aws_kms_key" "key" {
+  key_id = "alias/GitHubCloudTrailOpenEvent"
+}
+
 resource "aws_iam_policy" "github_audit_log_write_policy" {
   name = "github-audit-log-write-policy"
   policy = jsonencode({
@@ -38,6 +42,15 @@ resource "aws_iam_policy" "github_audit_log_write_policy" {
         Effect   = "Allow"
         Action   = "s3:PutObject"
         Resource = "arn:aws:s3:::${module.github-cloudtrail-auditlog.github_auditlog_s3bucket}/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "kms:Encrypt",
+          "kms:ReEncrypt",
+          "kms:GenerateDataKey"
+        ],
+        "Resource" : data.aws_kms_key.key.arn
       }
     ]
   })

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -21,12 +21,25 @@ module "github-cloudtrail-auditlog" {
   depends_on = [data.external.build_lambdas]
 }
 
-
 resource "aws_iam_openid_connect_provider" "github" {
   url = "https://oidc-configuration.audit-log.githubusercontent.com"
 
   client_id_list = [
     "sts.amazonaws.com"
   ]
+}
+
+resource "aws_iam_policy" "github_audit_log_write_policy" {
+  name = "github-audit-log-write-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::${module.github-cloudtrail-auditlog.github_auditlog_s3bucket}/*"
+      }
+    ]
+  })
 }
 

--- a/terraform/environments/operations-engineering/audit_log_streaming_github.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github.tf
@@ -43,3 +43,30 @@ resource "aws_iam_policy" "github_audit_log_write_policy" {
   })
 }
 
+resource "aws_iam_role" "github_audit_log_role" {
+  name = "github-audit-log-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "oidc-configuration.audit-log.githubusercontent.com:aud" = "sts.amazonaws.com",
+            "oidc-configuration.audit-log.githubusercontent.com:sub" = "https://github.com/ministry-of-justice-uk"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy_attachment" "github_policy_attachment" {
+  name       = "github-audit-log-policy-attachment"
+  policy_arn = aws_iam_policy.github_audit_log_write_policy.arn
+  roles      = [aws_iam_role.github_audit_log_role.name]
+}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5127
- To give GitHub permissions to stream audit log data to S3 Bucket

## ♻️ What's changed

- Added GitHub OIDC Provider
- Added a role for GitHub to assume to write to S3 Bucket and Encrypt data using custom KMS Keys