### PR TITLE
TM-1042: nomis: cert fix v1

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -31,6 +31,16 @@ locals {
           description = "wildcard cert for nomis development domains"
         }
       }
+      nomis_wildcard_cert_v2 = {
+        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name              = "*.development.nomis.service.justice.gov.uk"
+        subject_alternate_names = [
+          "*.nomis.hmpps-development.modernisation-platform.service.justice.gov.uk",
+        ]
+        tags = {
+          description = "wildcard cert for nomis development domains"
+        }
+      }
     }
 
     cloudwatch_dashboards = {

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -37,6 +37,19 @@ locals {
           description = "wildcard cert for nomis preproduction domains"
         }
       }
+      nomis_wildcard_cert_v2 = {
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name                         = "*.preproduction.nomis.service.justice.gov.uk"
+        external_validation_records_created = false
+        subject_alternate_names = [
+          "*.nomis.hmpps-preproduction.modernisation-platform.service.justice.gov.uk",
+          "*.pp-nomis.az.justice.gov.uk",
+          "*.lsast-nomis.az.justice.gov.uk",
+        ]
+        tags = {
+          description = "wildcard cert for nomis preproduction domains"
+        }
+      }
     }
 
     cloudwatch_dashboards = {

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -38,6 +38,19 @@ locals {
           description = "wildcard cert for nomis production domains"
         }
       }
+      nomis_wildcard_cert_v2 = {
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name                         = "*.nomis.service.justice.gov.uk"
+        external_validation_records_created = false
+        subject_alternate_names = [
+          "*.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk",
+          "*.production.nomis.service.justice.gov.uk",
+          "*.nomis.az.justice.gov.uk",
+        ]
+        tags = {
+          description = "wildcard cert for nomis production domains"
+        }
+      }
     }
 
     cloudwatch_dashboards = {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -32,6 +32,18 @@ locals {
         tags = {
           description = "wildcard cert for nomis test domains"
         }
+      },
+      nomis_wildcard_cert_v2 = {
+        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name                         = "*.test.nomis.service.justice.gov.uk"
+        external_validation_records_created = false
+        subject_alternate_names = [
+          "*.nomis.hmpps-test.modernisation-platform.service.justice.gov.uk",
+          "*.hmpp-azdt.justice.gov.uk",
+        ]
+        tags = {
+          description = "wildcard cert for nomis test domains"
+        }
       }
     }
 


### PR DESCRIPTION
Create new nomis cert in all environments. 
This will eventually replace the existing cert which includes a domain that has subsequently been removed.