### PR TITLE
Set max_file_size to 240000

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/dms/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms/main.tf
@@ -102,7 +102,7 @@ resource "aws_dms_s3_endpoint" "dms-s3-target-endpoint" {
   parquet_timestamp_in_millisecond = false
   include_op_for_full_load         = true
 
-  max_file_size          = 120000
+  max_file_size          = 240000
   cdc_max_batch_interval = 10
 
   depends_on = [aws_iam_policy.dms-s3-target-policy, aws_iam_policy.dms-operator-s3-policy]

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/main.tf
@@ -167,7 +167,7 @@ resource "aws_dms_s3_endpoint" "dms-s3-target-endpoint" {
   parquet_timestamp_in_millisecond = false
   include_op_for_full_load         = true
 
-  max_file_size          = 120000
+  max_file_size          = 240000
   cdc_max_batch_interval = 10
 
   tags = merge(


### PR DESCRIPTION
This PR doubles the max_file_size to 240000 to test in pre-prod if it will speed up the DMS task for large tables e.g. offender_course_attendances