### PR TITLE
TM-992: onr: tweak preprod url

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -272,7 +272,7 @@ locals {
                 conditions = [{
                   host_header = {
                     values = [
-                      "pp.preproduction.reporting.oasys.service.justice.gov.uk",
+                      "preproduction.reporting.oasys.service.justice.gov.uk",
                     ]
                   }
                 }]
@@ -390,7 +390,7 @@ locals {
     route53_zones = {
       "preproduction.reporting.oasys.service.justice.gov.uk" = {
         lb_alias_records = [
-          { name = "pp", type = "A", lbs_map_key = "public" },
+          { name = "", type = "A", lbs_map_key = "public" },
           { name = "pp-bods", type = "A", lbs_map_key = "public" }
         ],
       }


### PR DESCRIPTION
Be consistent with nomis, no need for the leading `pp.`.  Change from `pp.preproduction.reporting.oasys.service.justice.gov.uk` to `preproduction.reporting.oasys.service.justice.gov.uk`