### PR TITLE
🔒 Add secret for holding non MP account IDs

### DIFF
--- a/terraform/environments/observability-platform/iam-policies.tf
+++ b/terraform/environments/observability-platform/iam-policies.tf
@@ -17,7 +17,7 @@ module "amazon_managed_grafana_remote_cloudwatch_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.0"
+  version = "5.52.2"
 
   name_prefix = "amazon-managed-grafana-remote-cloudwatch"
 

--- a/terraform/environments/observability-platform/lambda-functions.tf
+++ b/terraform/environments/observability-platform/lambda-functions.tf
@@ -6,7 +6,7 @@ module "grafana_api_key_rotator" {
   #checkov:skip=CKV_AWS_258:Function is not invoked by URL
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.7.1"
+  version = "7.20.1"
 
   publish        = true
   create_package = false

--- a/terraform/environments/observability-platform/managed-grafana.tf
+++ b/terraform/environments/observability-platform/managed-grafana.tf
@@ -5,7 +5,7 @@ module "managed_grafana" {
   #checkov:skip=CKV2_AWS_5:AMG doesn't run in a VPC, so it doesn't need a security group
 
   source  = "terraform-aws-modules/managed-service-grafana/aws"
-  version = "2.1.1"
+  version = "2.2.0"
 
   name = local.application_name
 

--- a/terraform/environments/observability-platform/managed-prometheus.tf
+++ b/terraform/environments/observability-platform/managed-prometheus.tf
@@ -1,3 +1,4 @@
+// To be retired
 module "managed_prometheus" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/environments/observability-platform/modules/prometheus/iam-role/main.tf
+++ b/terraform/environments/observability-platform/modules/prometheus/iam-role/main.tf
@@ -21,7 +21,7 @@ module "iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.44.0"
+  version = "5.52.2"
 
   name_prefix = "${var.name}-prometheus"
 
@@ -33,7 +33,7 @@ module "iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.44.0"
+  version = "5.52.2"
 
   create_role             = true
   role_name               = "${var.name}-prometheus"

--- a/terraform/environments/observability-platform/secrets.tf
+++ b/terraform/environments/observability-platform/secrets.tf
@@ -29,3 +29,11 @@ resource "aws_secretsmanager_secret" "pagerduty_integration_keys" {
 
   name = "grafana/notifications/pagerduty-integration-keys"
 }
+
+#tfsec:ignore:avd-aws-0098 CMK not required currently
+resource "aws_secretsmanager_secret" "non_modernisation_platform_account_ids" {
+  #checkov:skip=CKV_AWS_149:CMK not required currently
+  #checkov:skip=CKV2_AWS_57:Rotation of secrets not required currently
+
+  name = "observability-platform/non-modernisation-platform-account-ids"
+}


### PR DESCRIPTION
This pull request:

- Relates to https://github.com/ministryofjustice/analytical-platform/issues/6628
- Adds a secret for storing account ID that aren't part of Modernisation Platform

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 