### PR TITLE
Add AWS Glue Crawler and SNS topic for FMS land bucket count

### DIFF
--- a/terraform/environments/electronic-monitoring-data/historic_crawler.tf
+++ b/terraform/environments/electronic-monitoring-data/historic_crawler.tf
@@ -4,7 +4,7 @@ resource "aws_glue_crawler" "iceberg_crawler" {
   role          = aws_iam_role.glue_role.arn
 
   iceberg_target {
-    paths                   = "s3://emds-test-cadt/data/test/models/domain_name=historic/database_name=historic_api_mart_mock/"
+    paths                   = toset(["s3://emds-test-cadt/data/test/models/domain_name=historic/database_name=historic_api_mart_mock/"])
     maximum_traversal_depth = 20
   }
 

--- a/terraform/environments/electronic-monitoring-data/historic_crawler.tf
+++ b/terraform/environments/electronic-monitoring-data/historic_crawler.tf
@@ -3,8 +3,9 @@ resource "aws_glue_crawler" "iceberg_crawler" {
   name          = "historic_api_mart_crawler"
   role          = aws_iam_role.glue_role.arn
 
-  s3_target {
-    path = "s3://emds-test-cadt/data/test/models/domain_name=historic/database_name=historic_api_mart_mock/"
+  iceberg_target {
+    paths                   = "s3://emds-test-cadt/data/test/models/domain_name=historic/database_name=historic_api_mart_mock/"
+    maximum_traversal_depth = 20
   }
 
   configuration = jsonencode({

--- a/terraform/environments/electronic-monitoring-data/historic_crawler.tf
+++ b/terraform/environments/electronic-monitoring-data/historic_crawler.tf
@@ -33,6 +33,17 @@ resource "aws_iam_role" "glue_role" {
   })
 }
 
+resource "aws_lakeformation_permissions" "s3_bucket_permissions_de" {
+  principal = aws_iam_role.glue_role.arn
+
+  permissions = ["DATA_LOCATION_ACCESS"]
+
+  data_location {
+    arn = aws_lakeformation_resource.data_bucket.arn
+  }
+}
+
+
 # Attach necessary policies to the role
 resource "aws_iam_role_policy_attachment" "glue_service" {
   role       = aws_iam_role.glue_role.name

--- a/terraform/environments/electronic-monitoring-data/historic_crawler.tf
+++ b/terraform/environments/electronic-monitoring-data/historic_crawler.tf
@@ -1,0 +1,65 @@
+resource "aws_glue_crawler" "iceberg_crawler" {
+  database_name = "historic_api_mart"
+  name          = "historic_api_mart_crawler"
+  role          = aws_iam_role.glue_role.arn
+
+  s3_target {
+    path = "s3://emds-test-cadt/data/test/models/domain_name=historic/database_name=historic_api_mart_mock/"
+  }
+
+  configuration = jsonencode({
+    Version = 1.0
+    Grouping = {
+      TableGroupingPolicy = "CombineCompatibleSchemas"
+    }
+  })
+}
+
+# IAM role for the crawler
+resource "aws_iam_role" "glue_role" {
+  name = "historic_api_mart_crawler_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach necessary policies to the role
+resource "aws_iam_role_policy_attachment" "glue_service" {
+  role       = aws_iam_role.glue_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+# Custom policy for S3 access
+resource "aws_iam_role_policy" "s3_access" {
+  name = "s3_access"
+  role = aws_iam_role.glue_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::emds-test-cadt/*",
+          "arn:aws:s3:::emds-test-cadt"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/environments/electronic-monitoring-data/metric_alarms.tf
+++ b/terraform/environments/electronic-monitoring-data/metric_alarms.tf
@@ -39,7 +39,7 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
 # Add a local to get the keys
 locals {
   pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
-  sns_names_map              = tomap({ "lambda_failure" : aws_sns_topic.lambda_failure.name, "fms_bucket_alarm" : aws_sns_topic.fms_land_bucket_count.name })
+  sns_names_map              = tomap({ "lambda_failure" : aws_sns_topic.lambda_failure.name })
 }
 
 # link the sns topic to the service

--- a/terraform/environments/electronic-monitoring-data/metric_alarms.tf
+++ b/terraform/environments/electronic-monitoring-data/metric_alarms.tf
@@ -25,39 +25,6 @@ module "all_lambdas_errors_alarm" {
   alarm_actions = [aws_sns_topic.lambda_failure.arn]
 }
 
-#tfsec:ignore:avd-aws-0136 No encryption is enabled on the SNS topic
-resource "aws_sns_topic" "fms_land_bucket_count" {
-  name              = "fms-land-bucket-count"
-  kms_master_key_id = "alias/aws/sns"
-}
-
-# Alarm - "Detect when no files land in fms bucket within 24 hours"
-module "files_in_fms_land_bucket_alarm" {
-  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash. No commit hash on this module
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "5.7.0"
-
-  alarm_name          = "fms-land-no-files"
-  alarm_description   = "Detect when no files land in fms bucket within 24 hours"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = 1
-  threshold           = 0
-  period              = 86400
-  unit                = "Count"
-
-  namespace   = "AWS/S3"
-  metric_name = "NumberOfObjects"
-  statistic   = "Sum"
-
-  dimensions = {
-    BucketName  = module.s3-fms-general-landing-bucket.bucket.id
-    StorageType = "AllStorageTypes"
-  }
-
-  alarm_actions = [aws_sns_topic.land_bucket_count.arn]
-}
-
-
 # Get the map of pagerduty integration keys from the modernisation platform account
 data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
   provider = aws.modernisation-platform


### PR DESCRIPTION
Introduce an AWS Glue Crawler and an IAM role for the Historic API Mart, along with an SNS topic and alarm configuration for monitoring the FMS land bucket count.