### PR TITLE
Add dummy secret and associated kms for CICA DMS Tempus database Credentials

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
@@ -20,3 +20,24 @@ module "cica_dms_tariff_database_credentials" {
 
   tags = local.tags
 }
+
+module "cica_dms_tempus_database_credentials" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name       = "ingestion/dms/tempus-credentials"
+  kms_key_id = module.cica_dms_credentials_kms.key_arn
+
+  ignore_secret_changes = true
+  secret_string = jsonencode({
+    username = "CHANGEME"
+    password = "CHANGEME"
+    port     = "CHANGEME"
+    host     = "CHANGEME"
+  })
+
+  tags = local.tags
+}


### PR DESCRIPTION
This sets up a dummy secret to hold database credentials for the AWS Database Manager Service endpoint to be added in a future PR. This secret will be referred to via [this parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#secrets_manager_arn-1) and requires the keys described in [AWS Documentation](https://docs.aws.amazon.com/dms/latest/userguide/security_iam_secretsmanager.html#security_iam_secretsmanager.console)