### PR TITLE
🛂 Update mwaa-external-secrets permissions

### DIFF
--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -112,6 +112,11 @@ resource "kubernetes_role" "mwaa_external_secrets" {
 
   }
   rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["list]
+  }
+  rule {
     api_groups = ["external-secrets.io"]
     resources  = ["externalsecrets"]
     verbs = [

--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -114,7 +114,14 @@ resource "kubernetes_role" "mwaa_external_secrets" {
   rule {
     api_groups = [""]
     resources  = ["secrets"]
-    verbs      = ["list"]
+    verbs = [
+      "create",
+      "delete",
+      "get",
+      "list",
+      "patch",
+      "update"
+    ]
   }
   rule {
     api_groups = ["external-secrets.io"]

--- a/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-roles.tf
@@ -114,7 +114,7 @@ resource "kubernetes_role" "mwaa_external_secrets" {
   rule {
     api_groups = [""]
     resources  = ["secrets"]
-    verbs      = ["list]
+    verbs      = ["list"]
   }
   rule {
     api_groups = ["external-secrets.io"]


### PR DESCRIPTION
## Proposed Changes

- Adds permissions so that GitHub Actions in Airflow can create External Secrets

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>