### PR TITLE
Remove sys.module override which isn't necessary in sqlalchemy>2.0

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/data.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/data.tf
@@ -1,9 +1,11 @@
 #### This file can be used to store data specific to the member account ####
 
+data "aws_region" "this" {}
+
 data "aws_availability_zones" "available" {
   filter {
     name   = "region-name"
-    values = ["eu-west-2"]
+    values = [ data.aws_region.this.name ]
   }
 }
 

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/lambda-functions/metadata_generator/main.py
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/lambda-functions/metadata_generator/main.py
@@ -7,7 +7,6 @@ import sys
 from datetime import datetime
 
 import boto3
-import oracledb
 from aws_xray_sdk.core import patch_all, xray_recorder
 from dotenv import load_dotenv
 from mojap_metadata import Metadata
@@ -51,8 +50,6 @@ logger.setLevel(log_level)
 secretsmanager = boto3.client("secretsmanager")
 s3 = boto3.client("s3")
 glue = _get_glue_client()
-oracledb.version = "8.3.0"
-sys.modules["cx_Oracle"] = oracledb
 load_dotenv()
 
 extraction_columns = [


### PR DESCRIPTION
This is to work around the following error:
Runtime.ImportModuleError: Unable to import module 'main': cannot import name 'base_impl' from partially initialized module 'oracledb' (most likely due to a circular import) (/var/task/oracledb/__init__.py)