### PR TITLE
PI-3021 Revert TEI version upgrade

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -10,7 +10,7 @@ locals {
         namespace       = "hmpps-probation-search-dev"           # MOJ Cloud Platform namespace where OpenSearch is hosted
         instance_type   = "ml.m5.xlarge"                         # SageMaker AI Real-time Inference instance type to use
         repository_name = "tei-cpu"                              # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
-        image_tag       = "2.0.1-tei1.6.0-cpu-py310-ubuntu22.04" # Version of the Hugging Face Text Embeddings Inference image to use. See:
+        image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04" # Version of the Hugging Face Text Embeddings Inference image to use. See:
         #  * https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/huggingface-tei.json for latest versions for GPU-accelerated instances
         #  * https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/huggingface-tei-cpu.json for latest versions for CPU-only instances
         s3_model_key = "ext/mixedbread-ai/mixedbread-ai_mxbai-embed-large-v1/" # To use a local model from S3
@@ -25,7 +25,7 @@ locals {
         namespace       = "hmpps-probation-search-preprod"
         instance_type   = "ml.g6.xlarge"
         repository_name = "tei"
-        image_tag       = "2.0.1-tei1.6.0-gpu-py310-cu122-ubuntu22.04"
+        image_tag       = "2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
         environment = {
           HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"
           MAX_CLIENT_BATCH_SIZE = 512
@@ -35,7 +35,7 @@ locals {
         namespace       = "hmpps-probation-search-prod"
         instance_type   = "ml.g6.xlarge"
         repository_name = "tei"
-        image_tag       = "2.0.1-tei1.6.0-gpu-py310-cu122-ubuntu22.04"
+        image_tag       = "2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
         environment = {
           HF_MODEL_ID           = "mixedbread-ai/mxbai-embed-large-v1"
           MAX_CLIENT_BATCH_SIZE = 512


### PR DESCRIPTION
We're seeing errors in OpenSearch that indicate SageMaker is now expecting a different request format following the TEI upgrade.

```
Received client error (422) from primary with message \\\"Failed to deserialize the JSON body into the target type: invalid length 3, expected struct EmbedRequest with 5 elements at line 1 column 139\\\". See https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logEventViewer:group=/aws/sagemaker/Endpoints/hmpps-probation-search-preprod in account 992382429243 for more information.
```