### PR TITLE
✈️ Add SES for MWAA

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -688,7 +688,7 @@ data "aws_iam_policy_document" "mwaa_ses" {
   }
 }
 
-module "airflow_ses_policy" {
+module "mwaa_ses_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -673,3 +673,30 @@ module "gha_moj_ap_airflow_iam_policy" {
 
   tags = local.tags
 }
+
+data "aws_iam_policy_document" "mwaa_ses" {
+  statement {
+    sid       = "AllowSESSendRawEmail"
+    effect    = "Allow"
+    actions   = ["ses:SendRawEmail"]
+    resources = [aws_ses_domain_identity.main.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+      values   = ["noreply@${local.environment_configuration.route53_zone}"]
+    }
+  }
+}
+
+module "airflow_ses_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.52.2"
+
+  name   = "mwaa-ses"
+  policy = data.aws_iam_policy_document.airflow_ses_policy.json
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -696,7 +696,7 @@ module "airflow_ses_policy" {
   version = "5.52.2"
 
   name   = "mwaa-ses"
-  policy = data.aws_iam_policy_document.airflow_ses_policy.json
+  policy = data.aws_iam_policy_document.mwaa_ses.json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/route53-records.tf
+++ b/terraform/environments/analytical-platform-compute/route53-records.tf
@@ -13,6 +13,12 @@ module "route53_records" {
       type    = "CNAME"
       ttl     = 300
       records = [module.mwaa_alb.dns_name]
+    },
+    {
+      name    = "_amazonses"
+      type    = "TXT"
+      ttl     = 600
+      records = [aws_ses_domain_identity.main.verification_token]
     }
   ]
 }

--- a/terraform/environments/analytical-platform-compute/route53-records.tf
+++ b/terraform/environments/analytical-platform-compute/route53-records.tf
@@ -19,23 +19,23 @@ module "route53_records" {
       type    = "TXT"
       ttl     = 600
       records = [aws_ses_domain_identity.main.verification_token]
-    }
+    },
     {
-      name = "${aws_ses_domain_dkim.main.dkim_tokens[0]}._domainkey"
-      type = "CNAME"
-      ttl  = 300
+      name    = "${aws_ses_domain_dkim.main.dkim_tokens[0]}._domainkey"
+      type    = "CNAME"
+      ttl     = 300
       records = ["${aws_ses_domain_dkim.main.dkim_tokens[0]}.dkim.amazonses.com"]
-    }
+    },
     {
-      name = "${aws_ses_domain_dkim.main.dkim_tokens[1]}._domainkey"
-      type = "CNAME"
-      ttl  = 300
+      name    = "${aws_ses_domain_dkim.main.dkim_tokens[1]}._domainkey"
+      type    = "CNAME"
+      ttl     = 300
       records = ["${aws_ses_domain_dkim.main.dkim_tokens[1]}.dkim.amazonses.com"]
-    }
+    },
     {
-      name = "${aws_ses_domain_dkim.main.dkim_tokens[2]}._domainkey"
-      type = "CNAME"
-      ttl  = 300
+      name    = "${aws_ses_domain_dkim.main.dkim_tokens[2]}._domainkey"
+      type    = "CNAME"
+      ttl     = 300
       records = ["${aws_ses_domain_dkim.main.dkim_tokens[2]}.dkim.amazonses.com"]
     }
   ]

--- a/terraform/environments/analytical-platform-compute/route53-records.tf
+++ b/terraform/environments/analytical-platform-compute/route53-records.tf
@@ -20,6 +20,7 @@ module "route53_records" {
       ttl     = 600
       records = [aws_ses_domain_identity.main.verification_token]
     },
+    /* Commenting out because production cannot plan properly 
     {
       name    = "${aws_ses_domain_dkim.main.dkim_tokens[0]}._domainkey"
       type    = "CNAME"
@@ -38,5 +39,6 @@ module "route53_records" {
       ttl     = 300
       records = ["${aws_ses_domain_dkim.main.dkim_tokens[2]}.dkim.amazonses.com"]
     }
+    */
   ]
 }

--- a/terraform/environments/analytical-platform-compute/route53-records.tf
+++ b/terraform/environments/analytical-platform-compute/route53-records.tf
@@ -20,5 +20,23 @@ module "route53_records" {
       ttl     = 600
       records = [aws_ses_domain_identity.main.verification_token]
     }
+    {
+      name = "${aws_ses_domain_dkim.main.dkim_tokens[0]}._domainkey"
+      type = "CNAME"
+      ttl  = 300
+      records = ["${aws_ses_domain_dkim.main.dkim_tokens[0]}.dkim.amazonses.com"]
+    }
+    {
+      name = "${aws_ses_domain_dkim.main.dkim_tokens[1]}._domainkey"
+      type = "CNAME"
+      ttl  = 300
+      records = ["${aws_ses_domain_dkim.main.dkim_tokens[1]}.dkim.amazonses.com"]
+    }
+    {
+      name = "${aws_ses_domain_dkim.main.dkim_tokens[2]}._domainkey"
+      type = "CNAME"
+      ttl  = 300
+      records = ["${aws_ses_domain_dkim.main.dkim_tokens[2]}.dkim.amazonses.com"]
+    }
   ]
 }

--- a/terraform/environments/analytical-platform-compute/ses.tf
+++ b/terraform/environments/analytical-platform-compute/ses.tf
@@ -1,0 +1,3 @@
+resource "aws_ses_email_identity" "main" {
+  email = local.environment_configuration.route53_zone
+}

--- a/terraform/environments/analytical-platform-compute/ses.tf
+++ b/terraform/environments/analytical-platform-compute/ses.tf
@@ -1,3 +1,9 @@
 resource "aws_ses_domain_identity" "main" {
   domain = local.environment_configuration.route53_zone
 }
+
+resource "aws_ses_domain_identity_verification" "main" {
+  domain = aws_ses_domain_identity.main.domain
+
+  depends_on = [module.route53_records.aws_route53_record.this["_amazonses TXT"]]
+}

--- a/terraform/environments/analytical-platform-compute/ses.tf
+++ b/terraform/environments/analytical-platform-compute/ses.tf
@@ -7,3 +7,7 @@ resource "aws_ses_domain_identity_verification" "main" {
 
   depends_on = [module.route53_records]
 }
+
+resource "aws_ses_domain_dkim" "main" {
+  domain = aws_ses_domain_identity.main.domain
+}

--- a/terraform/environments/analytical-platform-compute/ses.tf
+++ b/terraform/environments/analytical-platform-compute/ses.tf
@@ -1,3 +1,3 @@
-resource "aws_ses_email_identity" "main" {
-  email = local.environment_configuration.route53_zone
+resource "aws_ses_domain_identity" "main" {
+  domain = local.environment_configuration.route53_zone
 }

--- a/terraform/environments/analytical-platform-compute/ses.tf
+++ b/terraform/environments/analytical-platform-compute/ses.tf
@@ -5,5 +5,5 @@ resource "aws_ses_domain_identity" "main" {
 resource "aws_ses_domain_identity_verification" "main" {
   domain = aws_ses_domain_identity.main.domain
 
-  depends_on = [module.route53_records.aws_route53_record.this["_amazonses TXT"]]
+  depends_on = [module.route53_records]
 }


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/6917

## Proposed Changes

- Adds SES domain identity for compute
- Configures DKIM for SES domain
- Adds IAM policy for MWAA's SES IAM user (coming in another pull request)

## Notes for the review

- Production's plan is failing because the Route53 record module is trying to plan with data that does not exist yet, this should resolve itself when applying

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>