### PR TITLE
Update OIDC provider logic for preproduction environment

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -81,7 +81,7 @@ data "tls_certificate" "dbt_analytics" {
 
 ## OIDC, OpenID Connect
 resource "aws_iam_openid_connect_provider" "cluster" {
-  count           = local.is-production ? 0 : 1
+  count           = local.is-production || local.is-preproduction ? 0 : 1
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.tls_certificate.dbt_analytics.certificates[0].sha1_fingerprint]
   url             = "https://oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}"
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "dataapi_cross_assume" {
 
     principals {
       type        = "Federated"
-      identifiers = [local.is-production ? aws_iam_openid_connect_provider.analytical_platform_compute.arn : aws_iam_openid_connect_provider.cluster[0].arn]
+      identifiers = [local.is-production || local.is-preproduction ? aws_iam_openid_connect_provider.analytical_platform_compute.arn : aws_iam_openid_connect_provider.cluster[0].arn]
     }
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
Revise the OIDC provider count logic to include the preproduction environment, ensuring proper handling of IAM roles in both production and preproduction contexts.