### PR TITLE
tm-925-revert-tags

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -91,7 +91,7 @@ locals {
         })
         instance = merge(local.ec2_instances.rdgw.instance, {
           tags = {
-            backup-plan = "daily-and-weekly-vss"
+            backup-plan = "daily-and-weekly"
           }
         })
         tags = merge(local.ec2_instances.rdgw.tags, {


### PR DESCRIPTION
Revert tags post successful VSS test (moving back to scheduled shutdown and non-VSS backup).