### PR TITLE
Removing S3 access to certain buckets for sandbox role

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "landing_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::*:role/sandbox"]
+      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::*:role/sandbox"]
+      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "processed_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::*:role/sandbox"]
+      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "bold_egress_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::*:role/sandbox"]
+      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -238,7 +238,7 @@ data "aws_iam_policy_document" "datasync_opg_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::*:role/sandbox"]
+      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "landing_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "processed_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "bold_egress_bucket_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"
@@ -238,7 +238,7 @@ data "aws_iam_policy_document" "datasync_opg_policy" {
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = [local.environment == development ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
     }
     actions = [
       "s3:*"

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -1,3 +1,20 @@
+data "aws_iam_policy_document" "landing_bucket_policy" {
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/sandbox"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-landing/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-landing"
+    ]
+  }
+}
 module "landing_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
@@ -7,6 +24,8 @@ module "landing_bucket" {
   bucket = "mojap-ingestion-${local.environment}-landing"
 
   force_destroy = true
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.landing_bucket_policy.json
 
   server_side_encryption_configuration = {
     rule = {
@@ -36,6 +55,21 @@ data "aws_iam_policy_document" "quarantine_bucket_policy" {
       variable = "s3:ExistingObjectTag/scan-result"
       values   = ["infected"]
     }
+  }
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/sandbox"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-quarantine"
+    ]
   }
 }
 
@@ -73,6 +107,7 @@ module "quarantine_bucket" {
   ]
 }
 
+
 module "definitions_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
@@ -93,6 +128,24 @@ module "definitions_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "processed_bucket_policy" {
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/sandbox"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-processed/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-processed"
+    ]
+  }
+}
+
 module "processed_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
@@ -102,6 +155,8 @@ module "processed_bucket" {
   bucket = "mojap-ingestion-${local.environment}-processed"
 
   force_destroy = true
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.processed_bucket_policy.json
 
   server_side_encryption_configuration = {
     rule = {
@@ -130,6 +185,22 @@ data "aws_iam_policy_document" "bold_egress_bucket_policy" {
     ]
     resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-bold-egress/*"]
   }
+
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/sandbox"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-bold-egress/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-bold-egress"
+    ]
+  }
 }
 
 #tfsec:ignore:avd-aws-0088 - The bucket policy is attached to the bucket
@@ -143,13 +214,13 @@ module "bold_egress_bucket" {
   bucket = "mojap-ingestion-${local.environment}-bold-egress"
 
   force_destroy = true
+  attach_policy = true
 
   versioning = {
     enabled = true
   }
 
-  attach_policy = true
-  policy        = data.aws_iam_policy_document.bold_egress_bucket_policy.json
+  policy = data.aws_iam_policy_document.bold_egress_bucket_policy.json
 
   server_side_encryption_configuration = {
     rule = {
@@ -158,6 +229,24 @@ module "bold_egress_bucket" {
         sse_algorithm     = "aws:kms"
       }
     }
+  }
+}
+
+data "aws_iam_policy_document" "datasync_opg_policy" {
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::*:role/sandbox"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-datasync-opg/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-datasync-opg"
+    ]
   }
 }
 
@@ -170,6 +259,8 @@ module "datasync_opg_bucket" {
   bucket = "mojap-ingestion-${local.environment}-datasync-opg"
 
   force_destroy = true
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.datasync_opg_policy.json
 
   versioning = {
     enabled = true


### PR DESCRIPTION
This is to ensure that collaborators don't have access to certain specific buckets that might contain sensitive information.

