### PR TITLE
Enhance live_feed_dbs variable for additional databases

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -4,10 +4,18 @@ locals {
   dbt_k8s_secrets_placeholder = {
     oidc_cluster_identifier = "placeholder2"
   }
-  dbt_suffix             = local.is-production ? "" : "_${local.environment_shorthand}_dbt"
-  admin_roles            = local.is-development ? "sandbox_" : "data-eng"
-  suffix                 = local.is-production ? "" : local.is-preproduction ? "-pp" : local.is-test ? "-test" : "-dev"
-  live_feed_dbs          = ["serco_fms", "allied_mdss", "staged_fms", "preprocessed_fms"]
+  dbt_suffix  = local.is-production ? "" : "_${local.environment_shorthand}_dbt"
+  admin_roles = local.is-development ? "sandbox_" : "data-eng"
+  suffix      = local.is-production ? "" : local.is-preproduction ? "-pp" : local.is-test ? "-test" : "-dev"
+  live_feed_dbs = [
+    "serco_fms",
+    "allied_mdss",
+    "staged_fms",
+    "preprocessed_fms",
+    "staging",
+    "intermediate",
+    "mart"
+  ]
   prod_dbs_to_grant      = local.is-production ? ["am_stg", "cap_dw_stg", "emd_historic_int", "historic_api_mart", "historic_api_mart_mock", "historic_ears_and_sars_int", "historic_ears_and_sars_mart", "emsys_mvp_stg"] : []
   dev_dbs_to_grant       = local.is-production ? [for db in local.prod_dbs_to_grant : "${db}_historic_dev_dbt"] : []
   live_feed_dbs_to_grant = [for db in local.live_feed_dbs : "${db}${local.dbt_suffix}"]


### PR DESCRIPTION
Expand the live_feed_dbs variable to include new entries for staging, intermediate processing, and mart databases.