### PR TITLE
📌 Update APC ingress-nginx to 4.2.1

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -262,7 +262,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
-  version    = "4.12.0"
+  version    = "4.12.1"
   namespace  = kubernetes_namespace.ingress_nginx.metadata[0].name
   values = [
     templatefile(


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/7330

## Proposed Changes

- Updates APC ingress-nginx to 4.2.1

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>