### PR TITLE
Create secrets to hold crowdstrike API keys

### DIFF
--- a/terraform/environments/ccms-ebs/crowdstrike/platform_data.tf
+++ b/terraform/environments/ccms-ebs/crowdstrike/platform_data.tf
@@ -44,3 +44,8 @@ data "aws_iam_session_context" "whoami" {
 data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
+
+# Reference the shared KMS key
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}

--- a/terraform/environments/ccms-ebs/crowdstrike/secretsmanager.tf
+++ b/terraform/environments/ccms-ebs/crowdstrike/secretsmanager.tf
@@ -6,6 +6,10 @@ resource "aws_secretsmanager_secret" "crowdstrike" {
 }
 
 resource "aws_secretsmanager_secret_version" "crowdstrike" {
-  lifecycle { ignore_changes = [secret_string]}
+  lifecycle { ignore_changes = [secret_string] }
   secret_id = aws_secretsmanager_secret.crowdstrike.id
+  secret_string = jsonencode({
+    client_id     = ""
+    client_secret = ""
+  })
 }

--- a/terraform/environments/ccms-ebs/crowdstrike/secretsmanager.tf
+++ b/terraform/environments/ccms-ebs/crowdstrike/secretsmanager.tf
@@ -1,0 +1,11 @@
+resource "aws_secretsmanager_secret" "crowdstrike" {
+  #checkov:skip=CKV2_AWS_57
+  #checkov:skip=CKV_AWS_149
+  name_prefix = "falcon_client_secret"
+  tags        = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "crowdstrike" {
+  lifecycle { ignore_changes = [secret_string]}
+  secret_id = aws_secretsmanager_secret.crowdstrike.id
+}

--- a/terraform/environments/laa-portal-tactical/crowdstrike/platform_data.tf
+++ b/terraform/environments/laa-portal-tactical/crowdstrike/platform_data.tf
@@ -44,3 +44,8 @@ data "aws_iam_session_context" "whoami" {
 data "http" "environments_file" {
   url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
 }
+
+# Reference the shared KMS key
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-laa"
+}

--- a/terraform/environments/laa-portal-tactical/crowdstrike/secretsmanager.tf
+++ b/terraform/environments/laa-portal-tactical/crowdstrike/secretsmanager.tf
@@ -6,6 +6,10 @@ resource "aws_secretsmanager_secret" "crowdstrike" {
 }
 
 resource "aws_secretsmanager_secret_version" "crowdstrike" {
-  lifecycle { ignore_changes = [secret_string]}
+  lifecycle { ignore_changes = [secret_string] }
   secret_id = aws_secretsmanager_secret.crowdstrike.id
+  secret_string = jsonencode({
+    client_id     = ""
+    client_secret = ""
+  })
 }

--- a/terraform/environments/laa-portal-tactical/crowdstrike/secretsmanager.tf
+++ b/terraform/environments/laa-portal-tactical/crowdstrike/secretsmanager.tf
@@ -1,0 +1,11 @@
+resource "aws_secretsmanager_secret" "crowdstrike" {
+  #checkov:skip=CKV2_AWS_57
+  #checkov:skip=CKV_AWS_149
+  name_prefix = "falcon_client_secret"
+  tags        = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "crowdstrike" {
+  lifecycle { ignore_changes = [secret_string]}
+  secret_id = aws_secretsmanager_secret.crowdstrike.id
+}


### PR DESCRIPTION
This PR creates `aws_secretsmanager_secret` resources to hold API keys used by Crowdstrike.