### PR TITLE
PI-2908 Increase max batch size

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -10,7 +10,8 @@ locals {
         repository_name = "tei-cpu"
         image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"
         environment = {
-          HF_MODEL_ID = "mixedbread-ai/mxbai-embed-large-v1"
+          HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"
+          MAX_CLIENT_BATCH_SIZE = 512
         }
       }
     }
@@ -21,7 +22,8 @@ locals {
         repository_name = "tei-cpu"
         image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"
         environment = {
-          HF_MODEL_ID = "mixedbread-ai/mxbai-embed-large-v1"
+          HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"
+          MAX_CLIENT_BATCH_SIZE = 512
         }
       }
       hmpps-probation-search-prod = {
@@ -30,7 +32,8 @@ locals {
         repository_name = "tei"
         image_tag       = "2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
         environment = {
-          HF_MODEL_ID = "mixedbread-ai/mxbai-embed-large-v1"
+          HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"
+          MAX_CLIENT_BATCH_SIZE = 512
         }
       }
     }


### PR DESCRIPTION
This increases the maximum batch size passed to the Text Embeddings Inference container running on the SageMaker endpoint for Probation Search. This enables us to process larger text fields, and make use of smaller chunk sizes.

See:
* https://huggingface.co/docs/text-embeddings-inference/en/cli_arguments