### PR TITLE
📌 Bump DC's runner to 2.322.0-1

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -231,7 +231,7 @@ resource "helm_release" "actions_runner_moj_data_catalogue" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-moj-data-catalogue"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.322.0"
+  version    = "2.322.0-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [


### PR DESCRIPTION
## Proposed Changes

- Bumps @ministryofjustice/data-catalogue's runner to [2.322.0-1](https://github.com/ministryofjustice/analytical-platform-actions-runner/releases/tag/2.322.0-1)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>