### PR TITLE
🛂 Allow GHA role to assume infrastructure access role

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -128,7 +128,10 @@ data "aws_iam_policy_document" "analytical_platform_github_actions" {
     sid       = "AllowAssumeRole"
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
-    resources = [module.analytical_platform_terraform_iam_role.iam_role_arn]
+    resources = [
+      module.analytical_platform_terraform_iam_role.iam_role_arn,
+      "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/analytical-platform-infrastructure-access"
+    ]
   }
 }
 


### PR DESCRIPTION
This pull request:

- Allows `arn:aws:iam::509399598587:role/analytical-platform-github-actions` to assume `arn:aws:iam::593291632749:role/analytical-platform-infrastructure-access`

Reference: https://github.com/ministryofjustice/analytical-platform-airflow/actions/runs/12996713991/job/36246076658?pr=13

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 