### PR TITLE
Fix IAM role name suffix formatting in Airflow module

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf
@@ -110,7 +110,7 @@ module "ap_database_sharing" {
   source = "../ap_airflow_iam_role"
 
   environment          = var.environment
-  role_name_suffix     = "load-${var.name}-${local.env_suffixes[var.environment]}"
+  role_name_suffix     = "load-${var.name}${local.env_suffixes[var.environment]}"
   role_description     = "${var.name} database permissions"
   iam_policy_document  = data.aws_iam_policy_document.load_data.json
   secret_code          = var.secret_code


### PR DESCRIPTION
Correct the formatting of the IAM role name suffix in the Airflow module to ensure proper concatenation of variables.