### PR TITLE
Fix count logic for sharing non-CADT databases in production environment

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -468,7 +468,7 @@ resource "aws_lakeformation_resource" "rds_bucket" {
 }
 
 module "share_non_cadt_dbs_with_roles" {
-  count                   = local.is-production ? 0 : 1
+  count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
   dbs_to_grant            = ["dms_dbo_g4s_emsys_mvp"]
   data_bucket_lf_resource = aws_lakeformation_resource.rds_bucket.arn


### PR DESCRIPTION
Correct the logic to ensure that non-CADT databases are shared in the production environment.