### PR TITLE
send aws.health events to pagerduty integrations

### DIFF
--- a/terraform/environments/corporate-staff-rostering/main.tf
+++ b/terraform/environments/corporate-staff-rostering/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/hmpps-domain-services/main.tf
+++ b/terraform/environments/hmpps-domain-services/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/hmpps-oem/main.tf
+++ b/terraform/environments/hmpps-oem/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/nomis-combined-reporting/main.tf
+++ b/terraform/environments/nomis-combined-reporting/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/nomis-data-hub/main.tf
+++ b/terraform/environments/nomis-data-hub/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/oasys-national-reporting/main.tf
+++ b/terraform/environments/oasys-national-reporting/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/environments/planetfm/main.tf
+++ b/terraform/environments/planetfm/main.tf
@@ -73,6 +73,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_dashboards", {}),
   )
 
+  cloudwatch_event_rules = merge(
+    module.baseline_presets.cloudwatch_event_rules,
+    lookup(local.baseline_all_environments, "cloudwatch_event_rules", {}),
+    lookup(local.baseline_environment_specific, "cloudwatch_event_rules", {}),
+  )
+
   cloudwatch_metric_alarms = merge(
     module.baseline_presets.cloudwatch_metric_alarms_baseline,
     lookup(local.baseline_all_environments, "cloudwatch_metric_alarms", {}),

--- a/terraform/modules/baseline/cloudwatch.tf
+++ b/terraform/modules/baseline/cloudwatch.tf
@@ -44,6 +44,21 @@ module "cloudwatch_dashboard" {
   ]
 }
 
+resource "aws_cloudwatch_event_rule" "this" {
+  for_each = var.cloudwatch_event_rules
+
+  name = each.key
+
+  event_pattern = each.value.event_pattern
+}
+
+resource "aws_cloudwatch_event_target" "this" {
+  for_each = var.cloudwatch_event_rules
+
+  rule = aws_cloudwatch_event_rule.this[each.key].name
+  arn  = try(aws_sns_topic.this[each.value.sns_topic_name_or_arn].arn, each.value.sns_topic_name_or_arn)
+}
+
 resource "aws_cloudwatch_log_group" "this" {
   for_each = var.cloudwatch_log_groups
 

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -104,6 +104,14 @@ variable "cloudwatch_dashboards" {
   default = {}
 }
 
+variable "cloudwatch_event_rules" {
+  type = map(object({
+    event_pattern         = optional(string)
+    sns_topic_name_or_arn = optional(string)
+  }))
+  default = {}
+}
+
 variable "cloudwatch_log_groups" {
   description = "set of cloudwatch log groups to create where the key is the name of the group"
   type = map(object({

--- a/terraform/modules/baseline_presets/cloudwatch.tf
+++ b/terraform/modules/baseline_presets/cloudwatch.tf
@@ -1,4 +1,17 @@
 locals {
+  cloudwatch_event_rules = merge(
+    can(var.options.sns_topics.pagerduty_integrations["pagerduty"]) ? {
+      aws-health = {
+        event_pattern = jsonencode({
+          source = [
+            "aws.health"
+          ]
+        })
+        sns_topic_name_or_arn = "pagerduty"
+      }
+    } : {}
+  )
+
   cloudwatch_log_groups_retention_default = contains(["preproduction", "production"], var.environment.environment) ? 400 : 30 # 13 month retention on prod as per MOJ guidance
   cloudwatch_log_groups_filter = flatten([
     var.options.enable_ec2_session_manager_cloudwatch_logs ? ["session-manager-logs"] : [],
@@ -30,3 +43,4 @@ locals {
     }
   }
 }
+

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -31,6 +31,11 @@ output "cloudwatch_dashboards" {
   }
 }
 
+output "cloudwatch_event_rules" {
+  description = "Map of common cloudwatch_event_rules to create"
+  value       = local.cloudwatch_event_rules
+}
+
 output "cloudwatch_log_groups" {
   description = "Map of log groups"
 


### PR DESCRIPTION
This piggy backs off the already implemented `pagerduty` SNS topics, which are linked to the alerting Slack channels. This PR can be reverted if the Eventbridge rule doesn't work out.