### PR TITLE
Add airflow_cadt_secret_placeholder to Terraform configuration

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow.tf
@@ -7,6 +7,7 @@ locals {
   airflow_secret_placeholder = {
     oidc_cluster_identifier = "placeholder"
   }
+  airflow_cadt_secret_placeholder = "placeholder"
 }
 data "aws_secretsmanager_secret" "airflow_secret" {
   name = aws_secretsmanager_secret.airflow_secret[0].id

--- a/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_analytical_platform.tf
@@ -209,7 +209,7 @@ data "aws_iam_policy_document" "lake_formation_data_access" {
 # Policy Document
 
 data "aws_iam_policy_document" "lake_formation_lftag_access" {
-      #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints
   statement {
     actions = [
       "lakeformation:AddLFTagsToResource",
@@ -575,7 +575,7 @@ resource "aws_secretsmanager_secret_version" "airflow_ssh_secret" {
   count = local.is-preproduction || local.is-production ? 1 : 0
 
   secret_id     = aws_secretsmanager_secret.airflow_ssh_secret[0].id
-  secret_string = jsonencode(local.airflow_secret_placeholder)
+  secret_string = jsonencode(local.airflow_cadt_secret_placeholder)
 
   lifecycle {
     ignore_changes = [secret_string, ]


### PR DESCRIPTION
Introduce a new placeholder for the Airflow CADT secret in the Terraform configuration to enhance secret management. Update references to use this new placeholder where necessary.