### PR TITLE
dmet-prisons/318/revert admin permissions - still has tags

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -1,20 +1,18 @@
-# Modernisation platform - adding Admin Data Lake permissions
-# https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/adding-admin-data-lake-formation-permissions.html#configuration-overview
-
-data "aws_iam_role" "github_actions_role" {
-  name = "github-actions"
-}
-
-data "aws_iam_role" "dataapi_cross_account_role" {
-  name = "${local.project}-data-api-cross-account-role"
-  
-}
-
 resource "aws_lakeformation_data_lake_settings" "lake_formation" {
-  admins = [
-    data.aws_iam_role.dataapi_cross_account_role.arn,
-    data.aws_iam_role.github_actions_role.arn
-  ]
+  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn, try(one(data.aws_iam_roles.data_engineering_roles.arns), [])])
+
+  # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
+  create_database_default_permissions {
+    # These settings should replicate current behaviour: LakeFormation is Ignored
+    permissions = ["ALL"]
+    principal   = "IAM_ALLOWED_PRINCIPALS"
+  }
+
+  create_table_default_permissions {
+    # These settings should replicate current behaviour: LakeFormation is Ignored
+    permissions = ["ALL"]
+    principal   = "IAM_ALLOWED_PRINCIPALS"
+  }
 }
 
 resource "aws_lakeformation_lf_tag" "domain_tag" {
@@ -46,4 +44,5 @@ resource "aws_lakeformation_permissions" "sensitive_grant" {
     key    = aws_lakeformation_lf_tag.sensitive_tag.key
     values = aws_lakeformation_lf_tag.sensitive_tag.values
   }
+
 }


### PR DESCRIPTION
Checking whether admin permissions changes led to the loss of LF tags and the issue reported here: https://mojdt.slack.com/archives/C06FUCUN9GC/p1746793193175119