### PR TITLE
Adding get tagging permission to scan lambda

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -112,7 +112,8 @@ module "scan_lambda" {
         "s3:CopyObject",
         "s3:PutObject",
         "s3:DeleteObject",
-        "s3:PutObjectTagging"
+        "s3:PutObjectTagging",
+        "s3:GetObjectTagging"
       ]
       resources = [
         "arn:aws:s3:::${module.definitions_bucket.s3_bucket_id}/*",


### PR DESCRIPTION
This doesn't appear to impact the working of the function but in the logs, the scan lambda keeps hitting an access denied error due to being unable to read object tags form the source file.