### PR TITLE
change module refs

### DIFF
--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -15,7 +15,8 @@ module "ec2_autoscaling_group" {
 
   for_each = var.ec2_autoscaling_groups
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=fa80b9a735ef9e9595f9e16fdc3426eda2492323" # ASG test
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -18,7 +18,7 @@ module "ec2_autoscaling_group" {
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=fa80b9a735ef9e9595f9e16fdc3426eda2492323" # ASG test
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=46abfd5c9b41f87b2afece5e200ff0ae65cf3439" # updated ref for test
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=86134439dd3d38d585201ac344d85429abc4a581" # updated ref for test
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -37,18 +37,18 @@ module "ec2_autoscaling_group" {
     ]
   })
 
-  availability_zone               = each.value.config.availability_zone
-  subnet_ids                      = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id]
-  ebs_volumes_copy_all_from_ami   = each.value.config.ebs_volumes_copy_all_from_ami
-  ebs_kms_key_id                  = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
-  ebs_volume_config               = each.value.ebs_volume_config
-  ebs_volume_tags                 = each.value.ebs_volume_tags
-  ebs_volumes                     = each.value.ebs_volumes
-  user_data_raw                   = each.value.config.user_data_raw
-  user_data_cloud_init            = each.value.user_data_cloud_init
-  ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
-  secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
-  iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
+  availability_zone             = each.value.config.availability_zone
+  subnet_ids                    = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id]
+  ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
+  ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
+  ebs_volume_config             = each.value.ebs_volume_config
+  ebs_volume_tags               = each.value.ebs_volume_tags
+  ebs_volumes                   = each.value.ebs_volumes
+  user_data_raw                 = each.value.config.user_data_raw
+  user_data_cloud_init          = each.value.user_data_cloud_init
+  ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
+  iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
 
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -16,7 +16,9 @@ module "ec2_autoscaling_group" {
   for_each = var.ec2_autoscaling_groups
 
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=fa80b9a735ef9e9595f9e16fdc3426eda2492323" # ASG test
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=fa80b9a735ef9e9595f9e16fdc3426eda2492323" # ASG test
+
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=46abfd5c9b41f87b2afece5e200ff0ae65cf3439" # updated ref for test
 
   providers = {
     aws.core-vpc = aws.core-vpc
@@ -48,7 +50,6 @@ module "ec2_autoscaling_group" {
   user_data_raw                   = each.value.config.user_data_raw
   user_data_cloud_init            = each.value.user_data_cloud_init
   ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
-  skip_iam_role_policy_attachment = true
   secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
   iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
 

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -48,6 +48,7 @@ module "ec2_autoscaling_group" {
   user_data_raw                 = each.value.config.user_data_raw
   user_data_cloud_init          = each.value.user_data_cloud_init
   ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  skip_iam_role_policy_attachment = true
   secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
   iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
 

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -15,10 +15,7 @@ module "ec2_autoscaling_group" {
 
   for_each = var.ec2_autoscaling_groups
 
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=0111618bb1c7c52f59f11790b2f4b68a26b51cb3" # v2.6.1
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=fa80b9a735ef9e9595f9e16fdc3426eda2492323" # ASG test
-
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=86134439dd3d38d585201ac344d85429abc4a581" # updated ref for test
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-autoscaling-group?ref=v3.0.1" # replace managed_policy_arns argument in module with aws_iam_role_policy_attachment
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_autoscaling_group.tf
+++ b/terraform/modules/baseline/ec2_autoscaling_group.tf
@@ -38,19 +38,19 @@ module "ec2_autoscaling_group" {
     ]
   })
 
-  availability_zone             = each.value.config.availability_zone
-  subnet_ids                    = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id]
-  ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
-  ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
-  ebs_volume_config             = each.value.ebs_volume_config
-  ebs_volume_tags               = each.value.ebs_volume_tags
-  ebs_volumes                   = each.value.ebs_volumes
-  user_data_raw                 = each.value.config.user_data_raw
-  user_data_cloud_init          = each.value.user_data_cloud_init
-  ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  availability_zone               = each.value.config.availability_zone
+  subnet_ids                      = each.value.config.availability_zone == null ? var.environment.subnets[each.value.config.subnet_name].ids : [var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id]
+  ebs_volumes_copy_all_from_ami   = each.value.config.ebs_volumes_copy_all_from_ami
+  ebs_kms_key_id                  = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
+  ebs_volume_config               = each.value.ebs_volume_config
+  ebs_volume_tags                 = each.value.ebs_volume_tags
+  ebs_volumes                     = each.value.ebs_volumes
+  user_data_raw                   = each.value.config.user_data_raw
+  user_data_cloud_init            = each.value.user_data_cloud_init
+  ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
   skip_iam_role_policy_attachment = true
-  secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
-  iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
+  secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
+  iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
 
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -6,7 +6,7 @@ module "ec2_instance" {
   #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference using count
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=62ae13e33937dec42282fa27c16e4e7be405bb65"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=d7212e2a972d1e6eb19f28a43d18c156dca77e5d"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -6,7 +6,7 @@ module "ec2_instance" {
   #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference using count
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=15040cb3977eeeb49c97763a1ffb26989ec4e1d5"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=e5463b1bf8a79443b6def1272b673e916acbdd75" # pre-merge hash
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -26,19 +26,19 @@ module "ec2_instance" {
     ]
   })
 
-  availability_zone               = each.value.config.availability_zone
-  subnet_id                       = var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id
-  ebs_volumes_copy_all_from_ami   = each.value.config.ebs_volumes_copy_all_from_ami
-  ebs_kms_key_id                  = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
-  ebs_volume_config               = each.value.ebs_volume_config
-  ebs_volume_tags                 = each.value.ebs_volume_tags
-  ebs_volumes                     = each.value.ebs_volumes
-  user_data_raw                   = each.value.config.user_data_raw
-  user_data_cloud_init            = each.value.user_data_cloud_init
-  ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
-  secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
-  iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
-  route53_records                 = each.value.route53_records
+  availability_zone             = each.value.config.availability_zone
+  subnet_id                     = var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id
+  ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
+  ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
+  ebs_volume_config             = each.value.ebs_volume_config
+  ebs_volume_tags               = each.value.ebs_volume_tags
+  ebs_volumes                   = each.value.ebs_volumes
+  user_data_raw                 = each.value.config.user_data_raw
+  user_data_cloud_init          = each.value.user_data_cloud_init
+  ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
+  iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
+  route53_records               = each.value.route53_records
 
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -37,6 +37,7 @@ module "ec2_instance" {
   user_data_raw                 = each.value.config.user_data_raw
   user_data_cloud_init          = each.value.user_data_cloud_init
   ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  skip_iam_role_policy_attachment = true
   secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
   iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
   route53_records               = each.value.route53_records

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -6,7 +6,7 @@ module "ec2_instance" {
   #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference using count
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=d7212e2a972d1e6eb19f28a43d18c156dca77e5d"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=15040cb3977eeeb49c97763a1ffb26989ec4e1d5"
 
   providers = {
     aws.core-vpc = aws.core-vpc
@@ -39,7 +39,6 @@ module "ec2_instance" {
   user_data_raw                   = each.value.config.user_data_raw
   user_data_cloud_init            = each.value.user_data_cloud_init
   ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
-  skip_iam_role_policy_attachment = true
   secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
   iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
   route53_records                 = each.value.route53_records

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -27,20 +27,20 @@ module "ec2_instance" {
     ]
   })
 
-  availability_zone             = each.value.config.availability_zone
-  subnet_id                     = var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id
-  ebs_volumes_copy_all_from_ami = each.value.config.ebs_volumes_copy_all_from_ami
-  ebs_kms_key_id                = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
-  ebs_volume_config             = each.value.ebs_volume_config
-  ebs_volume_tags               = each.value.ebs_volume_tags
-  ebs_volumes                   = each.value.ebs_volumes
-  user_data_raw                 = each.value.config.user_data_raw
-  user_data_cloud_init          = each.value.user_data_cloud_init
-  ssm_parameters_prefix         = each.value.config.ssm_parameters_prefix
+  availability_zone               = each.value.config.availability_zone
+  subnet_id                       = var.environment.subnet[each.value.config.subnet_name][each.value.config.availability_zone].id
+  ebs_volumes_copy_all_from_ami   = each.value.config.ebs_volumes_copy_all_from_ami
+  ebs_kms_key_id                  = coalesce(each.value.config.ebs_kms_key_id, var.environment.kms_keys["ebs"].arn)
+  ebs_volume_config               = each.value.ebs_volume_config
+  ebs_volume_tags                 = each.value.ebs_volume_tags
+  ebs_volumes                     = each.value.ebs_volumes
+  user_data_raw                   = each.value.config.user_data_raw
+  user_data_cloud_init            = each.value.user_data_cloud_init
+  ssm_parameters_prefix           = each.value.config.ssm_parameters_prefix
   skip_iam_role_policy_attachment = true
-  secretsmanager_secrets_prefix = each.value.config.secretsmanager_secrets_prefix
-  iam_resource_names_prefix     = each.value.config.iam_resource_names_prefix
-  route53_records               = each.value.route53_records
+  secretsmanager_secrets_prefix   = each.value.config.secretsmanager_secrets_prefix
+  iam_resource_names_prefix       = each.value.config.iam_resource_names_prefix
+  route53_records                 = each.value.route53_records
 
   # add KMS Key Ids if they are referenced by name
   ssm_parameters = each.value.ssm_parameters == null ? null : {

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -3,7 +3,8 @@ module "ec2_instance" {
 
   for_each = var.ec2_instances
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
+  #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -4,7 +4,9 @@ module "ec2_instance" {
   for_each = var.ec2_instances
 
   #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference using count
+
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=62ae13e33937dec42282fa27c16e4e7be405bb65"
 
   providers = {
     aws.core-vpc = aws.core-vpc

--- a/terraform/modules/baseline/ec2_instance.tf
+++ b/terraform/modules/baseline/ec2_instance.tf
@@ -3,10 +3,7 @@ module "ec2_instance" {
 
   for_each = var.ec2_instances
 
-  #source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=ebf373aef70841d1c854689eb034b4e147be1709"
-  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=57296f508067f589ad107684b7c207c2a188ae9d" # Test reference using count
-
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=e5463b1bf8a79443b6def1272b673e916acbdd75" # pre-merge hash
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v3.0.1" # replace managed_policy_arns argument in module with aws_iam_role_policy_attachment
 
   providers = {
     aws.core-vpc = aws.core-vpc


### PR DESCRIPTION
- change ec2 and ec2 asg module references to v3.0.1
- replaces managed_policy_arns argument in module with aws_iam_role_policy_attachment
- this change is one-directional so will be applied to all environments using them