### PR TITLE
remove corr_recipient from column to remove rules

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tariff.json
+++ b/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tariff.json
@@ -1644,10 +1644,6 @@
     },
     {
       "object_name": "CLAIMS.TARIFF_REASON_TYPES",
-      "column_name": "CORR_RECIPIENT"
-    },
-    {
-      "object_name": "CLAIMS.TARIFF_REASON_TYPES",
       "column_name": "CURR"
     },
     {


### PR DESCRIPTION
The result will be that column corr_recipient will be loaded as it is required in the cica tariff data model