### PR TITLE
🪣 🔥 Remove old DataSync S3 bucket

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-policies.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "datasync" {
       "kms:DescribeKey",
       "kms:Decrypt",
     ]
-    resources = [module.s3_datasync_kms.key_arn]
+    resources = [module.s3_datasync_opg_kms.key_arn]
   }
   statement {
     sid    = "AllowS3BucketActions"
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "datasync_replication" {
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    resources = [module.s3_datasync_kms.key_arn]
+    resources = [module.s3_datasync_opg_kms.key_arn]
   }
   statement {
     sid    = "SourceBucketPermissions"

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -227,19 +227,6 @@ module "datasync_credentials_kms" {
   deletion_window_in_days = 7
 }
 
-module "s3_datasync_kms" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-
-  source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.0"
-
-  aliases               = ["s3/datasync"]
-  description           = "DataSync S3 KMS Key"
-  enable_default_policy = true
-
-  deletion_window_in_days = 7
-}
-
 module "s3_datasync_opg_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/environments/analytical-platform-ingestion/s3-notifications.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3-notifications.tf
@@ -6,6 +6,8 @@ module "ingestion_landing_bucket_notification" {
 
   bucket = module.landing_bucket.s3_bucket_id
 
+  eventbridge = true
+
   lambda_notifications = {
     ingestion_scan = {
       function_name = module.scan_lambda.lambda_function_name

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -161,31 +161,6 @@ module "bold_egress_bucket" {
   }
 }
 
-module "datasync_bucket" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-
-  source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
-
-  bucket = "mojap-ingestion-${local.environment}-datasync"
-
-  force_destroy = true
-
-  versioning = {
-    enabled = true
-  }
-
-  server_side_encryption_configuration = {
-    rule = {
-      apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.s3_datasync_kms.key_arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
-}
-
-
 module "datasync_opg_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 


### PR DESCRIPTION
This PR corrects a key and removes an old unneeded key/bucket.

Additionally this sets `eventbridge = true` on the landing S3 bucket. This is required to stop cycling which would occur post the implementation of guardduty.