### PR TITLE
TM-1247: nomis: remove unused prod cert

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -23,19 +23,6 @@ locals {
   baseline_production = {
 
     acm_certificates = {
-      nomis_wildcard_cert_v2 = {
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
-        domain_name                         = "*.nomis.service.justice.gov.uk"
-        external_validation_records_created = true
-        subject_alternate_names = [
-          "*.nomis.hmpps-production.modernisation-platform.service.justice.gov.uk",
-          "*.production.nomis.service.justice.gov.uk",
-          "*.nomis.az.justice.gov.uk",
-        ]
-        tags = {
-          description = "wildcard cert for nomis production domains"
-        }
-      }
       nomis_wildcard_cert_v3 = {
         cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
         domain_name                         = "*.nomis.service.justice.gov.uk"


### PR DESCRIPTION
Swapped over to the new cert, we can zap the old one