### PR TITLE
Remove use of now-defunct backend role for nuke jobs

### DIFF
--- a/.github/workflows/nuke-redeploy.yml
+++ b/.github/workflows/nuke-redeploy.yml
@@ -21,7 +21,6 @@ env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
   NUKE_REDEPLOY_ACCOUNTS: ${{ secrets.MODERNISATION_PLATFORM_AUTONUKE_REBUILD }}
-  BACKEND_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
   TF_IN_AUTOMATION: true
 
 permissions: {}
@@ -77,7 +76,7 @@ jobs:
         run: |
           terraform --version
           echo "Terraform Plan - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
-          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development} "assume_role={role_arn=\"arn:aws:iam::${{ env.BACKEND_NUMBER }}:role/modernisation-account-terraform-state-member-access\"}"
+          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
           terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
           bash scripts/terraform-plan.sh terraform/environments/${ACCOUNT_NAME%-development}
 
@@ -86,7 +85,7 @@ jobs:
         run: |
           terraform --version
           echo "Terraform apply - ${ACCOUNT_NAME%-development}" # removes the -development suffix in order to get the directory name
-          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development} "assume_role={role_arn=\"arn:aws:iam::${{ env.BACKEND_NUMBER }}:role/modernisation-account-terraform-state-member-access\"}"
+          bash scripts/terraform-init.sh terraform/environments/${ACCOUNT_NAME%-development}
           terraform -chdir="terraform/environments/${ACCOUNT_NAME%-development}" workspace select "${ACCOUNT_NAME}"
           bash scripts/terraform-apply.sh terraform/environments/${ACCOUNT_NAME%-development}
 

--- a/scripts/terraform-apply-after-nuke.sh
+++ b/scripts/terraform-apply-after-nuke.sh
@@ -14,9 +14,6 @@ nuke_account_ids_json=$(aws secretsmanager get-secret-value --secret-id nuke_acc
 declare -A account_ids
 eval "$(jq -r '.NUKE_ACCOUNT_IDS | to_entries | .[] |"account_ids[" + (.key | @sh) + "]=" + (.value | @sh)' <<<"$nuke_account_ids_json")"
 
-# Retrieve Modernisation Platform Account Id 
-BACKEND_NUMBER=$(aws ssm get-parameters --region eu-west-2 --names "modernisation_platform_account_id" --with-decryption --query "Parameters[*].{Value:Value}" --output text)
-
 redeployed_envs=()
 skipped_envs=()
 failed_envs=()
@@ -25,7 +22,7 @@ for key in "${!account_ids[@]}"; do
   to_dir_name "$key"
   if [[ "$NUKE_DO_NOT_RECREATE_ENVIRONMENTS" != *"${dir_name}-development,"* ]]; then
     echo "BEGIN: terraform apply ${dir_name}-development"
-    bash scripts/terraform-init.sh "terraform/environments/${dir_name}" "assume_role={role_arn=\"arn:aws:iam::${BACKEND_NUMBER}:role/modernisation-account-terraform-state-member-access\"}" || exit_code=$?
+    bash scripts/terraform-init.sh "terraform/environments/${dir_name}" || exit_code=$?
     terraform -chdir="terraform/environments/${dir_name}" workspace select "${dir_name}-development" || exit_code=$?
     bash scripts/terraform-apply.sh "terraform/environments/${dir_name}" || exit_code=$?
     if [[ $exit_code -ne 0 ]]; then

--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -3,12 +3,12 @@
 set -e
 
 # This script runs terraform init with input set to false, no color outputs, and backend-config, suitable for running as part of a CI/CD pipeline.
-# You need to pass through a Terraform directory and backend config as arguments, e.g.
-# sh terraform-init.sh terraform/environments "assume_role={role_arn=\"arn:aws:iam::123456789012:role/modernisation-account-terraform-state-member-access\"}"
+# You need to pass through a Terraform directory as an argument, e.g.
+# sh terraform-init.sh terraform/environments
 
-if [ -z "$1" ] || [ -z "$2" ]; then
-  echo "Unsure where to run terraform, exiting. (Usage: terraform-init.sh <terraform_directory> <backend_config>)"
+if [ -z "$1" ]; then
+  echo "Unsure where to run terraform, exiting."
   exit 1
 else
-  terraform -chdir="$1" init -input=false -no-color -backend-config="$2"
+  terraform -chdir="$1" init -input=false -no-color
 fi


### PR DESCRIPTION
Tracked upstream by [#8345](https://github.com/ministryofjustice/modernisation-platform/issues/8345) in the Modernisation Platform repository.

This PR removes configuration related to the legacy role used for S3 backend state locking. This should only relate to the Terraform runs that deploy customer configuration after we've cleaned the sandbox accounts with `AWS Nuke`.