### PR TITLE
Create CICA ingress bucket/kms in development, restrict replication to prod

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "s3:GetReplicationConfiguration",
       "s3:ListBucket"
     ]
-    resources = length(module.cica_dms_ingress_bucket) > 0 ? [module.cica_dms_ingress_bucket[0].s3_bucket_arn] : []
+    resources = module.cica_dms_ingress_bucket.s3_bucket_arn
   }
   statement {
     sid    = "SourceBucketObjectPermissions"
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "s3:GetObjectVersionTagging",
       "s3:ObjectOwnerOverrideToBucketOwner"
     ]
-    resources = length(module.cica_dms_ingress_bucket) > 0 ? ["${module.cica_dms_ingress_bucket[0].s3_bucket_arn}/*"] : []
+    resources = [ "${module.cica_dms_ingress_bucket.s3_bucket_arn}/*" ]
   }
   statement {
     sid    = "SourceBucketKMSKey"
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    resources = length(module.s3_cica_dms_ingress_kms) > 0 ? [module.s3_cica_dms_ingress_kms[0].key_arn] : []
+    resources = module.s3_cica_dms_ingress_kms.key_arn
   }
   statement {
     sid    = "DestinationBucketKMSKey"

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "s3:GetReplicationConfiguration",
       "s3:ListBucket"
     ]
-    resources = module.cica_dms_ingress_bucket.s3_bucket_arn
+    resources = [module.cica_dms_ingress_bucket.s3_bucket_arn]
   }
   statement {
     sid    = "SourceBucketObjectPermissions"
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "s3:GetObjectVersionTagging",
       "s3:ObjectOwnerOverrideToBucketOwner"
     ]
-    resources = [ "${module.cica_dms_ingress_bucket.s3_bucket_arn}/*" ]
+    resources = ["${module.cica_dms_ingress_bucket.s3_bucket_arn}/*"]
   }
   statement {
     sid    = "SourceBucketKMSKey"
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "production_cica_dms_replication" {
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    resources = module.s3_cica_dms_ingress_kms.key_arn
+    resources = [module.s3_cica_dms_ingress_kms.key_arn]
   }
   statement {
     sid    = "DestinationBucketKMSKey"

--- a/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
@@ -1,8 +1,6 @@
 module "s3_cica_dms_ingress_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  count = 1 # Needed (as originally conditional) to avoid destroy-create
-
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.0"
 

--- a/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
@@ -1,7 +1,7 @@
 module "s3_cica_dms_ingress_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  count = local.environment == "production" ? 1 : 0
+  count = 1 # Needed (as originally conditional) to avoid destroy-create
 
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.0"

--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -3,7 +3,7 @@
 module "cica_dms_ingress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  count = local.environment == "production" ? 1 : 0
+  count = 1 # Needed (as originally conditional) to avoid destroy-create
 
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.3.0"
@@ -16,7 +16,7 @@ module "cica_dms_ingress_bucket" {
     enabled = true
   }
 
-  replication_configuration = {
+  replication_configuration = local.environment == "production" ? {
     role = module.production_replication_cica_dms_iam_role[0].iam_role_arn
     rules = [
       {
@@ -51,7 +51,7 @@ module "cica_dms_ingress_bucket" {
         }
       }
     ]
-  }
+  } : {}
 
   server_side_encryption_configuration = {
     rule = {

--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -6,7 +6,7 @@ module "cica_dms_ingress_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.3.0"
 
-  bucket = "mojap-ingestion-production-cica-dms-ingress"
+  bucket = "mojap-ingestion-${local.environment}-cica-dms-ingress"
 
   force_destroy = true
 

--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -3,8 +3,6 @@
 module "cica_dms_ingress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  count = 1 # Needed (as originally conditional) to avoid destroy-create
-
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.3.0"
 
@@ -20,7 +18,7 @@ module "cica_dms_ingress_bucket" {
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.s3_cica_dms_ingress_kms[0].key_arn
+        kms_master_key_id = module.s3_cica_dms_ingress_kms.key_arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -30,7 +28,7 @@ module "cica_dms_ingress_bucket" {
 resource "aws_s3_bucket_replication_configuration" "cica_dms_ingress_bucket_replication" {
   count = local.environment == "production" ? 1 : 0
   role = module.production_replication_cica_dms_iam_role[0].iam_role_arn
-  bucket = module.cica_dms_ingress_bucket[0].s3_bucket_id
+  bucket = module.cica_dms_ingress_bucket.s3_bucket_id
   rule {
     id                        = "mojap-ingestion-cica-dms-ingress"
     status                    = "Enabled"


### PR DESCRIPTION
This is needed to unblock `terraform plan`/`apply`/testing in dev environment of [this PR](https://github.com/ministryofjustice/modernisation-platform-environments/pull/9955) by creating the dms ingestion bucket & KMS key in `analytical-platform-ingestion-development` as well as `analytical-platform-ingestion-production`

~Happy to remove the `count = 1` if people would prefer, but this removal will require either `terraform import`/destroy-create of (as yet unused) infrastructure in `analytical-platform-ingestion-production`~ 

Annoyingly i've had to break the replication out of the module to make it conditional, this is due to this issue https://github.com/hashicorp/terraform/issues/31039