### PR TITLE
:wrench: Disable DataSync task in Development

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
+++ b/terraform/environments/analytical-platform-ingestion/datasync-tasks.tf
@@ -1,4 +1,7 @@
 resource "aws_datasync_task" "opg" {
+
+  count = local.environment == "production" ? 1 : 0
+
   name                     = "opg"
   source_location_arn      = aws_datasync_location_smb.opg.arn
   destination_location_arn = aws_datasync_location_s3.opg.arn


### PR DESCRIPTION
This PR disables the DataSync task in the development ingestion account `analytical-platform-ingestion-development`