### PR TITLE
enable alarms for pd-onr-bods-1

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/oasys-national-reporting/locals_cloudwatch_metric_alarms.tf
@@ -32,7 +32,7 @@ locals {
         }
       }
     }
-    bods = {
+    bods_primary = {
       bods-cms-process-count = {
         alarm_description   = "This alarm checks that the PID count for the BODS CMS does not drop below 1."
         namespace           = "CWAgent"
@@ -48,6 +48,23 @@ locals {
           pid_finder = "native"
         }
       }
+      bods-data-services-process-count = {
+        alarm_description   = "This alarm checks that the PID count for Data Services does not drop below 1."
+        namespace           = "CWAgent"
+        metric_name         = "procstat_lookup pid_count"
+        period              = 60
+        evaluation_periods  = 1
+        statistic           = "Average"
+        comparison_operator = "LessThanThreshold"
+        threshold           = 1
+        treat_missing_data  = "breaching"
+        dimensions = {
+          exe        = "AL_JobService"
+          pid_finder = "native"
+        }
+      }
+    }
+    bods_secondary = {
       bods-data-services-process-count = {
         alarm_description   = "This alarm checks that the PID count for Data Services does not drop below 1."
         namespace           = "CWAgent"

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -144,12 +144,6 @@ locals {
         server-type      = "Bods"
         update-ssm-agent = "patchgroup1"
       }
-      cloudwatch_metric_alarms = merge(
-        module.baseline_presets.cloudwatch_metric_alarms.ec2,
-        module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
-        module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
-        local.cloudwatch_metric_alarms.windows,
-      )
     }
 
     boe_app = {

--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -149,7 +149,6 @@ locals {
         module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
         module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
         local.cloudwatch_metric_alarms.windows,
-        local.cloudwatch_metric_alarms.bods,
       )
     }
 

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -102,6 +102,13 @@ locals {
           oasys-national-reporting-environment = "pp"
           domain-name                          = "azure.hmpp.root"
         })
+        cloudwatch_metric_alarms = merge(
+          module.baseline_presets.cloudwatch_metric_alarms.ec2,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
+          local.cloudwatch_metric_alarms.windows,
+          local.cloudwatch_metric_alarms.bods_primary ,
+        )
       })
 
       # Pending sorting out cluster install of Bods in modernisation-platform-configuration-management repo

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -107,7 +107,7 @@ locals {
           module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
           module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
           local.cloudwatch_metric_alarms.windows,
-          local.cloudwatch_metric_alarms.bods_primary ,
+          local.cloudwatch_metric_alarms.bods_primary,
         )
       })
 

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -54,8 +54,14 @@ locals {
           oasys-national-reporting-environment = "pd"
           domain-name                          = "azure.hmpp.root"
         })
-        cloudwatch_metric_alarms = merge(local.ec2_instances.bods.cloudwatch_metric_alarms, { cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bods_primary })
-        })
+        cloudwatch_metric_alarms = merge(
+          module.baseline_presets.cloudwatch_metric_alarms.ec2,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
+          local.cloudwatch_metric_alarms.windows,
+          local.cloudwatch_metric_alarms.bods_primary ,
+        )
+      })
    
       pd-onr-bods-2 = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
@@ -73,7 +79,13 @@ locals {
           oasys-national-reporting-environment = "pd"
           domain-name                          = "azure.hmpp.root"
         })
-        cloudwatch_metric_alarms = merge(local.ec2_instances.bods.cloudwatch_metric_alarms, { cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bods_secondary })
+        cloudwatch_metric_alarms = merge(
+          module.baseline_presets.cloudwatch_metric_alarms.ec2,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
+          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
+          local.cloudwatch_metric_alarms.windows,
+          local.cloudwatch_metric_alarms.bods_secondary,
+        )
       })
     }
 

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -54,7 +54,6 @@ locals {
           oasys-national-reporting-environment = "pd"
           domain-name                          = "azure.hmpp.root"
         })
-        cloudwatch_metric_alarms = null # <= REMOVE THIS LATER
       })
 
       pd-onr-bods-2 = merge(local.ec2_instances.bods, {

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -59,7 +59,7 @@ locals {
           module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_windows,
           module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
           local.cloudwatch_metric_alarms.windows,
-          local.cloudwatch_metric_alarms.bods_primary ,
+          local.cloudwatch_metric_alarms.bods_primary,
         )
       })
    

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -54,8 +54,9 @@ locals {
           oasys-national-reporting-environment = "pd"
           domain-name                          = "azure.hmpp.root"
         })
-      })
-
+        cloudwatch_metric_alarms = merge(local.ec2_instances.bods.cloudwatch_metric_alarms, { cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bods_primary })
+        })
+   
       pd-onr-bods-2 = merge(local.ec2_instances.bods, {
         config = merge(local.ec2_instances.bods.config, {
           ami_name          = "hmpps_windows_server_2019_release_2025-01-02T00-00-37.501Z"
@@ -72,9 +73,8 @@ locals {
           oasys-national-reporting-environment = "pd"
           domain-name                          = "azure.hmpp.root"
         })
-        cloudwatch_metric_alarms = null # <= REMOVE THIS LATER
+        cloudwatch_metric_alarms = merge(local.ec2_instances.bods.cloudwatch_metric_alarms, { cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bods_secondary })
       })
-
     }
 
     fsx_windows = {


### PR DESCRIPTION
- created bods_primary and bods_secondary alarm groups
- bods_secondary does not have the CMS alarm as this service doesn't run there