### PR TITLE
if the config is too long we can't deploy it

### DIFF
--- a/terraform/environments/oasys-national-reporting/templates/cloud_watch_windows.json
+++ b/terraform/environments/oasys-national-reporting/templates/cloud_watch_windows.json
@@ -90,9 +90,7 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid",
-            "read_bytes",
-            "write_bytes"
+            "pid"
           ]
         },
         {
@@ -103,9 +101,7 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid",
-            "read_bytes",
-            "write_bytes"
+            "pid"
           ]
         },
         {
@@ -116,9 +112,7 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid",
-            "read_bytes",
-            "write_bytes"
+            "pid"
           ]
         },
         {
@@ -129,9 +123,7 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid",
-            "read_bytes",
-            "write_bytes"
+            "pid"
           ]
         }
       ]


### PR DESCRIPTION
In the current config we can't have an ssm doc > 4096 characters

Will ask Mod-Platform about changing this but in the meantime remove some params from procstat to take it to 3975 which makes it deployable