### PR TITLE
Filter `WAFv2IPSet` and `RDSClusterSnapshot` from aws nuke

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -63,6 +63,7 @@ resource-types:
     - SecurityHub
     - Transfer
     - WAFv2WebACL
+    - WAFv2IPSet
 
 accounts:
 $accounts_str
@@ -115,6 +116,11 @@ presets:
         - property: PackageName
           type: glob
           value: "rni*"
+      RDSClusterSnapshot:
+        - property: SnapshotType
+          value: "shared"
+        - property: SnapshotType
+          value: "automated"
       S3Bucket:
         - property: tag:component
           value: "secure-baselines"


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/9427

AWS Nuke was failing in the YJAF Dev environment

## How does this PR fix the problem?

This PR filters aws nuke for...

1. `WAFv2IPSet` - we already filter nuking WebACLs `WAFv2WebACL` and if IP sets are associated with an WebACL (as-is the case for YJAF) then they can't be deleted. In this case I suggest we just filter out nuking IP sets.

2. `RDSClusterSnapshot` - where they are of type `shared` or `automated`. In the case of YJAF the snapshot is shared in from another account so cannot be nuked. Also automated snapshots (if any are present) can also not be nuked so I've included this while I'm here for future-proofing.

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

In [this](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/13633258379/job/38105691303) dry run of the nuke the failing items have not been identified for nuke which is a good indication this should fix the issue.