### PR TITLE
DPR2-1772: Use a shorter name for health & medication api service

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -69,6 +69,7 @@
         "dps-incentives",
         "dps-non-associations",
         "dps-health-and-medi",
+        "dps-health-and-me",
         "dps-mj-and-ma",
         "dps-testing"
       ],
@@ -220,6 +221,7 @@
         "dps-incentives",
         "dps-non-associations",
         "dps-health-and-medi",
+        "dps-health-and-me",
         "dps-mj-and-ma",
         "dps-locations",
         "dps-calc-rel-date"
@@ -374,6 +376,7 @@
         "dps-incentives",
         "dps-non-associations",
         "dps-health-and-medi",
+        "dps-health-and-me",
         "dps-mj-and-ma",
         "dps-locations",
         "dps-calc-rel-date"
@@ -544,6 +547,7 @@
         "dps-incentives",
         "dps-non-associations",
         "dps-health-and-medi",
+        "dps-health-and-me",
         "dps-mj-and-ma",
         "dps-locations",
         "dps-calc-rel-date"


### PR DESCRIPTION
- Current name is too long for creating roles in Pre-Prod, e.g. 'dpr-create-reload-diff-dps-health-and-medi-preproduction-glue-role' is too long
- I have left the old 'dps-health-and-medi' on purpose so that I can transfer the existing secrets over
- I will follow up to delete 'dps-health-and-medi' once the secrets are transferred over and the domains repo is updated