### PR TITLE
change alarms start and end time

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals.tf
+++ b/terraform/environments/hmpps-domain-services/locals.tf
@@ -50,5 +50,10 @@ locals {
     }
 
     security_groups = local.security_groups
+
+    schedule_alarms_lambda = {
+      start_time = "20:00"
+      end_time   = "05:15"
+    }
   }
 }


### PR DESCRIPTION
- schedule alarm for LB's are out of sync with the actual situation in hmpps-domain-services accounts