### PR TITLE
Add glue:GetTableVersions to digital prisons reporting `glue_catalog_readonly`

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -710,6 +710,7 @@ data "aws_iam_policy_document" "glue_catalog_readonly" {
     actions = [
       "glue:GetTable",
       "glue:GetTables",
+      "glue:GetTableVersions",
       "glue:GetDatabase",
       "glue:GetDatabases",
       "glue:GetPartition",


### PR DESCRIPTION
[Deploy digital prisons reporting tables to preprod](https://github.com/moj-analytical-services/create-a-derived-table/actions/runs/14888174786/job/41813293250) fails:

```
An error occurred (AccessDeniedException) when calling the GetTableVersions operation:
User: arn:aws:sts::972272129531:assumed-role/dpr-data-api-cross-account-role/botocore-session-1746634758
is not authorized to perform: glue:GetTableVersions on resource:
arn:aws:glue:eu-west-2:972272129531:catalog
because no identity-based policy allows the glue:GetTableVersions action
```