### PR TITLE
Add IAM policy for Airflow service account role assumption

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -147,6 +147,25 @@ data "aws_iam_policy_document" "dataapi_cross_assume" {
       variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:aud"
     }
   }
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.analytical_platform_compute.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["system:serviceaccount:airflow:*"]
+      variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.airflow_secret.secret_string)["oidc_cluster_identifier"]}:sub"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.airflow_secret.secret_string)["oidc_cluster_identifier"]}:aud"
+    }
+  }
 }
 
 # Role used in create a derived table 


### PR DESCRIPTION
Introduce an IAM policy statement that allows the Airflow service account to assume a specified role using web identity.