### PR TITLE
TM-923: onr: use aws backup for fsx

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -181,12 +181,13 @@ locals {
     fsx_windows = {
 
       pp-bods-win-share = {
-        aliases             = ["pp-onr-fs.azure.hmpp.root"]
-        deployment_type     = "SINGLE_AZ_1"
-        security_groups     = ["bods"]
-        skip_final_backup   = true
-        storage_capacity    = 600
-        throughput_capacity = 8
+        aliases                         = ["pp-onr-fs.azure.hmpp.root"]
+        automatic_backup_retention_days = 0
+        deployment_type                 = "SINGLE_AZ_1"
+        security_groups                 = ["bods"]
+        skip_final_backup               = true
+        storage_capacity                = 600
+        throughput_capacity             = 8
 
         subnets = [
           {

--- a/terraform/environments/oasys-national-reporting/locals_production.tf
+++ b/terraform/environments/oasys-national-reporting/locals_production.tf
@@ -200,12 +200,13 @@ locals {
     fsx_windows = {
 
       pd-bods-win-share = {
-        preferred_availability_zone = "eu-west-2a"
-        deployment_type             = "MULTI_AZ_1"
-        security_groups             = ["bods"]
-        skip_final_backup           = true
-        storage_capacity            = 600
-        throughput_capacity         = 8
+        automatic_backup_retention_days = 0
+        deployment_type                 = "MULTI_AZ_1"
+        preferred_availability_zone     = "eu-west-2a"
+        security_groups                 = ["bods"]
+        skip_final_backup               = true
+        storage_capacity                = 600
+        throughput_capacity             = 8
 
         subnets = [
           {

--- a/terraform/environments/oasys-national-reporting/locals_test.tf
+++ b/terraform/environments/oasys-national-reporting/locals_test.tf
@@ -328,12 +328,13 @@ locals {
 
     fsx_windows = {
       t2-bods-win-share = {
-        aliases             = ["t2-onr-fs.azure.noms.root"]
-        deployment_type     = "SINGLE_AZ_1"
-        security_groups     = ["bods"]
-        skip_final_backup   = true
-        storage_capacity    = 128
-        throughput_capacity = 8
+        aliases                         = ["t2-onr-fs.azure.noms.root"]
+        automatic_backup_retention_days = 0
+        deployment_type                 = "SINGLE_AZ_1"
+        security_groups                 = ["bods"]
+        skip_final_backup               = true
+        storage_capacity                = 128
+        throughput_capacity             = 8
 
         subnets = [
           {
@@ -352,7 +353,8 @@ locals {
           password_secret_name = "/sap/bods/t2/passwords"
         }
         tags = {
-          backup = true
+          backup      = false
+          backup-plan = "daily-and-weekly"
         }
       }
     }


### PR DESCRIPTION
We're backing up FSX twice. Disable the automatic one, and align the backup tags in test with preprod and prod.