### PR TITLE
Add dummy secret and associated kms for CICA DMS Tariff Database Credentials

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
@@ -13,3 +13,17 @@ module "s3_cica_dms_ingress_kms" {
 
   deletion_window_in_days = 7
 }
+
+module "cica_dms_credentials_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  description           = "Used in the CICA DMS Solution to encode secrets"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}

--- a/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
@@ -1,1 +1,22 @@
 #### This file can be used to store secrets specific to the member account ####
+
+module "cica_dms_tariff_database_credentials" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name       = "ingestion/dms/tariff-credentials"
+  kms_key_id = module.cica_dms_credentials_kms.key_arn
+
+  ignore_secret_changes = true
+  secret_string = jsonencode({
+    username = "CHANGEME"
+    password = "CHANGEME"
+    port     = "CHANGEME"
+    host     = "CHANGEME"
+  })
+
+  tags = local.tags
+}


### PR DESCRIPTION
This sets up a dummy secret to hold database credentials for the AWS Database Manager Service endpoint to be added in a future PR. This secret will be referred to via [this parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#secrets_manager_arn-1) and requires the keys described in [AWS Documentation](https://docs.aws.amazon.com/dms/latest/userguide/security_iam_secretsmanager.html#security_iam_secretsmanager.console)

I've given this secret its own KMS, as this seems to be standard practice with credentials. This KMS will be also used for another secret to be added in a later PR