### PR TITLE
Add option to use existing replication instance

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/dms.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/dms.tf
@@ -34,7 +34,7 @@ module "cica_dms_tariff_dms_implementation" {
   db = local.tariff.short_resource_name
 
   dms_replication_instance = {
-    replication_instance_id    = local.tariff.resource_name
+    replication_instance_id    = "cica-ap-${local.environment}"
     subnet_cidrs               = local.environment_configuration.connected_vpc_private_subnets
     subnet_group_name          = local.tariff.resource_name
     allocated_storage          = 20
@@ -84,10 +84,12 @@ module "cica_dms_tempus_dms_implementation" {
   source      = "../modules/dms"
   vpc_id      = data.aws_vpc.connected_vpc.id
   environment = local.environment
-  db          = each.value.short_resource_name
+
+  db                          = each.value.short_resource_name
+  create_replication_instance = false
 
   dms_replication_instance = {
-    replication_instance_id    = each.value.resource_name
+    replication_instance_id    = "cica-ap-${local.environment}"
     subnet_cidrs               = local.environment_configuration.connected_vpc_private_subnets
     subnet_group_name          = each.value.resource_name
     allocated_storage          = 20

--- a/terraform/environments/analytical-platform-ingestion/dms/dms.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/dms.tf
@@ -133,4 +133,8 @@ module "cica_dms_tempus_dms_implementation" {
       source_arn = aws_cloudwatch_event_rule.metadata_generator.arn
     }
   }
+
+  depends_on = [
+    module.cica_dms_tariff_dms_implementation.aws_dms_replication_instance
+  ]
 }

--- a/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
@@ -1,3 +1,29 @@
+locals {
+  # We stagger these jobs as they share compute resource
+  # We want all these to be finished by the time the `Deploy dbt prod daily` job starts at ~4am
+  # All jobs need to start post-midnight to make sure any entries from the previous day are used
+  cron_timings = {
+    tempus = {
+      SPPFinishedJobs = {
+        cron_string = "cron(0 3 * * ? *)" # 3:00am every day
+        replication_task_arn = module.cica_dms_tempus_dms_implementation["SPPFinishedJobs"].dms_full_load_task_arn
+      }
+      SPPProcessPlatform = {
+        cron_string = "cron(0 2 * * ? *)" # 2am every day
+        replication_task_arn = module.cica_dms_tempus_dms_implementation["SPPProcessPlatform"].dms_full_load_task_arn
+      }
+      CaseWork = {
+        cron_string = "cron(0 1 * * ? *)" # 1:00am every day
+        replication_task_arn = module.cica_dms_tempus_dms_implementation["CaseWork"].dms_full_load_task_arn
+      }
+    }
+    tariff = {
+      cron_string = "cron(10 0 * * ? *)" # 12:10am every day
+      replication_task_arn = module.cica_dms_tariff_dms_implementation.dms_full_load_task_arn
+    }
+  }
+}
+
 resource "aws_scheduler_schedule" "tariff_dms_nightly_full_load" {
   name       = "tariff-dms-nightly-full-load"
   group_name = aws_scheduler_schedule_group.tariff_dms_nightly_full_load.name
@@ -6,7 +32,7 @@ resource "aws_scheduler_schedule" "tariff_dms_nightly_full_load" {
     mode = "OFF"
   }
 
-  schedule_expression = "cron(30 0 * * ? *)" # 12:30am every day, to capture submissions up till midnight for monthly reporting
+  schedule_expression = local.cron_timings.tariff.cron_string
   kms_key_arn         = module.cica_dms_eventscheduler_kms.key_arn
 
   target {
@@ -14,7 +40,7 @@ resource "aws_scheduler_schedule" "tariff_dms_nightly_full_load" {
     role_arn = module.tariff_eventbridge_dms_full_load_task_role.iam_role_arn
 
     input = jsonencode({
-      ReplicationTaskArn       = module.cica_dms_tariff_dms_implementation.dms_full_load_task_arn
+      ReplicationTaskArn       = local.cron_timings.tariff.replication_task_arn
       StartReplicationTaskType = "reload-target"
     })
   }
@@ -26,7 +52,7 @@ resource "aws_scheduler_schedule_group" "tariff_dms_nightly_full_load" {
 }
 
 resource "aws_scheduler_schedule" "tempus_dms_nightly_full_load" {
-  for_each   = module.cica_dms_tempus_dms_implementation
+  for_each   = local.cron_timings.tempus
   name       = "tempus-${each.key}-dms-nightly-full-load"
   group_name = aws_scheduler_schedule_group.tempus_dms_nightly_full_load.name
 
@@ -34,7 +60,7 @@ resource "aws_scheduler_schedule" "tempus_dms_nightly_full_load" {
     mode = "OFF"
   }
 
-  schedule_expression = "cron(30 0 * * ? *)" # 12:30am every day, to capture submissions up till midnight for monthly reporting
+  schedule_expression = each.value.cron_string
   kms_key_arn         = module.cica_dms_eventscheduler_kms.key_arn
 
   target {
@@ -42,7 +68,7 @@ resource "aws_scheduler_schedule" "tempus_dms_nightly_full_load" {
     role_arn = module.tempus_eventbridge_dms_full_load_task_role.iam_role_arn
 
     input = jsonencode({
-      ReplicationTaskArn       = each.value.dms_full_load_task_arn
+      ReplicationTaskArn       = each.value.replication_task_arn
       StartReplicationTaskType = "reload-target"
     })
   }

--- a/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
@@ -9,7 +9,7 @@ locals {
         replication_task_arn = module.cica_dms_tempus_dms_implementation["SPPFinishedJobs"].dms_full_load_task_arn
       }
       SPPProcessPlatform = {
-        cron_string = "cron(0 2 * * ? *)" # 2am every day
+        cron_string = "cron(10 0 * * ? *)" # 12:10 every day, runs in own replication instance
         replication_task_arn = module.cica_dms_tempus_dms_implementation["SPPProcessPlatform"].dms_full_load_task_arn
       }
       CaseWork = {

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/replication-instance.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/replication-instance.tf
@@ -56,6 +56,7 @@ resource "aws_dms_replication_subnet_group" "replication_subnet_group" {
 }
 
 resource "aws_dms_replication_instance" "instance" {
+  count                        = var.create_replication_instance ? 1 : 0
   allocated_storage            = var.dms_replication_instance.allocated_storage
   apply_immediately            = var.dms_replication_instance.apply_immediately
   auto_minor_version_upgrade   = true
@@ -73,4 +74,8 @@ resource "aws_dms_replication_instance" "instance" {
   tags = merge({ Name = var.dms_replication_instance.replication_instance_id },
     var.tags
   )
+}
+
+data "aws_dms_replication_instance" "instance" {
+  replication_instance_id = var.create_replication_instance ? aws_dms_replication_instance.instance[0].replication_instance_id: var.dms_replication_instance.replication_instance_id
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/replication-task.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/replication-task.tf
@@ -91,7 +91,7 @@ output "terraform_rules" {
 
 resource "aws_dms_replication_task" "full_load_replication_task" {
   migration_type            = "full-load"
-  replication_instance_arn  = aws_dms_replication_instance.instance.replication_instance_arn
+  replication_instance_arn  = data.aws_dms_replication_instance.instance.replication_instance_arn
   replication_task_id       = var.replication_task_id.full_load
   replication_task_settings = file("${path.module}/default_task_settings.json")
   source_endpoint_arn       = aws_dms_endpoint.source.endpoint_arn
@@ -108,7 +108,7 @@ resource "aws_dms_replication_task" "cdc_replication_task" {
   count                     = lookup(var.replication_task_id, "cdc", null) == null ? 0 : 1
   migration_type            = "cdc"
   cdc_start_time            = var.dms_source.cdc_start_time
-  replication_instance_arn  = aws_dms_replication_instance.instance.replication_instance_arn
+  replication_instance_arn  = data.aws_dms_replication_instance.instance.replication_instance_arn
   replication_task_id       = var.replication_task_id.cdc
   replication_task_settings = file("${path.module}/default_task_settings.json")
   source_endpoint_arn       = aws_dms_endpoint.source.endpoint_arn

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/variables.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/variables.tf
@@ -171,3 +171,9 @@ variable "metadata_generator_allowed_triggers" {
   default     = {}
   description = "Which services can invoke metadata generator lambda (see https://github.com/terraform-aws-modules/terraform-aws-lambda?tab=readme-ov-file#lambda-permissions-for-allowed-triggers)"
 }
+
+variable "create_replication_instance" {
+  type        = bool
+  default     = true
+  description = "Whether to create new replication instance in module"
+}


### PR DESCRIPTION
This is primarily envisioned as a cost-saving measure, as the replication instance is persistent and can't easily be shutdown/restarted when not in use.

Currently the DMS task associated with the SPPProcessPlatform won't run on the existing instance with 8GB RAM, requiring a 16GB RAM (`dms.r5.large`) instance. I have not put this job into the shared pool because I suspect it won't be possible for it to complete reliably in the shared instance in the necessary timeframe, which is the 4 hour window between midnight - which is the submission cut off  and 4am - which is currently when the downstream task runs job is scheduled as part of `Deploy dbt prod daily` Github Action