### PR TITLE
PI-2908 Trigger deployment of updated SageMaker endpoint

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -63,7 +63,7 @@ resource "aws_sagemaker_model" "probation_search_huggingface_embedding_model" {
 resource "aws_sagemaker_endpoint_configuration" "probation_search_config" {
   #checkov:skip=CKV_AWS_98:KMS key is not supported for NVMe instance storage.
   for_each    = aws_sagemaker_model.probation_search_huggingface_embedding_model
-  name_prefix = "${each.key}-sagemaker-endpoint-config"
+  name_prefix = "${each.key}-cfg"
   production_variants {
     variant_name           = "AllTraffic"
     model_name             = aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key].name

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -62,22 +62,20 @@ resource "aws_sagemaker_model" "probation_search_huggingface_embedding_model" {
 
 resource "aws_sagemaker_endpoint_configuration" "probation_search_config" {
   #checkov:skip=CKV_AWS_98:KMS key is not supported for NVMe instance storage.
-  for_each    = tomap(local.probation_search_environment)
-  name_prefix = "${each.value.namespace}-sagemaker-endpoint-config"
+  for_each    = aws_sagemaker_model.probation_search_huggingface_embedding_model
+  name_prefix = "${each.key}-sagemaker-endpoint-config"
   production_variants {
     variant_name           = "AllTraffic"
     model_name             = aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key].name
     initial_instance_count = 1
-    instance_type          = each.value.instance_type
+    instance_type          = tomap(local.probation_search_environment)[each.key].instance_type
   }
-  depends_on = [aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key]]
 }
 
 resource "aws_sagemaker_endpoint" "probation_search_endpoint" {
-  for_each             = tomap(local.probation_search_environment)
-  name                 = "${each.value.namespace}-sagemaker-endpoint"
-  endpoint_config_name = aws_sagemaker_endpoint_configuration.probation_search_config[each.key].name
-  depends_on           = [aws_sagemaker_endpoint_configuration.probation_search_config[each.key]]
+  for_each             = aws_sagemaker_endpoint_configuration.probation_search_config
+  name                 = "${each.key}-sagemaker-endpoint"
+  endpoint_config_name = each.value.name
 }
 
 


### PR DESCRIPTION
### What does this do?
This makes the dependencies more explicit between the following resources:
* `aws_sagemaker_endpoint` -> `aws_sagemaker_endpoint_configuration` -> `aws_sagemaker_model`

It also switches to a dynamically generated name for the `aws_sagemaker_endpoint_configuration` and `aws_sagemaker_model` resources.

### Why is it needed?
Previously, the endpoint configuration only depended on the model's _name_ - which was static.  This meant changes to the configuration (e.g. to the environment variables here: https://github.com/ministryofjustice/modernisation-platform-environments/pull/9868) were not applied.

By updating to a dynamic name, and updating the `for_each` to be dependent on the resources themselves rather than just the config locals, this ensures that Terraform detects any changes to the model or endpoint configuration, and applies it immediately to the SageMaker endpoint.