### PR TITLE
🗺️ Add Cloud Platform's 172 range to Transit Gateway routing

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -13,7 +13,10 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = ["10.0.0.0/8"]
+      transit_gateway_routes = [
+        "10.0.0.0/8",
+        "172.20.0.0/16"
+      ]
 
       /* Route53 */
       route53_zone = "compute.development.analytical-platform.service.justice.gov.uk"
@@ -62,7 +65,10 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = ["10.0.0.0/8"]
+      transit_gateway_routes = [
+        "10.0.0.0/8",
+        "172.20.0.0/16"
+      ]
 
       /* Route53 */
       route53_zone = "compute.test.analytical-platform.service.justice.gov.uk"
@@ -111,7 +117,10 @@ locals {
       vpc_single_nat_gateway     = false
 
       /* Transit Gateway */
-      transit_gateway_routes = ["10.0.0.0/8"]
+      transit_gateway_routes = [
+        "10.0.0.0/8",
+        "172.20.0.0/16"
+      ]
 
       /* Route53 */
       route53_zone = "compute.analytical-platform.service.justice.gov.uk"


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/7278

## Proposed Changes

- Adds Cloud Platform's [VPC range](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf#L46) to our Transit Gateway routing

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>