### PR TITLE
Update workflow to support component structure with reusable_terraform_plan_apply_components.yml

### DIFF
--- a/.github/workflows/ccms-ebs-upgrade.yml
+++ b/.github/workflows/ccms-ebs-upgrade.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'terraform/environments/ccms-ebs-upgrade/**'
       - '.github/workflows/ccms-ebs-upgrade.yml'
-
+      - '.github/workflows/reusable_terraform_components_strategy.yml'
   pull_request:
     branches:
       - main
@@ -25,6 +25,11 @@ on:
         options:
           - deploy
           - destroy
+      component:
+        description: "Optional: Target a specific component for destroy. Defaults to 'root' to destroy the root or <application> folder."
+        required: false
+        default: "root"
+        type: string
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -32,34 +37,47 @@ permissions:
 
 jobs:
   strategy:
-    uses: ./.github/workflows/reusable_terraform_strategy.yml
+    # This job generates a matrix of environments (and possibly components) by calling your reusable strategy workflow.
+    uses: ./.github/workflows/reusable_terraform_components_strategy.yml
     if: inputs.action != 'destroy'
     with:
       application: "${{ github.workflow }}"
 
+  skipping_terraform:
+      needs: strategy
+      if: ${{ inputs.action != 'destroy' && (needs.strategy.outputs.matrix == '' || toJson(fromJson(needs.strategy.outputs.matrix)) == '[]')}}  # conversion from and to Json standardises output
+      runs-on: ubuntu-latest
+      steps:
+        - name: Skip Terraform
+          run: echo "No terraform changes detected. Skipping Terraform plan/apply."
+
   terraform:
     needs: strategy
-    if: inputs.action != 'destroy'
+    if: ${{ inputs.action != 'destroy' && needs.strategy.outputs.matrix != '' && toJson(fromJson(needs.strategy.outputs.matrix)) != '[]'}}  # conversion from and to Json standardises output
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.strategy.outputs.matrix) }}
-    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    # Calls the plan/apply reusable workflow with each item in the matrix
+    uses: ./.github/workflows/reusable_terraform_components_plan_apply.yml
     with:
+      # Pass along the "application" and "environment" from the matrix
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
+      component: "${{ matrix.component }}"
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"
 
   destroy-development:
     if: inputs.action == 'destroy'
-    uses: ./.github/workflows/reusable_terraform_plan_apply.yml
+    uses: ./.github/workflows/reusable_terraform_components_plan_apply.yml
     with:
       application: "${{ github.workflow }}"
       environment: "development"
       action: "plan_apply"
       plan_apply_tfargs: "-destroy"
+      component: "${{ inputs.component }}"  # Targets a specific component for the destroy operation; defaults to 'root' if not specified.
     secrets:
       modernisation_platform_environments: "${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}"
       pipeline_github_token: "${{ secrets.MODERNISATION_PLATFORM_CI_USER_ENVIRONMENTS_REPO_PAT }}"


### PR DESCRIPTION
This PR updates the workflow to use `reusable_terraform_plan_apply_components.yml` instead of `reusable_terraform_plan_apply.yml`. The new reusable workflow supports both root and component structures, allowing teams to transition to a component-based approach. 