### PR TITLE
test instances, rds-2 and rdgw-2 setup for t2-jump2022-2 as session host

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -108,14 +108,14 @@ locals {
           from_port   = 3389
           to_port     = 3389
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.rd_session_hosts
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
         }
         rdp-session-host-udp = {
           description = "Allow connection to RD Session Host and internal RD Resources"
           from_port   = 3389
           to_port     = 3389
           protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.rd_session_hosts
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
         }
         rdp-udp = {
           description = "RDP over UDP from external RD Clients to the Gateway"

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -199,7 +199,7 @@ locals {
             ]
           })
 
-          Add RDS for web access
+          # Add RDS for web access
           test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
             attachments = [
               { ec2_instance_name = "test-rds-2-b" },

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -137,34 +137,34 @@ locals {
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
-      # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
-      #   config = merge(local.ec2_instances.rdgw.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-      #       }
-      #     ))
-      #   })
-      #   tags = merge(local.ec2_instances.rdgw.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
-      # test-rds-2-b = merge(local.ec2_instances.rds, {
-      #   config = merge(local.ec2_instances.rds.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-      #       }
-      #     ))
-      #   })
-      #   tags = merge(local.ec2_instances.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
+        config = merge(local.ec2_instances.rdgw.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.rdgw.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {
@@ -202,18 +202,18 @@ locals {
           })
 
           # Add new gateway 2 config
-          # test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rdgw-2-b" },
-          #   ]
-          # })
+          test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
+            attachments = [
+              { ec2_instance_name = "test-rdgw-2-b" },
+            ]
+          })
 
           # Add RDS for web access
-          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rds-2-b" },
-          #   ]
-          # })
+          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -239,36 +239,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              # test-rdgw-2-http = {
-              #   priority = 110
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rdgw-2-http"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rdgw-2-http = {
+                priority = 110
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdgw-2-http"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
 
               # add RDS rule
-              # test-rds-2-https = {
-              #   priority = 120
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rds-2-https"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rds-2-https = {
+                priority = 120
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-2-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           })
         })
@@ -286,8 +286,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -188,18 +188,18 @@ locals {
           })
 
           # Add new gateway 2 config
-          test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
-            attachments = [
-              { ec2_instance_name = "test-rdgw-2-a" },
-            ]
-          })
+          # test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rdgw-2-b" },
+          #   ]
+          # })
 
           # Add RDS for web access
-          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-            attachments = [
-              { ec2_instance_name = "test-rds-2-a" },
-            ]
-          })
+          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rds-2-b" },
+          #   ]
+          # })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -225,36 +225,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              test-rdgw-2-http = {
-                priority = 110
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rdgw-2-http"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rdgw-2-http = {
+              #   priority = 110
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rdgw-2-http"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
 
               # add RDS rule
-              test-rds-2-https = {
-                priority = 120
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rds-2-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rds-2-https = {
+              #   priority = 120
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rds-2-https"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
             }
           })
         })
@@ -272,8 +272,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -142,15 +142,20 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+      #       }
+      #     ))
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {
@@ -195,11 +200,11 @@ locals {
           })
 
           # Add RDS for web access
-          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-            attachments = [
-              { ec2_instance_name = "test-rds-2-b" },
-            ]
-          })
+          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rds-2-b" },
+          #   ]
+          # })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -241,20 +246,20 @@ locals {
               }
 
               # add RDS rule
-              test-rds-2-https = {
-                priority = 120
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rds-2-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rds-2-https = {
+              #   priority = 120
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rds-2-https"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
             }
           })
         })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -133,24 +133,24 @@ locals {
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
-      # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
-      #   config = merge(local.ec2_instances.rdgw.config, {
-      #     availability_zone = "eu-west-2b"
-      #   })
-      #   tags = merge(local.ec2_instances.rdgw.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
-      # test-rds-2-b = merge(local.ec2_instances.rds, {
-      #   config = merge(local.ec2_instances.rds.config, {
-      #     availability_zone = "eu-west-2b"
-      #   })
-      #   tags = merge(local.ec2_instances.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
+        config = merge(local.ec2_instances.rdgw.config, {
+          availability_zone = "eu-west-2b"
+        })
+        tags = merge(local.ec2_instances.rdgw.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          availability_zone = "eu-west-2b"
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {
@@ -188,18 +188,18 @@ locals {
           })
 
           # Add new gateway 2 config
-          # test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rdgw-2-b" },
-          #   ]
-          # })
+          test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
+            attachments = [
+              { ec2_instance_name = "test-rdgw-2-b" },
+            ]
+          })
 
           # Add RDS for web access
-          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rds-2-b" },
-          #   ]
-          # })
+          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -225,36 +225,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              # test-rdgw-2-http = {
-              #   priority = 110
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rdgw-2-http"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rdgw-2-http = {
+                priority = 110
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdgw-2-http"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
 
               # add RDS rule
-              # test-rds-2-https = {
-              #   priority = 120
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rds-2-https"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rds-2-https = {
+                priority = 120
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-2-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           })
         })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -134,7 +134,6 @@ locals {
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
       test-rdgw-2-a = merge(local.ec2_instances.rdgw, {
-        config = merge(loca)
         tags = merge(local.ec2_instances.rdgw.tags, {
           domain-name = "azure.noms.root"
         })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -133,14 +133,15 @@ locals {
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
-      test-rdgw-2-a = merge(local.ec2_autoscaling_groups.rdgw, {
-        tags = merge(local.ec2_autoscaling_groups.rdgw.tags, {
+      test-rdgw-2-a = merge(local.ec2_instances.rdgw, {
+        config = merge(loca)
+        tags = merge(local.ec2_instances.rdgw.tags, {
           domain-name = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null
       })
-      test-rds-2-a = merge(local.ec2_autoscaling_groups.rds, {
-        tags = merge(local.ec2_autoscaling_groups.rds.tags, {
+      test-rds-2-a = merge(local.ec2_instances.rds, {
+        tags = merge(local.ec2_instances.rds.tags, {
           domain-name = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -119,16 +119,16 @@ locals {
       })
 
       # testing only do not use
-      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-        config = merge(local.ec2_instances.jumpserver.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+      #   config = merge(local.ec2_instances.jumpserver.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   tags = merge(local.ec2_instances.jumpserver.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -142,20 +142,20 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-            }
-          ))
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+      #       }
+      #     ))
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {
@@ -200,11 +200,11 @@ locals {
           })
 
           # Add RDS for web access
-          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-            attachments = [
-              { ec2_instance_name = "test-rds-2-b" },
-            ]
-          })
+          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rds-2-b" },
+          #   ]
+          # })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -230,36 +230,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              test-rdgw-2-http = {
-                priority = 110
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rdgw-2-http"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rdgw-2-http = {
+              #   priority = 110
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rdgw-2-http"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
 
               # add RDS rule
-              test-rds-2-https = {
-                priority = 120
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rds-2-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rds-2-https = {
+              #   priority = 120
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rds-2-https"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
             }
           })
         })
@@ -277,8 +277,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -142,20 +142,20 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
-      # test-rds-2-b = merge(local.ec2_instances.rds, {
-      #   config = merge(local.ec2_instances.rds.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-      #       }
-      #     ))
-      #   })
-      #   tags = merge(local.ec2_instances.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {
@@ -199,12 +199,12 @@ locals {
             ]
           })
 
-          # Add RDS for web access
-          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rds-2-b" },
-          #   ]
-          # })
+          Add RDS for web access
+          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -246,20 +246,20 @@ locals {
               }
 
               # add RDS rule
-              # test-rds-2-https = {
-              #   priority = 120
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rds-2-https"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rds-2-https = {
+                priority = 120
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-2-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           })
         })
@@ -277,8 +277,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -119,16 +119,20 @@ locals {
       })
 
       # testing only do not use, use Feb AMI, possible issues with March/latest
-      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-        config = merge(local.ec2_instances.jumpserver.config, {
-          ami_namw          = "hmpps_windows_server_2022_release_2025-01-*"
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+      #   config = merge(local.ec2_instances.jumpserver.config, {
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+      #       }
+      #     ))
+      #   })
+      #   tags = merge(local.ec2_instances.jumpserver.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
@@ -136,6 +140,11 @@ locals {
       # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
       #   config = merge(local.ec2_instances.rdgw.config, {
       #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+      #       }
+      #     ))
       #   })
       #   tags = merge(local.ec2_instances.rdgw.tags, {
       #     domain-name = "azure.noms.root"

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -142,20 +142,20 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
-      # test-rds-2-b = merge(local.ec2_instances.rds, {
-      #   config = merge(local.ec2_instances.rds.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-      #       }
-      #     ))
-      #   })
-      #   tags = merge(local.ec2_instances.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {
@@ -200,11 +200,11 @@ locals {
           })
 
           # Add RDS for web access
-          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rds-2-b" },
-          #   ]
-          # })
+          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -230,36 +230,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              # test-rdgw-2-http = {
-              #   priority = 110
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rdgw-2-http"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rdgw-2-http = {
+                priority = 110
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rdgw-2-http"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
 
               # add RDS rule
-              # test-rds-2-https = {
-              #   priority = 120
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rds-2-https"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-              #       ]
-              #     }
-              #   }]
-              # }
+              test-rds-2-https = {
+                priority = 120
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-2-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+                    ]
+                  }
+                }]
+              }
             }
           })
         })
@@ -277,8 +277,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -164,6 +164,10 @@ locals {
           domain-name = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null
+        route53_records = {
+          create_external_record = true
+          create_internal_record = true
+        }
       })
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -143,6 +143,9 @@ locals {
         cloudwatch_metric_alarms = null
       })
       test-rds-2-a = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rdgw.config, {
+          availability_zone = "eu-west-2b"
+        })
         tags = merge(local.ec2_instances.rds.tags, {
           domain-name = "azure.noms.root"
         })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -119,16 +119,16 @@ locals {
       })
 
       # testing only do not use, use Feb AMI, possible issues with March/latest
-      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-      #   config = merge(local.ec2_instances.jumpserver.config, {
-      #     ami_namw          = "hmpps_windows_server_2022_release_2025-01-*"
-      #     availability_zone = "eu-west-2b"
-      #   })
-      #   tags = merge(local.ec2_instances.jumpserver.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+        config = merge(local.ec2_instances.jumpserver.config, {
+          ami_namw          = "hmpps_windows_server_2022_release_2025-01-*"
+          availability_zone = "eu-west-2b"
+        })
+        tags = merge(local.ec2_instances.jumpserver.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -133,24 +133,24 @@ locals {
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
-      test-rdgw-2-a = merge(local.ec2_instances.rdgw, {
-        config = merge(local.ec2_instances.rdgw.config, {
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.rdgw.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
-      test-rds-2-a = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rdgw.config, {
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
+      #   config = merge(local.ec2_instances.rdgw.config, {
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   tags = merge(local.ec2_instances.rdgw.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -98,6 +98,7 @@ locals {
         tags = merge(local.ec2_autoscaling_groups.rdgw.tags, {
           domain-name = "azure.noms.root"
         })
+        cloudwatch_metric_alarms = null
       })
       test-rds-2-a = merge(local.ec2_autoscaling_groups.rds, {
         tags = merge(local.ec2_autoscaling_groups.rds.tags, {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -253,7 +253,6 @@ locals {
                   host_header = {
                     values = [
                       "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-                      "hmppgw1.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -134,6 +134,9 @@ locals {
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
       test-rdgw-2-a = merge(local.ec2_instances.rdgw, {
+        config = merge(local.ec2_instances.rdgw.config, {
+          availability_zone = "eu-west-2b"
+        })
         tags = merge(local.ec2_instances.rdgw.tags, {
           domain-name = "azure.noms.root"
         })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -118,24 +118,23 @@ locals {
         })
       })
 
-      # testing only do not use
-      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-      #   config = merge(local.ec2_instances.jumpserver.config, {
-      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
-      #     availability_zone = "eu-west-2b"
-      #   })
-      #   tags = merge(local.ec2_instances.jumpserver.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      # testing only do not use, use Feb AMI, possible issues with March/latest
+      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+        config = merge(local.ec2_instances.jumpserver.config, {
+          ami_namw          = "hmpps_windows_server_2022_release_2025-02-02T00-00-40.706Z"
+          availability_zone = "eu-west-2b"
+        })
+        tags = merge(local.ec2_instances.jumpserver.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
       # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
       #   config = merge(local.ec2_instances.rdgw.config, {
-      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
       #     availability_zone = "eu-west-2b"
       #   })
       #   tags = merge(local.ec2_instances.rdgw.tags, {
@@ -145,7 +144,6 @@ locals {
       # })
       # test-rds-2-b = merge(local.ec2_instances.rds, {
       #   config = merge(local.ec2_instances.rds.config, {
-      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
       #     availability_zone = "eu-west-2b"
       #     user_data_raw = base64encode(templatefile(
       #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -133,29 +133,31 @@ locals {
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf
       # target_id doesn't exist
-      test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
-        config = merge(local.ec2_instances.rdgw.config, {
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.rdgw.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-            }
-          ))
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rdgw-2-b = merge(local.ec2_instances.rdgw, {
+      #   config = merge(local.ec2_instances.rdgw.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   tags = merge(local.ec2_instances.rdgw.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+      #       }
+      #     ))
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {
@@ -193,18 +195,18 @@ locals {
           })
 
           # Add new gateway 2 config
-          test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
-            attachments = [
-              { ec2_instance_name = "test-rdgw-2-b" },
-            ]
-          })
+          # test-rdgw-2-http = merge(local.lbs.public.instance_target_groups.http, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rdgw-2-b" },
+          #   ]
+          # })
 
           # Add RDS for web access
-          test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
-            attachments = [
-              { ec2_instance_name = "test-rds-2-b" },
-            ]
-          })
+          # test-rds-2-https = merge(local.lbs.public.instance_target_groups.https, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rds-2-b" },
+          #   ]
+          # })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
@@ -230,36 +232,36 @@ locals {
               }
 
               # Add new gateway 2 rule
-              test-rdgw-2-http = {
-                priority = 110
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rdgw-2-http"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rdgw-2-http = {
+              #   priority = 110
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rdgw-2-http"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
 
               # add RDS rule
-              test-rds-2-https = {
-                priority = 120
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rds-2-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb2.test.hmpps-domain.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
+              # test-rds-2-https = {
+              #   priority = 120
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rds-2-https"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdweb2.test.hmpps-domain.service.justice.gov.uk",
+              #       ]
+              #     }
+              #   }]
+              # }
             }
           })
         })
@@ -277,8 +279,8 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          { name = "rdgateway2", type = "A", lbs_map_key = "public" },
-          { name = "rdweb2", type = "A", lbs_map_key = "public" },
+          # { name = "rdgateway2", type = "A", lbs_map_key = "public" },
+          # { name = "rdweb2", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -249,6 +249,7 @@ locals {
                   host_header = {
                     values = [
                       "rdgateway2.test.hmpps-domain.service.justice.gov.uk",
+                      "hmppgw1.justice.gov.uk",
                     ]
                   }
                 }]

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -119,16 +119,16 @@ locals {
       })
 
       # testing only do not use, use Feb AMI, possible issues with March/latest
-      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-        config = merge(local.ec2_instances.jumpserver.config, {
-          ami_namw          = "hmpps_windows_server_2022_release_2025-02-02T00-00-40.706Z"
-          availability_zone = "eu-west-2b"
-        })
-        tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+      #   config = merge(local.ec2_instances.jumpserver.config, {
+      #     ami_namw          = "hmpps_windows_server_2022_release_2025-01-*"
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   tags = merge(local.ec2_instances.jumpserver.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -93,19 +93,7 @@ locals {
         })
       })
 
-      # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
-      test-rdgw-2-a = merge(local.ec2_autoscaling_groups.rdgw, {
-        tags = merge(local.ec2_autoscaling_groups.rdgw.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
-      test-rds-2-a = merge(local.ec2_autoscaling_groups.rds, {
-        tags = merge(local.ec2_autoscaling_groups.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+
     }
 
     ec2_instances = {
@@ -137,6 +125,22 @@ locals {
           availability_zone = "eu-west-2b"
         })
         tags = merge(local.ec2_instances.jumpserver.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
+
+      # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
+      # existing comment above but fails in modules/baseline/lb.tf
+      # target_id doesn't exist
+      test-rdgw-2-a = merge(local.ec2_autoscaling_groups.rdgw, {
+        tags = merge(local.ec2_autoscaling_groups.rdgw.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
+      test-rds-2-a = merge(local.ec2_autoscaling_groups.rds, {
+        tags = merge(local.ec2_autoscaling_groups.rds.tags, {
           domain-name = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -119,20 +119,20 @@ locals {
       })
 
       # testing only do not use, use Feb AMI, possible issues with March/latest
-      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-      #   config = merge(local.ec2_instances.jumpserver.config, {
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
-      #       }
-      #     ))
-      #   })
-      #   tags = merge(local.ec2_instances.jumpserver.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+        config = merge(local.ec2_instances.jumpserver.config, {
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-916/rdweb-interface-hmpps-domain-services-test"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.jumpserver.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
 
       # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
       # existing comment above but fails in modules/baseline/lb.tf

--- a/terraform/modules/baseline_presets/cloudwatch.tf
+++ b/terraform/modules/baseline_presets/cloudwatch.tf
@@ -7,6 +7,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-system"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-application"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-security"] : [],
+    var.options.enable_ec2_cloud_watch_agent ? ["kinesis-agent-windows-security"] : [],
   ])
 
   cloudwatch_log_groups = {

--- a/terraform/modules/baseline_presets/cloudwatch.tf
+++ b/terraform/modules/baseline_presets/cloudwatch.tf
@@ -29,5 +29,8 @@ locals {
     cwagent-windows-security = {
       retention_in_days = coalesce(var.options.cloudwatch_log_groups_retention_in_days, local.cloudwatch_log_groups_retention_default)
     }
+    kinesis-agent-windows-security = {
+      retention_in_days = coalesce(var.options.cloudwatch_log_groups_retention_in_days, local.cloudwatch_log_groups_retention_default)
+    }
   }
 }


### PR DESCRIPTION
- add lb settings for rdweb2
- add test t2-jump2022-lb
- add rdweb2 instance

will set up test-rds-2-a and connect to t2-jump2022-2 manually 