### PR TITLE
🛂 Add Kubernetes role and role binding for MWAA service account management

### DIFF
--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -170,13 +170,18 @@ module "eks" {
       username          = "apc-mwaa"
       kubernetes_groups = ["mwaa"]
     }
+    gha-moj-ap-airflow = {
+      principal_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-actions-ministryofjustice-analytical-platform-airflow"
+      username          = "github-actions-moj-ap-airflow"
+      kubernetes_groups = ["mwaa-serviceaccount-management"]
+    }
+    /* Legacy Airflow */
     data-engineering-airflow = {
       principal_arn     = local.environment_configuration.data_engineering_airflow_execution_role_arn
       username          = "data-engineering-airflow"
       kubernetes_groups = ["airflow"]
     }
     github-actions-mojas-airflow = {
-      # principal_arn doesn't use the module output because they reference each other
       principal_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-actions-mojas-airflow"
       username          = "github-actions-mojas-airflow"
       kubernetes_groups = ["airflow-serviceaccount-management"]

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -627,6 +627,12 @@ data "aws_iam_policy_document" "gha_moj_ap_airflow" {
     ]
     resources = ["${module.mwaa_bucket.s3_bucket_arn}/*"]
   }
+  statement {
+    sid       = "EKSAccess"
+    effect    = "Allow"
+    actions   = ["eks:DescribeCluster"]
+    resources = [module.eks.cluster_arn]
+  }
 }
 
 module "gha_moj_ap_airflow_iam_policy" {

--- a/terraform/environments/analytical-platform-compute/kubernetes-role-bindings.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-role-bindings.tf
@@ -48,3 +48,20 @@ resource "kubernetes_role_binding" "mwaa_execution" {
     name      = "mwaa"
   }
 }
+
+resource "kubernetes_role_binding" "mwaa_serviceaccount_management" {
+  metadata {
+    name      = "mwaa-serviceaccount-management"
+    namespace = kubernetes_namespace.mwaa.metadata[0].name
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.mwaa_serviceaccount_management.metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = "mwaa-serviceaccount-management"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -85,3 +85,22 @@ resource "kubernetes_role" "mwaa_execution" {
     ]
   }
 }
+
+resource "kubernetes_role" "mwaa_serviceaccount_management" {
+  metadata {
+    name      = "airflow-serviceaccount-management"
+    namespace = kubernetes_namespace.mwaa.metadata[0].name
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["serviceaccounts"]
+    verbs = [
+      "create",
+      "delete",
+      "get",
+      "list",
+      "patch",
+      "update"
+    ]
+  }
+}


### PR DESCRIPTION
This pull request:

- Creates a new role and rolebinding for MWAA namespace base on existing Airflow
- Adds entry to EKS access for Airflow repo role

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 