### PR TITLE
Remove ignore for GitHub integration and increase dependabot limit

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -27,10 +27,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 15
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 15
     reviewers:
       - "ministryofjustice/devcontainer-community"
 EOL
@@ -48,8 +50,7 @@ if [[ -n "$tf_dirs" ]]; then
   
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
-  echo "    ignore:" >> "$dependabot_file"
-  echo "      - dependency-name: \"integrations/github\"" >> "$dependabot_file"
+  echo "    open-pull-requests-limit: 15" >> "$dependabot_file"
 fi
 
 # Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)
@@ -65,6 +66,7 @@ if [[ -n "$gomod_dirs" ]]; then
 
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    open-pull-requests-limit: 15" >> "$dependabot_file"
 fi
 
 echo "dependabot.yml has been successfully generated."


### PR DESCRIPTION
GitHub support has informed me that the issue with `integrations/github` that we were seeing when using directories should now be resolved with this [PR](https://github.com/dependabot/dependabot-core/pull/12014) has been merged and the change has been included in version v0.308.0.

I also see we are hitting the default number of open dependabots (5), so I'm bumping this limit up to 15

![image](https://github.com/user-attachments/assets/a8f27fa1-5538-48d6-9a7c-06f2616a16c0)
