### PR TITLE
🛂 Add `ecr:DescribeImages` to ECR access policy

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "ecr_access" {
       "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
       "ecr:GetDownloadUrlForLayer",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",


### PR DESCRIPTION
## Proposed Changes

- Adds `ecr:DescribeImages` to resolve [this](https://github.com/ministryofjustice/analytical-platform-airflow/actions/runs/14103217684/job/39503856250?pr=102)

```
An error occurred (AccessDeniedException) when calling the DescribeImages operation: User: arn:aws:sts::509399598587:assumed-role/ecr-access/GitHubActions is not authorized to perform: ecr:DescribeImages on resource: arn:aws:ecr:eu-west-2:509399598587:repository/moj-analytical-services/analytical-platform-airflow-python-example because no identity-based policy allows the ecr:DescribeImages action
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>