### PR TITLE
DPR2-1857: Make reload pipeline configurable as batch-only

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/glue.tf
@@ -82,8 +82,8 @@ module "glue_reporting_hub_batch_job" {
 # Glue Job, Check All Raw Files Have Been Processed Job
 module "unprocessed_raw_files_check_job" {
   source                        = "../../glue_job"
-  create_job                    = var.setup_unprocessed_raw_files_check_job
-  create_role                   = var.glue_unprocessed_raw_files_check_create_role # Needs to Set to TRUE
+  create_job                    = var.batch_only ? false : var.setup_unprocessed_raw_files_check_job
+  create_role                   = var.batch_only ? false : var.glue_unprocessed_raw_files_check_create_role # Needs to Set to TRUE
   name                          = var.glue_unprocessed_raw_files_check_job_name
   short_name                    = var.glue_unprocessed_raw_files_check_job_short_name
   command_type                  = "glueetl"
@@ -121,8 +121,8 @@ module "unprocessed_raw_files_check_job" {
 # Glue Job, Reporting Hub Archive
 module "glue_archive_job" {
   source                        = "../../glue_job"
-  create_job                    = var.setup_archive_job
-  create_role                   = var.glue_archive_create_role # Needs to Set to TRUE
+  create_job                    = var.batch_only ? false : var.setup_archive_job
+  create_role                   = var.batch_only ? false : var.glue_archive_create_role # Needs to Set to TRUE
   name                          = var.glue_archive_job_name
   short_name                    = var.glue_archive_job_short_name
   command_type                  = "glueetl"

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -153,6 +153,17 @@ variable "setup_cdc_job" {
   description = "Enable CDC Job, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_cdc_job ? !var.batch_only : true
+    error_message = "CDC Glue job can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "glue_cdc_job_name" {
@@ -177,6 +188,11 @@ variable "glue_cdc_create_sec_conf" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS Glue Security Configuration associated with the job."
+
+  validation {
+    condition     = var.glue_cdc_create_sec_conf ? !var.batch_only : true
+    error_message = "CDC Glue security configuration can only be created when batch_only = false"
+  }
 }
 
 variable "glue_cdc_language" {
@@ -276,6 +292,11 @@ variable "glue_cdc_create_role" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS IAM role associated with the job."
+
+  validation {
+    condition     = var.glue_cdc_create_role ? !var.batch_only : true
+    error_message = "CDC Glue job role can only be created when batch_only = false"
+  }
 }
 
 
@@ -284,6 +305,11 @@ variable "setup_unprocessed_raw_files_check_job" {
   description = "Enable Job to Check If All Raw Files Have Been Processed, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_unprocessed_raw_files_check_job ? !var.batch_only : true
+    error_message = "Unprocessed raw files check job can only be created when batch_only = false"
+  }
 }
 
 variable "glue_unprocessed_raw_files_check_job_name" {
@@ -308,6 +334,11 @@ variable "glue_unprocessed_raw_files_check_create_sec_conf" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS Glue Security Configuration associated with the job."
+
+  validation {
+    condition     = var.glue_unprocessed_raw_files_check_create_sec_conf ? !var.batch_only : true
+    error_message = "Glue unprocessed raw files check job security configuration can only be created when batch_only = false"
+  }
 }
 
 variable "glue_unprocessed_raw_files_check_language" {
@@ -354,6 +385,7 @@ variable "glue_unprocessed_raw_files_check_enable_cont_log_filter" {
 variable "glue_unprocessed_raw_files_check_execution_class" {
   default     = "STANDARD"
   description = "Execution CLass Standard or FLex"
+  type        = string
 }
 
 variable "glue_unprocessed_raw_files_check_job_worker_type" {
@@ -389,6 +421,11 @@ variable "glue_unprocessed_raw_files_check_create_role" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS IAM role associated with the job."
+
+  validation {
+    condition     = var.glue_unprocessed_raw_files_check_create_role ? !var.batch_only : true
+    error_message = "Glue unprocessed raw files check job role can only be created when batch_only = false"
+  }
 }
 
 variable "glue_unprocessed_raw_files_check_arguments" {
@@ -402,6 +439,11 @@ variable "setup_archive_job" {
   description = "Enable Archive Job, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_archive_job ? !var.batch_only : true
+    error_message = "Archive job can only be created when batch_only = false"
+  }
 }
 
 variable "glue_archive_job_schedule" {
@@ -432,6 +474,11 @@ variable "glue_archive_create_sec_conf" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS Glue Security Configuration associated with the job."
+
+  validation {
+    condition     = var.glue_archive_create_sec_conf ? !var.batch_only : true
+    error_message = "Glue archive job security configuration can only be created when batch_only = false"
+  }
 }
 
 variable "glue_archive_language" {
@@ -478,6 +525,7 @@ variable "glue_archive_enable_cont_log_filter" {
 variable "glue_archive_execution_class" {
   default     = "STANDARD"
   description = "Execution CLass Standard or FLex"
+  type        = string
 }
 
 variable "glue_archive_job_worker_type" {
@@ -513,6 +561,11 @@ variable "glue_archive_create_role" {
   type        = bool
   default     = false
   description = "(Optional) Create AWS IAM role associated with the job."
+
+  validation {
+    condition     = var.glue_archive_create_role ? !var.batch_only : true
+    error_message = "Glue archive job role can only be created when batch_only = false"
+  }
 }
 
 variable "glue_archive_arguments" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.10"
+}

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -334,6 +334,25 @@ locals {
     }
   }
 
+  run_reconciliation_job = {
+    "StepName" : "Run Reconciliation Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_reconciliation_job,
+        "Arguments" : {
+          "--dpr.reconciliation.checks.to.run" : "current_state_counts",
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.glue_reconciliation_job_num_workers,
+        "WorkerType" : var.glue_reconciliation_job_worker_type
+      },
+      "Next" : local.switch_hive_tables_for_prisons_to_curated.StepName
+    }
+  }
+
   switch_hive_tables_for_prisons_to_curated = {
     "StepName" : "Switch Hive Tables for Prisons to Curated",
     "StepDefinition" : {
@@ -412,6 +431,7 @@ module "data_ingestion_pipeline" {
         (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
         (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
         (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.run_reconciliation_job.StepName) : local.run_reconciliation_job.StepDefinition,
         (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
         (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
       }

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -1,3 +1,388 @@
+locals {
+  deactivate_archive_trigger = {
+    "StepName" : "Deactivate Archive Trigger",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_trigger_activation_job,
+        "Arguments" : {
+          "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+          "--dpr.glue.trigger.activate" : "false"
+        }
+      },
+      "Next" : local.stop_archive_job.StepName
+    }
+  }
+
+  stop_archive_job = {
+    "StepName" : "Stop Archive Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_stop_glue_instance_job,
+        "Arguments" : {
+          "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
+        }
+      },
+      "Next" : local.stop_dms_replication_task.StepName
+    }
+  }
+
+  stop_dms_replication_task = {
+    "StepName" : "Stop DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.stop_dms_task_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.replication_task_id
+        }
+      },
+      "Next" : var.batch_only ? local.update_hive_tables.StepName : local.stop_glue_streaming_job.StepName
+    }
+  }
+
+  stop_glue_streaming_job = {
+    "StepName" : "Stop Glue Streaming Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_stop_glue_instance_job,
+        "Arguments" : {
+          "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
+        }
+      },
+      "Next" : local.update_hive_tables.StepName
+    }
+  }
+
+  update_hive_tables = {
+    "StepName" : "Update Hive Tables",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_hive_table_creation_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.prepare_temp_reload_bucket_data.StepName
+    }
+  }
+
+  prepare_temp_reload_bucket_data = {
+    "StepName" : "Prepare Temp Reload Bucket Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.copy_curated_data_to_temp_reload_bucket.StepName
+    }
+  }
+
+  copy_curated_data_to_temp_reload_bucket = {
+    "StepName" : "Copy Curated Data to Temp-Reload Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
+          "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "false",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName
+    }
+  }
+
+  switch_hive_tables_for_prisons_to_temp_reload_bucket = {
+    "StepName" : "Switch Hive Tables for Prisons to Temp-Reload Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_switch_prisons_hive_data_location_job,
+        "Arguments" : {
+          "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_temp_reload_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.empty_raw_archive_structured_and_curated_data.StepName
+    }
+  }
+
+  empty_raw_archive_structured_and_curated_data = {
+    "StepName" : "Empty Raw, Archive, Structured and Curated Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.start_dms_replication_task.StepName
+    }
+  }
+
+  start_dms_replication_task = {
+    "StepName" : "Start DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_replication_task_arn,
+        "StartReplicationTaskType" : "reload-target"
+      },
+      "Next" : local.invoke_dms_state_control_lambda.StepName
+    }
+  }
+
+  invoke_dms_state_control_lambda = {
+    "StepName" : "Invoke DMS State Control Lambda",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "TimeoutSeconds" : var.pipeline_dms_task_time_out,
+      "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "Parameters" : {
+        "Payload" : {
+          "token.$" : "$$.Task.Token",
+          "replicationTaskArn" : var.dms_replication_task_arn
+        },
+        "FunctionName" : var.pipeline_notification_lambda_function
+      },
+      "Retry" : [
+        {
+          "ErrorEquals" : [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds" : 60,
+          "MaxAttempts" : 2,
+          "BackoffRate" : 2
+        }
+      ],
+      "Next" : local.run_glue_batch_job.StepName
+    }
+  }
+
+  run_glue_batch_job = {
+    "StepName" : "Run Glue Batch Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_reporting_hub_batch_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.archive_raw_data.StepName
+    }
+  }
+
+  archive_raw_data = {
+    "StepName" : "Archive Raw Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
+          "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "true",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : "Run Compaction Job on Structured Zone"
+    }
+  }
+
+  run_compaction_job_on_structured_zone = {
+    "StepName" : "Run Compaction Job on Structured Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_compaction_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_structured_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.compaction_structured_num_workers,
+        "WorkerType" : var.compaction_structured_worker_type
+      },
+      "Next" : local.run_vacuum_job_on_structured_zone.StepName
+    }
+  }
+
+  run_vacuum_job_on_structured_zone = {
+    "StepName" : "Run Vacuum Job on Structured Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_retention_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_structured_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.retention_structured_num_workers,
+        "WorkerType" : var.retention_structured_worker_type
+      },
+      "Next" : local.run_compaction_job_on_curated_zone.StepName
+    }
+  }
+
+  run_compaction_job_on_curated_zone = {
+    "StepName" : "Run Compaction Job on Curated Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_compaction_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_curated_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.compaction_curated_num_workers,
+        "WorkerType" : var.compaction_curated_worker_type
+      },
+      "Next" : local.run_vacuum_job_on_curated_zone.StepName
+    }
+  }
+
+  run_vacuum_job_on_curated_zone = {
+    "StepName" : "Run Vacuum Job on Curated Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_retention_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_curated_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.retention_curated_num_workers,
+        "WorkerType" : var.retention_curated_worker_type
+      },
+      "Next" : var.batch_only ? local.switch_hive_tables_for_prisons_to_curated.StepName : local.resume_dms_replication_task.StepName
+    }
+  }
+
+  resume_dms_replication_task = {
+    "StepName" : "Resume DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_replication_task_arn,
+        "StartReplicationTaskType" : "resume-processing"
+      },
+      "Next" : local.start_glue_streaming_job.StepName
+    }
+  }
+
+  start_glue_streaming_job = {
+    "StepName" : "Start Glue Streaming Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun",
+      "Parameters" : {
+        "JobName" : var.glue_reporting_hub_cdc_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.switch_hive_tables_for_prisons_to_curated.StepName
+    }
+  }
+
+  switch_hive_tables_for_prisons_to_curated = {
+    "StepName" : "Switch Hive Tables for Prisons to Curated",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_switch_prisons_hive_data_location_job,
+        "Arguments" : {
+          "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : var.batch_only ? local.empty_temp_reload_bucket_data.StepName : local.reactivate_archive_trigger.StepName
+    }
+  }
+
+  reactivate_archive_trigger = {
+    "StepName" : "Reactivate Archive Trigger",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_trigger_activation_job,
+        "Arguments" : {
+          "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+          "--dpr.glue.trigger.activate" : "true"
+        }
+      },
+      "Next" : local.empty_temp_reload_bucket_data.StepName
+    }
+  }
+
+  empty_temp_reload_bucket_data = {
+    "StepName" : "Empty Temp Reload Bucket Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "End" : true
+    }
+  }
+}
+
 # Data Ingest Pipeline Step Function
 module "data_ingestion_pipeline" {
   source = "../../step_function"
@@ -8,318 +393,56 @@ module "data_ingestion_pipeline" {
 
   step_function_execution_role_arn = var.step_function_execution_role_arn
 
-  # Send this block to the calling repo Pipeline
-  #depends_on = [
-  #  aws_iam_policy.invoke_lambda_policy,
-  #  aws_iam_policy.start_dms_task_policy,
-  #  aws_iam_policy.trigger_glue_job_policy,
-  #  module.dms_nomis_to_s3_ingestor.dms_replication_task_arn,
-  #  module.glue_reporting_hub_batch_job.name,
-  #  module.glue_reporting_hub_cdc_job.name,
-  #  module.glue_hive_table_creation_job.name,
-  #  module.step_function_notification_lambda.lambda_function
-  #]
-
-  definition = jsonencode(
+  definition = var.batch_only ? jsonencode(
+    {
+      "Comment" : "Data Ingestion Pipeline Step Function (Batch Only)",
+      "StartAt" : local.stop_dms_replication_task.StepName,
+      "States" : {
+        (local.stop_dms_replication_task.StepName) : local.stop_dms_replication_task.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_archive_structured_and_curated_data.StepName) : local.empty_raw_archive_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.archive_raw_data.StepName) : local.archive_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
+      }
+    }
+  ) : jsonencode(
     {
       "Comment" : "Data Ingestion Pipeline Step Function",
-      "StartAt" : "Deactivate Archive Trigger",
+      "StartAt" : local.deactivate_archive_trigger.StepName,
       "States" : {
-        "Deactivate Archive Trigger" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_trigger_activation_job,
-            "Arguments" : {
-              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
-              "--dpr.glue.trigger.activate" : "false"
-            }
-          },
-          "Next" : "Stop Archive Job"
-        },
-        "Stop Archive Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_stop_glue_instance_job,
-            "Arguments" : {
-              "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
-            }
-          },
-          "Next" : "Stop DMS Replication Task"
-        },
-        "Stop DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.stop_dms_task_job,
-            "Arguments" : {
-              "--dpr.dms.replication.task.id" : var.replication_task_id
-            }
-          },
-          "Next" : "Stop Glue Streaming Job"
-        },
-        "Stop Glue Streaming Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_stop_glue_instance_job,
-            "Arguments" : {
-              "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
-            }
-          },
-          "Next" : "Update Hive Tables"
-        },
-        "Update Hive Tables" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_hive_table_creation_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Prepare Temp Reload Bucket Data"
-        },
-        "Prepare Temp Reload Bucket Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Copy Curated Data to Temp-Reload Bucket"
-        },
-        "Copy Curated Data to Temp-Reload Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
-              "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Switch Hive Tables for Prisons to Temp-Reload Bucket"
-        },
-        "Switch Hive Tables for Prisons to Temp-Reload Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_switch_prisons_hive_data_location_job,
-            "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_temp_reload_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Empty Raw, Archive, Structured and Curated Data"
-        },
-        "Empty Raw, Archive, Structured and Curated Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Start DMS Replication Task"
-        },
-        "Start DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
-          "Parameters" : {
-            "ReplicationTaskArn" : var.dms_replication_task_arn,
-            "StartReplicationTaskType" : "reload-target"
-          },
-          "Next" : "Invoke DMS State Control Lambda"
-        },
-        "Invoke DMS State Control Lambda" : {
-          "Type" : "Task",
-          "TimeoutSeconds" : var.pipeline_dms_task_time_out,
-          "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
-          "Parameters" : {
-            "Payload" : {
-              "token.$" : "$$.Task.Token",
-              "replicationTaskArn" : var.dms_replication_task_arn
-            },
-            "FunctionName" : var.pipeline_notification_lambda_function
-          },
-          "Retry" : [
-            {
-              "ErrorEquals" : [
-                "Lambda.ServiceException",
-                "Lambda.AWSLambdaException",
-                "Lambda.SdkClientException",
-                "Lambda.TooManyRequestsException"
-              ],
-              "IntervalSeconds" : 60,
-              "MaxAttempts" : 2,
-              "BackoffRate" : 2
-            }
-          ],
-          "Next" : "Start Glue Batch Job"
-        },
-        "Start Glue Batch Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_reporting_hub_batch_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Archive Raw Data"
-        },
-        "Archive Raw Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
-              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Run Compaction Job on Structured Zone"
-        },
-        "Run Compaction Job on Structured Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_compaction_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_structured_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.compaction_structured_num_workers,
-            "WorkerType" : var.compaction_structured_worker_type
-          },
-          "Next" : "Run Vacuum Job on Structured Zone"
-        },
-        "Run Vacuum Job on Structured Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_retention_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_structured_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.retention_structured_num_workers,
-            "WorkerType" : var.retention_structured_worker_type
-          },
-          "Next" : "Run Compaction Job on Curated Zone"
-        },
-        "Run Compaction Job on Curated Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_compaction_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_curated_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.compaction_curated_num_workers,
-            "WorkerType" : var.compaction_curated_worker_type
-          },
-          "Next" : "Run Vacuum Job on Curated Zone"
-        },
-        "Run Vacuum Job on Curated Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_retention_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_curated_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.retention_curated_num_workers,
-            "WorkerType" : var.retention_curated_worker_type
-          },
-          "Next" : "Resume DMS Replication Task"
-        },
-        "Resume DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
-          "Parameters" : {
-            "ReplicationTaskArn" : var.dms_replication_task_arn,
-            "StartReplicationTaskType" : "resume-processing"
-          },
-          "Next" : "Start Glue Streaming Job"
-        },
-        "Start Glue Streaming Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun",
-          "Parameters" : {
-            "JobName" : var.glue_reporting_hub_cdc_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Switch Hive Tables for Prisons to Curated"
-        },
-        "Switch Hive Tables for Prisons to Curated" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_switch_prisons_hive_data_location_job,
-            "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Reactivate Archive Trigger"
-        },
-        "Reactivate Archive Trigger" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_trigger_activation_job,
-            "Arguments" : {
-              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
-              "--dpr.glue.trigger.activate" : "true"
-            }
-          },
-          "Next" : "Empty Temp Reload Bucket Data"
-        },
-        "Empty Temp Reload Bucket Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "End" : true
-        }
+        (local.deactivate_archive_trigger.StepName) : local.deactivate_archive_trigger.StepDefinition,
+        (local.stop_archive_job.StepName) : local.stop_archive_job.StepDefinition,
+        (local.stop_dms_replication_task.StepName) : local.stop_dms_replication_task.StepDefinition,
+        (local.stop_glue_streaming_job.StepName) : local.stop_glue_streaming_job.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_archive_structured_and_curated_data.StepName) : local.empty_raw_archive_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.archive_raw_data.StepName) : local.archive_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.resume_dms_replication_task.StepName) : local.resume_dms_replication_task.StepDefinition,
+        (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.reactivate_archive_trigger.StepName) : local.reactivate_archive_trigger.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition,
       }
     }
   )

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
@@ -57,6 +57,33 @@ variable "glue_reporting_hub_cdc_jobname" {
   type        = string
 }
 
+variable "glue_reconciliation_job" {
+  description = "Name of the reconciliation glue job"
+  type        = string
+}
+
+variable "glue_reconciliation_job_worker_type" {
+  description = "(Optional) Worker type to use for the reconciliation job"
+  type        = string
+  default     = "G.1X"
+
+  validation {
+    condition     = contains(["G.1X", "G.2X", "G.4X", "G.8X"], var.glue_reconciliation_job_worker_type)
+    error_message = "Worker type can only be one of G.1X, G.2X, G.4X, G.8X"
+  }
+}
+
+variable "glue_reconciliation_job_num_workers" {
+  description = "(Optional) Number of workers to use for the reconciliation job. Must be >= 2"
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.glue_reconciliation_job_num_workers >= 2
+    error_message = "Number of workers must be >= 2"
+  }
+}
+
 variable "s3_glue_bucket_id" {
   description = "S3, Glue Bucket ID"
   type        = string

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
@@ -5,6 +5,12 @@ variable "setup_data_ingestion_pipeline" {
   default     = false
 }
 
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
+}
+
 variable "data_ingestion_pipeline" {
   description = "Name for Data Ingestion Pipeline"
   type        = string

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
@@ -2,6 +2,17 @@ variable "setup_maintenance_pipeline" {
   description = "Enable Maintenance Pipeline, True or False ?"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_maintenance_pipeline ? !var.batch_only : true
+    error_message = "CDC Glue security configurMaintenance pipeline can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "maintenance_pipeline_name" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
@@ -5,7 +5,7 @@ variable "setup_maintenance_pipeline" {
 
   validation {
     condition     = var.setup_maintenance_pipeline ? !var.batch_only : true
-    error_message = "CDC Glue security configurMaintenance pipeline can only be created when batch_only = false"
+    error_message = "Maintenance pipeline can only be created when batch_only = false"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
@@ -22,11 +22,6 @@ variable "create_job" {
   description = "Enable Reconciliation Job, True or False"
   type        = bool
   default     = false
-
-  validation {
-    condition     = var.create_job ? !var.batch_only : true
-    error_message = "Reconciliation job can only be created when batch_only = false"
-  }
 }
 
 variable "batch_only" {
@@ -150,6 +145,11 @@ variable "job_schedule" {
   description = "Cron schedule for the reconciliation job. Leave unset for no schedule."
   default     = ""
   type        = string
+
+  validation {
+    condition     = var.batch_only && (var.job_schedule != "") ? false : true
+    error_message = "Reconciliation job can only be scheduled when batch_only = false"
+  }
 }
 
 variable "enable_spark_ui" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reconciliation-job/variables.tf
@@ -22,6 +22,17 @@ variable "create_job" {
   description = "Enable Reconciliation Job, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.create_job ? !var.batch_only : true
+    error_message = "Reconciliation job can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "create_role" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -1,3 +1,520 @@
+locals {
+  deactivate_archive_trigger = {
+    "StepName" : "Deactivate Archive Trigger",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_trigger_activation_job,
+        "Arguments" : {
+          "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+          "--dpr.glue.trigger.activate" : "false"
+        }
+      },
+      "Next" : local.stop_archive_job.StepName
+    }
+  }
+
+  stop_archive_job = {
+    "StepName" : "Stop Archive Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_stop_glue_instance_job,
+        "Arguments" : {
+          "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
+        }
+      },
+      "Next" : local.stop_dms_replication_task.StepName
+    }
+  }
+
+  stop_dms_replication_task = {
+    "StepName" : "Stop DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.stop_dms_task_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.replication_task_id
+        }
+      },
+      "Next" : var.batch_only ? local.update_hive_tables.StepName : local.check_all_pending_files_have_been_processed.StepName
+    }
+  }
+
+  check_all_pending_files_have_been_processed = {
+    "StepName" : "Check All Pending Files Have Been Processed",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_unprocessed_raw_files_check_job,
+        "Arguments" : {
+          "--dpr.orchestration.wait.interval.seconds" : tostring(var.processed_files_check_wait_interval_seconds),
+          "--dpr.orchestration.max.attempts" : tostring(var.processed_files_check_max_attempts)
+        }
+      },
+      "Next" : local.stop_glue_streaming_job.StepName
+    }
+  }
+
+  stop_glue_streaming_job = {
+    "StepName" : "Stop Glue Streaming Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_stop_glue_instance_job,
+        "Arguments" : {
+          "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
+        }
+      },
+      "Next" : local.archive_remaining_raw_files.StepName
+    }
+  }
+
+  archive_remaining_raw_files = {
+    "StepName" : "Archive Remaining Raw Files",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
+          "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+          "--dpr.file.transfer.delete.copied.files" : "true",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.update_hive_tables.StepName
+    }
+  }
+
+  update_hive_tables = {
+    "StepName" : "Update Hive Tables",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_hive_table_creation_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.prepare_temp_reload_bucket_data.StepName
+    }
+  }
+
+  prepare_temp_reload_bucket_data = {
+    "StepName" : "Prepare Temp Reload Bucket Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.copy_curated_data_to_temp_reload_bucket.StepName
+    }
+  }
+
+  copy_curated_data_to_temp_reload_bucket = {
+    "StepName" : "Copy Curated Data to Temp-Reload Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
+          "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "false",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName
+    }
+  }
+
+  switch_hive_tables_for_prisons_to_temp_reload_bucket = {
+    "StepName" : "Switch Hive Tables for Prisons to Temp-Reload Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_switch_prisons_hive_data_location_job,
+        "Arguments" : {
+          "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_temp_reload_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.empty_raw_structured_and_curated_data.StepName
+    }
+  }
+
+  empty_raw_structured_and_curated_data = {
+    "StepName" : "Empty Raw, Structured and Curated Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.start_dms_replication_task.StepName
+    }
+  }
+
+  start_dms_replication_task = {
+    "StepName" : "Start DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_replication_task_arn,
+        "StartReplicationTaskType" : "reload-target"
+      },
+      "Next" : local.invoke_dms_state_control_lambda.StepName
+    }
+  }
+
+  invoke_dms_state_control_lambda = {
+    "StepName" : "Invoke DMS State Control Lambda",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "TimeoutSeconds" : var.pipeline_dms_task_time_out,
+      "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "Parameters" : {
+        "Payload" : {
+          "token.$" : "$$.Task.Token",
+          "replicationTaskArn" : var.dms_replication_task_arn
+        },
+        "FunctionName" : var.pipeline_notification_lambda_function
+      },
+      "Retry" : [
+        {
+          "ErrorEquals" : [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds" : 60,
+          "MaxAttempts" : 2,
+          "BackoffRate" : 2
+        }
+      ],
+      "Next" : local.run_glue_batch_job.StepName
+    }
+  }
+
+  run_glue_batch_job = {
+    "StepName" : "Run Glue Batch Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_reporting_hub_batch_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.delete_existing_reload_diffs.StepName
+    }
+  }
+
+  delete_existing_reload_diffs = {
+    "StepName" : "Delete Existing Reload Diffs",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.source.prefix" : var.reload_diff_folder,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.run_create_reload_diff_batch_job.StepName
+    }
+  }
+
+  run_create_reload_diff_batch_job = {
+    "StepName" : "Run Create Reload Diff Batch Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_create_reload_diff_job
+      },
+      "Next" : local.move_reload_diffs_toInsert_to_archive_bucket.StepName
+    }
+  }
+
+  move_reload_diffs_toInsert_to_archive_bucket = {
+    "StepName" : "Move Reload Diffs toInsert to Archive Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toInsert",
+          "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "true",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.move_reload_diffs_toDelete_to_archive_bucket.StepName
+    }
+  }
+
+  move_reload_diffs_toDelete_to_archive_bucket = {
+    "StepName" : "Move Reload Diffs toDelete to Archive Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toDelete",
+          "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "true",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.move_reload_diffs_toUpdate_to_archive_bucket.StepName
+    }
+  }
+
+  move_reload_diffs_toUpdate_to_archive_bucket = {
+    "StepName" : "Move Reload Diffs toUpdate to Archive Bucket",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_file_transfer_job,
+        "Arguments" : {
+          "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
+          "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toUpdate",
+          "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
+          "--dpr.file.transfer.retention.period.amount" : "0",
+          "--dpr.file.transfer.delete.copied.files" : "true",
+          "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
+          "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
+          "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.empty_raw_data.StepName
+    }
+  }
+
+  empty_raw_data = {
+    "StepName" : "Empty Raw Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_raw_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.run_compaction_job_on_structured_zone.StepName
+    }
+  }
+
+  run_compaction_job_on_structured_zone = {
+    "StepName" : "Run Compaction Job on Structured Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_compaction_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_structured_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.compaction_structured_num_workers,
+        "WorkerType" : var.compaction_structured_worker_type
+      },
+      "Next" : local.run_vacuum_job_on_structured_zone.StepName
+    }
+  }
+
+  run_vacuum_job_on_structured_zone = {
+    "StepName" : "Run Vacuum Job on Structured Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_retention_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_structured_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.retention_structured_num_workers,
+        "WorkerType" : var.retention_structured_worker_type
+      },
+      "Next" : local.run_compaction_job_on_curated_zone.StepName
+    }
+  }
+
+  run_compaction_job_on_curated_zone = {
+    "StepName" : "Run Compaction Job on Curated Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_compaction_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_curated_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.compaction_curated_num_workers,
+        "WorkerType" : var.compaction_curated_worker_type
+      },
+      "Next" : local.run_vacuum_job_on_curated_zone.StepName
+    }
+  }
+
+  run_vacuum_job_on_curated_zone = {
+    "StepName" : "Run Vacuum Job on Curated Zone",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_maintenance_retention_job,
+        "Arguments" : {
+          "--dpr.maintenance.root.path" : var.s3_curated_path,
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        },
+        "NumberOfWorkers" : var.retention_curated_num_workers,
+        "WorkerType" : var.retention_curated_worker_type
+      },
+      "Next" : var.batch_only ? local.switch_hive_tables_for_prisons_to_curated.StepName : local.resume_dms_replication_task.StepName
+    }
+  }
+
+  resume_dms_replication_task = {
+    "StepName" : "Resume DMS Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_replication_task_arn,
+        "StartReplicationTaskType" : "resume-processing"
+      },
+      "Next" : local.start_glue_streaming_job.StepName
+    }
+  }
+
+  start_glue_streaming_job = {
+    "StepName" : "Start Glue Streaming Job",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun",
+      "Parameters" : {
+        "JobName" : var.glue_reporting_hub_cdc_jobname,
+        "Arguments" : {
+          "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : local.switch_hive_tables_for_prisons_to_curated.StepName
+    }
+  }
+
+  switch_hive_tables_for_prisons_to_curated = {
+    "StepName" : "Switch Hive Tables for Prisons to Curated",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_switch_prisons_hive_data_location_job,
+        "Arguments" : {
+          "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : var.batch_only ? local.empty_temp_reload_bucket_data.StepName : local.reactivate_archive_trigger.StepName
+    }
+  }
+
+  reactivate_archive_trigger = {
+    "StepName" : "Reactivate Archive Trigger",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_trigger_activation_job,
+        "Arguments" : {
+          "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
+          "--dpr.glue.trigger.activate" : "true"
+        }
+      },
+      "Next" : local.empty_temp_reload_bucket_data.StepName
+    }
+  }
+
+  empty_temp_reload_bucket_data = {
+    "StepName" : "Empty Temp Reload Bucket Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "End" : true
+    }
+  }
+}
+
 # Reload Pipeline Step Function
 module "reload_pipeline" {
   source = "../../step_function"
@@ -8,410 +525,68 @@ module "reload_pipeline" {
 
   step_function_execution_role_arn = var.step_function_execution_role_arn
 
-  definition = jsonencode(
+  definition = var.batch_only ? jsonencode(
+    {
+      "Comment" : "Reload Pipeline Step Function (Batch Only)",
+      "StartAt" : local.stop_dms_replication_task.StepName,
+      "States" : {
+        (local.stop_dms_replication_task.StepName) : local.stop_dms_replication_task.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_structured_and_curated_data.StepName) : local.empty_raw_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.delete_existing_reload_diffs.StepName) : local.delete_existing_reload_diffs.StepDefinition,
+        (local.run_create_reload_diff_batch_job.StepName) : local.run_create_reload_diff_batch_job.StepDefinition,
+        (local.move_reload_diffs_toInsert_to_archive_bucket.StepName) : local.move_reload_diffs_toInsert_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toDelete_to_archive_bucket.StepName) : local.move_reload_diffs_toDelete_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toUpdate_to_archive_bucket.StepName) : local.move_reload_diffs_toUpdate_to_archive_bucket.StepDefinition,
+        (local.empty_raw_data.StepName) : local.empty_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
+      }
+    }
+  ) : jsonencode(
     {
       "Comment" : "Reload Pipeline Step Function",
-      "StartAt" : "Deactivate Archive Trigger",
+      "StartAt" : local.deactivate_archive_trigger.StepName,
       "States" : {
-        "Deactivate Archive Trigger" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_trigger_activation_job,
-            "Arguments" : {
-              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
-              "--dpr.glue.trigger.activate" : "false"
-            }
-          },
-          "Next" : "Stop Archive Job"
-        },
-        "Stop Archive Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_stop_glue_instance_job,
-            "Arguments" : {
-              "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
-            }
-          },
-          "Next" : "Stop DMS Replication Task"
-        },
-        "Stop DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.stop_dms_task_job,
-            "Arguments" : {
-              "--dpr.dms.replication.task.id" : var.replication_task_id
-            }
-          },
-          "Next" : "Check All Pending Files Have Been Processed"
-        },
-        "Check All Pending Files Have Been Processed" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_unprocessed_raw_files_check_job,
-            "Arguments" : {
-              "--dpr.orchestration.wait.interval.seconds" : tostring(var.processed_files_check_wait_interval_seconds),
-              "--dpr.orchestration.max.attempts" : tostring(var.processed_files_check_max_attempts)
-            }
-          },
-          "Next" : "Stop Glue Streaming Job"
-        },
-        "Stop Glue Streaming Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_stop_glue_instance_job,
-            "Arguments" : {
-              "--dpr.stop.glue.instance.job.name" : var.glue_reporting_hub_cdc_jobname
-            }
-          },
-          "Next" : "Archive Remaining Raw Files"
-        },
-        "Archive Remaining Raw Files" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_raw_bucket_id,
-              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
-              "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Update Hive Tables"
-        },
-        "Update Hive Tables" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_hive_table_creation_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Prepare Temp Reload Bucket Data"
-        },
-        "Prepare Temp Reload Bucket Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Copy Curated Data to Temp-Reload Bucket"
-        },
-        "Copy Curated Data to Temp-Reload Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_curated_bucket_id,
-              "--dpr.file.transfer.destination.bucket" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "false",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Switch Hive Tables for Prisons to Temp-Reload Bucket"
-        },
-        "Switch Hive Tables for Prisons to Temp-Reload Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_switch_prisons_hive_data_location_job,
-            "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_temp_reload_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Empty Raw, Structured and Curated Data"
-        },
-        "Empty Raw, Structured and Curated Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : "${var.s3_raw_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Start DMS Replication Task"
-        },
-        "Start DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
-          "Parameters" : {
-            "ReplicationTaskArn" : var.dms_replication_task_arn,
-            "StartReplicationTaskType" : "reload-target"
-          },
-          "Next" : "Invoke DMS State Control Lambda"
-        },
-        "Invoke DMS State Control Lambda" : {
-          "Type" : "Task",
-          "TimeoutSeconds" : var.pipeline_dms_task_time_out,
-          "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
-          "Parameters" : {
-            "Payload" : {
-              "token.$" : "$$.Task.Token",
-              "replicationTaskArn" : var.dms_replication_task_arn
-            },
-            "FunctionName" : var.pipeline_notification_lambda_function
-          },
-          "Retry" : [
-            {
-              "ErrorEquals" : [
-                "Lambda.ServiceException",
-                "Lambda.AWSLambdaException",
-                "Lambda.SdkClientException",
-                "Lambda.TooManyRequestsException"
-              ],
-              "IntervalSeconds" : 60,
-              "MaxAttempts" : 2,
-              "BackoffRate" : 2
-            }
-          ],
-          "Next" : "Run Glue Batch Job"
-        },
-        "Run Glue Batch Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_reporting_hub_batch_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Delete Existing Reload Diffs"
-        },
-        "Delete Existing Reload Diffs" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.source.prefix" : var.reload_diff_folder,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Run Create Reload Diff Batch Job"
-        },
-        "Run Create Reload Diff Batch Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_create_reload_diff_job
-          },
-          "Next" : "Move Reload Diffs toInsert to Archive Bucket"
-        },
-        "Move Reload Diffs toInsert to Archive Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toInsert",
-              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Move Reload Diffs toDelete to Archive Bucket"
-        },
-        "Move Reload Diffs toDelete to Archive Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toDelete",
-              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Move Reload Diffs toUpdate to Archive Bucket"
-        },
-        "Move Reload Diffs toUpdate to Archive Bucket" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_file_transfer_job,
-            "Arguments" : {
-              "--dpr.file.transfer.source.bucket" : var.s3_temp_reload_bucket_id,
-              "--dpr.file.source.prefix" : "${var.reload_diff_folder}/toUpdate",
-              "--dpr.file.transfer.destination.bucket" : var.s3_raw_archive_bucket_id,
-              "--dpr.file.transfer.retention.period.amount" : "0",
-              "--dpr.file.transfer.delete.copied.files" : "true",
-              "--dpr.datastorage.retry.maxAttempts" : tostring(var.glue_s3_max_attempts),
-              "--dpr.datastorage.retry.minWaitMillis" : tostring(var.glue_s3_retry_min_wait_millis),
-              "--dpr.datastorage.retry.maxWaitMillis" : tostring(var.glue_s3_retry_max_wait_millis),
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Empty Raw Data"
-        },
-        "Empty Raw Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_raw_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Run Compaction Job on Structured Zone"
-        },
-        "Run Compaction Job on Structured Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_compaction_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_structured_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.compaction_structured_num_workers,
-            "WorkerType" : var.compaction_structured_worker_type
-          },
-          "Next" : "Run Vacuum Job on Structured Zone"
-        },
-        "Run Vacuum Job on Structured Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_retention_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_structured_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.retention_structured_num_workers,
-            "WorkerType" : var.retention_structured_worker_type
-          },
-          "Next" : "Run Compaction Job on Curated Zone"
-        },
-        "Run Compaction Job on Curated Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_compaction_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_curated_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.compaction_curated_num_workers,
-            "WorkerType" : var.compaction_curated_worker_type
-          },
-          "Next" : "Run Vacuum Job on Curated Zone"
-        },
-        "Run Vacuum Job on Curated Zone" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_maintenance_retention_job,
-            "Arguments" : {
-              "--dpr.maintenance.root.path" : var.s3_curated_path,
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            },
-            "NumberOfWorkers" : var.retention_curated_num_workers,
-            "WorkerType" : var.retention_curated_worker_type
-          },
-          "Next" : "Resume DMS Replication Task"
-        },
-        "Resume DMS Replication Task" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
-          "Parameters" : {
-            "ReplicationTaskArn" : var.dms_replication_task_arn,
-            "StartReplicationTaskType" : "resume-processing"
-          },
-          "Next" : "Start Glue Streaming Job"
-        },
-        "Start Glue Streaming Job" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun",
-          "Parameters" : {
-            "JobName" : var.glue_reporting_hub_cdc_jobname,
-            "Arguments" : {
-              "--dpr.config.s3.bucket" : var.s3_glue_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Switch Hive Tables for Prisons to Curated"
-        },
-        "Switch Hive Tables for Prisons to Curated" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_switch_prisons_hive_data_location_job,
-            "Arguments" : {
-              "--dpr.prisons.data.switch.target.s3.path" : "s3://${var.s3_curated_bucket_id}",
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "Next" : "Reactivate Archive Trigger"
-        },
-        "Reactivate Archive Trigger" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_trigger_activation_job,
-            "Arguments" : {
-              "--dpr.glue.trigger.name" : var.archive_job_trigger_name,
-              "--dpr.glue.trigger.activate" : "true"
-            }
-          },
-          "Next" : "Empty Temp Reload Bucket Data"
-        },
-        "Empty Temp Reload Bucket Data" : {
-          "Type" : "Task",
-          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
-          "Parameters" : {
-            "JobName" : var.glue_s3_data_deletion_job,
-            "Arguments" : {
-              "--dpr.file.deletion.buckets" : var.s3_temp_reload_bucket_id,
-              "--dpr.config.key" : var.domain
-            }
-          },
-          "End" : true
-        }
+        (local.deactivate_archive_trigger.StepName) : local.deactivate_archive_trigger.StepDefinition,
+        (local.stop_archive_job.StepName) : local.stop_archive_job.StepDefinition,
+        (local.stop_dms_replication_task.StepName) : local.stop_dms_replication_task.StepDefinition,
+        (local.check_all_pending_files_have_been_processed.StepName) : local.check_all_pending_files_have_been_processed.StepDefinition,
+        (local.stop_glue_streaming_job.StepName) : local.stop_glue_streaming_job.StepDefinition,
+        (local.archive_remaining_raw_files.StepName) : local.archive_remaining_raw_files.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_structured_and_curated_data.StepName) : local.empty_raw_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.delete_existing_reload_diffs.StepName) : local.delete_existing_reload_diffs.StepDefinition,
+        (local.run_create_reload_diff_batch_job.StepName) : local.run_create_reload_diff_batch_job.StepDefinition,
+        (local.move_reload_diffs_toInsert_to_archive_bucket.StepName) : local.move_reload_diffs_toInsert_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toDelete_to_archive_bucket.StepName) : local.move_reload_diffs_toDelete_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toUpdate_to_archive_bucket.StepName) : local.move_reload_diffs_toUpdate_to_archive_bucket.StepDefinition,
+        (local.empty_raw_data.StepName) : local.empty_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.resume_dms_replication_task.StepName) : local.resume_dms_replication_task.StepDefinition,
+        (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.reactivate_archive_trigger.StepName) : local.reactivate_archive_trigger.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
       }
     }
   )

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -4,6 +4,12 @@ variable "setup_reload_pipeline" {
   default     = false
 }
 
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
+}
+
 variable "reload_pipeline" {
   description = "Name for the Reload Pipeline"
   type        = string

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -106,6 +106,33 @@ variable "glue_reporting_hub_cdc_jobname" {
   type        = string
 }
 
+variable "glue_reconciliation_job" {
+  description = "Name of the reconciliation glue job"
+  type        = string
+}
+
+variable "glue_reconciliation_job_worker_type" {
+  description = "(Optional) Worker type to use for the reconciliation job"
+  type        = string
+  default     = "G.1X"
+
+  validation {
+    condition     = contains(["G.1X", "G.2X", "G.4X", "G.8X"], var.glue_reconciliation_job_worker_type)
+    error_message = "Worker type can only be one of G.1X, G.2X, G.4X, G.8X"
+  }
+}
+
+variable "glue_reconciliation_job_num_workers" {
+  description = "(Optional) Number of workers to use for the reconciliation job. Must be >= 2"
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.glue_reconciliation_job_num_workers >= 2
+    error_message = "Number of workers must be >= 2"
+  }
+}
+
 variable "s3_glue_bucket_id" {
   description = "S3, Glue Bucket ID"
   type        = string

--- a/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/replay-pipeline/variables.tf
@@ -2,6 +2,17 @@ variable "setup_replay_pipeline" {
   description = "Enable Replay Pipeline, True or False?"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_replay_pipeline ? !var.batch_only : true
+    error_message = "Replay pipeline can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "replay_pipeline" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/start-cdc-pipeline/variables.tf
@@ -2,6 +2,17 @@ variable "setup_start_cdc_pipeline" {
   description = "Enable Maintenance Pipeline, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_start_cdc_pipeline ? !var.batch_only : true
+    error_message = "Start CDC pipeline can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "start_cdc_pipeline" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/stop-cdc-pipeline/variables.tf
@@ -2,6 +2,17 @@ variable "setup_stop_cdc_pipeline" {
   description = "Enable Maintenance Pipeline, True or False"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.setup_stop_cdc_pipeline ? !var.batch_only : true
+    error_message = "Stop CDC pipeline can only be created when batch_only = false"
+  }
+}
+
+variable "batch_only" {
+  description = "Determines if the pipeline is batch only, True or False?"
+  type        = bool
+  default     = false
 }
 
 variable "stop_cdc_pipeline" {

--- a/terraform/environments/digital-prison-reporting/modules/step_function/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/step_function/main.tf
@@ -4,7 +4,38 @@ resource "aws_sfn_state_machine" "data_ingestion_step_function" {
   name     = var.step_function_name
   role_arn = var.step_function_execution_role_arn
 
+  tracing_configuration {
+    enabled = true
+  }
+
+  logging_configuration {
+    log_destination        = "${aws_cloudwatch_log_group.step-function-log-group[count.index].arn}:*"
+    include_execution_data = true
+    level                  = "ERROR"
+  }
+
   definition = var.definition
 
   tags = var.tags
+
+  depends_on = [
+    aws_cloudwatch_log_group.step-function-log-group
+  ]
+}
+
+### Step function log group
+resource "aws_cloudwatch_log_group" "step-function-log-group" {
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS, Skipping for time being in view of Cost Savings”
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
+
+  count = var.enable_step_function ? 1 : 0
+  name  = "/aws/vendedlogs/states/log-group-${var.step_function_name}"
+
+  retention_in_days = var.step_function_log_retention_in_days
+
+  tags = merge(
+    var.tags,
+    {
+      name = "log-group-${var.step_function_name}"
+    })
 }

--- a/terraform/environments/digital-prison-reporting/modules/step_function/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/step_function/variables.tf
@@ -1,11 +1,13 @@
 variable "region" {
   description = "Current AWS Region."
   default     = "eu-west-2"
+  type        = string
 }
 
 variable "account" {
   description = "AWS Account ID."
   default     = ""
+  type        = string
 }
 
 variable "enable_step_function" {
@@ -33,6 +35,7 @@ variable "dms_task_time_out" {
 
 variable "definition" {
   description = "(Required) The definition of the step function"
+  type        = string
 }
 
 variable "tags" {

--- a/terraform/environments/digital-prison-reporting/modules/step_function/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/step_function/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.10"
+}


### PR DESCRIPTION
This PR:
- Refactors the reload, and ingestion step functions to support a batch only mode where the CDC phase is excluded
- Adds variable validation to prevent creation of jobs/pipelines which are not supported when batch only flag is set to true. These resources are: maintenance pipeline, CDC start pipeline, CDC stop pipeline, replay pipeline, glue streaming job.
- For batch only pipelines, the reconciliation glue job is ran in `current_state_counts` mode when the ingestion/reload is complete before switching the user data source to the newly loaded copy
- A validation is added to prevent configuring a schedule on the reconciliation glue job when batch_only = true