### PR TITLE
DPR2-1966: Create alert when tickle lambda fails

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -143,6 +143,13 @@
             "threshold": 100,
             "period": 60
           }
+        },
+        "lambda": {
+          "postgres_tickle_function_failure": {
+            "enable": true,
+            "threshold": 1,
+            "period": 60
+          }
         }
       },
       "biprws": {
@@ -299,6 +306,13 @@
           "cdc_inc_events_check": {
             "enable": true,
             "threshold": 100,
+            "period": 60
+          }
+        },
+        "lambda": {
+          "postgres_tickle_function_failure": {
+            "enable": true,
+            "threshold": 1,
             "period": 60
           }
         }
@@ -459,6 +473,13 @@
           "cdc_inc_events_check": {
             "enable": true,
             "threshold": 100,
+            "period": 60
+          }
+        },
+        "lambda": {
+          "postgres_tickle_function_failure": {
+            "enable": true,
+            "threshold": 1,
             "period": 60
           }
         }
@@ -632,6 +653,13 @@
           "cdc_inc_events_check": {
             "enable": true,
             "threshold": 100,
+            "period": 60
+          }
+        },
+        "lambda": {
+          "postgres_tickle_function_failure": {
+            "enable": true,
+            "threshold": 1,
             "period": 60
           }
         }

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -293,6 +293,10 @@ locals {
   thrld_dms_cdc_inc_events_check    = local.application_data.accounts[local.environment].alarms.dms.cdc_inc_events_check.threshold
   period_dms_cdc_inc_events_check   = local.application_data.accounts[local.environment].alarms.dms.cdc_inc_events_check.period
 
+  enable_postgres_tickle_function_failure_alarm = local.application_data.accounts[local.environment].alarms.lambda.postgres_tickle_function_failure.enable
+  thrld_postgres_tickle_function_failure_alarm  = local.application_data.accounts[local.environment].alarms.lambda.postgres_tickle_function_failure.threshold
+  period_postgres_tickle_function_failure_alarm = local.application_data.accounts[local.environment].alarms.lambda.postgres_tickle_function_failure.period
+
   # CW Insights
   enable_cw_insights = local.application_data.accounts[local.environment].setup_cw_insights
 

--- a/terraform/environments/digital-prison-reporting/metric_alarms.tf
+++ b/terraform/environments/digital-prison-reporting/metric_alarms.tf
@@ -114,3 +114,26 @@ module "dpr_dms_network_receive_throughput" {
 
   alarm_actions = [module.notifications_sns.sns_topic_arn]
 }
+
+module "dpr_postgres_tickle_function_failure_alarm" {
+  source              = "./modules/cw_alarm"
+  create_metric_alarm = local.enable_cw_alarm && local.enable_postgres_tickle_function_failure_alarm
+
+  alarm_name          = "dpr-postgres-tickle-function-failure"
+  alarm_description   = "ATTENTION: DPR Postgres Tickle Function Failure, Please investigate!"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1 # Boolean
+  threshold           = local.thrld_postgres_tickle_function_failure_alarm
+  period              = local.period_postgres_tickle_function_failure_alarm
+  unit                = "Count"
+
+  namespace   = "AWS/Lambda"
+  metric_name = "Errors"
+  statistic   = "Maximum"
+
+  dimensions = {
+    FunctionName = "dpr-postgres-tickle-function"
+  }
+
+  alarm_actions = [module.notifications_sns.sns_topic_arn]
+}

--- a/terraform/environments/digital-prison-reporting/notifications.tf
+++ b/terraform/environments/digital-prison-reporting/notifications.tf
@@ -109,6 +109,41 @@ PATTERN
   depends_on = [module.notifications_sns]
 }
 
+# DMS failure state rule
+module "postgres_tickle_function_failure_rule" {
+  count         = local.enable_cw_alarm && local.enable_postgres_tickle_function_failure_alarm ? 1 : 0
+  source        = "./modules/notifications/eventbridge"
+  sns_topic_arn = module.notifications_sns.sns_topic_arn
+
+  rule_name         = "${local.project}-postgres-tickle-function-failure-rule-${local.environment}"
+  event_target_name = "${local.project}-postgres-tickle-function-failure-rule-target-${local.environment}"
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.cloudwatch"
+  ],
+  "detail-type": [
+    "CloudWatch Alarm State Change"
+  ],
+  "resources": [
+    "arn:aws:cloudwatch:${local.account_region}:${local.account_id}:alarm:${local.project}-postgres-tickle-function-failure"
+  ]
+}
+PATTERN
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name = "${local.project}-postgres-tickle-function-failure-rule-${local.environment}",
+      Jira = "DPR2-1966",
+      Dept = "Digital-Prison-Reporting"
+    }
+  )
+
+  depends_on = [module.notifications_sns]
+}
+
 # Pager duty integration
 
 # Notification SNS


### PR DESCRIPTION
This PR creates a Cloudwatch alarm is created to check if there is at least one failed invocations of the `postgres-tickle-function`. The alarm then sends a message which can then be matched with the following Eventbridge rule.

```
{
  "source": [
    "aws.cloudwatch"
  ],
  "detail-type": [
    "CloudWatch Alarm State Change"
  ],
  "resources": [
    "arn:aws:cloudwatch:${local.account_region}:${local.account_id}:alarm:${local.project}-postgres-tickle-function-failure"
  ]
}
```