### PR TITLE
feat: add exclude filter from exclude paths secret string value

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
+++ b/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
@@ -18,6 +18,11 @@ resource "aws_datasync_task" "opg" {
     value       = "/Investigations/Cases/Closed Cases/*"
   }
 
+  excludes {
+    filter_type = "SIMPLE_PATTERN"
+    value       = data.aws_secretsmanager_secret.datasync_exclude_path.secret_string
+  }
+
   task_report_config {
     report_overrides {}
     report_level         = "ERRORS_ONLY"

--- a/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
+++ b/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
@@ -20,7 +20,7 @@ resource "aws_datasync_task" "opg" {
 
   excludes {
     filter_type = "SIMPLE_PATTERN"
-    value       = data.aws_secretsmanager_secret.datasync_exclude_path.secret_string
+    value       = data.aws_secretsmanager_secret_version.datasync_exclude_path.secret_string
   }
 
   task_report_config {


### PR DESCRIPTION
This PR relates to ministryofjustice/analytical-platform#5175.

This PR uses the secret from #9550 (updated manually) to exclude paths from the datasync task.
