### PR TITLE
🧪 Permissions Test - to be reverted

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
@@ -27,7 +27,8 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "s3:GetObjectVersionForReplication",
       "s3:GetObjectVersionAcl",
       "s3:GetObjectVersionTagging",
-      "s3:ObjectOwnerOverrideToBucketOwner"
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:*"
     ]
     resources = length(module.cica_dms_ingress_bucket) > 0 ? ["${module.cica_dms_ingress_bucket[0].s3_bucket_arn}/*"] : []
   }

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
@@ -16,7 +16,8 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
     effect = "Allow"
     actions = [
       "s3:GetReplicationConfiguration",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:*"
     ]
     resources = length(module.cica_dms_ingress_bucket) > 0 ? [module.cica_dms_ingress_bucket[0].s3_bucket_arn] : []
   }


### PR DESCRIPTION
This is a test to confirm that the inability to replication from `analytical-platform-ingestion` to `analytical-platform-data-production` is due to permissions 