### PR TITLE
🔒 Add resources for storing cluster data

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -125,12 +125,34 @@ module "analytical_platform_terraform_iam_policy" {
 
 data "aws_iam_policy_document" "analytical_platform_github_actions" {
   statement {
-    sid       = "AllowAssumeRole"
-    effect    = "Allow"
-    actions   = ["sts:AssumeRole"]
+    sid     = "AllowAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
     resources = [
       module.analytical_platform_terraform_iam_role.iam_role_arn,
       "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/analytical-platform-infrastructure-access"
+    ]
+  }
+  statement {
+    sid       = "AllowKMS"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [module.secrets_manager_common_kms.key_arn]
+  }
+  statement {
+    sid       = "AllowSecretsManager"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [module.secrets_manager_common.secret_arn]
+  }
+  statement {
+    sid     = "AllowEKS"
+    effect  = "Allow"
+    actions = ["eks:DescribeCluster"]
+    resources = [
+      "arn:aws:eks:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-development"]}:cluster/*",
+      "arn:aws:eks:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-test"]}:cluster/*",
+      "arn:aws:eks:eu-west-2:${local.environment_management.account_ids["analytical-platform-compute-production"]}:cluster/*"
     ]
   }
 }

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -143,7 +143,7 @@ data "aws_iam_policy_document" "analytical_platform_github_actions" {
     sid       = "AllowSecretsManager"
     effect    = "Allow"
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = [module.secrets_manager_common.secret_arn]
+    resources = [module.analytical_platform_compute_cluster_data_secret.secret_arn]
   }
   statement {
     sid     = "AllowEKS"

--- a/terraform/environments/analytical-platform-common/kms-keys.tf
+++ b/terraform/environments/analytical-platform-common/kms-keys.tf
@@ -29,3 +29,19 @@ module "terraform_s3_kms" {
 
   tags = local.tags
 }
+
+module "secrets_manager_common_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["secretsmanager/common"]
+  description           = "Secrets Manager Common KMS key"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-common/secrets.tf
+++ b/terraform/environments/analytical-platform-common/secrets.tf
@@ -2,8 +2,6 @@ module "analytical_platform_compute_cluster_data_secret" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
-
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "1.3.1"
 

--- a/terraform/environments/analytical-platform-common/secrets.tf
+++ b/terraform/environments/analytical-platform-common/secrets.tf
@@ -1,0 +1,19 @@
+module "analytical_platform_compute_cluster_data_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name       = "analytical-platform-compute/cluster-data"
+  kms_key_id = module.secrets_manager_common_kms.key_arn
+
+  secret_string = jsonencode({
+    change_me = "CHANGEME"
+  })
+  ignore_secret_changes = true
+
+  tags = local.tags
+}


### PR DESCRIPTION
This pull request:

- Creates a KMS key for common secrets
- Creates a secrets for APC cluster data
- Adds permissions to GHA role
  - Accessing KMS
  - Accessing Secret
  - Accessing EKS

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>  