### PR TITLE
TM-964: failed-backup-alert-preprod

### DIFF
--- a/terraform/environments/hmpps-domain-services/sns.tf
+++ b/terraform/environments/hmpps-domain-services/sns.tf
@@ -1,0 +1,6 @@
+resource "aws_sns_topic_subscription" "backup_failure_topic" {
+  count = local.environment == "preproduction" ? 1 : 0
+  topic_arn = module.environment.backup_failure_topic.arn
+  protocol  = "https"
+  endpoint  = "https://events.pagerduty.com/integration/7a6a31bc364c440fd0b947bf41c9aa7f/enqueue"
+}

--- a/terraform/modules/environment/data.tf
+++ b/terraform/modules/environment/data.tf
@@ -101,3 +101,8 @@ data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
   provider  = aws.modernisation-platform
   secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
 }
+
+# Data source to get the ARN of an existing SNS topic
+data "aws_sns_topic" "backup_failure_topic" {
+  name  = "backup_failure_topic"
+}

--- a/terraform/modules/environment/outputs.tf
+++ b/terraform/modules/environment/outputs.tf
@@ -141,3 +141,8 @@ output "pagerduty_integration_keys" {
   value       = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
   sensitive   = true
 }
+
+output "backup_failure_topic" {
+  description = "existing backup failure topic managed by modernisation platform"
+  value       = data.aws_sns_topic.backup_failure_topic
+}


### PR DESCRIPTION
Testing a subscription to the pre-existing failed backup topic.