### PR TITLE
DPR2-1772: Shorten Health and Medication API service identifier

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -68,7 +68,7 @@
         "dps-calculate-release-dates",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medication-api",
+        "dps-health-medic-api",
         "dps-testing"
       ],
       "alarms": {
@@ -218,7 +218,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medication-api",
+        "dps-health-medic-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -371,7 +371,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medication-api",
+        "dps-health-medic-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -540,7 +540,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medication-api",
+        "dps-health-medic-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -68,7 +68,7 @@
         "dps-calculate-release-dates",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-and-medication-api",
+        "dps-health-medication-api",
         "dps-testing"
       ],
       "alarms": {
@@ -218,7 +218,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-and-medication-api",
+        "dps-health-medication-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -371,7 +371,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-and-medication-api",
+        "dps-health-medication-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -540,7 +540,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-and-medication-api",
+        "dps-health-medication-api",
         "dps-locations",
         "dps-calculate-release-dates"
       ],

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -68,7 +68,7 @@
         "dps-calculate-release-dates",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic-api",
+        "dps-health-medic",
         "dps-testing"
       ],
       "alarms": {
@@ -218,7 +218,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic-api",
+        "dps-health-medic",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -371,7 +371,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic-api",
+        "dps-health-medic",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -540,7 +540,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic-api",
+        "dps-health-medic",
         "dps-locations",
         "dps-calculate-release-dates"
       ],

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -68,7 +68,7 @@
         "dps-calculate-release-dates",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic",
+        "dps-health-and-medi",
         "dps-testing"
       ],
       "alarms": {
@@ -218,7 +218,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic",
+        "dps-health-and-medi",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -371,7 +371,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic",
+        "dps-health-and-medi",
         "dps-locations",
         "dps-calculate-release-dates"
       ],
@@ -540,7 +540,7 @@
         "dps-use-of-force",
         "dps-incentives",
         "dps-non-associations",
-        "dps-health-medic",
+        "dps-health-and-medi",
         "dps-locations",
         "dps-calculate-release-dates"
       ],

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -404,4 +404,3 @@ locals {
     "arn:aws:iam::${local.account_id}:policy/${local.s3_read_write_policy}"
   ]
 }
-dpr-create-reload-diff-dps-health-medic-development-glue-role

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -404,3 +404,4 @@ locals {
     "arn:aws:iam::${local.account_id}:policy/${local.s3_read_write_policy}"
   ]
 }
+dpr-create-reload-diff-dps-health-medic-development-glue-role


### PR DESCRIPTION
- Replaces `dps-health-and-medication-api` with `dps-health-and-medi`
- This is because otherwise IAM role names are too long, e.g. dpr-create-reload-diff-dps-health-and-medication-api-development-glue-role
- This causes errors such as this in the domains repo:
```
Error: expected length of name to be in the range (1 - 64), got dpr-create-reload-diff-dps-health-and-medication-api-development-glue-role
│ 
│   with module.ingestion-jobs["dps-health-and-medication-api"].module.create_reload_diff_job.aws_iam_role.glue-service-role[0],
│   on .terraform/modules/ingestion-jobs/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf line 66, in resource "aws_iam_role" "glue-service-role":
│   66:   name  = "${var.name}-glue-role"
```