### PR TITLE
Bug #9789 - Add Quicksight resources to the exclude list.

### DIFF
--- a/scripts/nuke-config-template.txt
+++ b/scripts/nuke-config-template.txt
@@ -57,6 +57,8 @@ resource-types:
     - KMSAlias
     - KMSKey
     - OSPackage
+    - QuickSightSubscription
+    - QuickSightUser
     - S3AccessPoint
     - S3Bucket
     - S3MultipartUpload


### PR DESCRIPTION
Adds QuickSight resources to the nuke exclude list re issue 9789. These additional resource names were obtained by running "aws-nuke resource-types" from the latest version of aws-nuke installed on the local device.

```
~ » aws-nuke resource-types | grep Quick                                                                                                       
QuickSightSubscription                                native resource
QuickSightUser                                             native resource