### PR TITLE
TM-1042: nomis: remove unused zones

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -526,7 +526,6 @@ locals {
     }
 
     route53_zones = {
-      "development.nomis.az.justice.gov.uk" = {} # remove from cert before deleting
       "development.nomis.service.justice.gov.uk" = {
         records = [
           # SYSCON

--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -486,7 +486,6 @@ locals {
     }
 
     route53_zones = {
-      "preproduction.nomis.az.justice.gov.uk" = {} # remove from cert before deleting
       "preproduction.nomis.service.justice.gov.uk" = {
         records = [
           { name = "lsnomis", type = "CNAME", ttl = "300", records = ["lsnomis-a.preproduction.nomis.service.justice.gov.uk"] },

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -600,8 +600,6 @@ locals {
         ]
       }
 
-      "production.nomis.az.justice.gov.uk" = {} # remove from cert before deleting
-
       "production.nomis.service.justice.gov.uk" = {
         records = [
           { name = "pnomis", type = "CNAME", ttl = "300", records = ["prod-nomis-db-1-a.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk"] },

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -624,7 +624,6 @@ locals {
     }
 
     route53_zones = {
-      "test.nomis.az.justice.gov.uk" = {} # remove from cert before deleting
       "test.nomis.service.justice.gov.uk" = {
         records = [
           # T1


### PR DESCRIPTION
Remove old nomis azure zones. I've checked and there's no NS records pointing to these zones, and no DNS entries remaining within the zones.