### PR TITLE
PI-2859 Switch to pulling SageMaker model from S3 in dev

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -7,13 +7,13 @@ locals {
   probation_search_environments = {
     analytical-platform-compute-development = {
       hmpps-probation-search-dev = {
-        namespace       = "hmpps-probation-search-dev"                    # MOJ Cloud Platform namespace where OpenSearch is hosted
-        instance_type   = "ml.t2.large"                                   # SageMaker AI Real-time Inference instance type to use
-        repository_name = "tei-cpu"                                       # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
-        image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"          # Version of the Hugging Face Text Embeddings Inference image to use. See https://huggingface.co/docs/text-embeddings-inference.
-        s3_model_key    = "ext/mixedbread-ai/mxbai-embed-large-v1.tar.gz" # To use a local model from S3
-        environment = {                                                   # Environment variables to be passed to the Hugging Face Text Embeddings Inference image. See https://huggingface.co/docs/text-embeddings-inference/cli_arguments.
-          HF_MODEL_ID           = "/opt/ml/model"                         # To use a remote model from Hugging Face Hub (takes precedence over s3_model_key above, if present)
+        namespace       = "hmpps-probation-search-dev"                            # MOJ Cloud Platform namespace where OpenSearch is hosted
+        instance_type   = "ml.t2.large"                                           # SageMaker AI Real-time Inference instance type to use
+        repository_name = "tei-cpu"                                               # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
+        image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"                  # Version of the Hugging Face Text Embeddings Inference image to use. See https://huggingface.co/docs/text-embeddings-inference.
+        s3_model_key    = "ext/mixedbread-ai/mixedbread-ai_mxbai-embed-large-v1/" # To use a local model from S3
+        environment = {                                                           # Environment variables to be passed to the Hugging Face Text Embeddings Inference image. See https://huggingface.co/docs/text-embeddings-inference/cli_arguments.
+          HF_MODEL_ID           = "/opt/ml/model"                                 # Specifies the model to load from Hugging Face Hub, if you are specifying s3_model_key, this should be set to "/opt/ml/model"
           MAX_CLIENT_BATCH_SIZE = 512
         }
       }
@@ -63,9 +63,18 @@ resource "aws_sagemaker_model" "probation_search_huggingface_embedding_model" {
   execution_role_arn = module.probation_search_sagemaker_execution_iam_role[each.key].iam_role_arn
 
   primary_container {
-    image          = data.aws_sagemaker_prebuilt_ecr_image.probation_search_huggingface_embedding_image[each.key].registry_path
-    environment    = each.value.environment
-    model_data_url = can(each.value.s3_model_key) ? "s3://${local.probation_search_model_bucket_name}/${each.value.s3_model_key}" : null
+    image       = data.aws_sagemaker_prebuilt_ecr_image.probation_search_huggingface_embedding_image[each.key].registry_path
+    environment = each.value.environment
+    dynamic "model_data_source" {
+      for_each = can(each.value.s3_model_key) ? [1] : []
+      content {
+        s3_data_source {
+          compression_type = "None"
+          s3_data_type     = "S3Prefix"
+          s3_uri           = "s3://${local.probation_search_model_bucket_name}/${each.value.s3_model_key}"
+        }
+      }
+    }
   }
 
   tags = merge(local.tags, {

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -6,12 +6,13 @@ locals {
   probation_search_environments = {
     analytical-platform-compute-development = {
       hmpps-probation-search-dev = {
-        namespace       = "hmpps-probation-search-dev"                 # MOJ Cloud Platform namespace where OpenSearch is hosted
-        instance_type   = "ml.t2.large"                                # SageMaker AI Real-time Inference instance type to use
-        repository_name = "tei-cpu"                                    # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
-        image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"       # Version of the Hugging Face Text Embeddings Inference image to use. See https://huggingface.co/docs/text-embeddings-inference.
-        environment = {                                                # Environment variables to be passed to the Hugging Face Text Embeddings Inference image. See https://huggingface.co/docs/text-embeddings-inference/cli_arguments.
-          HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1" # To use a remote model from Hugging Face Hub (takes precedence over s3_model_key above, if present)
+        namespace       = "hmpps-probation-search-dev"                    # MOJ Cloud Platform namespace where OpenSearch is hosted
+        instance_type   = "ml.t2.large"                                   # SageMaker AI Real-time Inference instance type to use
+        repository_name = "tei-cpu"                                       # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
+        image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"          # Version of the Hugging Face Text Embeddings Inference image to use. See https://huggingface.co/docs/text-embeddings-inference.
+        s3_model_key    = "ext/mixedbread-ai/mxbai-embed-large-v1.tar.gz" # To use a local model from S3
+        environment = {                                                   # Environment variables to be passed to the Hugging Face Text Embeddings Inference image. See https://huggingface.co/docs/text-embeddings-inference/cli_arguments.
+          #HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"    # To use a remote model from Hugging Face Hub (takes precedence over s3_model_key above, if present)
           MAX_CLIENT_BATCH_SIZE = 512
         }
       }

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -13,7 +13,7 @@ locals {
         image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04"          # Version of the Hugging Face Text Embeddings Inference image to use. See https://huggingface.co/docs/text-embeddings-inference.
         s3_model_key    = "ext/mixedbread-ai/mxbai-embed-large-v1.tar.gz" # To use a local model from S3
         environment = {                                                   # Environment variables to be passed to the Hugging Face Text Embeddings Inference image. See https://huggingface.co/docs/text-embeddings-inference/cli_arguments.
-          #HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"    # To use a remote model from Hugging Face Hub (takes precedence over s3_model_key above, if present)
+          HF_MODEL_ID           = "/opt/ml/model"                         # To use a remote model from Hugging Face Hub (takes precedence over s3_model_key above, if present)
           MAX_CLIENT_BATCH_SIZE = 512
         }
       }

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -147,7 +147,13 @@ module "probation_search_sagemaker_execution_iam_role" {
       resources = [local.probation_search_model_kms_arn]
     },
     {
-      sid       = "S3Access"
+      sid       = "S3BucketAccess"
+      effect    = "Allow"
+      actions   = ["s3:ListBucket"]
+      resources = ["arn:aws:s3:::${local.probation_search_model_bucket_name}"]
+    },
+    {
+      sid       = "S3ObjectAccess"
       effect    = "Allow"
       actions   = ["s3:GetObject"]
       resources = ["arn:aws:s3:::${local.probation_search_model_bucket_name}/*"]

--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -2,7 +2,8 @@
 # Cloud Platform namespace mapping
 # ------------------------------------------------------------------------------
 locals {
-  probation_search_model_bucket_name = "mojap-probation-search-model-export"
+  probation_search_model_bucket_name = "mojap-data-production-sagemaker-ai-probation-search-models"
+  probation_search_model_kms_arn     = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/55286d64-9b9d-4473-8750-0546f583f19e"
   probation_search_environments = {
     analytical-platform-compute-development = {
       hmpps-probation-search-dev = {
@@ -135,6 +136,15 @@ module "probation_search_sagemaker_execution_iam_role" {
         "logs:PutLogEvents",
       ]
       resources = ["*"]
+    },
+    {
+      sid    = "KMSAccess"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = [local.probation_search_model_kms_arn]
     },
     {
       sid       = "S3Access"


### PR DESCRIPTION
## Proposed Changes

- Adds logic to use models from S3
- Updates execution role to connect to model storage in APDP 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>