### PR TITLE
change param to advanced

### DIFF
--- a/terraform/environments/oasys-national-reporting/templates/cloud_watch_windows.json
+++ b/terraform/environments/oasys-national-reporting/templates/cloud_watch_windows.json
@@ -90,7 +90,9 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid"
+            "pid",
+            "read_bytes",
+            "write_bytes"
           ]
         },
         {
@@ -101,7 +103,9 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid"
+            "pid",
+            "read_bytes",
+            "write_bytes"
           ]
         },
         {
@@ -112,7 +116,9 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid"
+            "pid",
+            "read_bytes",
+            "write_bytes"
           ]
         },
         {
@@ -123,7 +129,9 @@
             "memory_rss",
             "num_threads",
             "pid_count",
-            "pid"
+            "pid",
+            "read_bytes",
+            "write_bytes"
           ]
         }
       ]

--- a/terraform/modules/baseline/ssm.tf
+++ b/terraform/modules/baseline/ssm.tf
@@ -120,6 +120,7 @@ resource "aws_ssm_parameter" "fixed" {
   type        = each.value.type
   key_id      = each.value.type == "SecureString" && each.value.kms_key_id != null ? try(var.environment.kms_keys[each.value.kms_key_id].arn, each.value.kms_key_id) : null
   value       = each.value.value
+  tier        = each.value.tier
 
   tags = merge(local.tags, {
     Name = each.key

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1105,7 +1105,7 @@ variable "ssm_parameters" {
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      teir        = optional(string, "Standard")
+      tier        = optional(string, "Standard")
       kms_key_id  = optional(string)
       file        = optional(string)
       random = optional(object({

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1105,6 +1105,7 @@ variable "ssm_parameters" {
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
+      teir        = optional(string, "Standard")
       kms_key_id  = optional(string)
       file        = optional(string)
       random = optional(object({

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1105,7 +1105,7 @@ variable "ssm_parameters" {
     parameters = map(object({
       description = optional(string)
       type        = optional(string, "SecureString")
-      tier        = optional(string, "Standard")
+      tier        = optional(string)
       kms_key_id  = optional(string)
       file        = optional(string)
       random = optional(object({

--- a/terraform/modules/baseline_presets/ssm.tf
+++ b/terraform/modules/baseline_presets/ssm.tf
@@ -196,6 +196,7 @@ locals {
           description = "cloud watch agent config for windows managed by baseline module"
           file        = local.cloud_watch_windows_filename
           type        = "String"
+          tier        = "Advanced"
         }
       }
     }


### PR DESCRIPTION
I think this is all that's needed to change the ssm parameter store for 'cloudwatch-config-windows' from Standard (4Kb) to 'Advanced' (8Kb)
- set defaults to null so nothing else is impacted
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter#tier-1