### PR TITLE
🛂 Add `DeleteObject` permissions

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -101,6 +101,7 @@ data "aws_iam_policy_document" "analytical_platform_github_actions" {
     sid    = "AllowS3Write"
     effect = "Allow"
     actions = [
+      "s3:DeleteObject",
       "s3:GetObject",
       "s3:PutObject"
     ]


### PR DESCRIPTION
This pull request:

- Adds `DeleteObject` as per https://developer.hashicorp.com/terraform/language/backend/s3#permissions-required as we want to use workspaces

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 