### PR TITLE
DPR2-1872: Add heartbeat_endpoint to DPS secrets

### DIFF
--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -325,11 +325,13 @@ locals {
   # DPS Secrets PlaceHolder
   dps_domains_list = local.application_data.accounts[local.environment].dps_domains
   dps_secrets_placeholder = {
-    db_name  = "dps"
-    password = "placeholder"
-    user     = "placeholder"
-    endpoint = "0.0.0.0"
-    port     = "5432"
+    db_name          = "dps"
+    password         = "placeholder"
+    user             = "placeholder"
+    endpoint         = "0.0.0.0"
+    port             = "5432"
+    tickle_endpoint  = "0.0.0.0"
+    tickle_frequency = "5 minutes"
   }
 
   # Operational DataStore Secrets PlaceHolder

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -325,13 +325,12 @@ locals {
   # DPS Secrets PlaceHolder
   dps_domains_list = local.application_data.accounts[local.environment].dps_domains
   dps_secrets_placeholder = {
-    db_name          = "dps"
-    password         = "placeholder"
-    user             = "placeholder"
-    endpoint         = "0.0.0.0"
-    port             = "5432"
-    tickle_endpoint  = "0.0.0.0"
-    tickle_frequency = "5 minutes"
+    db_name             = "dps"
+    password            = "placeholder"
+    user                = "placeholder"
+    endpoint            = "0.0.0.0"
+    port                = "5432"
+    heartbeat_endpoint  = "0.0.0.0"
   }
 
   # Operational DataStore Secrets PlaceHolder


### PR DESCRIPTION
This PR adds the `heartbeat_endpoint` field to the DPS secrets