### PR TITLE
Add database import script and update Glue catalog lifecycle settings

### DIFF
--- a/terraform/environments/electronic-monitoring-data/bash_scripts/import_databases.sh
+++ b/terraform/environments/electronic-monitoring-data/bash_scripts/import_databases.sh
@@ -1,0 +1,15 @@
+environment=$1
+account_id=$2
+databases=$3
+
+# Initialize Terraform
+terraform init --upgrade -reconfigure
+terraform workspace select electronic-monitoring-data-$environment
+IFS=',' read -r -a databases_array <<< "$databases"
+
+for database in "${databases_array[@]}"; do
+    terraform import module.share_dbs_with_roles[0].aws_glue_catalog_database.cadt_databases[\"${database}\"] $account_id:$database
+done
+
+# example use: bash import_database.sh development 000111222333 database1_name_in_environment,database2_name_in_environment
+

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -64,9 +64,8 @@ resource "aws_glue_catalog_database" "cadt_databases" {
   for_each = var.dbs_to_grant
 
   name = each.value
-
   lifecycle {
-    # Only ignore changes to the properties, but allow the resource itself to be removed
+    prevent_destroy = true
     ignore_changes = [
       description,
       location_uri,


### PR DESCRIPTION
Introduce a script for importing databases into the Glue catalog and modify lifecycle settings to prevent resource destruction.