### PR TITLE
DPR2-1884: Create glue job and trigger for the postgres data generation

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -153,7 +153,8 @@
       "dpr_generic_athena_workgroup": true,
       "analytics_generic_athena_workgroup": true,
       "redshift_table_expiry_days": 7,
-      "enable_s3_data_migrate_lambda": true
+      "enable_s3_data_migrate_lambda": true,
+      "create_postgres_load_generator_job": true
     },
     "test": {
       "project_short_id": "dpr",
@@ -306,7 +307,8 @@
       "dpr_generic_athena_workgroup": true,
       "analytics_generic_athena_workgroup": true,
       "redshift_table_expiry_days": 7,
-      "enable_s3_data_migrate_lambda": true
+      "enable_s3_data_migrate_lambda": true,
+      "create_postgres_load_generator_job": false
     },
     "preproduction": {
       "project_short_id": "dpr",
@@ -479,7 +481,8 @@
         }
       ],
       "redshift_table_expiry_days": 7,
-      "enable_s3_data_migrate_lambda": true
+      "enable_s3_data_migrate_lambda": true,
+      "create_postgres_load_generator_job": false
     },
     "production": {
       "project_short_id": "dpr",
@@ -647,7 +650,8 @@
         }
       ],
       "redshift_table_expiry_days": 1,
-      "enable_s3_data_migrate_lambda": false
+      "enable_s3_data_migrate_lambda": false,
+      "create_postgres_load_generator_job": false
     }
   }
 }

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -438,4 +438,6 @@ locals {
     "arn:aws:iam::${local.account_id}:policy/${local.kms_read_access_policy}",
     "arn:aws:iam::${local.account_id}:policy/${local.s3_read_write_policy}"
   ]
+
+  create_postgres_load_generator_job = local.application_data.accounts[local.environment].create_postgres_load_generator_job
 }

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -153,7 +153,8 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "secretsmanager:DescribeSecret"
     ]
     resources = concat(var.additional_secret_arns, [
-      "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*"
+      "arn:aws:secretsmanager:${var.region}:${var.account}:secret:${var.project_id}-redshift-secret-*",
+      "arn:aws:secretsmanager:${var.region}:${var.account}:secret:external/${var.project_id}-dps-*"
     ])
   }
   statement {

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.10"
+  required_providers {
+    aws = {
+      version = "~> 5.0"
+      source  = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
This PR creates:
- The glue job which generates the load on the DPR Postgres database
- The job is configured to insert data into Postgres for 1 hour per run
- A glue trigger which runs every 2 hours