### PR TITLE
Use latest released version of the scheduled dataset lambda in each environment

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -55,6 +55,7 @@
       "setup_sonatype_secrets": true,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
+      "scheduled_dataset_lambda_version": "vLatest",
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -206,6 +207,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
+      "scheduled_dataset_lambda_version": "vLatest",
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -358,6 +360,7 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "enable_redshift_health_check": true,
+      "scheduled_dataset_lambda_version": "vLatest",
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -526,6 +529,7 @@
       "setup_sonatype_secrets": false,
       "setup_scheduled_action_iam_role": false,
       "setup_redshift_schedule": false,
+      "scheduled_dataset_lambda_version": "vLatest",
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -191,7 +191,7 @@ locals {
   lambda_scheduled_dataset_tracing        = "Active"
   lambda_scheduled_dataset_handler        = "uk.gov.justice.digital.hmpps.scheduled.lambda.ReportSchedulerLambda::handleRequest"
   lambda_scheduled_dataset_code_s3_bucket = module.s3_artifacts_store.bucket_id
-  lambda_scheduled_dataset_jar_version    = "vLatest"
+  lambda_scheduled_dataset_jar_version    = local.application_data.accounts[local.environment].scheduled_dataset_lambda_version
   lambda_scheduled_dataset_code_s3_key = (
     local.env == "production" || local.env == "preproduction"
     ? "build-artifacts/hmpps-dpr-scheduled-dataset-lambda/jars/hmpps-dpr-scheduled-dataset-lambda-${local.lambda_scheduled_dataset_jar_version}.rel-all.jar"

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -191,7 +191,7 @@ locals {
   lambda_scheduled_dataset_tracing        = "Active"
   lambda_scheduled_dataset_handler        = "uk.gov.justice.digital.hmpps.scheduled.lambda.ReportSchedulerLambda::handleRequest"
   lambda_scheduled_dataset_code_s3_bucket = module.s3_artifacts_store.bucket_id
-  lambda_scheduled_dataset_jar_version    = "v0.0.8"
+  lambda_scheduled_dataset_jar_version    = "vLatest"
   lambda_scheduled_dataset_code_s3_key = (
     local.env == "production" || local.env == "preproduction"
     ? "build-artifacts/hmpps-dpr-scheduled-dataset-lambda/jars/hmpps-dpr-scheduled-dataset-lambda-${local.lambda_scheduled_dataset_jar_version}.rel-all.jar"


### PR DESCRIPTION
- We currently configure the scheduled dataset lambda version for all environments (Dev, Test, Pre-Prod, Prod) in one variable shared across environments. 
- This causes issues where pipelines fail due to missing artifacts when a new version is released in one environment but not another.
- We also push a vLatest artifact which is the most recently released artifact for that environment ![image](https://github.com/user-attachments/assets/260174cb-5133-4024-b61b-44a8c2a81e21)
- This PR uses the vLatest tag to take the latest released version in each environment but also allows configuring the version by environment separately if required



