### PR TITLE
🩹  Specify `local` version 2.5.2

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/versions.tf
@@ -18,7 +18,7 @@ terraform {
     }
     local = {
       version = "2.5.2"
-      source  = "hashicorp/local"
+      source  = "registry.opentofu.org/hashicorp/local"
     }
   }
   required_version = "~> 1.10"

--- a/terraform/environments/analytical-platform-ingestion/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/versions.tf
@@ -16,6 +16,10 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
+    local = {
+      version = "2.5.2"
+      source  = "hashicorp/local"
+    }
   }
   required_version = "~> 1.10"
 }


### PR DESCRIPTION
This is a test to see if specifying the previous version will fix the ongoing issues described [here](https://github.com/hashicorp/terraform-provider-local/issues/408). The thread leads me to believe this won't help but I want to confirm.