### PR TITLE
🔒 Add secret for paths to include in DataSync

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -39,6 +39,22 @@ module "datasync_dom1_secret" {
   tags = local.tags
 }
 
+module "datasync_include_paths_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name       = "datasync/include-paths"
+  kms_key_id = module.secretsmanager_common_kms.key_arn
+
+  ignore_secret_changes = true
+  secret_string         = "CHANGEME"
+
+  tags = local.tags
+}
+
 module "datasync_exclude_path_secret" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/7008

## Proposed Changes

- Adds a secret to hold paths to include

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>