### PR TITLE
Add db_exists variable for IAM roles and LakeFormation modules

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -253,6 +253,7 @@ module "load_fms" {
   oidc_arn           = aws_iam_openid_connect_provider.analytical_platform_compute.arn
   athena_dump_bucket = module.s3-athena-bucket.bucket
   cadt_bucket        = module.s3-create-a-derived-table-bucket.bucket
+  db_exists          = true
 }
 
 
@@ -272,4 +273,5 @@ module "load_mdss" {
   oidc_arn           = aws_iam_openid_connect_provider.analytical_platform_compute.arn
   athena_dump_bucket = module.s3-athena-bucket.bucket
   cadt_bucket        = module.s3-create-a-derived-table-bucket.bucket
+  db_exists          = true
 }

--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
@@ -118,4 +118,5 @@ module "share_dbs_with_roles" {
   data_bucket_lf_resource = var.data_bucket_lf_resource
   role_arn                = module.ap_database_sharing.iam_role.arn
   de_role_arn             = var.de_role_arn
+  db_exists               = var.db_exists
 }

--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/variables.tf
@@ -62,3 +62,9 @@ variable "data_bucket_lf_resource" {
   type        = string
   description = "The arn of the LakeFormation resource where our parquet files are held"
 }
+
+variable "db_exists" {
+  default     = false
+  type        = bool
+  description = "Whether the database exists"
+}

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/main.tf
@@ -1,3 +1,6 @@
+locals {
+  dbs_to_create = var.db_exists ? toset([]) : toset(var.dbs_to_grant)
+}
 data "aws_caller_identity" "current" {}
 
 resource "aws_lakeformation_permissions" "s3_bucket_permissions" {
@@ -61,7 +64,7 @@ resource "aws_lakeformation_permissions" "grant_cadt_tables_de" {
 }
 
 resource "aws_glue_catalog_database" "cadt_databases" {
-  for_each = var.dbs_to_grant
+  for_each = local.dbs_to_create
 
   name = each.value
   lifecycle {

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/variables.tf
@@ -18,3 +18,9 @@ variable "de_role_arn" {
   description = "DE Role to grant permissions to"
   type        = string
 }
+
+variable "db_exists" {
+  description = "Whether the database exists"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Introduce a `db_exists` variable to manage the existence of the database within IAM roles and LakeFormation modules.