### PR TITLE
add other trusted roles and allowed domains to fmd quicksight policy

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -476,7 +476,6 @@ data "aws_iam_policy_document" "find_moj_data_quicksight_policy" {
 
       values = [
         "https://dev.find-moj-data.service.justice.gov.uk",
-        "https://test.find-moj-data.service.justice.gov.uk",
         "https://preprod.find-moj-data.service.justice.gov.uk",
         "https://find-moj-data.service.justice.gov.uk"
       ]

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -476,6 +476,9 @@ data "aws_iam_policy_document" "find_moj_data_quicksight_policy" {
 
       values = [
         "https://dev.find-moj-data.service.justice.gov.uk",
+        "https://test.find-moj-data.service.justice.gov.uk",
+        "https://preprod.find-moj-data.service.justice.gov.uk",
+        "https://find-moj-data.service.justice.gov.uk"
       ]
     }
   }

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -407,7 +407,11 @@ module "find_moj_data_quicksight_sa_assumable_role" {
   version = "5.52.1"
 
   allow_self_assume_role = false
-  trusted_role_arns      = ["arn:aws:iam::754256621582:role/cloud-platform-irsa-e5ba8827240d2ff3-live"]
+  trusted_role_arns      = [
+    "arn:aws:iam::754256621582:role/cloud-platform-irsa-e5ba8827240d2ff3-live",
+    "arn:aws:iam::754256621582:role/cloud-platform-irsa-1003dc6e42f4229f-live",
+    "arn:aws:iam::754256621582:role/cloud-platform-irsa-25d122a26f9264de-live"
+  ]
 
   create_role       = true
   role_requires_mfa = false


### PR DESCRIPTION
adds in other allowed domains to the policy and the new IRSAs from prod and preprod to trusted role arns