### PR TITLE
DPR2-1751: Operational DataStore access secret placeholder for incident reporting.

### DIFF
--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -362,6 +362,15 @@ locals {
     username            = module.datamart.redshift_master_user
   }
 
+  # Placeholder for unpopulated Operational DataStore access secrets
+  ods_access_secret_placeholder = {
+    host     = module.aurora_operational_db.cluster_endpoint
+    port     = local.operational_db_port
+    database = local.operational_db_default_database
+    username = "placeholder"
+    password = "placeholder"
+  }
+
   analytical_platform_share = can(local.application_data.accounts[local.environment].analytical_platform_share) ? { for share in local.application_data.accounts[local.environment].analytical_platform_share : share.target_account_name => share } : {}
 
   # Observability Platform & Analytical Platform

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -387,22 +387,22 @@ resource "aws_secretsmanager_secret_version" "transfer_component_role_secret_ver
 # Operational DataStore Access Secrets
 
 # Incident Reporting
-resource "aws_secretsmanager_secret" "ods_dps_inc_reporting" {
+resource "aws_secretsmanager_secret" "ods_dps_inc_reporting_access" {
   #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
   #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
 
-  name = "dpr-ods-irs-dps-inc-reporting-${local.env}"
+  name = "dpr-ods-dps-inc-reporting-${local.env}"
   tags = merge(
     local.all_tags,
     {
-      Name          = "dpr-ods-irs-dps-inc-reporting-${local.env}"
+      Name          = "dpr-ods-dps-inc-reporting-${local.env}"
       Resource_Type = "Secrets"
       Jira          = "DPR-1751"
     }
   )
 }
 
-resource "aws_secretsmanager_secret_version" "ods_dps_inc_reporting" {
+resource "aws_secretsmanager_secret_version" "ods_dps_inc_reporting_access" {
   secret_id     = aws_secretsmanager_secret.ods_dps_inc_reporting.id
   secret_string = jsonencode(local.ods_access_secret_placeholder)
 }

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -383,3 +383,26 @@ resource "aws_secretsmanager_secret_version" "transfer_component_role_secret_ver
     password = random_password.transfer_component_role_password.result
   })
 }
+
+# Operational DataStore Access Secrets
+
+# Incident Reporting
+resource "aws_secretsmanager_secret" "ods_dps_inc_reporting" {
+  #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
+  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
+
+  name = "dpr-ods-irs-dps-inc-reporting-${local.env}"
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "dpr-ods-irs-dps-inc-reporting-${local.env}"
+      Resource_Type = "Secrets"
+      Jira          = "DPR-1751"
+    }
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "ods_dps_inc_reporting" {
+  secret_id     = aws_secretsmanager_secret.ods_dps_inc_reporting.id
+  secret_string = jsonencode(local.ods_access_secret_placeholder)
+}

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -403,6 +403,6 @@ resource "aws_secretsmanager_secret" "ods_dps_inc_reporting_access" {
 }
 
 resource "aws_secretsmanager_secret_version" "ods_dps_inc_reporting_access" {
-  secret_id     = aws_secretsmanager_secret.ods_dps_inc_reporting.id
+  secret_id     = aws_secretsmanager_secret.ods_dps_inc_reporting_access.id
   secret_string = jsonencode(local.ods_access_secret_placeholder)
 }


### PR DESCRIPTION
- Creates a secret placeholder for Incident Reporting to be able to access the Operational DataStore via a foreign data wrapper
- Username and password should be populated manually once the user is provisioned and given the appropriate grants