### PR TITLE
🔨 Patch APC and upgrade EKS cluster

### DIFF
--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -6,7 +6,7 @@ module "eks" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks/aws"
-  version = "20.31.6"
+  version = "20.33.1"
 
   cluster_name    = local.eks_cluster_name
   cluster_version = local.environment_configuration.eks_cluster_version
@@ -200,7 +200,7 @@ module "karpenter" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "20.31.6"
+  version = "20.33.1"
 
   cluster_name = module.eks.cluster_name
 

--- a/terraform/environments/analytical-platform-compute/eks-pod-identities.tf
+++ b/terraform/environments/analytical-platform-compute/eks-pod-identities.tf
@@ -7,7 +7,7 @@ module "aws_cloudwatch_metrics_pod_identity" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.9.0"
+  version = "1.10.0"
 
   name = "aws-cloudwatch-metrics"
 

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -21,7 +21,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
       eks_cluster_version = "1.32"
-      eks_node_version    = "1.32.0-cacc4ce"
+      eks_node_version    = "1.32.0-cacc4ce9"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
         kube_proxy             = "v1.32.0-eksbuild.2"
@@ -70,7 +70,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.32"
-      eks_node_version    = "1.32.0-cacc4ce"
+      eks_node_version    = "1.32.0-cacc4ce9"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
         kube_proxy             = "v1.32.0-eksbuild.2"
@@ -119,7 +119,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.32"
-      eks_node_version    = "1.32.0-cacc4ce"
+      eks_node_version    = "1.32.0-cacc4ce9"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
         kube_proxy             = "v1.32.0-eksbuild.2"

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -20,13 +20,13 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
-      eks_cluster_version = "1.31"
-      eks_node_version    = "1.29.0-c55d099c"
+      eks_cluster_version = "1.32"
+      eks_node_version    = "1.32.0-cacc4ce"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
-        kube_proxy             = "v1.31.3-eksbuild.2"
-        aws_ebs_csi_driver     = "v1.38.1-eksbuild.1"
-        aws_efs_csi_driver     = "v2.1.3-eksbuild.1"
+        kube_proxy             = "v1.32.0-eksbuild.2"
+        aws_ebs_csi_driver     = "v1.39.0-eksbuild.1"
+        aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
         vpc_cni                = "v1.19.2-eksbuild.1"
@@ -69,13 +69,13 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.31"
-      eks_node_version    = "1.29.0-c55d099c"
+      eks_cluster_version = "1.32"
+      eks_node_version    = "1.32.0-cacc4ce"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
-        kube_proxy             = "v1.31.3-eksbuild.2"
-        aws_ebs_csi_driver     = "v1.38.1-eksbuild.1"
-        aws_efs_csi_driver     = "v2.1.3-eksbuild.1"
+        kube_proxy             = "v1.32.0-eksbuild.2"
+        aws_ebs_csi_driver     = "v1.39.0-eksbuild.1"
+        aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
         vpc_cni                = "v1.19.2-eksbuild.1"
@@ -118,13 +118,13 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.31"
-      eks_node_version    = "1.29.0-c55d099c"
+      eks_cluster_version = "1.32"
+      eks_node_version    = "1.32.0-cacc4ce"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.2"
-        kube_proxy             = "v1.31.3-eksbuild.2"
-        aws_ebs_csi_driver     = "v1.38.1-eksbuild.1"
-        aws_efs_csi_driver     = "v2.1.3-eksbuild.1"
+        kube_proxy             = "v1.32.0-eksbuild.2"
+        aws_ebs_csi_driver     = "v1.39.0-eksbuild.1"
+        aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
         vpc_cni                = "v1.19.2-eksbuild.1"

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -29,7 +29,7 @@ locals {
         aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
-        vpc_cni                = "v1.19.2-eksbuild.1"
+        vpc_cni                = "v1.19.2-eksbuild.5"
       }
 
       /* Data Engineering Airflow */
@@ -78,7 +78,7 @@ locals {
         aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
-        vpc_cni                = "v1.19.2-eksbuild.1"
+        vpc_cni                = "v1.19.2-eksbuild.5"
       }
 
       /* Data Engineering Airflow */
@@ -127,7 +127,7 @@ locals {
         aws_efs_csi_driver     = "v2.1.4-eksbuild.1"
         aws_guardduty_agent    = "v1.8.1-eksbuild.2"
         eks_pod_identity_agent = "v1.3.4-eksbuild.1"
-        vpc_cni                = "v1.19.2-eksbuild.1"
+        vpc_cni                = "v1.19.2-eksbuild.5"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -4,7 +4,7 @@ resource "helm_release" "kyverno" {
   name       = "kyverno"
   repository = "https://kyverno.github.io/kyverno"
   chart      = "kyverno"
-  version    = "3.3.4"
+  version    = "3.3.6"
   namespace  = kubernetes_namespace.kyverno.metadata[0].name
   values = [
     templatefile(
@@ -71,7 +71,7 @@ resource "helm_release" "amazon_prometheus_proxy" {
   name       = "amazon-prometheus-proxy"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  version    = "67.8.0"
+  version    = "69.2.2"
   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
   values = [
     templatefile(
@@ -96,7 +96,7 @@ resource "helm_release" "cluster_autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.45.0"
+  version    = "9.46.0"
   namespace  = kubernetes_namespace.cluster_autoscaler.metadata[0].name
 
   values = [
@@ -119,7 +119,7 @@ resource "helm_release" "karpenter_crd" {
   name       = "karpenter-crd"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter-crd"
-  version    = "1.1.1"
+  version    = "1.2.1"
   namespace  = kubernetes_namespace.karpenter.metadata[0].name
 
   values = [
@@ -141,7 +141,7 @@ resource "helm_release" "karpenter" {
   name       = "karpenter"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
-  version    = "1.1.1"
+  version    = "1.2.1"
   namespace  = kubernetes_namespace.karpenter.metadata[0].name
 
   values = [
@@ -188,7 +188,7 @@ resource "helm_release" "external_dns" {
   name       = "external-dns"
   repository = "https://kubernetes-sigs.github.io/external-dns"
   chart      = "external-dns"
-  version    = "1.15.0"
+  version    = "1.15.1"
   namespace  = kubernetes_namespace.external_dns.metadata[0].name
   values = [
     templatefile(
@@ -209,7 +209,7 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.16.2"
+  version    = "v1.17.0"
   namespace  = kubernetes_namespace.cert_manager.metadata[0].name
   values = [
     templatefile(
@@ -283,7 +283,7 @@ resource "helm_release" "external_secrets" {
   name       = "external-secrets"
   repository = "https://charts.external-secrets.io"
   chart      = "external-secrets"
-  version    = "0.12.1"
+  version    = "0.14.1"
   namespace  = kubernetes_namespace.external_secrets.metadata[0].name
   values = [
     templatefile(

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -18,7 +18,7 @@ module "eks_cluster_logs_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "eks-cluster-logs-kms-access"
 
@@ -47,7 +47,7 @@ module "karpenter_sqs_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "karpenter-sqs-kms-access"
 
@@ -75,7 +75,7 @@ module "amazon_prometheus_proxy_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "amazon-prometheus-proxy"
 
@@ -104,7 +104,7 @@ module "managed_prometheus_kms_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "managed-prometheus-kms-access"
 
@@ -155,7 +155,7 @@ module "mlflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "mlflow"
 
@@ -178,7 +178,7 @@ module "gha_mojas_airflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "github-actions-mojas-airflow"
 
@@ -268,7 +268,7 @@ module "analytical_platform_lake_formation_share_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "analytical-platform-lake-formation-sharing-policy"
 
@@ -299,7 +299,7 @@ module "quicksight_vpc_connection_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "quicksight-vpc-connection"
 
@@ -346,7 +346,7 @@ module "data_production_mojap_derived_bucket_lake_formation_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "analytical-platform-data-bucket-lake-formation-policy"
 
@@ -451,7 +451,7 @@ module "copy_apdp_cadet_metadata_to_compute_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "copy-apdp-cadet-metadata-to-compute-"
 
@@ -488,7 +488,7 @@ module "find_moj_data_quicksight_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name_prefix = "find-moj-data-quicksight-policy-"
 
@@ -642,7 +642,7 @@ module "gha_moj_ap_airflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name = "github-actions-ministryofjustice-analytical-platform-airflow"
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -3,7 +3,7 @@ module "vpc_cni_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix      = "vpc-cni"
   attach_vpc_cni_policy = true
@@ -24,7 +24,7 @@ module "ebs_csi_driver_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix      = "ebs-csi-driver"
   attach_ebs_csi_policy = true
@@ -44,7 +44,7 @@ module "efs_csi_driver_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix      = "efs-csi-driver"
   attach_efs_csi_policy = true
@@ -64,7 +64,7 @@ module "aws_for_fluent_bit_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix = "aws-for-fluent-bit"
 
@@ -88,7 +88,7 @@ module "amazon_prometheus_proxy_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix = "amazon-prometheus-proxy"
 
@@ -111,7 +111,7 @@ module "cluster_autoscaler_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix = "cluster-autoscaler"
 
@@ -133,7 +133,7 @@ module "external_dns_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix              = "external-dns"
   attach_external_dns_policy    = true
@@ -154,7 +154,7 @@ module "cert_manager_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix              = "cert-manager"
   attach_cert_manager_policy    = true
@@ -175,7 +175,7 @@ module "external_secrets_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix               = "external-secrets"
   attach_external_secrets_policy = true
@@ -196,7 +196,7 @@ module "mlflow_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   role_name_prefix = "mlflow"
 
@@ -219,7 +219,7 @@ module "gha_mojas_airflow_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name = "github-actions-mojas-airflow"
 
@@ -237,7 +237,7 @@ module "lake_formation_share_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   create_role       = true
   role_requires_mfa = false
@@ -264,7 +264,7 @@ module "analytical_platform_ui_service_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.52.1"
+  version = "5.52.2"
 
   create_role = true
 
@@ -288,7 +288,7 @@ module "analytical_platform_control_panel_service_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   allow_self_assume_role = true
   trusted_role_arns = [
@@ -313,7 +313,7 @@ module "analytical_platform_data_eng_dba_service_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   allow_self_assume_role = false
   trusted_role_arns      = formatlist("arn:aws:iam::%s:root", [local.environment_management.account_ids[local.analytical_platform_environment], local.environment_management.account_ids["analytical-platform-management-production"]])
@@ -335,7 +335,7 @@ module "quicksight_vpc_connection_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   create_role       = true
   role_name_prefix  = "quicksight-vpc-connection"
@@ -353,7 +353,7 @@ module "lake_formation_to_data_production_mojap_derived_tables_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   create_role       = true
   role_requires_mfa = false
@@ -382,7 +382,7 @@ module "copy_apdp_cadet_metadata_to_compute_assumable_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   allow_self_assume_role = false
   trusted_role_arns = [
@@ -404,7 +404,7 @@ module "find_moj_data_quicksight_sa_assumable_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   allow_self_assume_role = false
   trusted_role_arns = [
@@ -449,7 +449,7 @@ module "gha_moj_ap_airflow_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.52.1"
+  version = "5.52.2"
 
   name = "github-actions-ministryofjustice-analytical-platform-airflow"
 

--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -17,7 +17,7 @@ locals {
   eks_cloudwatch_log_group_retention_in_days = 400
 
   /* Kube Prometheus Stack */
-  prometheus_operator_crd_version = "v0.79.2"
+  prometheus_operator_crd_version = "v0.80.0"
 
   /* Mapping Analytical Platform Environments to Modernisation Platform */
 

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -3,7 +3,7 @@ module "mlflow_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = "mojap-compute-${local.environment}-mlflow"
 
@@ -46,7 +46,7 @@ module "mojap_compute_logs_bucket_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = "mojap-compute-${local.environment}-logs-eu-west-2"
 
@@ -101,7 +101,7 @@ module "mojap_compute_logs_bucket_eu_west_1" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   providers = {
     aws = aws.analytical-platform-compute-eu-west-1
@@ -163,7 +163,7 @@ module "mojap_compute_athena_query_results_bucket_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = "mojap-compute-${local.environment}-athena-query-results-eu-west-2"
 
@@ -199,7 +199,7 @@ module "mwaa_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = "mojap-compute-${local.environment}-mwaa"
 

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -3,7 +3,7 @@ module "mlflow_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
+  version = "4.5.0"
 
   bucket = "mojap-compute-${local.environment}-mlflow"
 
@@ -46,7 +46,7 @@ module "mojap_compute_logs_bucket_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
+  version = "4.5.0"
 
   bucket = "mojap-compute-${local.environment}-logs-eu-west-2"
 
@@ -101,7 +101,7 @@ module "mojap_compute_logs_bucket_eu_west_1" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
+  version = "4.5.0"
 
   providers = {
     aws = aws.analytical-platform-compute-eu-west-1
@@ -163,7 +163,7 @@ module "mojap_compute_athena_query_results_bucket_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
+  version = "4.5.0"
 
   bucket = "mojap-compute-${local.environment}-athena-query-results-eu-west-2"
 
@@ -199,7 +199,7 @@ module "mwaa_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.4.0"
+  version = "4.5.0"
 
   bucket = "mojap-compute-${local.environment}-mwaa"
 

--- a/terraform/environments/analytical-platform-compute/s3-objects.tf
+++ b/terraform/environments/analytical-platform-compute/s3-objects.tf
@@ -3,7 +3,7 @@ module "airflow_requirements_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "requirements.txt"
@@ -19,7 +19,7 @@ module "airflow_kube_config_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = module.mwaa_bucket.s3_bucket_id
   key    = "dags/.kube/config"
@@ -38,7 +38,7 @@ module "airflow_plugins_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "plugins.zip"

--- a/terraform/environments/analytical-platform-compute/s3-objects.tf
+++ b/terraform/environments/analytical-platform-compute/s3-objects.tf
@@ -3,7 +3,7 @@ module "airflow_requirements_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.4.0"
+  version = "4.5.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "requirements.txt"
@@ -19,7 +19,7 @@ module "airflow_kube_config_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.4.0"
+  version = "4.5.0"
 
   bucket = module.mwaa_bucket.s3_bucket_id
   key    = "dags/.kube/config"
@@ -38,7 +38,7 @@ module "airflow_plugins_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "4.4.0"
+  version = "4.5.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "plugins.zip"

--- a/terraform/environments/analytical-platform-compute/security-groups.tf
+++ b/terraform/environments/analytical-platform-compute/security-groups.tf
@@ -3,7 +3,7 @@ module "vpc_endpoints_security_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/security-group/aws"
-  version = "5.2.0"
+  version = "5.3.0"
 
   name        = "${module.vpc.name}-vpc-endpoints"
   description = "VPC endpoints security group"
@@ -21,7 +21,7 @@ module "rds_security_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/security-group/aws"
-  version = "5.2.0"
+  version = "5.3.0"
 
   name = "rds"
 
@@ -44,7 +44,7 @@ module "quicksight_shared_vpc_security_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/security-group/aws"
-  version = "5.2.0"
+  version = "5.3.0"
 
   name = "quicksight-shared-vpc"
 

--- a/terraform/environments/analytical-platform-compute/vpc-endpoints.tf
+++ b/terraform/environments/analytical-platform-compute/vpc-endpoints.tf
@@ -3,7 +3,7 @@ module "vpc_endpoints" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "5.18.1"
+  version = "5.19.0"
 
   vpc_id             = module.vpc.vpc_id
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/environments/analytical-platform-compute/vpc-endpoints.tf
+++ b/terraform/environments/analytical-platform-compute/vpc-endpoints.tf
@@ -3,7 +3,7 @@ module "vpc_endpoints" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "5.17.0"
+  version = "5.18.1"
 
   vpc_id             = module.vpc.vpc_id
   subnet_ids         = module.vpc.private_subnets

--- a/terraform/environments/analytical-platform-compute/vpc.tf
+++ b/terraform/environments/analytical-platform-compute/vpc.tf
@@ -6,7 +6,7 @@ module "vpc" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.17.0"
+  version = "5.19.0"
 
   name                = local.our_vpc_name
   azs                 = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
This pull request:

- completes this ticket: https://github.com/ministryofjustice/analytical-platform/issues/6651
- patches `analytical-platform-compute` and upgrades the EKS cluster to new version

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>