### PR TITLE
Replace use of `dynamodb_table` with `use_lockfile`

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -121,8 +121,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
-          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
+          echo "terraform init"
+          terraform init
 
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/.github/workflows/reusable_terraform_plan_apply_test.yml
+++ b/.github/workflows/reusable_terraform_plan_apply_test.yml
@@ -117,8 +117,8 @@ jobs:
         working-directory: "terraform/environments/${{ inputs.application }}"
         run: |
           terraform --version
-          echo "terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}"
-          terraform init -backend-config=assume_role={role_arn=\"arn:aws:iam::${{env.BACKEND_NUMBER}}:role/modernisation-account-terraform-state-member-access\"}
+          echo "terraform init"
+          terraform init
 
       - name: Terraform Workspace Select
         working-directory: "terraform/environments/${{ inputs.application }}"

--- a/terraform/environments/analytical-platform-common/platform_backend.tf
+++ b/terraform/environments/analytical-platform-common/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/analytical-platform-common" # This will store the object as environments/members/analytical-platform-common/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/analytical-platform-common/versions.tf
+++ b/terraform/environments/analytical-platform-common/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/analytical-platform-compute/platform_backend.tf
+++ b/terraform/environments/analytical-platform-compute/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/analytical-platform-compute" # This will store the object as environments/members/analytical-platform-compute/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/analytical-platform-compute/versions.tf
+++ b/terraform/environments/analytical-platform-compute/versions.tf
@@ -25,5 +25,5 @@ terraform {
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/analytical-platform-ingestion/platform_backend.tf
+++ b/terraform/environments/analytical-platform-ingestion/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/analytical-platform-ingestion" # This will store the object as environments/members/analytical-platform-ingestion/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/analytical-platform-ingestion/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/apex/platform_backend.tf
+++ b/terraform/environments/apex/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/apex" # This will store the object as environments/members/apex/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/apex/versions.tf
+++ b/terraform/environments/apex/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/ccms-ebs-upgrade/platform_backend.tf
+++ b/terraform/environments/ccms-ebs-upgrade/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/ccms-ebs-upgrade" # This will store the object as environments/members/ccms-ebs-upgrade/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/ccms-ebs-upgrade/versions.tf
+++ b/terraform/environments/ccms-ebs-upgrade/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/ccms-ebs/platform_backend.tf
+++ b/terraform/environments/ccms-ebs/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/ccms-ebs" # This will store the object as environments/members/ccms-ebs/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/ccms-ebs/versions.tf
+++ b/terraform/environments/ccms-ebs/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cdpt-chaps/platform_backend.tf
+++ b/terraform/environments/cdpt-chaps/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cdpt-chaps" # This will store the object as environments/members/cdpt-chaps/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cdpt-chaps/versions.tf
+++ b/terraform/environments/cdpt-chaps/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cdpt-ifs/platform_backend.tf
+++ b/terraform/environments/cdpt-ifs/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cdpt-ifs" # This will store the object as environments/members/cdpt-ifs/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cdpt-ifs/versions.tf
+++ b/terraform/environments/cdpt-ifs/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cica-copilot/platform_backend.tf
+++ b/terraform/environments/cica-copilot/platform_backend.tf
@@ -8,6 +8,7 @@ terraform {
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cica-copilot" # This will store the object as environments/members/cica-copilot/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cica-copilot/versions.tf
+++ b/terraform/environments/cica-copilot/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cica-data-extraction/platform_backend.tf
+++ b/terraform/environments/cica-data-extraction/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cica-data-extraction" # This will store the object as environments/members/cica-data-extraction/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cica-data-extraction/versions.tf
+++ b/terraform/environments/cica-data-extraction/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cica-tariff/platform_backend.tf
+++ b/terraform/environments/cica-tariff/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cica-tariff" # This will store the object as environments/members/cica-tariff/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cica-tariff/versions.tf
+++ b/terraform/environments/cica-tariff/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/contract-work-administration/platform_backend.tf
+++ b/terraform/environments/contract-work-administration/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/contract-work-administration" # This will store the object as environments/members/contract-work-administration/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/contract-work-administration/versions.tf
+++ b/terraform/environments/contract-work-administration/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 2.0"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/cooker/platform_backend.tf
+++ b/terraform/environments/cooker/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/cooker" # This will store the object as environments/members/cooker/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/corporate-information-system/platform_backend.tf
+++ b/terraform/environments/corporate-information-system/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/corporate-information-system" # This will store the object as environments/members/corporate-information-system/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/corporate-information-system/versions.tf
+++ b/terraform/environments/corporate-information-system/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/corporate-staff-rostering/platform_backend.tf
+++ b/terraform/environments/corporate-staff-rostering/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/corporate-staff-rostering" # This will store the object as environments/members/corporate-staff-rostering/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/corporate-staff-rostering/versions.tf
+++ b/terraform/environments/corporate-staff-rostering/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/dacp/platform_backend.tf
+++ b/terraform/environments/dacp/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/dacp" # This will store the object as environments/members/dacp/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/dacp/versions.tf
+++ b/terraform/environments/dacp/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/data-and-insights-wepi/platform_backend.tf
+++ b/terraform/environments/data-and-insights-wepi/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/data-and-insights-wepi" # This will store the object as environments/members/data-and-insights-wepi/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/data-and-insights-wepi/versions.tf
+++ b/terraform/environments/data-and-insights-wepi/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/data-platform-apps-and-tools/platform_backend.tf
+++ b/terraform/environments/data-platform-apps-and-tools/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/data-platform-apps-and-tools" # This will store the object as environments/members/data-platform-apps-and-tools/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/data-platform-apps-and-tools/versions.tf
+++ b/terraform/environments/data-platform-apps-and-tools/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/helm"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/data-platform/platform_backend.tf
+++ b/terraform/environments/data-platform/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/data-platform" # This will store the object as environments/members/data-platform/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/data-platform/versions.tf
+++ b/terraform/environments/data-platform/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-alfresco/platform_backend.tf
+++ b/terraform/environments/delius-alfresco/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-alfresco" # This will store the object as environments/members/delius-alfresco/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-alfresco/versions.tf
+++ b/terraform/environments/delius-alfresco/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-core/platform_backend.tf
+++ b/terraform/environments/delius-core/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-core" # This will store the object as environments/members/delius-core/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-core/versions.tf
+++ b/terraform/environments/delius-core/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-iaps/platform_backend.tf
+++ b/terraform/environments/delius-iaps/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-iaps" # This will store the object as environments/members/delius-iaps/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-iaps/versions.tf
+++ b/terraform/environments/delius-iaps/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-jitbit/platform_backend.tf
+++ b/terraform/environments/delius-jitbit/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-jitbit" # This will store the object as environments/members/delius-jitbit/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-jitbit/versions.tf
+++ b/terraform/environments/delius-jitbit/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-mis/platform_backend.tf
+++ b/terraform/environments/delius-mis/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-mis" # This will store the object as environments/members/delius-mis/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-mis/versions.tf
+++ b/terraform/environments/delius-mis/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/delius-nextcloud/platform_backend.tf
+++ b/terraform/environments/delius-nextcloud/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/delius-nextcloud" # This will store the object as environments/members/delius-nextcloud/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/delius-nextcloud/versions.tf
+++ b/terraform/environments/delius-nextcloud/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/apigateway/serverless-lambda-gw/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/apigateway/serverless-lambda-gw/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/ec2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/ec2/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/lambdas/generic/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/lambdas/generic/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/notifications/sns/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/notifications/sns/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
 
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/digital-prison-reporting/platform_backend.tf
+++ b/terraform/environments/digital-prison-reporting/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/digital-prison-reporting" # This will store the object as environments/members/digital-prison-reporting/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/digital-prison-reporting/versions.tf
+++ b/terraform/environments/digital-prison-reporting/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/edw/platform_backend.tf
+++ b/terraform/environments/edw/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/edw" # This will store the object as environments/members/edw/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/edw/versions.tf
+++ b/terraform/environments/edw/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/electronic-monitoring-data/platform_backend.tf
+++ b/terraform/environments/electronic-monitoring-data/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/electronic-monitoring-data" # This will store the object as environments/members/electronic-monitoring-data/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/electronic-monitoring-data/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/versions.tf
@@ -29,5 +29,5 @@ terraform {
       version = "~> 2.0"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/equip/platform_backend.tf
+++ b/terraform/environments/equip/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/equip" # This will store the object as environments/members/equip/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/equip/versions.tf
+++ b/terraform/environments/equip/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/eric/platform_backend.tf
+++ b/terraform/environments/eric/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/eric" # This will store the object as environments/members/eric/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/eric/versions.tf
+++ b/terraform/environments/eric/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/example/platform_backend.tf
+++ b/terraform/environments/example/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/example" # This will store the object as environments/members/example/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/example/versions.tf
+++ b/terraform/environments/example/versions.tf
@@ -21,5 +21,5 @@ terraform {
       version = "~> 3.0"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/genesys-call-centre-data/platform_backend.tf
+++ b/terraform/environments/genesys-call-centre-data/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/genesys-call-centre-data" # This will store the object as environments/members/genesys-call-centre-data/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/genesys-call-centre-data/versions.tf
+++ b/terraform/environments/genesys-call-centre-data/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/hmpps-domain-services/platform_backend.tf
+++ b/terraform/environments/hmpps-domain-services/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/hmpps-domain-services" # This will store the object as environments/members/hmpps-domain-services/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/hmpps-domain-services/versions.tf
+++ b/terraform/environments/hmpps-domain-services/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 2.4"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/hmpps-oem/platform_backend.tf
+++ b/terraform/environments/hmpps-oem/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/hmpps-oem" # This will store the object as environments/members/hmpps-oem/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/hmpps-oem/versions.tf
+++ b/terraform/environments/hmpps-oem/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_backend.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/laa-ccms-infra-azure-ad-sso" # This will store the object as environments/members/laa-ccms-infra-azure-ad-sso/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/versions.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/laa-mail-relay/platform_backend.tf
+++ b/terraform/environments/laa-mail-relay/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/laa-mail-relay" # This will store the object as environments/members/laa-mail-relay/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/laa-mail-relay/versions.tf
+++ b/terraform/environments/laa-mail-relay/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/laa-oem/platform_backend.tf
+++ b/terraform/environments/laa-oem/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/laa-oem" # This will store the object as environments/members/laa-oem/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/laa-oem/versions.tf
+++ b/terraform/environments/laa-oem/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/laa-stabilisation-cdc-poc/platform_backend.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/laa-stabilisation-cdc-poc" # This will store the object as environments/members/laa-stabilisation-cdc-poc/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/laa-stabilisation-cdc-poc/versions.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/long-term-storage/platform_backend.tf
+++ b/terraform/environments/long-term-storage/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/long-term-storage" # This will store the object as environments/members/long-term-storage/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/long-term-storage/versions.tf
+++ b/terraform/environments/long-term-storage/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/maat/platform_backend.tf
+++ b/terraform/environments/maat/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/maat" # This will store the object as environments/members/maat/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/maat/versions.tf
+++ b/terraform/environments/maat/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/maatdb/platform_backend.tf
+++ b/terraform/environments/maatdb/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/maatdb" # This will store the object as environments/members/maatdb/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/maatdb/versions.tf
+++ b/terraform/environments/maatdb/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/mlra/platform_backend.tf
+++ b/terraform/environments/mlra/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/mlra" # This will store the object as environments/members/mlra/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/mlra/versions.tf
+++ b/terraform/environments/mlra/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/mojfin/platform_backend.tf
+++ b/terraform/environments/mojfin/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/mojfin" # This will store the object as environments/members/mojfin/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/mojfin/versions.tf
+++ b/terraform/environments/mojfin/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/ncas/platform_backend.tf
+++ b/terraform/environments/ncas/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/ncas" # This will store the object as environments/members/ncas/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/ncas/versions.tf
+++ b/terraform/environments/ncas/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/nomis-combined-reporting/platform_backend.tf
+++ b/terraform/environments/nomis-combined-reporting/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/nomis-combined-reporting" # This will store the object as environments/members/nomis-combined-reporting/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/nomis-combined-reporting/versions.tf
+++ b/terraform/environments/nomis-combined-reporting/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/nomis-data-hub/platform_backend.tf
+++ b/terraform/environments/nomis-data-hub/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/nomis-data-hub" # This will store the object as environments/members/nomis-data-hub/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/nomis-data-hub/versions.tf
+++ b/terraform/environments/nomis-data-hub/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/nomis/platform_backend.tf
+++ b/terraform/environments/nomis/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/nomis" # This will store the object as environments/members/nomis/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/oas/platform_backend.tf
+++ b/terraform/environments/oas/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/oas" # This will store the object as environments/members/oas/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/oas/versions.tf
+++ b/terraform/environments/oas/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/oasys-national-reporting/platform_backend.tf
+++ b/terraform/environments/oasys-national-reporting/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/oasys-national-reporting" # This will store the object as environments/members/oasys-national-reporting/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/oasys-national-reporting/versions.tf
+++ b/terraform/environments/oasys-national-reporting/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/oasys/platform_backend.tf
+++ b/terraform/environments/oasys/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/oasys" # This will store the object as environments/members/oasys/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/oasys/versions.tf
+++ b/terraform/environments/oasys/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/observability-platform/platform_backend.tf
+++ b/terraform/environments/observability-platform/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/observability-platform" # This will store the object as environments/members/observability-platform/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/observability-platform/versions.tf
+++ b/terraform/environments/observability-platform/versions.tf
@@ -13,5 +13,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/operations-engineering/platform_backend.tf
+++ b/terraform/environments/operations-engineering/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/operations-engineering" # This will store the object as environments/members/operations-engineering/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/operations-engineering/versions.tf
+++ b/terraform/environments/operations-engineering/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/panda-cyber-appsec-lab/platform_backend.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/panda-cyber-appsec-lab" # This will store the object as environments/members/panda-cyber-appsec-lab/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/panda-cyber-appsec-lab/versions.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/performance-hub/platform_backend.tf
+++ b/terraform/environments/performance-hub/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/performance-hub" # This will store the object as environments/members/performance-hub/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/performance-hub/versions.tf
+++ b/terraform/environments/performance-hub/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/planetfm/platform_backend.tf
+++ b/terraform/environments/planetfm/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/planetfm" # This will store the object as environments/members/planetfm/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/planetfm/versions.tf
+++ b/terraform/environments/planetfm/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/portal/platform_backend.tf
+++ b/terraform/environments/portal/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/portal" # This will store the object as environments/members/portal/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/portal/versions.tf
+++ b/terraform/environments/portal/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/ppud/platform_backend.tf
+++ b/terraform/environments/ppud/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/ppud" # This will store the object as environments/members/ppud/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/ppud/versions.tf
+++ b/terraform/environments/ppud/versions.tf
@@ -17,5 +17,5 @@ terraform {
       source  = "hashicorp/archive"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/pra-register/platform_backend.tf
+++ b/terraform/environments/pra-register/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/pra-register" # This will store the object as environments/members/pra-register/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/pra-register/versions.tf
+++ b/terraform/environments/pra-register/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/refer-monitor/platform_backend.tf
+++ b/terraform/environments/refer-monitor/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/refer-monitor" # This will store the object as environments/members/refer-monitor/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/refer-monitor/versions.tf
+++ b/terraform/environments/refer-monitor/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/sprinkler/platform_backend.tf
+++ b/terraform/environments/sprinkler/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/sprinkler" # This will store the object as environments/members/sprinkler/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/sprinkler/versions.tf
+++ b/terraform/environments/sprinkler/versions.tf
@@ -17,5 +17,5 @@ terraform {
       version = "~> 2"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/tipstaff/platform_backend.tf
+++ b/terraform/environments/tipstaff/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/tipstaff" # This will store the object as environments/members/tipstaff/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/tipstaff/versions.tf
+++ b/terraform/environments/tipstaff/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/tribunals/platform_backend.tf
+++ b/terraform/environments/tribunals/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/tribunals" # This will store the object as environments/members/tribunals/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/tribunals/versions.tf
+++ b/terraform/environments/tribunals/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/wardship/platform_backend.tf
+++ b/terraform/environments/wardship/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/wardship" # This will store the object as environments/members/wardship/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/wardship/versions.tf
+++ b/terraform/environments/wardship/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/xhibit-portal/platform_backend.tf
+++ b/terraform/environments/xhibit-portal/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/xhibit-portal" # This will store the object as environments/members/xhibit-portal/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/environments/youth-justice-app-framework/modules/s3/variables.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/s3/variables.tf
@@ -46,4 +46,4 @@ variable "allow_replication" {
 variable "s3_source_account" {
   type        = string
   description = "Source account from whch s3 buckets may be replicated."
- }
+}

--- a/terraform/environments/youth-justice-app-framework/platform_backend.tf
+++ b/terraform/environments/youth-justice-app-framework/platform_backend.tf
@@ -5,10 +5,10 @@ terraform {
   backend "s3" {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"
-    dynamodb_table       = "modernisation-platform-terraform-state-lock"
     encrypt              = true
     key                  = "terraform.tfstate"
     region               = "eu-west-2"
+    use_lockfile         = true
     workspace_key_prefix = "environments/members/youth-justice-app-framework" # This will store the object as environments/members/youth-justice-app-framework/${workspace}/terraform.tfstate
   }
 }

--- a/terraform/environments/youth-justice-app-framework/versions.tf
+++ b/terraform/environments/youth-justice-app-framework/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/acm_certificate/versions.tf
+++ b/terraform/modules/acm_certificate/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.core-vpc, aws.core-network-services]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/baseline/versions.tf
+++ b/terraform/modules/baseline/versions.tf
@@ -10,5 +10,5 @@ terraform {
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/baseline_presets/versions.tf
+++ b/terraform/modules/baseline_presets/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/cloudwatch_dashboard/versions.tf
+++ b/terraform/modules/cloudwatch_dashboard/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/cost_usage_report/versions.tf
+++ b/terraform/modules/cost_usage_report/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.us-east-1, aws.bucket-replication]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/environment/versions.tf
+++ b/terraform/modules/environment/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.modernisation-platform]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/ip_addresses/versions.tf
+++ b/terraform/modules/ip_addresses/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/lb_listener/versions.tf
+++ b/terraform/modules/lb_listener/versions.tf
@@ -5,5 +5,5 @@ terraform {
       source  = "hashicorp/aws"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/schedule_alarms_lambda/versions.tf
+++ b/terraform/modules/schedule_alarms_lambda/versions.tf
@@ -9,5 +9,5 @@ terraform {
       source  = "hashicorp/archive"
     }
   }
-  required_version = "~> 1.8"
+  required_version = "~> 1.10"
 }

--- a/terraform/modules/shield_advanced/required_providers.tf
+++ b/terraform/modules/shield_advanced/required_providers.tf
@@ -10,5 +10,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 }


### PR DESCRIPTION
This PR is tracked upstream by #[8345](https://github.com/ministryofjustice/modernisation-platform/issues/8345). You can see the context for this PR in the linked issue. In short, though, we know that stale state file locks have been a source of some friction for our customers, and now that a better alternative exists we'd like to implement it for you.

You can see an example of this PR being tested in #9443 .

This PR does the following:
* Sets the minimum Terraform version to `1.10` in any `required_providers {}` block as this is the minimum version that allows the use of native S3 state locking
* Replaces the use of `dynamodb_table` with `use_lockfile` in all **platform_versions.tf**
* Removes the `-backend-config=` statements from `terraform init` steps in our reusable Terraform jobs.