### PR TITLE
🚑 Fix self-hosted runners for ministryofjustice repositories

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -91,6 +91,37 @@ resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_se
   }
 }
 
+resource "kubernetes_manifest" "actions_runners_token_moj_apc_self_hosted_runners_secret" {
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "external-secrets.io/v1beta1"
+    "kind"       = "ExternalSecret"
+    "metadata" = {
+      "name"      = "actions-runners-token-moj-apc-self-hosted-runners"
+      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+    }
+    "spec" = {
+      "refreshInterval" = "1m"
+      "secretStoreRef" = {
+        "kind" = "ClusterSecretStore"
+        "name" = "aws-secretsmanager"
+      }
+      "target" = {
+        "name" = "actions-runners-token-moj-apc-self-hosted-runners"
+      }
+      "data" = [
+        {
+          "remoteRef" = {
+            "key" = module.actions_runners_token_moj_apc_self_hosted_runners_secret[0].secret_id
+          }
+          "secretKey" = "token"
+        }
+      ]
+    }
+  }
+}
+
 resource "kubernetes_manifest" "actions_runners_github_app_apc_self_hosted_runners_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 

--- a/terraform/environments/analytical-platform-compute/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/secrets.tf
@@ -128,7 +128,31 @@ module "actions_runners_token_apc_self_hosted_runners_secret" {
   version = "1.3.1"
 
   name        = "actions-runners/token/apc-self-hosted-runners"
-  description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/4281036"
+  description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/4282353"
+  kms_key_id  = module.common_secrets_manager_kms.key_arn
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    {
+      "expiry-date" = "2025-10-23"
+    }
+  )
+}
+
+module "actions_runners_token_moj_apc_self_hosted_runners_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name        = "actions-runners/token/moj-apc-self-hosted-runners"
+  description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/5605162"
   kms_key_id  = module.common_secrets_manager_kms.key_arn
 
   secret_string         = "CHANGEME"

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/data-catalogue/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/data-catalogue/values.yml.tftpl
@@ -5,5 +5,7 @@ github:
     installationID: "${github_app_installation_id}"
   organisation: ${github_organisation}
   repository: ${github_repository}
+  tokenSecretName: actions-runners-token-moj-apc-self-hosted-runners
+  tokenSecretKey: token
   runner:
     labels: ${github_runner_labels}


### PR DESCRIPTION
## Proposed Changes

- Adds a Secrets Manager secret to hold fine-grained token for `ministryofjustice`
- Adds a Kubernetes External Secret for the above Secrets Manager secret
- Updates DC self-hosted runner to use above External Secret

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>