### PR TITLE
Add glue wildcard to DPR preprod

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -484,10 +484,7 @@
           "resource_shares": [
             {
               "glue_database": "curated_prisons_history_preprod_dbt",
-              "glue_tables": [
-                "nomis_offender_course_attendances",
-                "nomis_offender_program_profiles"
-              ]
+              "glue_tables": ["*"]
             }
           ]
         }


### PR DESCRIPTION
Github Action [Deploy digital prisons reporting tables to preprod](https://github.com/moj-analytical-services/create-a-derived-table/actions/workflows/deploy-preprod-digital-prisons-reporting.yml) fails with insufficient permissions.

This mirrors the Prod action workflow [configuration ](https://github.com/ministryofjustice/modernisation-platform-environments/blob/d8a334594ec3b0ee8bc205906165f1c0d85d418d/terraform/environments/digital-prison-reporting/application_variables.json#L663)to Preprod



Issue here: https://github.com/moj-analytical-services/dmet-prisons/issues/318

Slack discussion here: https://mojdt.slack.com/archives/C07U58QKEPL/p1746016926043149