### PR TITLE
✨ Add Role For GitHub Actions to Query CloudTrail

### DIFF
--- a/terraform/environments/operations-engineering/audit_log_streaming_github_cloudtrail.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_cloudtrail.tf
@@ -50,6 +50,8 @@ resource "aws_iam_policy" "cloudtrail_query_policy" {
           "cloudtrail:StartQuery",
           "cloudtrail:GetQueryResults"
         ],
+        #checkov:skip=CKV_AWS_290:Cannot not define specific resources for cloudtrail
+        #checkov:skip=CKV_AWS_355:Cannot not define specific resources for cloudtrail
         "Resource" : "*"
       }
     ]

--- a/terraform/environments/operations-engineering/audit_log_streaming_github_cloudtrail.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_cloudtrail.tf
@@ -1,10 +1,6 @@
 locals {
   oidc_provider = "token.actions.githubusercontent.com"
-}
-
-resource "aws_iam_openid_connect_provider" "github_actions" {
-  url            = "https://${local.oidc_provider}"
-  client_id_list = ["sts.amazonaws.com"]
+  account_id    = local.environment_management.account_ids[terraform.workspace]
 }
 
 data "aws_iam_policy_document" "github_actions_assume_role_policy_document" {
@@ -16,7 +12,7 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy_document" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+      identifiers = ["arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com"]
     }
 
     condition {


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5127
- To create a role that allows our Dormant Users Python script to query CloudTrail

## ♻️ What's changed

- Added GitHub Actions OIDC Provider
- Added Role for Dormant Users Python Script to assume to query CloudTrail