### PR TITLE
🐛 Ignore Terraform AWS provider version v5.86

### DIFF
--- a/terraform/environments/analytical-platform-common/versions.tf
+++ b/terraform/environments/analytical-platform-common/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
+++ b/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = "~> 1.0"

--- a/terraform/environments/analytical-platform-compute/versions.tf
+++ b/terraform/environments/analytical-platform-compute/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/analytical-platform-ingestion/dms/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/analytical-platform-ingestion/modules/routes/providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/routes/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = "~> 1.0"

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/analytical-platform-ingestion/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/apex/modules/ecs/versions.tf
+++ b/terraform/environments/apex/modules/ecs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/apex/versions.tf
+++ b/terraform/environments/apex/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/ccms-ebs-upgrade/versions.tf
+++ b/terraform/environments/ccms-ebs-upgrade/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/ccms-ebs/versions.tf
+++ b/terraform/environments/ccms-ebs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cdpt-chaps/versions.tf
+++ b/terraform/environments/cdpt-chaps/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cdpt-ifs/versions.tf
+++ b/terraform/environments/cdpt-ifs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cica-copilot/versions.tf
+++ b/terraform/environments/cica-copilot/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cica-data-extraction/versions.tf
+++ b/terraform/environments/cica-data-extraction/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cica-tariff/versions.tf
+++ b/terraform/environments/cica-tariff/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/contract-work-administration/versions.tf
+++ b/terraform/environments/contract-work-administration/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/corporate-information-system/versions.tf
+++ b/terraform/environments/corporate-information-system/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/corporate-staff-rostering/versions.tf
+++ b/terraform/environments/corporate-staff-rostering/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/dacp/versions.tf
+++ b/terraform/environments/dacp/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.8, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/data-and-insights-wepi/versions.tf
+++ b/terraform/environments/data-and-insights-wepi/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/data-platform-apps-and-tools/versions.tf
+++ b/terraform/environments/data-platform-apps-and-tools/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/data-platform/versions.tf
+++ b/terraform/environments/data-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/delius-alfresco/versions.tf
+++ b/terraform/environments/delius-alfresco/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/delius-core/modules/helpers/ebs_volume/versions.tf
+++ b/terraform/environments/delius-core/modules/helpers/ebs_volume/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/delius-core/versions.tf
+++ b/terraform/environments/delius-core/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/delius-iaps/versions.tf
+++ b/terraform/environments/delius-iaps/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/delius-jitbit/versions.tf
+++ b/terraform/environments/delius-jitbit/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/delius-mis/versions.tf
+++ b/terraform/environments/delius-mis/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/digital-prison-reporting/modules/apigateway/serverless-lambda-gw/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/apigateway/serverless-lambda-gw/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/oracle/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/ec2/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/ec2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/lambdas/generic/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/lambdas/generic/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/notifications/sns/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/notifications/sns/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/redshift/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
 

--- a/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/s3_bucket/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/digital-prison-reporting/versions.tf
+++ b/terraform/environments/digital-prison-reporting/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/edw/versions.tf
+++ b/terraform/environments/edw/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_iam_role/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_iam_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/electronic-monitoring-data/modules/api_step_function/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/api_step_function/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/electronic-monitoring-data/modules/dms/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/dms/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_presigned_url/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_presigned_url/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_database_share/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/modules/lakeformation_w_data_filter/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lakeformation_w_data_filter/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/modules/lambdas/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/lambdas/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/terraform/environments/electronic-monitoring-data/modules/landing_bucket/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_bucket/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/landing_zone_user/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/landing_zone_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/server_security_group/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/server_security_group/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/modules/landing_zone/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/landing_zone/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/modules/step_function/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/step_function/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/electronic-monitoring-data/versions.tf
+++ b/terraform/environments/electronic-monitoring-data/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/equip/dlm-snapshot/versions.tf
+++ b/terraform/environments/equip/dlm-snapshot/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/equip/versions.tf
+++ b/terraform/environments/equip/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/eric/versions.tf
+++ b/terraform/environments/eric/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/example/versions.tf
+++ b/terraform/environments/example/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/genesys-call-centre-data/versions.tf
+++ b/terraform/environments/genesys-call-centre-data/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/hmpps-domain-services/versions.tf
+++ b/terraform/environments/hmpps-domain-services/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/hmpps-oem/versions.tf
+++ b/terraform/environments/hmpps-oem/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/laa-ccms-infra-azure-ad-sso/versions.tf
+++ b/terraform/environments/laa-ccms-infra-azure-ad-sso/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/laa-mail-relay/versions.tf
+++ b/terraform/environments/laa-mail-relay/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/laa-oem/versions.tf
+++ b/terraform/environments/laa-oem/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/laa-stabilisation-cdc-poc/versions.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/long-term-storage/versions.tf
+++ b/terraform/environments/long-term-storage/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/maat/versions.tf
+++ b/terraform/environments/maat/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/maatdb/versions.tf
+++ b/terraform/environments/maatdb/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/mlra/modules/alb/versions.tf
+++ b/terraform/environments/mlra/modules/alb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       configuration_aliases = [aws.core-vpc,
         aws.core-network-services,
         aws.bucket-replication,

--- a/terraform/environments/mlra/modules/ecs/versions.tf
+++ b/terraform/environments/mlra/modules/ecs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/mlra/versions.tf
+++ b/terraform/environments/mlra/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/mojfin/versions.tf
+++ b/terraform/environments/mojfin/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/ncas/versions.tf
+++ b/terraform/environments/ncas/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/nomis-combined-reporting/versions.tf
+++ b/terraform/environments/nomis-combined-reporting/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/nomis-data-hub/versions.tf
+++ b/terraform/environments/nomis-data-hub/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/nomis/versions.tf
+++ b/terraform/environments/nomis/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/oas/versions.tf
+++ b/terraform/environments/oas/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/oasys-national-reporting/versions.tf
+++ b/terraform/environments/oasys-national-reporting/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.8"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/oasys/versions.tf
+++ b/terraform/environments/oasys/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/providers.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/pagerduty/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/environments/observability-platform/modules/grafana/contact-point/slack/providers.tf
+++ b/terraform/environments/observability-platform/modules/grafana/contact-point/slack/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/environments/observability-platform/modules/grafana/team/providers.tf
+++ b/terraform/environments/observability-platform/modules/grafana/team/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/environments/observability-platform/modules/prometheus/iam-role/providers.tf
+++ b/terraform/environments/observability-platform/modules/prometheus/iam-role/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = "~> 1.0"

--- a/terraform/environments/observability-platform/versions.tf
+++ b/terraform/environments/observability-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.8, != 5.86.0"
       source  = "hashicorp/aws"
     }
     grafana = {

--- a/terraform/environments/operations-engineering/versions.tf
+++ b/terraform/environments/operations-engineering/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/panda-cyber-appsec-lab/versions.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/performance-hub/module/ecs/versions.tf
+++ b/terraform/environments/performance-hub/module/ecs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
   }

--- a/terraform/environments/performance-hub/versions.tf
+++ b/terraform/environments/performance-hub/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/planetfm/versions.tf
+++ b/terraform/environments/planetfm/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/portal/versions.tf
+++ b/terraform/environments/portal/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/ppud/versions.tf
+++ b/terraform/environments/ppud/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/pra-register/versions.tf
+++ b/terraform/environments/pra-register/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/refer-monitor/versions.tf
+++ b/terraform/environments/refer-monitor/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/sprinkler/playground/versions.tf
+++ b/terraform/environments/sprinkler/playground/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/sprinkler/testbed/versions.tf
+++ b/terraform/environments/sprinkler/testbed/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/sprinkler/versions.tf
+++ b/terraform/environments/sprinkler/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/tipstaff/versions.tf
+++ b/terraform/environments/tipstaff/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/tribunals/versions.tf
+++ b/terraform/environments/tribunals/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/wardship/versions.tf
+++ b/terraform/environments/wardship/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/youth-justice-app-framework/modules/codedeploy/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/codedeploy/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/youth-justice-app-framework/modules/directory-service/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/directory-service/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/environments/youth-justice-app-framework/modules/dns/certs/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/dns/certs/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/youth-justice-app-framework/modules/dns/hosted_zone/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/dns/hosted_zone/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/terraform/environments/youth-justice-app-framework/modules/ecs/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/ecs/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform/environments/youth-justice-app-framework/modules/s3/providers.tf
+++ b/terraform/environments/youth-justice-app-framework/modules/s3/providers.tf
@@ -2,9 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
     }
   }
   required_version = ">= 1.0.1"
 }
-

--- a/terraform/environments/youth-justice-app-framework/versions.tf
+++ b/terraform/environments/youth-justice-app-framework/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
Following issues identified with Terraform AWS provider version v5.86 in our ask channel [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1738919794838099) and confirmed [here](https://github.com/hashicorp/terraform-provider-aws/issues/41268) with the provider this PR will skip the v5.86 release.

This should be merged as the issues caused in v5.86 are not backward scompatible with v5.85 as shown [here](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/13197466700/job/36841844549?pr=9596#step:11:444) 