### PR TITLE
feat: AP-5175 create datasync 'exclude paths' secret

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/data.tf
+++ b/terraform/environments/analytical-platform-ingestion/data.tf
@@ -41,3 +41,7 @@ data "aws_ec2_transit_gateway" "moj_tgw" {
 data "aws_secretsmanager_secret_version" "datasync_dom1" {
   secret_id = module.datasync_dom1_secret.secret_id
 }
+
+data "aws_secretsmanager_secret_version" "datasync_exclude_path" {
+  secret_id = module.datasync_exclude_path_secret.secret_id
+}

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -241,14 +241,14 @@ module "s3_datasync_kms" {
   deletion_window_in_days = 7
 }
 
-module "datasync_exclude_paths_kms" {
+module "common_secretsmanager_secret" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.0"
 
-  aliases               = ["datasync/exclude-paths"]
-  description           = "DataSync Exclude paths secret KMS Key"
+  aliases               = ["secretsmanager/common"]
+  description           = "Common secretsmanager KMS Key"
   enable_default_policy = true
 
   deletion_window_in_days = 7

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -241,7 +241,7 @@ module "s3_datasync_kms" {
   deletion_window_in_days = 7
 }
 
-module "common_secretsmanager_secret" {
+module "secretsmanager_common_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -240,3 +240,16 @@ module "s3_datasync_kms" {
 
   deletion_window_in_days = 7
 }
+
+module "datasync_exclude_paths_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  aliases               = ["datasync/exclude-paths"]
+  description           = "DataSync Exclude paths secret KMS Key"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+}

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -47,7 +47,7 @@ module "datasync_exclude_path_secret" {
   version = "1.3.1"
 
   name       = "datasync/exclude-paths"
-  kms_key_id = module.secretsmanager_common_secret.key_arn
+  kms_key_id = module.secretsmanager_common_kms.key_arn
 
   ignore_secret_changes = true
   secret_string         = "CHANGEME"

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -47,7 +47,7 @@ module "datasync_exclude_path_secret" {
   version = "1.3.1"
 
   name       = "datasync/exclude-paths"
-  kms_key_id = module.common_secretsmanager_secret.key_arn
+  kms_key_id = module.secretsmanager_common_secret.key_arn
 
   ignore_secret_changes = true
   secret_string         = "CHANGEME"

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -38,3 +38,19 @@ module "datasync_dom1_secret" {
 
   tags = local.tags
 }
+
+module "datasync_exclude_path_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name       = "datasync/exclude-paths"
+  kms_key_id = module.datasync_exclude_paths_kms.key_arn
+
+  ignore_secret_changes = true
+  secret_string         = "CHANGEME"
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -47,7 +47,7 @@ module "datasync_exclude_path_secret" {
   version = "1.3.1"
 
   name       = "datasync/exclude-paths"
-  kms_key_id = module.datasync_exclude_paths_kms.key_arn
+  kms_key_id = module.common_secretsmanager_secret.key_arn
 
   ignore_secret_changes = true
   secret_string         = "CHANGEME"


### PR DESCRIPTION
This PR relates to ministryofjustice/analytical-platform#5175.

This PR adds a secret to hold the paths to exclude as part of the datasync task.


**Questions for the reviewer:**
- why is the [CIDR group changing](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/13134364902/job/36646326486?pr=9550#step:11:687)?
- Is it necessary to add a new kms key for this secret?