### PR TITLE
TM: hmpps-domain-services: silence overnight alarms

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -172,6 +172,7 @@ locals {
     schedule_alarms_lambda = {
       alarm_patterns = [
         "public-https-*-unhealthy-load-balancer-host",
+        "*-instance-or-cloudwatch-agent-stopped",
       ]
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -206,6 +206,7 @@ locals {
     schedule_alarms_lambda = {
       alarm_patterns = [
         "public-https-*-unhealthy-load-balancer-host",
+        "*-instance-or-cloudwatch-agent-stopped",
       ]
     }
 


### PR DESCRIPTION
EC2s are powered down overnight, silence the corresponding alarms