### PR TITLE
DPR2-1553: Expose flag to create/destroy reconciliation job role

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/main.tf
@@ -3,6 +3,7 @@
 module "glue_s3_data_reconciliation_job" {
   source                        = "../../glue_job"
   create_job                    = var.create_job
+  create_role                   = var.create_role
   name                          = var.job_name
   short_name                    = var.short_name
   command_type                  = "glueetl"

--- a/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
@@ -24,6 +24,12 @@ variable "create_job" {
   default     = false
 }
 
+variable "create_role" {
+  description = "(Optional) Create AWS IAM role associated with the job."
+  type        = bool
+  default     = false
+}
+
 variable "job_name" {
   description = "Name of the Glue Reconciliation Job"
   type        = string


### PR DESCRIPTION
This PR exposes a flag to either create or destroy the service role for the reconciliation job.
This is required to cleanup domains which were partially created due to a failure during the terraform apply.