### PR TITLE
tm-1165-tuning-baseline

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_development.tf
+++ b/terraform/environments/hmpps-domain-services/locals_development.tf
@@ -125,7 +125,7 @@ locals {
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
         # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -189,7 +189,7 @@ locals {
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
         # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -170,7 +170,7 @@ locals {
       maintenance_window_cutoff   = 2
       patch_classifications = {
         # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates"]
       }
     }
 

--- a/terraform/environments/hmpps-domain-services/locals_test.tf
+++ b/terraform/environments/hmpps-domain-services/locals_test.tf
@@ -272,7 +272,7 @@ locals {
       maintenance_window_cutoff   = 1 # 2 for prod
       patch_classifications = {
         # REDHAT_ENTERPRISE_LINUX = ["Security", "Bugfix"] # Linux Options=(Security,Bugfix,Enhancement,Recommended,Newpackage)
-        WINDOWS = ["SecurityUpdates", "CriticalUpdates", "DefinitionUpdates"]
+        WINDOWS = ["SecurityUpdates", "CriticalUpdates"]
       }
     }
 


### PR DESCRIPTION
removing definitions from the baseline as this may be conflicting with auto-approval days setting and should not be applied to a baseline.