### PR TITLE
TM: nomis dev: enable backup and disable autoscaling schedule

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -31,6 +31,25 @@ locals {
       }
     }
 
+    backup_plans = {
+      # delete once qa11g-nomis-web12-a removed
+      qa11g-nomis-web12-a-workaround = {
+        rule = {
+          schedule          = "cron(30 23 ? * MON-FRI *)"
+          start_window      = 60
+          completion_window = 3600
+          delete_after      = 10
+        }
+        selection = {
+          selection_tags = [{
+            type  = "STRINGEQUALS"
+            key   = "server-name"
+            value = "qa11g-nomis-web12-a"
+          }]
+        }
+      }
+    }
+
     cloudwatch_dashboards = {
       "CloudWatch-Default" = {
         periodOverride = "auto"
@@ -130,6 +149,7 @@ locals {
         })
       })
 
+      # remember to delete associated backup plan
       qa11g-nomis-web12-a = merge(local.ec2_autoscaling_groups.web12, {
         autoscaling_schedules = {}
         config = merge(local.ec2_autoscaling_groups.web12.config, {

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -157,11 +157,6 @@ locals {
             "Ec2Qa11GWeblogicPolicy",
           ])
         })
-        instance = merge(local.ec2_autoscaling_groups.web12.instance, {
-          tags = {
-            backup-plan = "daily-and-weekly"
-          }
-        })
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.web12.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.web12.user_data_cloud_init.args, {
             branch = "main"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -131,10 +131,16 @@ locals {
       })
 
       qa11g-nomis-web12-a = merge(local.ec2_autoscaling_groups.web12, {
+        autoscaling_schedules = {}
         config = merge(local.ec2_autoscaling_groups.web12.config, {
           instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
             "Ec2Qa11GWeblogicPolicy",
           ])
+        })
+        instance = merge(local.ec2_autoscaling_groups.web12.instance, {
+          tags = {
+            backup-plan = "daily-and-weekly"
+          }
         })
         user_data_cloud_init = merge(local.ec2_autoscaling_groups.web12.user_data_cloud_init, {
           args = merge(local.ec2_autoscaling_groups.web12.user_data_cloud_init.args, {


### PR DESCRIPTION
Remove scaling schedule for qa11g-nomis-web12-a on request from Syscon + enable backup.
Since an ASG and we can't easily modify tags on an existing EC2, adding a temporary backup plan just for this instance. Should only be needed for a few weeks according to Syscon.
