### PR TITLE
Amedning the resource name on an S3 bucket create

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_preproduction.tf
@@ -412,9 +412,7 @@ locals {
               "s3:GetObjectTagging",
               "s3:ListBucket",
             ]
-            resources = [
-              "arn:aws:s3:::csr-db-backup-bucket*",
-            ]
+            resources = "arn:aws:s3:::csr-db-backup-bucket*",
           },
           {
             effect = "Allow"


### PR DESCRIPTION
A minor code change to point to the resource without the square brackets - not needed now.