### PR TITLE
Migrate aws-nuke from rebuy-de to ekristen fork 

### DIFF
--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -122,55 +122,50 @@ jobs:
           export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
           export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
 
-          echo "🔍 Verifying identity..."
+          echo "Verifying identity..."
           aws sts get-caller-identity || {
             echo "Invalid credentials"
             exit 1
           }
           echo "Running AWS Nuke (dry run)..."
-          echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+          $HOME/bin/aws-nuke run \
             --config nuke-config.yml \
             --no-prompt
 
-      # - name: Nuke Apply (Destructive)
-      #   if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-      #   run: |
-      #     # The environment gets reset between steps, so the role needs to be re-assumed.
-      #     aws sts assume-role \
-      #       --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-      #       --role-session-name githubactionsgoliveapply > creds.json || {
-      #         echo "Failed to assume role"
-      #         exit 1
-      #     }
-      #     export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-      #     export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-      #     export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+      - name: Nuke Apply (Destructive)
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+        run: |
+          # The environment gets reset between steps, so the role needs to be re-assumed.
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgoliveapply > creds.json || {
+              echo "Failed to assume role"
+              exit 1
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
 
-      #     echo "Verifying identity..."
-      #     aws sts get-caller-identity || {
-      #       echo "Invalid credentials"
-      #       exit 1
-      #     }
-      #     echo "Running AWS Nuke (full apply)..."
-      #     $HOME/bin/aws-nuke run \
-      #       --config nuke-config.yml \
-      #       --force \
-      #     $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-      #       --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-      #       --session-token "$AWS_SESSION_TOKEN" \
-      #       --config nuke-config.yml \
-      #       --no-prompt \
-      #       --no-dry-run
+          echo "Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (full apply)..."
+           $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt \
+            --no-dry-run
 
-      # - name: Slack failure notification
-      #   uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-      #   with:
-      #     webhook-type: incoming-webhook
-      #     payload: |
-      #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #   if: ${{ failure() }}
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
     env:
       ACCOUNT_NAME: ${{ matrix.nuke_accts }}
 
@@ -239,12 +234,12 @@ jobs:
             exit 1
           }
           echo "Running AWS Nuke (dry run)..."
-          echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+           $HOME/bin/aws-nuke run \
             --config nuke-config.yml \
             --no-prompt
 
       - name: Nuke Apply (Destructive)
-        # if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
         run: |
           aws sts assume-role \
             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
@@ -267,15 +262,15 @@ jobs:
             --no-prompt \
             --no-dry-run
 
-      # - name: Slack failure notification
-      #   uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-      #   with:
-      #     webhook-type: incoming-webhook
-      #     payload: |
-      #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #   if: ${{ failure() }}
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.TESTING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TESTING_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      account_blocklist_str : ${{ steps.set-blocklist-string.outputs.account_blocklist_str }}
+      account_blocklist_str: ${{ steps.set-blocklist-string.outputs.account_blocklist_str }}
     steps:
       - id: set-matrix
         name: Set Up Matrix
@@ -50,98 +50,120 @@ jobs:
           done <<< "$(jq -c -r '.[]' <<< $NUKE_BLOCKLIST_ACCOUNTS)" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
           # Encoding and passing blocklist string as an output
           echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> $GITHUB_OUTPUT
-  nuke:
-    strategy:
-      fail-fast: false
-      matrix:
-        nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
-    name: Sandbox Nuke
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
-    runs-on: ubuntu-latest
-    needs: setup-prerequisites
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - name: Set Account Number
-        run: |
-          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
-          echo "::add-mask::$ACCOUNT_NUMBER"
-          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
-        with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
-          role-session-name: githubactionsrolesession
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Setup Nuke Account String
-        run: |
-          accounts_str=''
-          accounts_str+="  \"${ACCOUNT_NUMBER}\": # ${ACCOUNT_NAME}"
-          accounts_str+=$'\n'
-          accounts_str+="    presets:"
-          accounts_str+=$'\n'
-          accounts_str+="      - \"common\""
-          accounts_str+=$'\n'
-          echo "$accounts_str"
-          echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
-          echo "$accounts_str" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - name: Setup Nuke Config
-        run: |
-          export accounts_str="$ACCOUNTS_STR"
-          export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
-          cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
-      - name: Install AWS Nuke
-        run: |
-          echo "BEGIN: Install AWS Nuke"
-          mkdir -p $HOME/bin
-          wget -c "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
-          mv "$HOME/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64" $HOME/bin/aws-nuke
-          chmod +x $HOME/bin/aws-nuke
-          echo "END: Install AWS Nuke"
-        env:
-          AWS_NUKE_VERSION: v2.25.0
-      - name: Nuke Plan (Dry Run)
-        run: |
-          aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds
-          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
-          grep "MemberInfrastructureAccess" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
-          $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-            --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-            --session-token "$AWS_SESSION_TOKEN" \
-            --config nuke-config.yml \
-            --force
-      - name: Nuke Apply (-no-dry-run)
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-        run: |
-          # The environment gets reset between steps, so the role needs to be re-assumed.
-          aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds
-          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
-          grep "MemberInfrastructureAccess" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
-          $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-            --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-            --session-token "$AWS_SESSION_TOKEN" \
-            --config nuke-config.yml \
-            --force \
-            --no-dry-run
-      - name: Slack failure notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          webhook-type: incoming-webhook
-          payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: ${{ failure() }}
-    env:
-      ACCOUNT_NAME: ${{ matrix.nuke_accts }}
+  # nuke:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
+  #   name: Sandbox Nuke
+  #   permissions:
+  #     id-token: write # This is required for requesting the JWT
+  #     contents: read # This is required for actions/checkout
+  #   needs: setup-prerequisites
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+  #     - name: Set Account Number
+  #       run: |
+  #         ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+  #         echo "::add-mask::$ACCOUNT_NUMBER"
+  #         echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+  #     - name: configure aws credentials
+  #       uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
+  #       with:
+  #         role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+  #         role-session-name: githubactionsrolesession
+  #         aws-region: ${{ env.AWS_REGION }}
+  #     - name: Setup Nuke Account String
+  #       run: |
+  #         accounts_str=''
+  #         accounts_str+="  \"${ACCOUNT_NUMBER}\": # ${ACCOUNT_NAME}"
+  #         accounts_str+=$'\n'
+  #         accounts_str+="    presets:"
+  #         accounts_str+=$'\n'
+  #         accounts_str+="      - \"common\""
+  #         accounts_str+=$'\n'
+  #         echo "$accounts_str"
+  #         echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
+  #         echo "$accounts_str" >> $GITHUB_ENV
+  #         echo "EOF" >> $GITHUB_ENV
+  #     - name: Setup Nuke Config
+  #       run: |
+  #         export accounts_str="$ACCOUNTS_STR"
+  #         export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+  #         cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
+  #     - name: Install AWS Nuke
+  #       run: |
+  #         echo "BEGIN: Install AWS Nuke"
+  #         mkdir -p $HOME/bin
+  #         wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
+  #         chmod +x $HOME/bin/aws-nuke
+  #         echo "END: Install AWS Nuke"
+  #       env:
+  #         AWS_NUKE_VERSION: v3.51.1
+  #     - name: Nuke Plan (Dry Run)
+  #       run: |
+  #           aws sts assume-role \
+  #             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+  #             --role-session-name githubactionsgotestrolesession > creds.json || {
+  #               echo "Failed to assume role"
+  #               exit 1
+  #           }
+  #           export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+  #           export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+  #           export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+        
+  #           echo "🔍 Verifying identity..."
+  #           aws sts get-caller-identity || {
+  #             echo "Invalid credentials"
+  #             exit 1
+  #           }
+  #           echo "Running AWS Nuke (dry run)..."
+  #           echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+  #             --config nuke-config.yml \
+  #             --no-prompt
 
+  #     - name: Nuke Apply (Destructive)
+  #       if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+  #       run: |
+  #         # The environment gets reset between steps, so the role needs to be re-assumed.
+  #                     aws sts assume-role \
+  #             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+  #             --role-session-name githubactionsgoliveapply > creds.json || {
+  #               echo "Failed to assume role"
+  #               exit 1
+  #           }
+  #           export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+  #           export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+  #           export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+        
+  #           echo "Verifying identity..."
+  #           aws sts get-caller-identity || {
+  #             echo "Invalid credentials"
+  #             exit 1
+  #           }
+  #           echo "Running AWS Nuke (full apply)..."
+  #           $HOME/bin/aws-nuke run \
+  #             --config nuke-config.yml \
+  #             --force \
+  #         $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
+  #           --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
+  #           --session-token "$AWS_SESSION_TOKEN" \
+  #           --config nuke-config.yml \
+  #           --no-prompt \
+  #           --no-dry-run
+  #     - name: Slack failure notification
+  #       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+  #       with:
+  #         webhook-type: incoming-webhook
+  #         payload: |
+  #           {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       if: ${{ failure() }}
+  #   env:
+  #     ACCOUNT_NAME: ${{ matrix.nuke_accts }}
 
   # testing-test account is not set up with OIDC because it is used to terratest OIDC-related resources. Therefore it's handled as a special case
   # using testing-ci user static credentials.
@@ -181,48 +203,64 @@ jobs:
         run: |
           echo "BEGIN: Install AWS Nuke"
           mkdir -p $HOME/bin
-          wget -c "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
-          mv "$HOME/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64" $HOME/bin/aws-nuke
+          wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
           chmod +x $HOME/bin/aws-nuke
           echo "END: Install AWS Nuke"
         env:
-          AWS_NUKE_VERSION: v2.25.0
+          AWS_NUKE_VERSION: v3.51.1
       - name: Nuke Plan (Dry Run)
         run: |
-          aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds
-          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
-          grep "MemberInfrastructureAccess" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
-          $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-            --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-            --session-token "$AWS_SESSION_TOKEN" \
-            --config nuke-config.yml \
-            --force
-      - name: Nuke Apply (-no-dry-run)
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+            aws sts assume-role \
+              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+              --role-session-name githubactionsgotestrolesession > creds.json || {
+                echo "Failed to assume role"
+                exit 1
+            }
+            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+            echo "Verifying identity..."
+            aws sts get-caller-identity || {
+              echo "Invalid credentials"
+              exit 1
+            }
+            echo "Running AWS Nuke (dry run)..."
+            echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+              --config nuke-config.yml \
+              --no-prompt
+        
+      - name: Nuke Apply (Destructive)
+        # if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
         run: |
-          # The environment gets reset between steps, so the AWS credentials get overwritten and the role needs to be re-assumed.
-          aws sts assume-role --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" --role-session-name githubactionsgotestrolesession > creds
-          $(echo "export AWS_ACCESS_KEY_ID=$(echo $(cat creds) | sed -n 's/.*"AccessKeyId": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SECRET_ACCESS_KEY=$(echo $(cat creds) | sed -n 's/.*"SecretAccessKey": "\([^"]*\)".*/\1/p')")
-          $(echo "export AWS_SESSION_TOKEN=$(echo $(cat creds) | sed -n 's/.*"SessionToken": "\([^"]*\)".*/\1/p')")
-          grep "MemberInfrastructureAccess" <<< $(aws sts get-caller-identity) || { echo 'Failed to assume role' ; exit 1; }
-          $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-            --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-            --session-token "$AWS_SESSION_TOKEN" \
-            --config nuke-config.yml \
-            --force \
-            --no-dry-run
-      - name: Slack failure notification
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          webhook-type: incoming-webhook
-          payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: ${{ failure() }}
+            aws sts assume-role \
+              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+              --role-session-name githubactionsgoliveapply > creds.json || {
+                echo "Failed to assume role"
+                exit 1
+            }
+            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+            echo "Verifying identity..."
+            aws sts get-caller-identity || {
+              echo "Invalid credentials"
+              exit 1
+            }
+            echo "Running AWS Nuke (full apply)..."
+            $HOME/bin/aws-nuke run \
+              --config nuke-config.yml \
+              --no-prompt \
+              --no-dry-run
+
+      # - name: Slack failure notification
+      #   uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      #   with:
+      #     webhook-type: incoming-webhook
+      #     payload: |
+      #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #   if: ${{ failure() }}
     env:
       AWS_ACCESS_KEY_ID:  ${{ secrets.TESTING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.TESTING_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -50,79 +50,79 @@ jobs:
           done <<< "$(jq -c -r '.[]' <<< $NUKE_BLOCKLIST_ACCOUNTS)" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
           # Encoding and passing blocklist string as an output
           echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> $GITHUB_OUTPUT
-  # nuke:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
-  #   name: Sandbox Nuke
-  #   permissions:
-  #     id-token: write # This is required for requesting the JWT
-  #     contents: read # This is required for actions/checkout
-  #   needs: setup-prerequisites
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-  #     - name: Set Account Number
-  #       run: |
-  #         ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
-  #         echo "::add-mask::$ACCOUNT_NUMBER"
-  #         echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
-  #     - name: configure aws credentials
-  #       uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
-  #       with:
-  #         role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
-  #         role-session-name: githubactionsrolesession
-  #         aws-region: ${{ env.AWS_REGION }}
-  #     - name: Setup Nuke Account String
-  #       run: |
-  #         accounts_str=''
-  #         accounts_str+="  \"${ACCOUNT_NUMBER}\": # ${ACCOUNT_NAME}"
-  #         accounts_str+=$'\n'
-  #         accounts_str+="    presets:"
-  #         accounts_str+=$'\n'
-  #         accounts_str+="      - \"common\""
-  #         accounts_str+=$'\n'
-  #         echo "$accounts_str"
-  #         echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
-  #         echo "$accounts_str" >> $GITHUB_ENV
-  #         echo "EOF" >> $GITHUB_ENV
-  #     - name: Setup Nuke Config
-  #       run: |
-  #         export accounts_str="$ACCOUNTS_STR"
-  #         export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
-  #         cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
-  #     - name: Install AWS Nuke
-  #       run: |
-  #         echo "BEGIN: Install AWS Nuke"
-  #         mkdir -p $HOME/bin
-  #         wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
-  #         chmod +x $HOME/bin/aws-nuke
-  #         echo "END: Install AWS Nuke"
-  #       env:
-  #         AWS_NUKE_VERSION: v3.51.1
-  #     - name: Nuke Plan (Dry Run)
-  #       run: |
-  #           aws sts assume-role \
-  #             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-  #             --role-session-name githubactionsgotestrolesession > creds.json || {
-  #               echo "Failed to assume role"
-  #               exit 1
-  #           }
-  #           export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-  #           export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-  #           export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+  nuke:
+    strategy:
+      fail-fast: false
+      matrix:
+        nuke_accts: ${{ fromJSON(needs.setup-prerequisites.outputs.matrix) }}
+    name: Sandbox Nuke
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    needs: setup-prerequisites
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-session-name: githubactionsrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Setup Nuke Account String
+        run: |
+          accounts_str=''
+          accounts_str+="  \"${ACCOUNT_NUMBER}\": # ${ACCOUNT_NAME}"
+          accounts_str+=$'\n'
+          accounts_str+="    presets:"
+          accounts_str+=$'\n'
+          accounts_str+="      - \"common\""
+          accounts_str+=$'\n'
+          echo "$accounts_str"
+          echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
+          echo "$accounts_str" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Setup Nuke Config
+        run: |
+          export accounts_str="$ACCOUNTS_STR"
+          export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
+          cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
+      - name: Install AWS Nuke
+        run: |
+          echo "BEGIN: Install AWS Nuke"
+          mkdir -p $HOME/bin
+          wget -c "https://github.com/ekristen/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" -O - | tar -xz -C $HOME/bin
+          chmod +x $HOME/bin/aws-nuke
+          echo "END: Install AWS Nuke"
+        env:
+          AWS_NUKE_VERSION: v3.51.1
+      - name: Nuke Plan (Dry Run)
+        run: |
+            aws sts assume-role \
+              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+              --role-session-name githubactionsgotestrolesession > creds.json || {
+                echo "Failed to assume role"
+                exit 1
+            }
+            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
         
-  #           echo "🔍 Verifying identity..."
-  #           aws sts get-caller-identity || {
-  #             echo "Invalid credentials"
-  #             exit 1
-  #           }
-  #           echo "Running AWS Nuke (dry run)..."
-  #           echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
-  #             --config nuke-config.yml \
-  #             --no-prompt
+            echo "🔍 Verifying identity..."
+            aws sts get-caller-identity || {
+              echo "Invalid credentials"
+              exit 1
+            }
+            echo "Running AWS Nuke (dry run)..."
+            echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+              --config nuke-config.yml \
+              --no-prompt
 
   #     - name: Nuke Apply (Destructive)
   #       if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
@@ -162,8 +162,8 @@ jobs:
   #       env:
   #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   #       if: ${{ failure() }}
-  #   env:
-  #     ACCOUNT_NAME: ${{ matrix.nuke_accts }}
+    env:
+      ACCOUNT_NAME: ${{ matrix.nuke_accts }}
 
   # testing-test account is not set up with OIDC because it is used to terratest OIDC-related resources. Therefore it's handled as a special case
   # using testing-ci user static credentials.

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -63,8 +63,8 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: setup-prerequisites
     runs-on: ubuntu-latest
+    needs: setup-prerequisites
     steps:
       - name: Checkout Repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/awsnuke.yml
+++ b/.github/workflows/awsnuke.yml
@@ -17,6 +17,7 @@ on:
     # trigger every sunday at 12:00am
     - cron: '0 12 * * 0'
   workflow_dispatch:
+
 env:
   AWS_REGION: "eu-west-2"
   ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENTS }}
@@ -38,7 +39,9 @@ jobs:
     steps:
       - id: set-matrix
         name: Set Up Matrix
-        run: echo "matrix=$(jq -c '.| map(select(. !="testing-test"))|sort' <<< $NUKE_ACCOUNTS)" >> $GITHUB_OUTPUT
+        run: |
+          echo "matrix=$(jq -c '.| map(select(. !="testing-test"))|sort' <<< $NUKE_ACCOUNTS)" >> $GITHUB_OUTPUT
+
       - id: set-blocklist-string
         name: Set Up Blocklist
         run: |
@@ -50,6 +53,7 @@ jobs:
           done <<< "$(jq -c -r '.[]' <<< $NUKE_BLOCKLIST_ACCOUNTS)" # Taking this approach as piping (|) to a read opens a subshell and passes the variables to it by value
           # Encoding and passing blocklist string as an output
           echo "account_blocklist_str=$(echo -n "${account_blocklist_str}" | base64 -w 0)" >> $GITHUB_OUTPUT
+
   nuke:
     strategy:
       fail-fast: false
@@ -75,6 +79,7 @@ jobs:
           role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
           role-session-name: githubactionsrolesession
           aws-region: ${{ env.AWS_REGION }}
+
       - name: Setup Nuke Account String
         run: |
           accounts_str=''
@@ -88,11 +93,13 @@ jobs:
           echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
           echo "$accounts_str" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+
       - name: Setup Nuke Config
         run: |
           export accounts_str="$ACCOUNTS_STR"
           export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
           cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
+
       - name: Install AWS Nuke
         run: |
           echo "BEGIN: Install AWS Nuke"
@@ -102,66 +109,68 @@ jobs:
           echo "END: Install AWS Nuke"
         env:
           AWS_NUKE_VERSION: v3.51.1
+
       - name: Nuke Plan (Dry Run)
         run: |
-            aws sts assume-role \
-              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-              --role-session-name githubactionsgotestrolesession > creds.json || {
-                echo "Failed to assume role"
-                exit 1
-            }
-            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-        
-            echo "🔍 Verifying identity..."
-            aws sts get-caller-identity || {
-              echo "Invalid credentials"
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgotestrolesession > creds.json || {
+              echo "Failed to assume role"
               exit 1
-            }
-            echo "Running AWS Nuke (dry run)..."
-            echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
-              --config nuke-config.yml \
-              --no-prompt
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
 
-  #     - name: Nuke Apply (Destructive)
-  #       if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-  #       run: |
-  #         # The environment gets reset between steps, so the role needs to be re-assumed.
-  #                     aws sts assume-role \
-  #             --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-  #             --role-session-name githubactionsgoliveapply > creds.json || {
-  #               echo "Failed to assume role"
-  #               exit 1
-  #           }
-  #           export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-  #           export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-  #           export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-        
-  #           echo "Verifying identity..."
-  #           aws sts get-caller-identity || {
-  #             echo "Invalid credentials"
-  #             exit 1
-  #           }
-  #           echo "Running AWS Nuke (full apply)..."
-  #           $HOME/bin/aws-nuke run \
-  #             --config nuke-config.yml \
-  #             --force \
-  #         $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
-  #           --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
-  #           --session-token "$AWS_SESSION_TOKEN" \
-  #           --config nuke-config.yml \
-  #           --no-prompt \
-  #           --no-dry-run
-  #     - name: Slack failure notification
-  #       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-  #       with:
-  #         webhook-type: incoming-webhook
-  #         payload: |
-  #           {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       if: ${{ failure() }}
+          echo "🔍 Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (dry run)..."
+          echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt
+
+      # - name: Nuke Apply (Destructive)
+      #   if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+      #   run: |
+      #     # The environment gets reset between steps, so the role needs to be re-assumed.
+      #     aws sts assume-role \
+      #       --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+      #       --role-session-name githubactionsgoliveapply > creds.json || {
+      #         echo "Failed to assume role"
+      #         exit 1
+      #     }
+      #     export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+      #     export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+      #     export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+
+      #     echo "Verifying identity..."
+      #     aws sts get-caller-identity || {
+      #       echo "Invalid credentials"
+      #       exit 1
+      #     }
+      #     echo "Running AWS Nuke (full apply)..."
+      #     $HOME/bin/aws-nuke run \
+      #       --config nuke-config.yml \
+      #       --force \
+      #     $HOME/bin/aws-nuke --access-key-id "$AWS_ACCESS_KEY_ID" \
+      #       --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
+      #       --session-token "$AWS_SESSION_TOKEN" \
+      #       --config nuke-config.yml \
+      #       --no-prompt \
+      #       --no-dry-run
+
+      # - name: Slack failure notification
+      #   uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      #   with:
+      #     webhook-type: incoming-webhook
+      #     payload: |
+      #       {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #   if: ${{ failure() }}
     env:
       ACCOUNT_NAME: ${{ matrix.nuke_accts }}
 
@@ -181,6 +190,7 @@ jobs:
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "::add-mask::$ACCOUNT_NUMBER"
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
       - name: Setup Nuke Account String
         run: |
           accounts_str=''
@@ -194,11 +204,13 @@ jobs:
           echo "ACCOUNTS_STR<<EOF" >> $GITHUB_ENV
           echo "$accounts_str" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+
       - name: Setup Nuke Config
         run: |
           export accounts_str="$ACCOUNTS_STR"
           export account_blocklist_str=$(echo "${{ needs.setup-prerequisites.outputs.account_blocklist_str }}" | base64 --decode)
           cat scripts/nuke-config-template.txt | envsubst > nuke-config.yml
+
       - name: Install AWS Nuke
         run: |
           echo "BEGIN: Install AWS Nuke"
@@ -208,49 +220,52 @@ jobs:
           echo "END: Install AWS Nuke"
         env:
           AWS_NUKE_VERSION: v3.51.1
+
       - name: Nuke Plan (Dry Run)
         run: |
-            aws sts assume-role \
-              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-              --role-session-name githubactionsgotestrolesession > creds.json || {
-                echo "Failed to assume role"
-                exit 1
-            }
-            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-            echo "Verifying identity..."
-            aws sts get-caller-identity || {
-              echo "Invalid credentials"
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgotestrolesession > creds.json || {
+              echo "Failed to assume role"
               exit 1
-            }
-            echo "Running AWS Nuke (dry run)..."
-            echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
-              --config nuke-config.yml \
-              --no-prompt
-        
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+
+          echo "Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (dry run)..."
+          echo "${ACCOUNT_NAME}" | $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt
+
       - name: Nuke Apply (Destructive)
         # if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
         run: |
-            aws sts assume-role \
-              --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
-              --role-session-name githubactionsgoliveapply > creds.json || {
-                echo "Failed to assume role"
-                exit 1
-            }
-            export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
-            export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
-            export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
-            echo "Verifying identity..."
-            aws sts get-caller-identity || {
-              echo "Invalid credentials"
+          aws sts assume-role \
+            --role-arn "arn:aws:iam::${ACCOUNT_NUMBER}:role/MemberInfrastructureAccess" \
+            --role-session-name githubactionsgoliveapply > creds.json || {
+              echo "Failed to assume role"
               exit 1
-            }
-            echo "Running AWS Nuke (full apply)..."
-            $HOME/bin/aws-nuke run \
-              --config nuke-config.yml \
-              --no-prompt \
-              --no-dry-run
+          }
+          export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' creds.json)
+          export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' creds.json)
+          export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' creds.json)
+
+          echo "Verifying identity..."
+          aws sts get-caller-identity || {
+            echo "Invalid credentials"
+            exit 1
+          }
+          echo "Running AWS Nuke (full apply)..."
+          $HOME/bin/aws-nuke run \
+            --config nuke-config.yml \
+            --no-prompt \
+            --no-dry-run
 
       # - name: Slack failure notification
       #   uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
@@ -262,6 +277,6 @@ jobs:
       #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       #   if: ${{ failure() }}
     env:
-      AWS_ACCESS_KEY_ID:  ${{ secrets.TESTING_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY:  ${{ secrets.TESTING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TESTING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TESTING_AWS_SECRET_ACCESS_KEY }}
       ACCOUNT_NAME: "testing-test"

--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -1,16 +1,15 @@
 ---
 # This file is consumed by the awsnuke.yml workflow
-feature-flags:
+settings:
   disable-deletion-protection:
     RDSInstance: true
     EC2Instance: true
     CloudformationStack: true
-  force-delete-lightsail-addons: true
 
 regions:
   - "eu-west-2"
 
-account-blocklist:
+blocklist:
 $account_blocklist_str
 
 resource-types:


### PR DESCRIPTION
Tracked in ticket [9557](https://github.com/ministryofjustice/modernisation-platform/issues/9557).
This PR updates the aws nuke workflow and nuke-config-template.txt to use the actively maintained [ekristen/aws-nuke](https://github.com/ekristen/aws-nuke) fork instead of the deprecated [rebuy-de/aws-nuke](https://github.com/rebuy-de/aws-nuke).

**What has changed:**
Removed deprecated CLI flags:
--access-key-id, --secret-access-key, --session-token 
Credentials are now exported via environment variables.
Removed echo $ACCOUNT_NAME as the flag --no-prompt means that I can skip interactive prompt. 
Renamed config keys:
feature-flags -> settings
account-blocklist -> blocklist
