### PR TITLE
tm-1165-patch-manager-deployment-tags

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -124,8 +124,8 @@ locals {
       maintenance_window_duration = 2 # 4 for prod
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
-        REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS                 = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
@@ -28,6 +28,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids       = ["rds-ec2s"]
+        tags = {
+          patch-manager = "group2"
+        }
       }
       user_data_cloud_init = {
         args = {
@@ -41,9 +44,8 @@ locals {
         ]
       }
       tags = {
-        backup  = "false"
-        os-type = "Linux"
-        # Patching         = "Yes"
+        backup           = "false"
+        os-type          = "Linux"
         server-type      = "hmpps-domain-services"
         update-ssm-agent = "patchgroup1"
       }
@@ -139,6 +141,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids       = ["rds-ec2s"]
+        tags = {
+          patch-manager = "group2"
+        }
       }
       lb_target_groups = {
         http = local.lbs.public.instance_target_groups.http
@@ -148,7 +153,6 @@ locals {
         description      = "Remote Desktop Gateway Windows Server 2022"
         os-type          = "Windows"
         server-type      = "RDGateway"
-        Patching         = "Yes"
         update-ssm-agent = "patchgroup1"
       }
     }
@@ -196,6 +200,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids       = ["rds-ec2s"]
+        tags = {
+          patch-manager = "group2"
+        }
       }
       lb_target_groups = {
         https = local.lbs.public.instance_target_groups.https
@@ -205,7 +212,6 @@ locals {
         description      = "Remote Desktop Services Connection Broker and Web Windows Server 2022"
         os-type          = "Windows"
         server-type      = "RDServices"
-        Patching         = "Yes"
         update-ssm-agent = "patchgroup1"
       }
     }

--- a/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
@@ -43,7 +43,7 @@ locals {
       tags = {
         backup           = "false"
         os-type          = "Linux"
-        Patching         = "Yes"
+        # Patching         = "Yes"
         server-type      = "hmpps-domain-services"
         update-ssm-agent = "patchgroup1"
       }

--- a/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
@@ -41,8 +41,8 @@ locals {
         ]
       }
       tags = {
-        backup           = "false"
-        os-type          = "Linux"
+        backup  = "false"
+        os-type = "Linux"
         # Patching         = "Yes"
         server-type      = "hmpps-domain-services"
         update-ssm-agent = "patchgroup1"
@@ -85,11 +85,13 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids       = ["rds-ec2s"]
+        tags = {
+          patch-manager = "group2"
+        }
       }
       tags = {
         backup           = "false"
         os-type          = "Windows"
-        Patching         = "Yes"
         server-type      = "HmppsDomainServicesTest"
         update-ssm-agent = "patchgroup1"
       }

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -81,9 +81,13 @@ locals {
           ami_name          = "hmpps_windows_server_2022_release_2025-01-02T00-00-40.487Z"
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.jumpserver.instance, {
+          tags = {
+            patch-manager = "group2"
+          }
+        })
         tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name   = "azure.hmpp.root"
-          patch-manager = "group2"
+          domain-name = "azure.hmpp.root"
         })
       })
 

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -107,10 +107,14 @@ locals {
         config = merge(local.ec2_instances.rds.config, {
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.rds.instance, {
+          tags = {
+            patch-manager = "group2"
+          }
+        })
         tags = merge(local.ec2_instances.rds.tags, {
-          description   = "Remote Desktop Services for azure.hmpp.root domain"
-          domain-name   = "azure.hmpp.root"
-          patch-manager = "group2"
+          description = "Remote Desktop Services for azure.hmpp.root domain"
+          domain-name = "azure.hmpp.root"
         })
       })
     }

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -82,7 +82,8 @@ locals {
           availability_zone = "eu-west-2a"
         })
         tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name = "azure.hmpp.root"
+          domain-name   = "azure.hmpp.root"
+          patch-manager = "group2"
         })
       })
 
@@ -96,8 +97,9 @@ locals {
           }
         })
         tags = merge(local.ec2_instances.rdgw.tags, {
-          description = "Remote Desktop Gateway for azure.hmpp.root domain"
-          domain-name = "azure.hmpp.root"
+          description   = "Remote Desktop Gateway for azure.hmpp.root domain"
+          domain-name   = "azure.hmpp.root"
+          patch-manager = "group1"
         })
       })
 
@@ -106,8 +108,9 @@ locals {
           availability_zone = "eu-west-2a"
         })
         tags = merge(local.ec2_instances.rds.tags, {
-          description = "Remote Desktop Services for azure.hmpp.root domain"
-          domain-name = "azure.hmpp.root"
+          description   = "Remote Desktop Services for azure.hmpp.root domain"
+          domain-name   = "azure.hmpp.root"
+          patch-manager = "group2"
         })
       })
     }
@@ -177,8 +180,8 @@ locals {
       maintenance_window_duration = 2 # 4 for prod
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
-        REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS                 = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -93,13 +93,13 @@ locals {
         })
         instance = merge(local.ec2_instances.rdgw.instance, {
           tags = {
-            backup-plan = "daily-and-weekly"
+            backup-plan   = "daily-and-weekly"
+            patch-manager = "group1"
           }
         })
         tags = merge(local.ec2_instances.rdgw.tags, {
-          description   = "Remote Desktop Gateway for azure.hmpp.root domain"
-          domain-name   = "azure.hmpp.root"
-          patch-manager = "group1"
+          description = "Remote Desktop Gateway for azure.hmpp.root domain"
+          domain-name = "azure.hmpp.root"
         })
       })
 

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -50,11 +50,15 @@ locals {
         config = merge(local.ec2_instances.rdgw.config, {
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.rdgw.instance, {
+          tags = {
+            patch-manager = "group1"
+          }
+        })
         tags = merge(local.ec2_instances.rdgw.tags, {
           description      = "Remote Desktop Gateway for azure.hmpp.root domain"
           domain-name      = "azure.hmpp.root"
           update-ssm-agent = "patchgroup1"
-          patch-manager    = "group1"
         })
       })
 
@@ -78,8 +82,8 @@ locals {
           # patch-manager = "group2"
         })
         tags = merge(local.ec2_instances.rds.tags, {
-          description   = "Remote Desktop Services for azure.hmpp.root domain"
-          domain-name   = "azure.hmpp.root"
+          description = "Remote Desktop Services for azure.hmpp.root domain"
+          domain-name = "azure.hmpp.root"
         })
       })
     }

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -75,11 +75,11 @@ locals {
         })
         instance = merge(local.ec2_instances.rds.instance, {
           instance_type = "t3.large"
+          # patch-manager = "group2"
         })
         tags = merge(local.ec2_instances.rds.tags, {
           description   = "Remote Desktop Services for azure.hmpp.root domain"
           domain-name   = "azure.hmpp.root"
-          patch-manager = "group2"
         })
       })
     }

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -41,7 +41,8 @@ locals {
           availability_zone = "eu-west-2a"
         })
         tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name = "azure.hmpp.root"
+          domain-name   = "azure.hmpp.root"
+          patch-manager = "group2"
         })
       })
 
@@ -53,6 +54,7 @@ locals {
           description      = "Remote Desktop Gateway for azure.hmpp.root domain"
           domain-name      = "azure.hmpp.root"
           update-ssm-agent = "patchgroup1"
+          patch-manager    = "group1"
         })
       })
 
@@ -75,8 +77,9 @@ locals {
           instance_type = "t3.large"
         })
         tags = merge(local.ec2_instances.rds.tags, {
-          description = "Remote Desktop Services for azure.hmpp.root domain"
-          domain-name = "azure.hmpp.root"
+          description   = "Remote Desktop Services for azure.hmpp.root domain"
+          domain-name   = "azure.hmpp.root"
+          patch-manager = "group2"
         })
       })
     }
@@ -151,8 +154,8 @@ locals {
       maintenance_window_duration = 4
       maintenance_window_cutoff   = 2
       patch_classifications = {
-        REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS                 = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -88,7 +88,9 @@ locals {
         })
         instance = merge(local.ec2_instances.rds.instance, {
           instance_type = "t3.large"
-          # patch-manager = "group2"
+          tags = {
+            # patch-manager = "group2"
+          }
         })
         tags = merge(local.ec2_instances.rds.tags, {
           description = "Remote Desktop Services for azure.hmpp.root domain"

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -40,9 +40,13 @@ locals {
           ami_name          = "hmpps_windows_server_2022_release_2025-01-02T00-00-40.487Z"
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.jumpserver.instance, {
+          tags = {
+            # patch-manager = "group2"
+          }
+        })
         tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name   = "azure.hmpp.root"
-          patch-manager = "group2"
+          domain-name = "azure.hmpp.root"
         })
       })
 
@@ -52,7 +56,7 @@ locals {
         })
         instance = merge(local.ec2_instances.rdgw.instance, {
           tags = {
-            patch-manager = "group1"
+            # patch-manager = "group1"
           }
         })
         tags = merge(local.ec2_instances.rdgw.tags, {
@@ -65,6 +69,11 @@ locals {
       pd-rdgw-1-b = merge(local.ec2_instances.rdgw, {
         config = merge(local.ec2_instances.rdgw.config, {
           availability_zone = "eu-west-2b"
+        })
+        instance = merge(local.ec2_instances.rdgw.instance, {
+          tags = {
+            # patch-manager = "group2"
+          }
         })
         tags = merge(local.ec2_instances.rdgw.tags, {
           description      = "Remote Desktop Gateway for azure.hmpp.root domain"

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -41,6 +41,9 @@ locals {
         })
         instance = merge(local.ec2_autoscaling_groups.base_linux.instance, {
           instance_type = "t3.medium"
+          tags = {
+            patch-manager = "group2"
+          }
         })
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.base_linux.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.base_linux.user_data_cloud_init.args, {

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -126,6 +126,7 @@ locals {
         })
         tags = merge(local.ec2_instances.jumpserver.tags, {
           domain-name = "azure.noms.root"
+          patch-manager = "group1"
         })
         cloudwatch_metric_alarms = null
       })
@@ -140,6 +141,7 @@ locals {
         })
         tags = merge(local.ec2_instances.rds.tags, {
           domain-name = "azure.noms.root"
+          patch-manager = "group2"
         })
         cloudwatch_metric_alarms = null
       })
@@ -206,9 +208,9 @@ locals {
           https = merge(local.lbs.public.listeners.https, {
             alarm_target_group_names = [
               "test-rdgw-1-http",
-             "test-rds-1-https",
+              "test-rds-1-https",
             ]
-           certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
+            certificate_names_or_arns = ["remote_desktop_wildcard_cert"]
             rules = {
               test-rdgw-1-http = {
                 priority = 100
@@ -237,7 +239,7 @@ locals {
                       "rdweb1.test.hmpps-domain.service.justice.gov.uk"
                     ]
                   }
-                }]                
+                }]
               }
             }
           })
@@ -253,8 +255,8 @@ locals {
       maintenance_window_duration = 2 # 4 for prod
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
-        REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS                 = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -100,10 +100,14 @@ locals {
         config = merge(local.ec2_instances.rdgw.config, {
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.rdgw.instance, {
+          tags = {
+            patch-manager = "group1"
+          }
+        })
         tags = merge(local.ec2_instances.rdgw.tags, {
-          description   = "Remote Desktop Gateway for azure.noms.root domain"
-          domain-name   = "azure.noms.root"
-          patch-manager = "group1"
+          description = "Remote Desktop Gateway for azure.noms.root domain"
+          domain-name = "azure.noms.root"
         })
       })
 
@@ -112,9 +116,13 @@ locals {
           ami_name          = "hmpps_windows_server_2022_release_2025-01-02T00-00-40.487Z"
           availability_zone = "eu-west-2a"
         })
+        instance = merge(local.ec2_instances.jumpserver.instance, {
+          tags = {
+            patch-manager = "group2"
+          }
+        })
         tags = merge(local.ec2_instances.jumpserver.tags, {
-          domain-name   = "azure.noms.root"
-          patch-manager = "group2"
+          domain-name = "azure.noms.root"
         })
       })
 
@@ -124,9 +132,13 @@ locals {
           ami_name          = "hmpps_windows_server_2022_release_2025-04-02T00-00-40.543Z"
           availability_zone = "eu-west-2b"
         })
+        instance = merge(local.ec2_instances.jumpserver.instance, {
+          tags = {
+            patch-manager = "group1"
+          }
+        })
         tags = merge(local.ec2_instances.jumpserver.tags, {
           domain-name = "azure.noms.root"
-          patch-manager = "group1"
         })
         cloudwatch_metric_alarms = null
       })
@@ -139,9 +151,13 @@ locals {
             "Ec2SecretPolicy"]
           )
         })
+        instance = merge(local.ec2_instances.rds.instance, {
+          tags = {
+            patch-manager = "group2"
+          }
+        })
         tags = merge(local.ec2_instances.rds.tags, {
           domain-name = "azure.noms.root"
-          patch-manager = "group2"
         })
         cloudwatch_metric_alarms = null
       })

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -41,9 +41,6 @@ locals {
         })
         instance = merge(local.ec2_autoscaling_groups.base_linux.instance, {
           instance_type = "t3.medium"
-          tags = {
-            patch-manager = "group2"
-          }
         })
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.base_linux.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.base_linux.user_data_cloud_init.args, {


### PR DESCRIPTION
Adding tags to ec2 instances for patch-manager.

Removing REDHAT baseline and hmpps-domain-service is Windows only.