### PR TITLE
DPR2-1744: Update EOL DMS instance types and delete unused variables.

### DIFF
--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -857,7 +857,6 @@ module "dms_nomis_to_s3_ingestor" {
   source_db_port               = jsondecode(data.aws_secretsmanager_secret_version.nomis.secret_string)["port"]
   vpc                          = data.aws_vpc.shared.id
   project_id                   = local.project
-  env                          = local.environment
   dms_source_name              = "oracle"
   dms_target_name              = "s3"
   short_name                   = "nomis"

--- a/terraform/environments/digital-prison-reporting/modules/dms/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/variables.tf
@@ -20,11 +20,6 @@ variable "project_id" {
   description = "(Required) Project Short ID that will be used for resources."
 }
 
-variable "env" {
-  type        = string
-  description = "Env Type"
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}
@@ -92,86 +87,6 @@ variable "create" {
   default = true
 }
 
-variable "create_iam_roles" {
-  type    = bool
-  default = true
-}
-
-variable "iam_role_permissions_boundary" {
-  description = "ARN of the policy that is used to set the permissions boundary for the role"
-  type        = string
-  default     = null
-}
-
-# Used in tagginga and naming the resources
-
-variable "stack_name" {
-  type        = string
-  description = "The name of our application"
-  default     = "dblink"
-}
-
-variable "owner" {
-  type        = string
-  description = "A group email address to be used in tags"
-  default     = "autobots@ga.gov.au"
-}
-
-#--------------------------------------------------------------
-# DMS general config
-#--------------------------------------------------------------
-
-variable "identifier" {
-  type        = string
-  default     = "rds"
-  description = "Name of the database in the RDS"
-}
-
-#--------------------------------------------------------------
-# DMS target config
-#--------------------------------------------------------------
-
-variable "target_backup_retention_period" {
-  type = string
-  # Days
-  default     = "30"
-  description = "Retention of RDS backups"
-}
-
-variable "target_backup_window" {
-  type        = string
-  default     = "14:00-17:00"
-  description = "RDS backup window"
-}
-
-variable "target_db_port" {
-  type        = number
-  description = "The port the Application Server will access the database on"
-  default     = 5432
-}
-
-variable "target_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "9.3.14"
-}
-
-variable "target_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "target_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-#variable "target_username" {
-#  description = "Username to access the target database"
-#}
-
 #--------------------------------------------------------------
 # DMS source config
 #--------------------------------------------------------------
@@ -186,13 +101,6 @@ variable "source_app_username" {
   description = "Username for the endpoint to access the source database"
 }
 
-variable "source_backup_window" {
-  type = string
-  # 12:00AM-03:00AM AEST
-  default     = "14:00-17:00"
-  description = "RDS backup window"
-}
-
 variable "source_db_name" {
   type        = string
   description = "Name of the target database"
@@ -205,52 +113,10 @@ variable "source_db_port" {
   default     = null
 }
 
-variable "source_engine" {
-  type        = string
-  default     = "oracle-se2"
-  description = "Engine type, example values mysql, postgres"
-}
-
 variable "source_engine_name" {
   type        = string
   default     = ""
   description = "Engine name for DMS"
-}
-
-variable "source_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "12.1.0.2.v8"
-}
-
-variable "source_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "source_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-variable "source_password" {
-  type        = string
-  description = "Password of the source database"
-  default     = ""
-}
-
-variable "source_storage_encrypted" {
-  type        = bool
-  description = "Encrypt storage or leave unencrypted"
-  default     = false
-}
-
-variable "source_username" {
-  type        = string
-  description = "Username to access the source database"
-  default     = ""
 }
 
 #--------------------------------------------------------------
@@ -278,7 +144,7 @@ variable "replication_instance_version" {
 variable "replication_instance_class" {
   type        = string
   description = "Instance class of replication instance"
-  default     = "dms.t2.micro"
+  default     = "dms.t3.micro"
 }
 
 variable "allow_major_version_upgrade" {
@@ -290,12 +156,6 @@ variable "allow_major_version_upgrade" {
 #--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
-
-variable "database_subnet_cidr" {
-  type        = list(string)
-  default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
-  description = "List of subnets to be used for databases"
-}
 
 variable "vpc_cidr" {
   description = "CIDR for the  VPC"

--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/variables.tf
@@ -20,11 +20,6 @@ variable "project_id" {
   description = "(Required) Project Short ID that will be used for resources."
 }
 
-variable "env" {
-  type        = string
-  description = "Env Type"
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}
@@ -81,93 +76,15 @@ variable "create" {
   default = true
 }
 
-variable "create_iam_roles" {
-  type    = bool
-  default = true
-}
-
-variable "iam_role_permissions_boundary" {
-  description = "ARN of the policy that is used to set the permissions boundary for the role"
-  type        = string
-  default     = null
-}
-
-# Used in tagginga and naming the resources
-
-variable "stack_name" {
-  type        = string
-  description = "The name of our application"
-  default     = "dblink"
-}
-
-variable "owner" {
-  type        = string
-  description = "A group email address to be used in tags"
-  default     = "autobots@ga.gov.au"
-}
-
-#--------------------------------------------------------------
-# DMS general config
-#--------------------------------------------------------------
-
-variable "identifier" {
-  type        = string
-  default     = "rds"
-  description = "Name of the database in the RDS"
-}
-
 #--------------------------------------------------------------
 # DMS target config
 #--------------------------------------------------------------
-
-variable "target_backup_window" {
-  type = string
-  # 12:00AM-03:00AM AEST
-  default     = "14:00-17:00"
-  description = "RDS backup window"
-}
-
-#variable "target_db_name" {
-#  description = "Name of the target database"
-#}
-
-variable "target_db_port" {
-  type        = number
-  description = "The port the Application Server will access the database on"
-  default     = 5432
-}
 
 variable "target_engine" {
   type        = string
   default     = "kinesis"
   description = "Engine type, example values mysql, postgres"
 }
-
-variable "target_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "9.3.14"
-}
-
-variable "target_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "target_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-#variable "target_password" {
-#  description = "Password of the target database"
-#}
-
-#variable "target_username" {
-#  description = "Username to access the target database"
-#}
 
 variable "kinesis_settings" {
   type        = map(any)
@@ -188,13 +105,6 @@ variable "source_app_username" {
   description = "Username for the endpoint to access the source database"
 }
 
-variable "source_backup_window" {
-  type = string
-  # 12:00AM-03:00AM AEST
-  default     = "14:00-17:00"
-  description = "RDS backup window"
-}
-
 variable "source_db_name" {
   type        = string
   description = "Name of the target database"
@@ -207,52 +117,10 @@ variable "source_db_port" {
   default     = null
 }
 
-variable "source_engine" {
-  type        = string
-  default     = "oracle-se2"
-  description = "Engine type, example values mysql, postgres"
-}
-
 variable "source_engine_name" {
   type        = string
   default     = ""
   description = "Engine name for DMS"
-}
-
-variable "source_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "12.1.0.2.v8"
-}
-
-variable "source_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "source_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-variable "source_password" {
-  type        = string
-  description = "Password of the source database"
-  default     = ""
-}
-
-variable "source_storage_encrypted" {
-  type        = bool
-  description = "Encrypt storage or leave unencrypted"
-  default     = false
-}
-
-variable "source_username" {
-  type        = string
-  description = "Username to access the source database"
-  default     = ""
 }
 
 #--------------------------------------------------------------
@@ -280,18 +148,12 @@ variable "replication_instance_version" {
 variable "replication_instance_class" {
   type        = string
   description = "Instance class of replication instance"
-  default     = "dms.t2.micro"
+  default     = "dms.t3.micro"
 }
 
 #--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
-
-variable "database_subnet_cidr" {
-  type        = list(string)
-  default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
-  description = "List of subnets to be used for databases"
-}
 
 variable "vpc_cidr" {
   description = "CIDR for the  VPC"

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/variables.tf
@@ -1,16 +1,3 @@
-
-variable "account_region" {
-  description = "Current AWS Region."
-  type        = string
-  default     = "eu-west-2"
-}
-
-variable "account_id" {
-  description = "AWS Account ID."
-  type        = string
-  default     = ""
-}
-
 variable "name" {
   description = "DMS Replication name."
   type        = string
@@ -60,41 +47,6 @@ variable "create" {
   default = true
 }
 
-variable "create_iam_roles" {
-  type    = bool
-  default = true
-}
-
-variable "iam_role_permissions_boundary" {
-  description = "ARN of the policy that is used to set the permissions boundary for the role"
-  type        = string
-  default     = null
-}
-
-# Used in tagginga and naming the resources
-
-variable "stack_name" {
-  description = "The name of our application"
-  type        = string
-  default     = "dblink"
-}
-
-variable "owner" {
-  description = "A group email address to be used in tags"
-  type        = string
-  default     = "autobots@ga.gov.au"
-}
-
-#--------------------------------------------------------------
-# DMS general config
-#--------------------------------------------------------------
-
-variable "identifier" {
-  default     = "rds"
-  type        = string
-  description = "Name of the database in the RDS"
-}
-
 #--------------------------------------------------------------
 # DMS Replication Instance
 #--------------------------------------------------------------
@@ -120,7 +72,7 @@ variable "replication_instance_version" {
 variable "replication_instance_class" {
   description = "Instance class of replication instance"
   type        = string
-  default     = "dms.t2.micro"
+  default     = "dms.t3.micro"
 }
 
 variable "allow_major_version_upgrade" {
@@ -138,12 +90,6 @@ variable "dms_log_retention_in_days" {
 #--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
-
-variable "database_subnet_cidr" {
-  default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
-  type        = list(string)
-  description = "List of subnets to be used for databases"
-}
 
 variable "vpc_cidr" {
   description = "CIDR for the  VPC"
@@ -252,7 +198,6 @@ variable "dms_target_name" {
   default = ""
 }
 
-
 variable "short_name" {
   type    = string
   default = ""
@@ -292,12 +237,6 @@ variable "source_db_port" {
   description = "The port the Application Server will access the database on"
   type        = number
   default     = null
-}
-
-variable "source_engine" {
-  default     = "oracle-se2"
-  type        = string
-  description = "Engine type, example values mysql, postgres"
 }
 
 variable "source_engine_name" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-endpoints/variables.tf
@@ -84,91 +84,6 @@ variable "bucket_name" {
   type = string
 }
 
-variable "create" {
-  type    = bool
-  default = true
-}
-
-variable "create_iam_roles" {
-  type    = bool
-  default = true
-}
-
-variable "iam_role_permissions_boundary" {
-  description = "ARN of the policy that is used to set the permissions boundary for the role"
-  type        = string
-  default     = null
-}
-
-# Used in tagginga and naming the resources
-
-variable "stack_name" {
-  type        = string
-  description = "The name of our application"
-  default     = "dblink"
-}
-
-variable "owner" {
-  type        = string
-  description = "A group email address to be used in tags"
-  default     = "autobots@ga.gov.au"
-}
-
-#--------------------------------------------------------------
-# DMS general config
-#--------------------------------------------------------------
-
-variable "identifier" {
-  type        = string
-  default     = "rds"
-  description = "Name of the database in the RDS"
-}
-
-#--------------------------------------------------------------
-# DMS target config
-#--------------------------------------------------------------
-
-variable "target_backup_retention_period" {
-  type = string
-  # Days
-  default     = "30"
-  description = "Retention of RDS backups"
-}
-
-variable "target_backup_window" {
-  type        = string
-  default     = "14:00-17:00"
-  description = "RDS backup window"
-}
-
-variable "target_db_port" {
-  type        = number
-  description = "The port the Application Server will access the database on"
-  default     = 5432
-}
-
-variable "target_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "9.3.14"
-}
-
-variable "target_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "target_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-#variable "target_username" {
-#  description = "Username to access the target database"
-#}
-
 #--------------------------------------------------------------
 # DMS source config
 #--------------------------------------------------------------
@@ -195,50 +110,8 @@ variable "source_db_port" {
   default     = null
 }
 
-variable "source_engine" {
-  type        = string
-  default     = "oracle-se2"
-  description = "Engine type, example values mysql, postgres"
-}
-
 variable "source_engine_name" {
   type        = string
   default     = ""
   description = "Engine name for DMS"
-}
-
-variable "source_engine_version" {
-  type        = string
-  description = "Engine version"
-  default     = "12.1.0.2.v8"
-}
-
-variable "source_instance_class" {
-  type        = string
-  default     = "db.t2.micro"
-  description = "Instance class"
-}
-
-variable "source_maintenance_window" {
-  type        = string
-  default     = "Mon:00:00-Mon:03:00"
-  description = "RDS maintenance window"
-}
-
-variable "source_password" {
-  type        = string
-  description = "Password of the source database"
-  default     = ""
-}
-
-variable "source_storage_encrypted" {
-  type        = bool
-  description = "Encrypt storage or leave unencrypted"
-  default     = false
-}
-
-variable "source_username" {
-  type        = string
-  description = "Username to access the source database"
-  default     = ""
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/dms-instance/variables.tf
@@ -1,35 +1,6 @@
-
-variable "account_region" {
-  type        = string
-  description = "Current AWS Region."
-  default     = "eu-west-2"
-}
-
-variable "account_id" {
-  type        = string
-  description = "AWS Account ID."
-  default     = ""
-}
-
-variable "dms_source_endpoint" {
-  type    = string
-  default = ""
-}
-
-variable "dms_target_endpoint" {
-  type    = string
-  default = ""
-}
-
 variable "name" {
   type        = string
   description = "DMS Replication name."
-}
-
-variable "enable_replication_task" {
-  description = "Enable DMS Replication Task, True or False"
-  type        = bool
-  default     = false
 }
 
 variable "setup_dms_instance" {
@@ -54,44 +25,10 @@ variable "tags" {
   description = "(Optional) Key-value map of resource tags."
 }
 
-variable "extra_attributes" {
-  type    = string
-  default = null
-}
-
-variable "dms_source_name" {
-  type    = string
-  default = ""
-}
-
-variable "dms_target_name" {
-  type    = string
-  default = ""
-}
-
 variable "short_name" {
   type    = string
   default = ""
 }
-
-variable "migration_type" {
-  type        = string
-  description = "DMS Migration Type"
-  default     = ""
-}
-
-variable "rename_rule_source_schema" {
-  description = "The source schema we will rename to a target output 'space'"
-  type        = string
-  default     = ""
-}
-
-variable "rename_rule_output_space" {
-  description = "The name of the target output 'space' that the source schema will be renamed to"
-  type        = string
-  default     = ""
-}
-
 
 variable "subnet_ids" {
   description = "An List of VPC subnet IDs to use in the subnet group"
@@ -104,56 +41,9 @@ variable "vpc" {
   default = ""
 }
 
-variable "availability_zone" {
-  type    = string
-  default = null
-}
-
-variable "create" {
-  type    = bool
-  default = true
-}
-
-variable "create_iam_roles" {
-  type    = bool
-  default = true
-}
-
-variable "iam_role_permissions_boundary" {
-  description = "ARN of the policy that is used to set the permissions boundary for the role"
-  type        = string
-  default     = null
-}
-
-# Used in tagginga and naming the resources
-
-variable "stack_name" {
-  type        = string
-  description = "The name of our application"
-  default     = "dblink"
-}
-
-variable "owner" {
-  type        = string
-  description = "A group email address to be used in tags"
-  default     = "autobots@ga.gov.au"
-}
-
 #--------------------------------------------------------------
 # DMS Replication Instance
 #--------------------------------------------------------------
-
-variable "replication_instance_maintenance_window" {
-  type        = string
-  description = "Maintenance window for the replication instance"
-  default     = "sun:10:30-sun:14:30"
-}
-
-variable "replication_instance_storage" {
-  type        = string
-  description = "Size of the replication instance in GB"
-  default     = "10"
-}
 
 variable "replication_instance_version" {
   type        = string
@@ -164,7 +54,7 @@ variable "replication_instance_version" {
 variable "replication_instance_class" {
   type        = string
   description = "Instance class of replication instance"
-  default     = "dms.t2.micro"
+  default     = "dms.t3.micro"
 }
 
 variable "allow_major_version_upgrade" {
@@ -180,24 +70,8 @@ variable "dms_log_retention_in_days" {
 }
 
 #--------------------------------------------------------------
-# DMS general config
-#--------------------------------------------------------------
-
-variable "identifier" {
-  type        = string
-  default     = "rds"
-  description = "Name of the database in the RDS"
-}
-
-#--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
-
-variable "database_subnet_cidr" {
-  type        = list(string)
-  default     = ["10.26.25.208/28", "10.26.25.224/28", "10.26.25.240/28"]
-  description = "List of subnets to be used for databases"
-}
 
 variable "vpc_cidr" {
   description = "CIDR for the  VPC"


### PR DESCRIPTION
* t2 instance type is now migrating to t3
* Additional PR to follow in the domains repo

From AWS:
```Q - What instance type(s) will my Replication instances be auto-upgraded to?
• We will make our best effort to upgrade your Replication instance from C4→C5, M4→R5, R4→R5, and T2→T3 and typically keep its original sizes.
• In cases that we cannot keep the original size, we will first attempt to migrate your Replication instance to another Availability Zone (AZ) in the same region. If this is unsuccessful, we will migrate your Replication instances to one size smaller than its original size.
• The upgraded instance types are priced identically or lower than the older generation instance types. For the most up-to-date prices, please refer to the AWS DMS pricing page [1].
```