### PR TITLE
🪣 Add CICA DMS Ingress S3 bucket

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -1,0 +1,47 @@
+#tfsec:ignore:avd-aws-0088 - The bucket policy is attached to the bucket
+#tfsec:ignore:avd-aws-0132 - The bucket policy is attached to the bucket
+module "cica_dms_egress_bucket" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.3.0"
+
+  bucket = "mojap-ingestion-${local.environment}-cica-dms-egress"
+
+  force_destroy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.cica_dms_egress_bucket_policy.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.s3_cica_dms_egress_kms.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cica_dms_egress_bucket_policy" {
+  statement {
+    sid    = "ReplicationPermissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::593291632749:role/mojap-data-production-cica-dms-egress-${local.environment}"]
+    }
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:GetObjectVersionTagging",
+      "s3:ReplicateTags",
+      "s3:ReplicateDelete"
+    ]
+    resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-cica-dms-egress/*"]
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -119,6 +119,34 @@ module "s3_bold_egress_kms" {
   deletion_window_in_days = 7
 }
 
+module "s3_cica_dms_egress_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  aliases               = ["s3/cica-dms-egress"]
+  description           = "Used in the Bold Egress Solution"
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowAnalyticalPlatformDataProduction"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::593291632749:role/mojap-data-production-cica-dms-egress-${local.environment}"]
+        }
+      ]
+    }
+  ]
+  deletion_window_in_days = 7
+}
 
 module "quarantined_sns_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions


### PR DESCRIPTION
This PR relates to [this](https://github.com/ministryofjustice/analytical-platform/issues/6748) piece of work. 

It creates an S3 bucket called `mojap-ingestion-${local.environment}-cica-dms-egress`.

Additionally this PR creates a new policy and KMS key for use in the replication. The policy and key mirror the policy used for previous BOLD work in the same account. 