### PR TITLE
refactor: move ccms lambda security group rules

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-lambda.tf
+++ b/terraform/environments/ccms-ebs/ccms-lambda.tf
@@ -24,25 +24,30 @@ resource "aws_security_group" "lambda_security_group" {
   description = "SG traffic control for Payment Load Lambda"
   vpc_id      = data.aws_vpc.shared.id
 
-  ingress {
-    from_port   = 1521
-    to_port     = 1522
-    protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.shared.cidr_block]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = merge(local.tags,
     { Name = "${local.application_name}-${local.environment}-lambda-sg" }
   )
 }
 
+#--Ingresses
+resource "aws_security_group_rule" "ingress_oracledb" {
+  type              = "ingress"
+  from_port         = 1521
+  to_port           = 1521
+  protocol          = "tcp"
+  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+  security_group_id = aws_security_group.lambda_security_group.id
+}
+
+#--Egresses
+resource "aws_security_group_rule" "egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1" #--Any
+  cidr_blocks       = [data.aws_vpc.shared.cidr_block]
+  security_group_id = aws_security_group.lambda_security_group.id
+}
 
 # Lambda Function
 resource "aws_lambda_function" "lambda_function" {


### PR DESCRIPTION
move `aws_security_group.lambda_security_group` rules to external resources