### PR TITLE
Add CloudWatch alarm for AWS Lambda errors with SNS notification

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch_alarms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch_alarms.tf
@@ -1,0 +1,22 @@
+resource "aws_sns_topic" "lambda_failure" {
+  name_prefix = "lambda-failure-"
+}
+
+# Alarm - "there is at least one error in a minute in AWS Lambda functions"
+module "all_lambdas_errors_alarm" {
+  source = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+
+  alarm_name          = "all-lambdas-errors"
+  alarm_description   = "Lambdas with errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 0
+  period              = 60
+  unit                = "Count"
+
+  namespace   = "AWS/Lambda"
+  metric_name = "Errors"
+  statistic   = "Maximum"
+
+  alarm_actions = [aws_sns_topic.lambda_failure.arn]
+}


### PR DESCRIPTION
Implement a CloudWatch alarm to monitor AWS Lambda errors and send notifications via SNS when errors occur.