### PR TITLE
oasys-db-disk-resize-u01

### DIFF
--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -94,7 +94,7 @@ locals {
           ])
         })
         ebs_volumes = {
-          "/dev/sdb" = { label = "app", size = 100 }  # /u01
+          "/dev/sdb" = { label = "app", size = 200 }  # /u01
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
           "/dev/sde" = { label = "data", size = 2000 }
           "/dev/sdf" = { label = "data", size = 2000 }

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -242,7 +242,7 @@ locals {
           ])
         })
         ebs_volumes = {
-          "/dev/sdb" = { label = "app", size = 100 }  # /u01
+          "/dev/sdb" = { label = "app", size = 200 }  # /u01
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
           "/dev/sde" = { label = "data", size = 2000, iops = 12000, throughput = 750 }
           "/dev/sdf" = { label = "data", size = 2000, iops = 12000, throughput = 750 }
@@ -272,7 +272,7 @@ locals {
           ])
         })
         ebs_volumes = {
-          "/dev/sdb" = { label = "app", size = 100 }  # /u01
+          "/dev/sdb" = { label = "app", size = 200 }  # /u01
           "/dev/sdc" = { label = "app", size = 1000 } # /u02
           "/dev/sde" = { label = "data", size = 2000, iops = 12000, throughput = 750 }
           "/dev/sdf" = { label = "data", size = 2000, iops = 12000, throughput = 750 }

--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -151,7 +151,7 @@ locals {
           ])
         })
         ebs_volumes = {
-          "/dev/sdb" = { label = "app", size = 100 } # /u01
+          "/dev/sdb" = { label = "app", size = 200 } # /u01
           "/dev/sdc" = { label = "app", size = 500 } # /u02
           "/dev/sde" = { label = "data", size = 500 }
           "/dev/sdf" = { label = "data", size = 50 }


### PR DESCRIPTION
increasing the db disk size for OASys database servers test --> prod.  As database patching will use out of place database home patching when updated to 19c, doubling the space requirement. (Concierge) 