### PR TITLE
Add IAM role and policy for SCRAM alcohol monitoring data loading

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -439,8 +439,8 @@ data "aws_iam_policy_document" "scram_am_ap_airflow" {
       "s3:ListBucket"
     ]
     resources = [
-      module.s3-data-bucket.bucket_arn,
-      "${module.s3-data-bucket.bucket_arn}/scram/alcohol_monitoring/*",
+      module.s3-data-bucket.bucket.arn,
+      "${module.s3-data-bucket.bucket.arn}/scram/alcohol_monitoring/*",
     ]
   }
   statement {
@@ -451,8 +451,8 @@ data "aws_iam_policy_document" "scram_am_ap_airflow" {
       "s3:ListBucket"
     ]
     resources = [
-      module.s3-create-a-derived-table-bucket.bucket_arn,
-      "${module.s3-create-a-derived-table-bucket.bucket_arn}/*",
+      module.s3-create-a-derived-table-bucket.bucket.arn,
+      "${module.s3-create-a-derived-table-bucket.bucket.arn}/*",
     ]
   }
   statement {

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -451,8 +451,8 @@ data "aws_iam_policy_document" "scram_am_ap_airflow" {
       "s3:ListBucket"
     ]
     resources = [
-      module.s3-cadt-bucket.bucket_arn,
-      "${module.s3-cadt-bucket.bucket_arn}/*",
+      module.s3-create-a-derived-table-bucket.bucket_arn,
+      "${module.s3-create-a-derived-table-bucket.bucket_arn}/*",
     ]
   }
   statement {

--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -394,6 +394,8 @@ module "load_scram_alcohol_monitoring" {
 }
 
 data "aws_iam_policy_document" "scram_am_ap_airflow" {
+  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_111
   statement {
     sid    = "AthenaPermissionsForScramAlcoholMonitoring"
     effect = "Allow"


### PR DESCRIPTION
Introduce an IAM role and policy to facilitate the loading of SCRAM alcohol monitoring data, ensuring necessary permissions for Athena, S3, and Glue operations.