### PR TITLE
🔀 Amend role assumption flow

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -80,7 +80,7 @@ module "ecr_access_iam_policy" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "analytical_platform_github_actions" {
+data "aws_iam_policy_document" "analytical_platform_terraform" {
   statement {
     sid    = "AllowKMS"
     effect = "Allow"
@@ -106,6 +106,29 @@ data "aws_iam_policy_document" "analytical_platform_github_actions" {
       "s3:PutObject"
     ]
     resources = ["${module.terraform_bucket.s3_bucket_arn}/*"]
+  }
+}
+
+module "analytical_platform_terraform_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.52.2"
+
+  name_prefix = "analytical-platform-terraform"
+
+  policy = data.aws_iam_policy_document.analytical_platform_terraform.json
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "analytical_platform_github_actions" {
+  statement {
+    sid       = "AllowAssumeRole"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = [module.analytical_platform_terraform_iam_role.arn]
   }
 }
 

--- a/terraform/environments/analytical-platform-common/iam-role.tf
+++ b/terraform/environments/analytical-platform-common/iam-role.tf
@@ -36,3 +36,26 @@ module "analytical_platform_github_actions_iam_role" {
 
   tags = local.tags
 }
+
+module "analytical_platform_terraform_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.52.2"
+
+  create_role = true
+
+  role_name         = "analytical-platform-terraform"
+  role_requires_mfa = true
+
+  trusted_role_arns = [
+    module.analytical_platform_github_actions_iam_role.arn
+  ]
+
+  custom_role_policy_arns = [
+    module.analytical_platform_terraform_iam_policy.arn
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
This pull request:

- Creates a new Terraform role that is used for the backend
- Updates the GitHub Actions role so it can only assume Terraform role

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 