### PR TITLE
:bug: Pin TSA Checkov Version

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@3cd73da46642bf52bb4045d8abf05e1d96fc4a53 # v3.1.0
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@e6e439e4a738a965051fc2de5f8dbb5b674bfeee # pinned checkov
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@3cd73da46642bf52bb4045d8abf05e1d96fc4a53 # v3.1.0
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@e6e439e4a738a965051fc2de5f8dbb5b674bfeee # pinned checkov
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -81,7 +81,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@3cd73da46642bf52bb4045d8abf05e1d96fc4a53 # v3.1.0
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@e6e439e4a738a965051fc2de5f8dbb5b674bfeee # pinned checkov
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR updates the terraform-static-analysis.yml to use the recently pinned `checkov` version here https://github.com/ministryofjustice/modernisation-platform-github-actions/pull/55, while the syntax errors are investigated on newer versions of `checkov` (this is just a temporary measure). 