### PR TITLE
Add 'scheduled' attribute to dynamo DPD table attributes

### DIFF
--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -30,13 +30,13 @@ module "dynamo_table_dpd" {
 
   global_secondary_indexes = [
     {
-      name            = "category-index"
-      hash_key        = "category"
+      name            = "scheduled-index"
+      hash_key        = "scheduled"
       projection_type = "ALL"
     },
     {
-      name            = "scheduled-index"
-      hash_key        = "scheduled"
+      name            = "category-index"
+      hash_key        = "category"
       projection_type = "ALL"
     }
   ]

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -26,9 +26,10 @@ module "dynamo_table_dpd" {
 
   global_secondary_indexes = [
     {
-      name            = "scheduled-index2"
+      name            = "scheduled-index"
       hash_key        = "scheduled"
       projection_type = "ALL"
+      range_key       = "data-product-id"
     },
     {
       name            = "category-index"

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -21,10 +21,6 @@ module "dynamo_table_dpd" {
     {
       name = "category"
       type = "S"
-    },
-    {
-      name = "scheduled"
-      type = "S"
     }
   ]
 
@@ -32,11 +28,6 @@ module "dynamo_table_dpd" {
     {
       name            = "category-index"
       hash_key        = "category"
-      projection_type = "ALL"
-    },
-    {
-      name            = "scheduled-index"
-      hash_key        = "scheduled"
       projection_type = "ALL"
     }
   ]

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -21,6 +21,10 @@ module "dynamo_table_dpd" {
     {
       name = "category"
       type = "S"
+    },
+    {
+      name = "scheduled"
+      type = "S"
     }
   ]
 

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -21,16 +21,12 @@ module "dynamo_table_dpd" {
     {
       name = "category"
       type = "S"
-    },
-    {
-      name = "scheduled"
-      type = "S"
     }
   ]
 
   global_secondary_indexes = [
     {
-      name            = "scheduled-index"
+      name            = "scheduled-index2"
       hash_key        = "scheduled"
       projection_type = "ALL"
     },

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -33,6 +33,11 @@ module "dynamo_table_dpd" {
       name            = "category-index"
       hash_key        = "category"
       projection_type = "ALL"
+    },
+    {
+      name            = "scheduled-index"
+      hash_key        = "scheduled"
+      projection_type = "ALL"
     }
   ]
 

--- a/terraform/environments/digital-prison-reporting/data_product_definitions.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions.tf
@@ -21,6 +21,10 @@ module "dynamo_table_dpd" {
     {
       name = "category"
       type = "S"
+    },
+    {
+      name = "scheduled"
+      type = "S"
     }
   ]
 
@@ -28,6 +32,11 @@ module "dynamo_table_dpd" {
     {
       name            = "category-index"
       hash_key        = "category"
+      projection_type = "ALL"
+    },
+    {
+      name            = "scheduled-index"
+      hash_key        = "scheduled"
       projection_type = "ALL"
     }
   ]


### PR DESCRIPTION
This fixes this pipeline error:

```│ Error: all indexes must match a defined attribute. Unmatched indexes: ["scheduled"]
│ 
│   with module.dynamo_table_dpd.aws_dynamodb_table.this[0],
│   on modules/dynamo_tables/main.tf line 1, in resource "aws_dynamodb_table" "this":
│    1: resource "aws_dynamodb_table" "this" {```