### PR TITLE
✨ Add `operations-engineering` Team as Observability Platform Admins

### DIFF
--- a/terraform/environments/observability-platform/data.tf
+++ b/terraform/environments/observability-platform/data.tf
@@ -6,14 +6,16 @@ data "aws_ssoadmin_instances" "main" {
   provider = aws.sso-readonly
 }
 
-data "aws_identitystore_group" "observability_platform" {
+data "aws_identitystore_group" "observability_platform_admins" {
+  for_each = toset(["observability-platform", "operations-engineering"])
+
   provider = aws.sso-readonly
 
   identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
 
   filter {
     attribute_path  = "DisplayName"
-    attribute_value = "observability-platform"
+    attribute_value = each.value
   }
 }
 

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -31,7 +31,7 @@ module "managed_grafana" {
 
   role_associations = {
     "ADMIN" = {
-      "group_ids" = [data.aws_identitystore_group.observability_platform.id]
+      "group_ids" = [for group in data.aws_identitystore_group.observability_platform_admins : group.id]
     }
     "EDITOR" = {
       "group_ids" = [for team in data.aws_identitystore_group.all_identity_centre_teams : team.id]


### PR DESCRIPTION
## 👀 Purpose

- Operations Engineering will soon be assessing tools and services to visualise FinOps/GreenOps type data sets, giving them admin access to assess how the Observability Platform currently does this for other existing tenants will be useful during this proccess

## ♻️ What's changed

- Updated the admin assignment to allow for multiple identity groups to be given admin privileges
- Added `operations-engineering` to the list of admins

## 📝 Notes

- NA