### PR TITLE
Update export bucket module to conditionally create resources based on destination bucket ID

### DIFF
--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
@@ -118,15 +118,18 @@ data "aws_iam_policy_document" "push_lambda" {
     ]
   }
 
-  statement {
-    sid    = "S3PermissionsForDestinationBucket"
-    effect = "Allow"
-    actions = [
-      "s3:PutObject",
-    ]
-    resources = [
-      "arn:aws:s3:::${var.destination_bucket_id}/*",
-    ]
+  dynamic "statement" {
+    for_each = var.destination_bucket_id != null ? [1] : []
+    content {
+      sid    = "S3PermissionsForDestinationBucket"
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+      ]
+      resources = [
+        "arn:aws:s3:::${var.destination_bucket_id}/*",
+      ]
+    }
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
@@ -54,6 +54,8 @@ module "this-bucket" {
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   statement_id  = "AllowExecutionFromS3Bucket-${var.export_destination}"
   action        = "lambda:InvokeFunction"
   function_name = module.push_lambda.lambda_function_arn
@@ -62,6 +64,8 @@ resource "aws_lambda_permission" "allow_bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   bucket = module.this-bucket.bucket.id
 
   lambda_function {
@@ -77,6 +81,8 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 #------------------------------------------------------------------------------
 
 module "push_lambda" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   source                  = "../lambdas"
   function_name           = "push_data_export_to_${var.export_destination}"
   image_name              = "push_data_export"
@@ -99,11 +105,13 @@ module "push_lambda" {
 #------------------------------------------------------------------------------
 
 resource "aws_iam_role" "push_lambda" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   name               = "${var.export_destination}_export_bucket_files"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
-data "aws_iam_policy_document" "push_lambda" {
+data "aws_iam_policy_document" "push_lambda" {  
   statement {
     sid    = "S3PermissionsForExportBucket"
     effect = "Allow"
@@ -129,12 +137,16 @@ data "aws_iam_policy_document" "push_lambda" {
 }
 
 resource "aws_iam_policy" "push_lambda" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   name        = "${var.export_destination}_export_bucket_files_policy"
   description = "Policy for Lambda to push file from source to destination S3 location"
   policy      = data.aws_iam_policy_document.push_lambda.json
 }
 
 resource "aws_iam_role_policy_attachment" "push_lambda" {
+  count         = var.destination_bucket_id != null ? 1 : 0
+
   role       = aws_iam_role.push_lambda.name
   policy_arn = aws_iam_policy.push_lambda.arn
 }

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
@@ -105,8 +105,6 @@ module "push_lambda" {
 #------------------------------------------------------------------------------
 
 resource "aws_iam_role" "push_lambda" {
-  count         = var.destination_bucket_id != null ? 1 : 0
-
   name               = "${var.export_destination}_export_bucket_files"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
@@ -137,16 +135,12 @@ data "aws_iam_policy_document" "push_lambda" {
 }
 
 resource "aws_iam_policy" "push_lambda" {
-  count         = var.destination_bucket_id != null ? 1 : 0
-
   name        = "${var.export_destination}_export_bucket_files_policy"
   description = "Policy for Lambda to push file from source to destination S3 location"
   policy      = data.aws_iam_policy_document.push_lambda.json
 }
 
 resource "aws_iam_role_policy_attachment" "push_lambda" {
-  count         = var.destination_bucket_id != null ? 1 : 0
-
   role       = aws_iam_role.push_lambda.name
   policy_arn = aws_iam_policy.push_lambda.arn
 }

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/main.tf
@@ -54,8 +54,6 @@ module "this-bucket" {
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  count         = var.destination_bucket_id != null ? 1 : 0
-
   statement_id  = "AllowExecutionFromS3Bucket-${var.export_destination}"
   action        = "lambda:InvokeFunction"
   function_name = module.push_lambda.lambda_function_arn
@@ -81,8 +79,6 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 #------------------------------------------------------------------------------
 
 module "push_lambda" {
-  count         = var.destination_bucket_id != null ? 1 : 0
-
   source                  = "../lambdas"
   function_name           = "push_data_export_to_${var.export_destination}"
   image_name              = "push_data_export"

--- a/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/export_bucket_push/variables.tf
@@ -6,6 +6,7 @@ variable "core_shared_services_id" {
 variable "destination_bucket_id" {
   description = "The id of the bucket data will be pushed to"
   type        = string
+  default     = null
 }
 
 variable "export_destination" {

--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -20,7 +20,6 @@ locals {
     "test"          = null
     "development"   = null
   }
-}
 
   # Adding new buckets for logging needs to happen after buckets have been created
   # as an error occurs otherwise because local.buckets_to_log contains keys that 

--- a/terraform/environments/electronic-monitoring-data/s3.tf
+++ b/terraform/environments/electronic-monitoring-data/s3.tf
@@ -14,6 +14,14 @@ locals {
     }
   }
 
+  p1_export_bucket_destination_mapping = {
+    "production"    = "tct-339712706964-prearrivals"
+    "preproduction" = null
+    "test"          = null
+    "development"   = null
+  }
+}
+
   # Adding new buckets for logging needs to happen after buckets have been created
   # as an error occurs otherwise because local.buckets_to_log contains keys that 
   # are derived  from resource attributes, which are not known until the apply phase.
@@ -746,7 +754,7 @@ module "s3-p1-export-bucket" {
   source = "./modules/export_bucket_push/"
 
   core_shared_services_id = local.environment_management.account_ids["core-shared-services-production"]
-  destination_bucket_id   = "tct-339712706964-prearrivals"
+  destination_bucket_id   = local.p1_export_bucket_destination_mapping[local.environment]
   export_destination      = "p1"
   local_bucket_prefix     = local.bucket_prefix
   local_tags              = local.tags


### PR DESCRIPTION
To account for the instance where the export location doesn't have a full mapping for our environments, tweaked the export bucket code to not spin up the lambda trigger if a destination bucket has not been provided.