### PR TITLE
DPR2-1751: Convert number to string to avoid issues updating secrets manually in secrets manager

### DIFF
--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -391,7 +391,7 @@ locals {
   # Placeholder for unpopulated Operational DataStore access secrets
   ods_access_secret_placeholder = {
     host     = module.aurora_operational_db.cluster_endpoint
-    port     = local.operational_db_port
+    port     = tostring(local.operational_db_port)
     database = local.operational_db_default_database
     username = "placeholder"
     password = "placeholder"


### PR DESCRIPTION
- If values are set to numeric values in AWS Secrets Manager it causes issues updating the secret values easily via the UI
- This solves this issue for the ODS incident reporting secret by converting the number to a string before storing it in the secret