### PR TITLE
♻️ Replace SageMaker Endpoints on changes to SageMaker Models

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -71,12 +71,20 @@ resource "aws_sagemaker_endpoint_configuration" "probation_search_config" {
     initial_instance_count = 1
     instance_type          = each.value.instance_type
   }
+
+  lifecycle {
+    replace_triggered_by = [aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key]]
+  }
 }
 
 resource "aws_sagemaker_endpoint" "probation_search_endpoint" {
   for_each             = tomap(local.probation_search_environment)
   name                 = "${each.value.namespace}-sagemaker-endpoint"
   endpoint_config_name = aws_sagemaker_endpoint_configuration.probation_search_config[each.key].name
+
+  lifecycle {
+    replace_triggered_by = [aws_sagemaker_endpoint_configuration.probation_search_config[each.key]]
+  }
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytical-platform/issues/7152

## Proposed Changes

- Adds `lifecycle.replace_triggered_by` to `aws_sagemaker_endpoint` and `aws_sagemaker_endpoint_configuration` so that these resources get recreated on change.

## Notes for the reviewer

This is required because changing `aws_sagemaker_model` does not cause an update to `aws_sagemaker_endpoint_configuration` or `aws_sagemaker_endpoint`.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>