### PR TITLE
Remove conditional count for share_non_cadt_dbs_with_roles module

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -468,7 +468,6 @@ resource "aws_lakeformation_resource" "rds_bucket" {
 }
 
 module "share_non_cadt_dbs_with_roles" {
-  count                   = local.is-production ? 1 : 0
   source                  = "./modules/lakeformation_database_share"
   dbs_to_grant            = ["dms_dbo_g4s_emsys_mvp"]
   data_bucket_lf_resource = aws_lakeformation_resource.rds_bucket.arn


### PR DESCRIPTION
Eliminate the conditional count for the share_non_cadt_dbs_with_roles module in the share_analytical_platform.tf file to ensure it is always included.