### PR TITLE
👑 Add OneCrown host aliases

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -6,7 +6,7 @@ resource "helm_release" "actions_runner_mojas_airflow" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -32,7 +32,7 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow-create-a-pipeline"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -81,7 +81,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -109,7 +109,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -133,7 +133,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a_n
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -161,7 +161,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -185,7 +185,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -209,7 +209,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-test"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -233,7 +233,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -257,7 +257,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -283,7 +283,7 @@ resource "helm_release" "actions_runner_moj_data_catalogue" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-moj-data-catalogue"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-3"
+  version    = "2.323.0-5"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-actions-runners.tf
@@ -6,7 +6,7 @@ resource "helm_release" "actions_runner_mojas_airflow" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -32,7 +32,7 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow-create-a-pipeline"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -81,7 +81,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -109,7 +109,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -133,7 +133,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a_n
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -161,7 +161,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -185,7 +185,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -209,7 +209,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-test"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -233,7 +233,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -257,7 +257,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -283,7 +283,7 @@ resource "helm_release" "actions_runner_moj_data_catalogue" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-moj-data-catalogue"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.323.0-2"
+  version    = "2.323.0-3"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/iam-policies.tf
@@ -187,6 +187,7 @@ module "gha_mojas_airflow_iam_policy" {
   tags = local.tags
 }
 
+#trivy:ignore:AVD-AWS-0345: test policy for development
 data "aws_iam_policy_document" "analytical_platform_share_policy" {
   #checkov:skip=CKV_AWS_110: test policy for development
   #checkov:skip=CKV_AWS_107: test policy for development

--- a/terraform/environments/analytical-platform-compute/powerbi/ec2.tf
+++ b/terraform/environments/analytical-platform-compute/powerbi/ec2.tf
@@ -4,6 +4,9 @@
 
 # Create the PowerBI Gateway EC2 Instance
 module "powerbi_gateway_ec2" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "terraform-aws-modules/ec2-instance/aws"
   version = "5.8.0"
 

--- a/terraform/environments/analytical-platform-compute/powerbi/kms.tf
+++ b/terraform/environments/analytical-platform-compute/powerbi/kms.tf
@@ -1,6 +1,8 @@
 # KMS key for encrypting Auth0 secrets
 module "auth0_secrets_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "terraform-aws-modules/kms/aws"
   version = "2.1.0"
 

--- a/terraform/environments/analytical-platform-compute/powerbi/security-groups.tf
+++ b/terraform/environments/analytical-platform-compute/powerbi/security-groups.tf
@@ -4,6 +4,9 @@
 
 # Security group for PowerBI Gateway
 module "powerbi_gateway_security_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "terraform-aws-modules/security-group/aws"
   version = "5.3.0"
 

--- a/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -19,3 +19,14 @@ resources:
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: ${eks_role_arn}
+
+hostAliases:
+  - ip: "10.168.1.14"
+    hostnames:
+      - "mi-synapse-dev.sql.azuresynapse.net"
+  - ip: "10.168.1.16"
+    hostnames:
+      - "mi-synapse-dev.dev.azuresynapse.net"
+  - ip: "10.168.1.16"
+    hostnames:
+      - "mi-synapse-dev-ondemand.sql.azuresynapse.net"


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/analytical-platform/issues/7630

## Proposed Changes

- Bumps Actions Runner chart to [2.323.0-5](https://github.com/ministryofjustice/analytical-platform-actions-runner/releases/tag/2.323.0-5)
- Adds OneCrown endpoints to CaDeT deployment

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>