### PR TITLE
Amending strategy workflow to only pass changed app/components

### DIFF
--- a/.github/workflows/analytical-platform-ingestion.yml
+++ b/.github/workflows/analytical-platform-ingestion.yml
@@ -8,6 +8,7 @@
       paths:
         - 'terraform/environments/analytical-platform-ingestion/**'
         - '.github/workflows/analytical-platform-ingestion.yml'
+        - '.github/workflows/reusable_terraform_component_strategy.yml'
 
     pull_request:
       branches:
@@ -43,7 +44,7 @@
 
     terraform:
       needs: strategy
-      if: inputs.action != 'destroy'
+      if: ${{ inputs.action != 'destroy' && needs.strategy.outputs.matrix != '' && toJson(fromJson(needs.strategy.outputs.matrix)) != '[]'}} # if this works, I don't know why
       strategy:
         fail-fast: false
         matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
@@ -54,7 +55,7 @@
         application: "${{ github.workflow }}"
         environment: "${{ matrix.target }}"
         action: "${{ matrix.action }}"
-        component: "${{ matrix.component }}"      # If your strategy workflow also outputs "matrix.component"
+        component: "${{ matrix.component }}"
       secrets:
         modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
         pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"

--- a/.github/workflows/analytical-platform-ingestion.yml
+++ b/.github/workflows/analytical-platform-ingestion.yml
@@ -42,9 +42,17 @@
         # so the strategy can load environment info from it.
         application: "${{ github.workflow }}"  # Typically: "analytical-platform-ingestion"
 
+    skipping_terraform:
+      needs: strategy
+      if: ${{ inputs.action != 'destroy' && (needs.strategy.outputs.matrix == '' || toJson(fromJson(needs.strategy.outputs.matrix)) == '[]')}}  # conversion from and to Json standardises output
+      runs-on: ubuntu-latest
+      steps:
+        - name: Skip Terraform
+          run: echo "No terraform changes detected. Skipping Terraform plan/apply."
+
     terraform:
       needs: strategy
-      if: ${{ inputs.action != 'destroy' && needs.strategy.outputs.matrix != '' && toJson(fromJson(needs.strategy.outputs.matrix)) != '[]'}} # if this works, I don't know why
+      if: ${{ inputs.action != 'destroy' && needs.strategy.outputs.matrix != '' && toJson(fromJson(needs.strategy.outputs.matrix)) != '[]'}}  # conversion from and to Json standardises output
       strategy:
         fail-fast: false
         matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}

--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -58,7 +58,8 @@ jobs:
           fi
 
           # 2) Discover valid subfolders that contain a platform_backend.tf file.
-          COMPONENTS="root"  # Include the root folder as "root".
+          # We always include the application folder itself as "root".
+          COMPONENTS="root"
           if [ -d "terraform/environments/${{ inputs.application }}" ]; then
             for d in $(find "terraform/environments/${{ inputs.application }}" -mindepth 1 -maxdepth 1 -type d); do
               subfolder="$(basename "$d" | tr -d '\r\n')"
@@ -72,32 +73,52 @@ jobs:
           echo "Discovered components (folders with platform_backend.tf): $COMPONENTS"
 
           # 3) Build the final matrix by looping over environments and components.
-          #    Only add an entry if the component folder has changes relative to main.
+          #    Only add an entry if the folder has changes relative to main.
+          #    For "root", we only consider changes to files directly in the application folder.
           echo "[" > final-list.json
           firstEntry=true
 
           while IFS= read -r envobj; do
             for comp in $COMPONENTS; do
-              # Determine which folder to check.
               if [ "$comp" = "root" ]; then
-                folder="."
-              else
-                folder="terraform/environments/${{ inputs.application }}/$comp"
-              fi
-
-              if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-                # Compute the merge base using the branch tip.
-                merge_base=$(git merge-base origin/main "$head_commit")
-                # Compare the changes between the merge base and the branch tip for the folder.
-                if git diff --quiet "$merge_base" "$head_commit" -- "$folder"; then
-                  echo "Skipping '$comp' as no changes detected in '$folder' (branch compared to merge base)"
+                # For the top-level (application) folder, restrict to files directly within it.
+                folder="terraform/environments/${{ inputs.application }}"
+                if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+                  merge_base=$(git merge-base origin/main "$head_commit")
+                  changed_files=$(git diff --name-only "$merge_base" "$head_commit" -- "$folder")
+                else
+                  changed_files=$(git diff --name-only HEAD~1 HEAD -- "$folder")
+                fi
+                top_level_changed=false
+                prefix="$folder/"
+                for f in $changed_files; do
+                  # Only consider files directly under $folder (i.e. with no further subdirectories)
+                  if [[ "$f" == "$prefix"* ]]; then
+                    rel="${f#$prefix}"
+                    if [[ "$rel" != *"/"* ]]; then
+                      top_level_changed=true
+                      break
+                    fi
+                  fi
+                done
+                if ! $top_level_changed; then
+                  echo "Skipping 'root' as no top-level changes detected in '$folder'"
                   continue
                 fi
               else
-                # On main, compare the last commit.
-                if git diff --quiet HEAD~1 HEAD -- "$folder"; then
-                  echo "Skipping '$comp' as no changes detected in '$folder' (main branch)"
-                  continue
+                # For component subfolders, use the standard diff check.
+                folder="terraform/environments/${{ inputs.application }}/$comp"
+                if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+                  merge_base=$(git merge-base origin/main "$head_commit")
+                  if git diff --quiet "$merge_base" "$head_commit" -- "$folder"; then
+                    echo "Skipping '$comp' as no changes detected in '$folder' (branch compared to merge base)"
+                    continue
+                  fi
+                else
+                  if git diff --quiet HEAD~1 HEAD -- "$folder"; then
+                    echo "Skipping '$comp' as no changes detected in '$folder' (main branch)"
+                    continue
+                  fi
                 fi
               fi
 

--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -21,7 +21,7 @@ jobs:
       matrix: "${{ steps.strategy.outputs.matrix }}"
     steps:
       - name: Check out Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: Generate Strategy Matrix
         id: strategy
@@ -39,8 +39,8 @@ jobs:
             head_commit=HEAD
           fi
 
-          # 1) Fetch environment data from <application>.json.
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+          # Fetch environment data from <application>.json.
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             # On a branch: production gets "plan", dev/test get "plan_apply".
             curl -s -X GET "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json" \
               | jq -c '.environments[] as $env |
@@ -57,8 +57,7 @@ jobs:
               > envlist.json
           fi
 
-          # 2) Discover valid subfolders that contain a platform_backend.tf file.
-          # We always include the application folder itself as "root".
+          # Discover valid subfolders that contain a platform_backend.tf file and check for changes.
           COMPONENTS="root"
           if [ -d "terraform/environments/${{ inputs.application }}" ]; then
             for d in $(find "terraform/environments/${{ inputs.application }}" -mindepth 1 -maxdepth 1 -type d); do
@@ -72,54 +71,39 @@ jobs:
 
           echo "Discovered components (folders with platform_backend.tf): $COMPONENTS"
 
-          # 3) Build the final matrix by looping over environments and components.
-          #    Only add an entry if the folder has changes relative to main.
-          #    For "root", we only consider changes to files directly in the application folder.
+          # Build the final matrix by looping over environments and components.
           echo "[" > final-list.json
           firstEntry=true
 
           while IFS= read -r envobj; do
+            root_changed=false
+            component_changed=false
+
             for comp in $COMPONENTS; do
-              if [ "$comp" = "root" ]; then
-                # For the top-level (application) folder, restrict to files directly within it.
-                folder="terraform/environments/${{ inputs.application }}"
-                if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-                  merge_base=$(git merge-base origin/main "$head_commit")
-                  changed_files=$(git diff --name-only "$merge_base" "$head_commit" -- "$folder")
-                else
-                  changed_files=$(git diff --name-only HEAD~1 HEAD -- "$folder")
-                fi
-                top_level_changed=false
-                prefix="$folder/"
-                for f in $changed_files; do
-                  # Only consider files directly under $folder (i.e. with no further subdirectories)
-                  if [[ "$f" == "$prefix"* ]]; then
-                    rel="${f#$prefix}"
-                    if [[ "$rel" != *"/"* ]]; then
-                      top_level_changed=true
-                      break
-                    fi
-                  fi
-                done
-                if ! $top_level_changed; then
-                  echo "Skipping 'root' as no top-level changes detected in '$folder'"
+              folder="terraform/environments/${{ inputs.application }}"
+              if [ "$comp" != "root" ]; then
+                folder="$folder/$comp"
+              fi
+
+              # Check for changes in the folder.
+              if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+                merge_base=$(git merge-base origin/main "$head_commit")
+                if git diff --quiet "$merge_base" "$head_commit" -- "$folder"; then
+                  echo "Skipping '$comp' as no changes detected in '$folder' (branch compared to merge base)"
                   continue
                 fi
               else
-                # For component subfolders, use the standard diff check.
-                folder="terraform/environments/${{ inputs.application }}/$comp"
-                if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-                  merge_base=$(git merge-base origin/main "$head_commit")
-                  if git diff --quiet "$merge_base" "$head_commit" -- "$folder"; then
-                    echo "Skipping '$comp' as no changes detected in '$folder' (branch compared to merge base)"
-                    continue
-                  fi
-                else
-                  if git diff --quiet HEAD~1 HEAD -- "$folder"; then
-                    echo "Skipping '$comp' as no changes detected in '$folder' (main branch)"
-                    continue
-                  fi
+                if git diff --quiet HEAD~1 HEAD -- "$folder"; then
+                  echo "Skipping '$comp' as no changes detected in '$folder' (main branch)"
+                  continue
                 fi
+              fi
+
+              # If changes are detected, mark the appropriate flag.
+              if [ "$comp" == "root" ]; then
+                root_changed=true
+              else
+                component_changed=true
               fi
 
               # If changes are detected, add an entry to the matrix.
@@ -130,6 +114,17 @@ jobs:
               fi
               echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp}' >> final-list.json
             done
+
+            # If root has changes but no components, add root to the matrix.
+            if $root_changed && ! $component_changed; then
+              if [ "$firstEntry" = true ]; then
+                firstEntry=false
+              else
+                echo "," >> final-list.json
+              fi
+              echo -n "$envobj" | jq --arg comp "root" '. + {"component": $comp}' >> final-list.json
+            fi
+
           done < envlist.json || true
 
           echo "]" >> final-list.json

--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -107,12 +107,14 @@ jobs:
               fi
 
               # If changes are detected, add an entry to the matrix.
-              if [ "$firstEntry" = true ]; then
-                firstEntry=false
-              else
-                echo "," >> final-list.json
+              if [ "$comp" != "root" ]; then
+                if [ "$firstEntry" = true ]; then
+                  firstEntry=false
+                else
+                  echo "," >> final-list.json
+                fi
+                echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp}' >> final-list.json
               fi
-              echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp}' >> final-list.json
             done
 
             # If root has changes but no components, add root to the matrix.

--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -1,107 +1,128 @@
 ---
-    name: terraform strategy
+name: terraform strategy
 
-    on:
-      workflow_call:
-        inputs:
-          application:
-            type: string
-            required: true
-            description: "Application name for which this strategy matrix pipeline should run."
-        outputs:
-          matrix:
-            description: "Matrix JSON string to feed that can be used as strategy in a separate terraform job"
-            value: ${{ jobs.strategy.outputs.matrix }}
+on:
+  workflow_call:
+    inputs:
+      application:
+        type: string
+        required: true
+        description: "Application name for which this strategy matrix pipeline should run."
+    outputs:
+      matrix:
+        description: "Matrix JSON string to feed that can be used as strategy in a separate terraform job"
+        value: ${{ jobs.strategy.outputs.matrix }}
 
-    jobs:
-      strategy:
-        name: "strategy"
-        runs-on: ubuntu-latest
-        outputs:
-          matrix: "${{ steps.strategy.outputs.matrix }}"
-        steps:
-          - name: Check out Repo
-            uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
+jobs:
+  strategy:
+    name: "strategy"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: "${{ steps.strategy.outputs.matrix }}"
+    steps:
+      - name: Check out Repo
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
 
-          - name: Generate Strategy Matrix
-            id: strategy
-            run: |
-              set -euo pipefail
+      - name: Generate Strategy Matrix
+        id: strategy
+        run: |
+          set -euo pipefail
 
-              # 1) Fetch environment data from <application>.json, produce newline-separated JSON objects
-              if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-                # On a branch => plan on all accounts, but plan_apply on dev/test
-                curl -X GET "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json" \
-                  | jq -c '.environments[] as $env |
-                      if $env.name | contains("production") then
-                        {"target": $env.name, "action": "plan"}
-                      else
-                        {"target": $env.name, "action": "plan_apply"}
-                      end' \
-                  > envlist.json
-              else
-                # On main => plan_apply on all accounts
-                curl -X GET "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json" \
-                  | jq -c '.environments[] | {"target": .name, "action": "plan_apply"}' \
-                  > envlist.json
-              fi
+          # Fetch the main branch so we can compare against it.
+          git fetch origin main
 
-              # At this point, envlist.json might look like:
-              # {"target":"development","action":"plan_apply"}
-              # {"target":"test","action":"plan_apply"}
-              # {"target":"production","action":"plan"}
+          # Determine the commit to use as the tip of the branch.
+          # For pull request events (ref starts with "refs/pull/"), use the PR's head commit.
+          if [[ "${GITHUB_REF}" == refs/pull/* ]]; then
+            head_commit=$(jq --raw-output .pull_request.head.sha "$GITHUB_EVENT_PATH")
+          else
+            head_commit=HEAD
+          fi
 
-              # 2) Discover valid subfolders with platform_backend.tf
-              COMPONENTS=""
-              # Optionally include the root folder as a blank component:
-              COMPONENTS="$COMPONENTS root"
-
-              if [ -d "terraform/environments/${{ inputs.application }}" ]; then
-                for d in $(find "terraform/environments/${{ inputs.application }}" -mindepth 1 -maxdepth 1 -type d); do
-                  subfolder="$(basename "$d" | tr -d '\r\n')"
-                  # Only include if there's a platform_backend.tf in this folder
-                  if [ -f "$d/platform_backend.tf" ]; then
-                    # e.g. skip .terraform or other special folders if needed
-                    [ "$subfolder" = ".terraform" ] && continue
-                    COMPONENTS="$COMPONENTS $subfolder"
-                  fi
-                done
-              fi
-
-              echo "Discovered components (folders with platform_backend.tf): $COMPONENTS"
-
-              # 3) Double loop to merge each environment object with each component
-              echo "[" > final-list.json
-              firstOuter=true
-
-              while IFS= read -r envobj; do
-                # envobj is a single-line JSON obj, e.g. {"target":"development","action":"plan_apply"}
-                for c in $COMPONENTS; do
-                  rawC=$(echo "$c" | sed 's/"//g') # remove quotes
-
-                  if [ "$firstOuter" = true ]; then
-                    firstOuter=false
+          # 1) Fetch environment data from <application>.json.
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            # On a branch: production gets "plan", dev/test get "plan_apply".
+            curl -s -X GET "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json" \
+              | jq -c '.environments[] as $env |
+                  if $env.name | contains("production") then
+                    {"target": $env.name, "action": "plan"}
                   else
-                    echo "," >> final-list.json
-                  fi
+                    {"target": $env.name, "action": "plan_apply"}
+                  end' \
+              > envlist.json
+          else
+            # On main: all accounts get "plan_apply".
+            curl -s -X GET "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${{ inputs.application }}.json" \
+              | jq -c '.environments[] | {"target": .name, "action": "plan_apply"}' \
+              > envlist.json
+          fi
 
-                  # Merge environment + { component: $rawC }
-                  echo -n "$envobj" | jq --arg comp "$rawC" '. + {"component": $comp}' >> final-list.json
-                done
-              done < envlist.json
+          # 2) Discover valid subfolders that contain a platform_backend.tf file.
+          COMPONENTS="root"  # Include the root folder as "root".
+          if [ -d "terraform/environments/${{ inputs.application }}" ]; then
+            for d in $(find "terraform/environments/${{ inputs.application }}" -mindepth 1 -maxdepth 1 -type d); do
+              subfolder="$(basename "$d" | tr -d '\r\n')"
+              if [ -f "$d/platform_backend.tf" ]; then
+                [ "$subfolder" = ".terraform" ] && continue
+                COMPONENTS="$COMPONENTS $subfolder"
+              fi
+            done
+          fi
 
-              echo "]" >> final-list.json
+          echo "Discovered components (folders with platform_backend.tf): $COMPONENTS"
 
-              # Wrap in {"include":[ ... ]} for GitHub Actions
-              echo -n '{"include":' > matrix.out
-              cat final-list.json >> matrix.out
-              echo -n '}' >> matrix.out
+          # 3) Build the final matrix by looping over environments and components.
+          #    Only add an entry if the component folder has changes relative to main.
+          echo "[" > final-list.json
+          firstEntry=true
 
-              matrix=$(cat matrix.out | jq -r)
-              echo "Matrix is:"
-              echo "$matrix"
+          while IFS= read -r envobj; do
+            for comp in $COMPONENTS; do
+              # Determine which folder to check.
+              if [ "$comp" = "root" ]; then
+                folder="."
+              else
+                folder="terraform/environments/${{ inputs.application }}/$comp"
+              fi
 
-              # Output for the next job
-              echo 'matrix<<EOF' >> $GITHUB_OUTPUT
-              echo "${matrix}" >> $GITHUB_OUTPUT
-              echo 'EOF' >> $GITHUB_OUTPUT
+              if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+                # Compute the merge base using the branch tip.
+                merge_base=$(git merge-base origin/main "$head_commit")
+                # Compare the changes between the merge base and the branch tip for the folder.
+                if git diff --quiet "$merge_base" "$head_commit" -- "$folder"; then
+                  echo "Skipping '$comp' as no changes detected in '$folder' (branch compared to merge base)"
+                  continue
+                fi
+              else
+                # On main, compare the last commit.
+                if git diff --quiet HEAD~1 HEAD -- "$folder"; then
+                  echo "Skipping '$comp' as no changes detected in '$folder' (main branch)"
+                  continue
+                fi
+              fi
+
+              # If changes are detected, add an entry to the matrix.
+              if [ "$firstEntry" = true ]; then
+                firstEntry=false
+              else
+                echo "," >> final-list.json
+              fi
+              echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp}' >> final-list.json
+            done
+          done < envlist.json || true
+
+          echo "]" >> final-list.json
+
+          # Wrap the JSON array in {"include": [...] } for the GitHub Actions matrix.
+          echo -n '{"include":' > matrix.out
+          cat final-list.json >> matrix.out
+          echo '}' >> matrix.out
+
+          matrix=$(cat matrix.out | jq -r)
+          echo "Matrix is:"
+          echo "$matrix"
+
+          # Output the matrix for subsequent jobs.
+          echo 'matrix<<EOF' >> $GITHUB_OUTPUT
+          echo "${matrix}" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT

--- a/terraform/environments/analytical-platform-ingestion/dms/platform_base_variables.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/platform_base_variables.tf
@@ -4,6 +4,8 @@ variable "networking" {
 
 }
 
+#####
+
 variable "collaborator_access" {
   type        = string
   default     = "developer"


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/6602

With introduction of components, it now becomes important to differentiate between components that have committed changes in a branch and those that aren't.
This PR introduces code into the strategy workflow that only includes components (and/or root) that have `git diff` from `main`.

The complexity to arises out of the fact that new code can be in either root or component level so it's important to identify which one. 


