### PR TITLE
we need another endpoint to test using the kinesis endpoint for windows

### DIFF
--- a/terraform/modules/baseline_presets/cloudwatch.tf
+++ b/terraform/modules/baseline_presets/cloudwatch.tf
@@ -7,6 +7,7 @@ locals {
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-system"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-application"] : [],
     var.options.enable_ec2_cloud_watch_agent ? ["cwagent-windows-security"] : [],
+    var.options.enable_ec2_cloud_watch_agent ? ["kinesis-agent-windows-security"] : [],
   ])
 
   cloudwatch_log_groups = {

--- a/terraform/modules/baseline_presets/cloudwatch.tf
+++ b/terraform/modules/baseline_presets/cloudwatch.tf
@@ -28,5 +28,8 @@ locals {
     cwagent-windows-security = {
       retention_in_days = coalesce(var.options.cloudwatch_log_groups_retention_in_days, local.cloudwatch_log_groups_retention_default)
     }
+    kinesis-agent-windows-security = {
+      retention_in_days = coalesce(var.options.cloudwatch_log_groups_retention_in_days, local.cloudwatch_log_groups_retention_default)
+    }
   }
 }


### PR DESCRIPTION
- if we want to test using the kinesis agent for sending a subset of windows security logs we need a Log Group
- EC2 instances/ the general IAM role has a hard deny for logs:CreateLogGroup permissions so we need to create this elsewhere