### PR TITLE
PI-3053 Increase pre-prod initial instance count

### DIFF
--- a/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-probation-search.tf
@@ -9,6 +9,7 @@ locals {
       hmpps-probation-search-dev = {
         namespace       = "hmpps-probation-search-dev"           # MOJ Cloud Platform namespace where OpenSearch is hosted
         instance_type   = "ml.m5.xlarge"                         # SageMaker AI Real-time Inference instance type to use
+        instance_count  = 1                                      # The number of instances to use
         repository_name = "tei-cpu"                              # "tei" for GPU-accelerated instances, "tei-cpu" for CPU-only instances
         image_tag       = "2.0.1-tei1.2.3-cpu-py310-ubuntu22.04" # Version of the Hugging Face Text Embeddings Inference image to use. See:
         #  * https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/huggingface-tei.json for latest versions for GPU-accelerated instances
@@ -24,6 +25,7 @@ locals {
       hmpps-probation-search-preprod = {
         namespace       = "hmpps-probation-search-preprod"
         instance_type   = "ml.g6.xlarge"
+        instance_count  = 4
         repository_name = "tei"
         image_tag       = "2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
         environment = {
@@ -34,6 +36,7 @@ locals {
       hmpps-probation-search-prod = {
         namespace       = "hmpps-probation-search-prod"
         instance_type   = "ml.g6.xlarge"
+        instance_count  = 1
         repository_name = "tei"
         image_tag       = "2.0.1-tei1.2.3-gpu-py310-cu122-ubuntu22.04"
         environment = {
@@ -94,7 +97,7 @@ resource "aws_sagemaker_endpoint_configuration" "probation_search" {
   production_variants {
     variant_name           = "AllTraffic"
     model_name             = aws_sagemaker_model.probation_search_huggingface_embedding_model[each.key].name
-    initial_instance_count = 1
+    initial_instance_count = each.value.instance_count
     instance_type          = each.value.instance_type
   }
 


### PR DESCRIPTION
We need to test the performance of a bulk data ingestion job, which relies on SageMaker for generating text embeddings. Based on rough estimates, we expect to be able to complete this within a weekend with 4 GPU-accelerated instances. Once confirmed in pre-prod, we will scale back to 1 instance and work on implementing auto-scaling to support future ingestion jobs.

This will require an AWS quota increase from 2 to 5.