### PR TITLE
TM-1185: add nomis web12 manual build

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -284,6 +284,23 @@ locals {
         })
       })
 
+      qa11g-nomis-web12-b = merge(local.ec2_instances.web12, {
+        config = merge(local.ec2_instances.web12.config, {
+          availability_zone = "eu-west-2b"
+          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
+            "Ec2Qa11GWeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.ec2_instances.web12.user_data_cloud_init, {
+          args = merge(local.ec2_instances.web12.user_data_cloud_init.args, {
+            branch = "TM-1185/nomis-web12-manual-build"
+          })
+        })
+        tags = merge(local.ec2_instances.web12.tags, {
+          nomis-environment = "qa11g"
+        })
+      })
+
       qa11r-nomis-web-a = merge(local.ec2_instances.web, {
         config = merge(local.ec2_instances.web.config, {
           availability_zone = "eu-west-2a"

--- a/terraform/environments/nomis/locals_ec2_instances.tf
+++ b/terraform/environments/nomis/locals_ec2_instances.tf
@@ -247,6 +247,53 @@ locals {
       }
     }
 
+    web12 = {
+      config = {
+        ami_name                  = "base_ol_8_5_2023-06-08T09-45-10.579Z"
+        iam_resource_names_prefix = "ec2-instance"
+        instance_profile_policies = [
+          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+          "EC2Default",
+          "EC2S3BucketWriteAndDeleteAccessPolicy",
+          "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"
+        ]
+        subnet_name = "private"
+      }
+      ebs_volumes = {
+        "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
+      }
+      instance = {
+        disable_api_termination      = false
+        instance_type                = "t3.large"
+        key_name                     = "ec2-user"
+        metadata_options_http_tokens = "required"
+        vpc_security_group_ids       = ["private-web"]
+
+        tags = {
+          backup-plan = "daily-and-weekly"
+        }
+      }
+      user_data_cloud_init = {
+        args = {
+          branch       = "main"
+          ansible_args = "--tags ec2provision"
+        }
+        scripts = [ # paths are relative to templates/ dir
+          "../../../modules/baseline_presets/ec2-user-data/install-ssm-agent.sh",
+          "../../../modules/baseline_presets/ec2-user-data/ansible-ec2provision.sh.tftpl",
+          "../../../modules/baseline_presets/ec2-user-data/post-ec2provision.sh",
+        ]
+      }
+      tags = {
+        backup           = "false"
+        component        = "web"
+        description      = "For testing nomis weblogic 12 image"
+        os-type          = "Linux"
+        server-type      = "nomis-web12"
+        update-ssm-agent = "patchgroup1"
+      }
+    }
+
     xtag = {
       config = {
         ami_name                  = "nomis_rhel_7_9_weblogic_xtag_10_3_release_2023-07-19T09-01-29.168Z"


### PR DESCRIPTION
Create qa11g nomis web server as a standalone EC2 instance for manual configuration