### PR TITLE
✈️ Create IAM user for MWAA SMTP

### DIFF
--- a/terraform/environments/analytical-platform-compute/iam-users.tf
+++ b/terraform/environments/analytical-platform-compute/iam-users.tf
@@ -1,0 +1,14 @@
+module "mwaa_ses_iam_user" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "5.52.2"
+
+  name                          = "mwaa-ses"
+  create_iam_user_login_profile = false
+
+  policy_arns = [module.mwaa_ses_policy.arn]
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-compute/mwaa.tf
+++ b/terraform/environments/analytical-platform-compute/mwaa.tf
@@ -24,6 +24,12 @@ resource "aws_mwaa_environment" "main" {
   airflow_configuration_options = {
     "secrets.backend"                    = "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend"
     "secrets.backend_kwargs"             = "{\"connections_prefix\": \"airflow/connections\", \"variables_prefix\": \"airflow/variables\"}"
+    "smtp.smtp_host"                     = "email-smtp.${data.aws_region.current.name}.amazonaws.com"
+    "smtp.smtp_port"                     = 587
+    "smtp.smtp_starttls"                 = 1
+    "smtp.smtp_user"                     = module.mwaa_ses_iam_user.iam_access_key_id
+    "smtp.smtp_password"                 = module.mwaa_ses_iam_user.iam_access_key_ses_smtp_password_v4
+    "smtp.smtp_mail_from"                = "noreply@${local.environment_configuration.route53_zone}"
     "webserver.warn_deployment_exposure" = 0
     "webserver.base_url"                 = "airflow.${local.environment_configuration.route53_zone}"
     "webserver.instance_name"            = local.environment_configuration.airflow_webserver_instance_name

--- a/terraform/environments/analytical-platform-compute/route53-records.tf
+++ b/terraform/environments/analytical-platform-compute/route53-records.tf
@@ -20,7 +20,6 @@ module "route53_records" {
       ttl     = 600
       records = [aws_ses_domain_identity.main.verification_token]
     },
-    /* Commenting out because production cannot plan properly 
     {
       name    = "${aws_ses_domain_dkim.main.dkim_tokens[0]}._domainkey"
       type    = "CNAME"
@@ -39,6 +38,5 @@ module "route53_records" {
       ttl     = 300
       records = ["${aws_ses_domain_dkim.main.dkim_tokens[2]}.dkim.amazonses.com"]
     }
-    */
   ]
 }


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/6917

## Proposed Changes

- Adds an IAM user which is consumed by MWAA
- Adds DKIM records back in

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>