### PR TITLE
test instance, make sure it can be moved to correct OU

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -146,24 +146,24 @@ locals {
         cloudwatch_metric_alarms = null
       })
       # testing only do not use
-      # test-rds-2-b = merge(local.ec2_instances.rds, {
-      #   config = merge(local.ec2_instances.rds.config, {
-      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
-      #     availability_zone = "eu-west-2b"
-      #     user_data_raw = base64encode(templatefile(
-      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-      #         branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-      #       }
-      #     ))
-      #     instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
-      #       "Ec2SecretPolicy"]
-      #     )
-      #   })
-      #   tags = merge(local.ec2_instances.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          ami_name          = "hmpps_windows_server_2022_release_2025-*"
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+            }
+          ))
+          instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
+            "Ec2SecretPolicy"]
+          )
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -146,24 +146,24 @@ locals {
         cloudwatch_metric_alarms = null
       })
       # testing only do not use
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
-            "Ec2SecretPolicy"]
-          )
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy"]
+      #     )
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {
@@ -217,19 +217,19 @@ locals {
               { ec2_instance_name = "test-rdgw-1-a" },
             ]
           })
-          test-rds-1-https = merge(local.lbs.public.instance_target_groups.https, {
-            attachments = [
-              { ec2_instance_name = "test-rds-2-b" },
-            ]
-          })
+          # test-rds-1-https = merge(local.lbs.public.instance_target_groups.https, {
+          #   attachments = [
+          #     { ec2_instance_name = "test-rds-2-b" },
+          #   ]
+          # })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
             alarm_target_group_names = [
               "test-rdgw-1-http",
-              "test-rds-1-https",
+#              "test-rds-1-https",
             ]
-            certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
+#            certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
             rules = {
               test-rdgw-1-http = {
                 priority = 100
@@ -246,20 +246,20 @@ locals {
                   }
                 }]
               }
-              test-rds-1-https = {
-                priority = 200
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "test-rds-1-https"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "rdweb1.test.hmpps-domain.service.justice.gov.uk"
-                    ]
-                  }
-                }]                
-              }
+              # test-rds-1-https = {
+              #   priority = 200
+              #   actions = [{
+              #     type              = "forward"
+              #     target_group_name = "test-rds-1-https"
+              #   }]
+              #   conditions = [{
+              #     host_header = {
+              #       values = [
+              #         "rdweb1.test.hmpps-domain.service.justice.gov.uk"
+              #       ]
+              #     }
+              #   }]                
+              # }
             }
           })
         })
@@ -277,7 +277,7 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          { name = "rdweb1", type = "A", lbs_map_key = "public" },
+          # { name = "rdweb1", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -145,6 +145,22 @@ locals {
         })
         cloudwatch_metric_alarms = null
       })
+      # testing only do not use
+      test-rds-2-b = merge(local.ec2_instances.rds, {
+        config = merge(local.ec2_instances.rds.config, {
+          ami_name          = "hmpps_windows_server_2022_release_2025-*"
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.rds.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -146,24 +146,24 @@ locals {
         cloudwatch_metric_alarms = null
       })
       # testing only do not use
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-            }
-          ))
-          instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
-            "Ec2SecretPolicy"]
-          )
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy"]
+      #     )
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -130,16 +130,21 @@ locals {
       })
 
       # testing only do not use
-      # t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
-      #   config = merge(local.ec2_instances.jumpserver.config, {
-      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
-      #     availability_zone = "eu-west-2b"
-      #   })
-      #   tags = merge(local.ec2_instances.jumpserver.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
+      t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
+        config = merge(local.ec2_instances.jumpserver.config, {
+          ami_name          = "hmpps_windows_server_2022_release_2025-*"
+          availability_zone = "eu-west-2b"
+          user_data_raw = base64encode(templatefile(
+            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+            }
+          ))
+        })
+        tags = merge(local.ec2_instances.jumpserver.tags, {
+          domain-name = "azure.noms.root"
+        })
+        cloudwatch_metric_alarms = null
+      })
     }
 
     fsx_windows = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -146,21 +146,24 @@ locals {
         cloudwatch_metric_alarms = null
       })
       # testing only do not use
-      test-rds-2-b = merge(local.ec2_instances.rds, {
-        config = merge(local.ec2_instances.rds.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
-          availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-            }
-          ))
-        })
-        tags = merge(local.ec2_instances.rds.tags, {
-          domain-name = "azure.noms.root"
-        })
-        cloudwatch_metric_alarms = null
-      })
+      # test-rds-2-b = merge(local.ec2_instances.rds, {
+      #   config = merge(local.ec2_instances.rds.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-*"
+      #     availability_zone = "eu-west-2b"
+      #     user_data_raw = base64encode(templatefile(
+      #       "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
+      #       }
+      #     ))
+      #     instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy"]
+      #     )
+      #   })
+      #   tags = merge(local.ec2_instances.rds.tags, {
+      #     domain-name = "azure.noms.root"
+      #   })
+      #   cloudwatch_metric_alarms = null
+      # })
     }
 
     fsx_windows = {
@@ -186,6 +189,24 @@ locals {
       #     password_secret_name = "/microsoft/AD/azure.noms.root/shared-passwords"
       #   }
       # }
+    }
+
+    iam_policies = {
+      Ec2SecretPolicy = {
+        description = "Permissions required for secret value access by instances"
+        statements = [
+          {
+            effect = "Allow"
+            actions = [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+            ]
+            resources = [
+              "arn:aws:secretsmanager:*:*:secret:/microsoft/AD/azure.noms.root/shared-passwords-*",
+            ]
+          }
+        ]
+      }
     }
 
     lbs = {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -217,19 +217,19 @@ locals {
               { ec2_instance_name = "test-rdgw-1-a" },
             ]
           })
-          # test-rds-1-https = merge(local.lbs.public.instance_target_groups.https, {
-          #   attachments = [
-          #     { ec2_instance_name = "test-rds-2-b" },
-          #   ]
-          # })
+          test-rds-1-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
             alarm_target_group_names = [
               "test-rdgw-1-http",
-#              "test-rds-1-https",
+             "test-rds-1-https",
             ]
-#            certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
+           certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
             rules = {
               test-rdgw-1-http = {
                 priority = 100
@@ -246,20 +246,20 @@ locals {
                   }
                 }]
               }
-              # test-rds-1-https = {
-              #   priority = 200
-              #   actions = [{
-              #     type              = "forward"
-              #     target_group_name = "test-rds-1-https"
-              #   }]
-              #   conditions = [{
-              #     host_header = {
-              #       values = [
-              #         "rdweb1.test.hmpps-domain.service.justice.gov.uk"
-              #       ]
-              #     }
-              #   }]                
-              # }
+              test-rds-1-https = {
+                priority = 200
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-1-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb1.test.hmpps-domain.service.justice.gov.uk"
+                    ]
+                  }
+                }]                
+              }
             }
           })
         })
@@ -277,7 +277,7 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
-          # { name = "rdweb1", type = "A", lbs_map_key = "public" },
+          { name = "rdweb1", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -217,12 +217,19 @@ locals {
               { ec2_instance_name = "test-rdgw-1-a" },
             ]
           })
+          test-rds-1-https = merge(local.lbs.public.instance_target_groups.https, {
+            attachments = [
+              { ec2_instance_name = "test-rds-2-b" },
+            ]
+          })
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
             alarm_target_group_names = [
               "test-rdgw-1-http",
+              "test-rds-1-https",
             ]
+            certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
             rules = {
               test-rdgw-1-http = {
                 priority = 100
@@ -238,6 +245,20 @@ locals {
                     ]
                   }
                 }]
+              }
+              test-rds-1-https = {
+                priority = 200
+                actions = [{
+                  type              = "forward"
+                  target_group_name = "test-rds-1-https"
+                }]
+                conditions = [{
+                  host_header = {
+                    values = [
+                      "rdweb1.test.hmpps-domain.service.justice.gov.uk"
+                    ]
+                  }
+                }]                
               }
             }
           })
@@ -256,6 +277,7 @@ locals {
       "test.hmpps-domain.service.justice.gov.uk" = {
         lb_alias_records = [
           { name = "rdgateway1", type = "A", lbs_map_key = "public" },
+          { name = "rdweb1", type = "A", lbs_map_key = "public" },
         ]
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -92,19 +92,6 @@ locals {
           domain-name = "azure.noms.root"
         })
       })
-
-      # RDGW/RDS infra can be build as ASG now (1 server only for RDS)
-      # test-rdgw-2-a = merge(local.ec2_autoscaling_groups.rdgw, {
-      #   tags = merge(local.ec2_autoscaling_groups.rdgw.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      # }
-      # test-rds-2-a = merge(local.ec2_autoscaling_groups.rds, {
-      #   tags = merge(local.ec2_autoscaling_groups.rds.tags, {
-      #     domain-name = "azure.noms.root"
-      #   })
-      #   cloudwatch_metric_alarms = null
-      # })
     }
 
     ec2_instances = {
@@ -129,32 +116,22 @@ locals {
         })
       })
 
-      # testing only do not use
+      # NOTE: will likely be rebuilt again, needs deploying BEFORE associated rds instance!
       t2-jump2022-2 = merge(local.ec2_instances.jumpserver, {
         config = merge(local.ec2_instances.jumpserver.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
+          ami_name          = "hmpps_windows_server_2022_release_2025-04-02T00-00-40.543Z"
           availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-            }
-          ))
         })
         tags = merge(local.ec2_instances.jumpserver.tags, {
           domain-name = "azure.noms.root"
         })
         cloudwatch_metric_alarms = null
       })
-      # testing only do not use
+
       test-rds-2-b = merge(local.ec2_instances.rds, {
         config = merge(local.ec2_instances.rds.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-*"
+          ami_name          = "hmpps_windows_server_2022_release_2025-04-02T00-00-40.543Z"
           availability_zone = "eu-west-2b"
-          user_data_raw = base64encode(templatefile(
-            "../../modules/baseline_presets/ec2-user-data/user-data-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1080/move-rds-instances-to-their-own-ou"
-            }
-          ))
           instance_profile_policies = concat(local.ec2_instances.rds.config.instance_profile_policies, [
             "Ec2SecretPolicy"]
           )


### PR DESCRIPTION
- use modified NartClient script for t2-jump2022-2 instance and adds to domain with this name
- adds test-rds-2-b instance
- set the ami names so they don't get accidentally recreated

Basically want to keep these there while messing about with the user-data scripts again 

