### PR TITLE
PI-2526 Add lifecycle block to SageMaker endpoint

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -74,6 +74,9 @@ resource "aws_sagemaker_endpoint" "probation_search_endpoint" {
   for_each             = tomap(local.probation_search_environment)
   name                 = "${each.value.namespace}-sagemaker-endpoint"
   endpoint_config_name = aws_sagemaker_endpoint_configuration.probation_search_config[each.key].name
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 


### PR DESCRIPTION
To hopefully fix https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/12827149197/job/35775569787#step:10:53
```
│ Error: creating SageMaker Endpoint (hmpps-probation-search-preprod-sagemaker-endpoint): operation error SageMaker: CreateEndpoint, https response error StatusCode: 400, RequestID: 3b74375b-21cd-4a28-ab64-0e5505b4d9ba, api error ValidationException: Cannot create already existing endpoint "arn:aws:sagemaker:eu-west-2:***:endpoint/hmpps-probation-search-preprod-sagemaker-endpoint".
│
│   with aws_sagemaker_endpoint.probation_search_endpoint["hmpps-probation-search-preprod"],
│   on sagemaker-probation-search.tf line 73, in resource "aws_sagemaker_endpoint" "probation_search_endpoint":
│   73: resource "aws_sagemaker_endpoint" "probation_search_endpoint" {
│
╵
```