### PR TITLE
Force AWS to provision v2 replication configuration

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -32,7 +32,9 @@ resource "aws_s3_bucket_replication_configuration" "cica_dms_ingress_bucket_repl
   rule {
     id                        = "mojap-ingestion-cica-dms-ingress"
     status                    = "Enabled"
-    prefix                    = ""
+    filter {
+    }
+
     delete_marker_replication {
       status = "Enabled"
     }


### PR DESCRIPTION
~Though this is deprecated, this is necessary to force AWS to use V1 of the replication configuration V2 does not support DeleteMarkerReplication in cross-region transfer 
See https://stackoverflow.com/questions/52854094/status-on-aws-s3-cross-region-replication-delete-operations-behaviour~

~There's a bit of inconsistency here; [from looking at the destroy statement for the previous replication resource in the terraform plan](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/13921880986/job/38956920939#step:9:428), it looks like the previous replication_configuration had a `filter` attribute.~
~According to the docs, if the `filter` attribute is supplied on creation it should be V2 not V1, but given that the documentation also says that V2 is the version for which the `DeleteMarkerReplication` must be set to Disabled, both of these statements can't be true and result in the behaviour we're seeing.~
~That is unless the `filter` was added to an old V1 configuration in the background, rather than being supplied on creation and therefore resulting in a V2 instance.~
~We want a V1 configuration (if nothing else this is clear from the behaviour described), so we shouldn't specify filter on creation, instead we should force V1 by specifying `prefix`~

Contrary to the documented behaviour, it looks like V2 fixes this issue, whereas V1 causes it