### PR TITLE
:wrench: Common: Terraform Module Patching

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -71,7 +71,7 @@ module "ecr_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.2"
+  version = "5.54.0"
 
   name_prefix = "ecr-access"
 

--- a/terraform/environments/analytical-platform-common/iam-role.tf
+++ b/terraform/environments/analytical-platform-common/iam-role.tf
@@ -3,7 +3,7 @@ module "ecr_access_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.52.2"
+  version = "5.54.0"
 
   name = "ecr-access"
 

--- a/terraform/environments/analytical-platform-common/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-common/s3-buckets.tf
@@ -3,7 +3,7 @@ module "terraform_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.5.0"
+  version = "4.6.0"
 
   bucket = "mojap-common-${local.environment}-tfstate"
 


### PR DESCRIPTION
This PR patches the following: 

- **Module Updates:**
  - **iam-policy:** Updated version from `5.52.2` to `5.54.0`.
  - **ecr_access_iam_role:** Updated version from `5.52.2` to `5.54.0`.
  - **terraform_bucket:** Updated version from `4.5.0` to `4.6.0`.