### PR TITLE
🔗 Add Amazon Prometheus KMS policy Analytical Platform Observability role

### DIFF
--- a/terraform/environments/analytical-platform-compute/observability-platform.tf
+++ b/terraform/environments/analytical-platform-compute/observability-platform.tf
@@ -16,7 +16,7 @@ module "observability_platform_tenant" {
 }
 
 module "analytical_platform_observability" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=875fbc699f51c77a2d4cbb77c2366acd4b343cd9" # 1.0.0
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=840c2351c6d8ee16b36e8138e77bb9ae5d1e8442" # TEST
 
   enable_cloudwatch_read_only_access    = true
   enable_amazon_prometheus_query_access = true

--- a/terraform/environments/analytical-platform-compute/observability-platform.tf
+++ b/terraform/environments/analytical-platform-compute/observability-platform.tf
@@ -16,7 +16,7 @@ module "observability_platform_tenant" {
 }
 
 module "analytical_platform_observability" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=840c2351c6d8ee16b36e8138e77bb9ae5d1e8442" # TEST
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=bd09ac68fb3050ddd9992fe4326148aa5d2b1c9b" # 1.1.0
 
   enable_cloudwatch_read_only_access    = true
   enable_amazon_prometheus_query_access = true

--- a/terraform/environments/analytical-platform-compute/observability-platform.tf
+++ b/terraform/environments/analytical-platform-compute/observability-platform.tf
@@ -18,5 +18,9 @@ module "observability_platform_tenant" {
 module "analytical_platform_observability" {
   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=875fbc699f51c77a2d4cbb77c2366acd4b343cd9" # 1.0.0
 
+  additional_policies = {
+    managed_prometheus_kms_access = module.managed_prometheus_kms_access_iam_policy.arn
+  }
+
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/observability-platform.tf
+++ b/terraform/environments/analytical-platform-compute/observability-platform.tf
@@ -18,6 +18,10 @@ module "observability_platform_tenant" {
 module "analytical_platform_observability" {
   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=875fbc699f51c77a2d4cbb77c2366acd4b343cd9" # 1.0.0
 
+  enable_cloudwatch_read_only_access    = true
+  enable_amazon_prometheus_query_access = true
+  enable_aws_xray_read_only_access      = true
+
   additional_policies = {
     managed_prometheus_kms_access = module.managed_prometheus_kms_access_iam_policy.arn
   }


### PR DESCRIPTION
Relates to https://github.com/ministryofjustice/analytical-platform/pull/7548

## Proposed Changes

- Attaches Amazon Prometheus KMS policy Analytical Platform Observability role

## TODO

- [x] Merge and release https://github.com/ministryofjustice/terraform-aws-analytical-platform-observability/pull/2

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>