### PR TITLE
Deploy dashboard service v0.1.5

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.1.4"
+  version    = "0.1.5"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [


### PR DESCRIPTION
Deploy dashboard service v0.1.5. See changes in this release [here](https://github.com/ministryofjustice/analytical-platform-dashboard-service/releases/tag/0.1.5)