### PR TITLE
dmet-prisons/318 - add cross account role to admins

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -1,5 +1,11 @@
 resource "aws_lakeformation_data_lake_settings" "lake_formation" {
-  admins = flatten([[for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn], data.aws_iam_session_context.current.issuer_arn, try(one(data.aws_iam_roles.data_engineering_roles.arns), [])])
+  admins = flatten([
+  [for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn],
+  data.aws_iam_session_context.current.issuer_arn,
+  try(one(data.aws_iam_roles.data_engineering_roles.arns), []),
+  aws_iam_role.dataapi_cross_role.arn
+    ]
+  )
 
   # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
   create_database_default_permissions {


### PR DESCRIPTION
Related to #10559 

Now adding the cross account role to the existing list of admins