### PR TITLE
Release 0.1.6 of Dashboard Service

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.1.4"
+  version    = "0.1.6"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [


### PR DESCRIPTION
Release 0.1.6 of Dashboard Service. This is a bump of 2 versions, as 0.1.5 was not deployed. For full list of changes see https://github.com/ministryofjustice/analytical-platform-dashboard-service/compare/0.1.4...0.1.6