### PR TITLE
Test native state locking with Cooker

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -121,8 +121,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
-          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
+          echo "terraform init"
+          terraform init
 
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/terraform/environments/cooker/platform_backend.tf
+++ b/terraform/environments/cooker/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cooker" # This will store the object as environments/members/cooker/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }


### PR DESCRIPTION
Tracked upstream by #[8345](https://github.com/ministryofjustice/modernisation-platform/issues/8345).

This PR is not meant to be merged in, it's a way for me to test the behaviour of GitHub actions with native state locking and no backend role assumption during `terraform init`.