### PR TITLE
Renable glue connectivity for CICA Tempus

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/dms.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/dms.tf
@@ -115,7 +115,7 @@ module "cica_dms_tempus_dms_implementation" {
 
     create_ancillary_static_roles             = false
     create_premigration_assessement_resources = local.environment == "development" ? true : false
-    write_metadata_to_glue_catalog            = false
+    write_metadata_to_glue_catalog            = true
     retry_failed_after_recreate_metadata      = false
     valid_files_mutable                       = true
     glue_catalog_account_id                   = local.environment_management.account_ids["analytical-platform-data-production"]


### PR DESCRIPTION
This was toggled off in terraform and toggled on manually for testing in development, but I negelected to renable it before merging the last PR 