### PR TITLE
Add IAM policy and role for P1 export data in Airflow

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -58,12 +58,14 @@ data "aws_iam_policy_document" "p1_export_airflow" {
     resources = ["*"]
   }
   statement {
-    sid    = "S3PutPermissionsForP1Export"
+    sid    = "S3ExportBucketPermissionsForP1Export"
     effect = "Allow"
     actions = [
       "s3:PutObject",
+      "s3:ListBucket"
     ]
     resources = [
+      module.s3-p1-export-bucket.bucket_arn,
       "${module.s3-p1-export-bucket.bucket_arn}/*",
     ]
   }
@@ -80,7 +82,7 @@ data "aws_iam_policy_document" "p1_export_airflow" {
     resources = ["*"]
   }
   statement {
-    sid       = "ListAllBucketForP1Export"
+    sid       = "ListAllBuckesForP1Export"
     effect    = "Allow"
     actions   = ["s3:ListAllMyBuckets", "s3:GetBucketLocation"]
     resources = ["*"]

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "p1_export_airflow" {
       "s3:PutObject",
     ]
     resources = [
-      "${module.s3-p1-export-bucket.bucket.arn}/*",
+      "${module.s3-p1-export-bucket.bucket_arn}/*",
     ]
   }
 

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -41,8 +41,8 @@ data "aws_iam_policy_document" "p1_export_airflow" {
       "s3:ListBucket"
     ]
     resources = [
-      "module.s3-athena-bucket.bucket.arn",
-       "${module.s3-athena-bucket.bucket.arn}/*",
+      module.s3-athena-bucket.bucket.arn,
+      "${module.s3-athena-bucket.bucket.arn}/*",
     ]
   }
   statement {

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -21,6 +21,7 @@ module "test_ap_airflow" {
 data "aws_iam_policy_document" "p1_export_airflow" {
 
   statement {
+    sid = "AthenaPermissionsForP1Export"
     effect = "Allow"
     actions = [
       "athena:StartQueryExecution",
@@ -34,6 +35,7 @@ data "aws_iam_policy_document" "p1_export_airflow" {
     resources = ["*"]
   }
   statement {
+    sid = "S3AthenaQueryBucketPermissionsForP1Export"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -46,6 +48,7 @@ data "aws_iam_policy_document" "p1_export_airflow" {
     ]
   }
   statement {
+    sid = "GluePermissionsForP1Export"
     effect = "Allow"
     actions = [
       "glue:GetDatabase",
@@ -55,7 +58,7 @@ data "aws_iam_policy_document" "p1_export_airflow" {
     resources = ["*"]
   }
   statement {
-    sid    = "P1ExportAirflowS3PutPermissions"
+    sid    = "S3PutPermissionsForP1Export"
     effect = "Allow"
     actions = [
       "s3:PutObject",
@@ -64,7 +67,24 @@ data "aws_iam_policy_document" "p1_export_airflow" {
       "${module.s3-p1-export-bucket.bucket_arn}/*",
     ]
   }
-
+  statement {
+    sid       = "GetDataAccessForLakeFormationForP1Export"
+    effect    = "Allow"
+    actions   = ["lakeformation:GetDataAccess"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "ListAccountAliasForP1Export"
+    effect    = "Allow"
+    actions   = ["iam:ListAccountAliases"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "ListAllBucketForP1Export"
+    effect    = "Allow"
+    actions   = ["s3:ListAllMyBuckets", "s3:GetBucketLocation"]
+    resources = ["*"]
+  }
 }
 
 module "p1_export_airflow" {

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -19,7 +19,8 @@ module "test_ap_airflow" {
 }
 
 data "aws_iam_policy_document" "p1_export_airflow" {
-
+  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_111
   statement {
     sid = "AthenaPermissionsForP1Export"
     effect = "Allow"


### PR DESCRIPTION
This adds all the permissions required to configure an airflow pipeline for creating the p1 data exports.

That python code, runs an athena query and then copies the resulting query output from the athena query bucket to the p1 export bucket.

Run in test and the dev airflow account to check all is right.