### PR TITLE
Update workflow to trigger on changes to `platform_backend.tf` files

### DIFF
--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/generate-dependabot-file.yml'
       - 'scripts/generate-dependabot-file.sh'
+      - 'terraform/environments/**/platform_backend.tf'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to trigger on changes to `platform_backend.tf` files in the `terraform/environments/**` directory. The change ensures that whenever a `platform_backend.tf` file is added or updated, the corresponding workflow will run, which will also update the `CODEOWNERS` file.