### PR TITLE
TM-1259: tidy up of unused nomis resources

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -138,17 +138,6 @@ locals {
         })
       })
 
-      dev-nomis-web19c-a = merge(local.ec2_autoscaling_groups.web19c, {
-      })
-
-      dev-nomis-web19c-b = merge(local.ec2_autoscaling_groups.web19c, {
-        user_data_cloud_init = merge(local.ec2_autoscaling_groups.web19c.user_data_cloud_init, {
-          args = merge(local.ec2_autoscaling_groups.web19c.user_data_cloud_init.args, {
-            branch = "main"
-          })
-        })
-      })
-
       # remember to delete associated backup plan
       qa11g-nomis-web12-a = merge(local.ec2_autoscaling_groups.web12, {
         autoscaling_schedules = {}
@@ -494,34 +483,6 @@ locals {
                   }
                 }]
               }
-              dev-nomis-web19c-a-http-7777 = {
-                priority = 400
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "dev-nomis-web19c-a-http-7777"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "dev-nomis-web19c-a.development.nomis.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
-              dev-nomis-web19c-b-http-7777 = {
-                priority = 410
-                actions = [{
-                  type              = "forward"
-                  target_group_name = "dev-nomis-web19c-b-http-7777"
-                }]
-                conditions = [{
-                  host_header = {
-                    values = [
-                      "dev-nomis-web19c-b.development.nomis.service.justice.gov.uk",
-                    ]
-                  }
-                }]
-              }
               qa11g-nomis-web12-a-http-7777 = {
                 priority = 500
                 actions = [{
@@ -586,8 +547,6 @@ locals {
           { name = "qa11r-nomis-web-b", type = "A", lbs_map_key = "private" },
           { name = "c-qa11r", type = "A", lbs_map_key = "private" },
           # weblogic 12
-          { name = "dev-nomis-web19c-a", type = "A", lbs_map_key = "private" },
-          { name = "dev-nomis-web19c-b", type = "A", lbs_map_key = "private" },
           { name = "qa11g-nomis-web12-a", type = "A", lbs_map_key = "private" },
         ]
       }

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -322,6 +322,23 @@ locals {
         })
       })
 
+      qa11g-nomis-web12-c = merge(local.ec2_instances.web12, {
+        config = merge(local.ec2_instances.web12.config, {
+          availability_zone = "eu-west-2b"
+          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
+            "Ec2Qa11GWeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.ec2_instances.web12.user_data_cloud_init, {
+          args = merge(local.ec2_instances.web12.user_data_cloud_init.args, {
+            branch = "TM-1259/nomis/web12c-reporting-fixes"
+          })
+        })
+        tags = merge(local.ec2_instances.web12.tags, {
+          nomis-environment = "qa11g"
+        })
+      })
+
       qa11r-nomis-web-a = merge(local.ec2_instances.web, {
         config = merge(local.ec2_instances.web.config, {
           availability_zone = "eu-west-2a"

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -305,6 +305,7 @@ locals {
         })
       })
 
+      # built by code and then handed over to Syscon for remaining manual configuration
       qa11g-nomis-web12-b = merge(local.ec2_instances.web12, {
         config = merge(local.ec2_instances.web12.config, {
           availability_zone = "eu-west-2b"
@@ -314,24 +315,7 @@ locals {
         })
         user_data_cloud_init = merge(local.ec2_instances.web12.user_data_cloud_init, {
           args = merge(local.ec2_instances.web12.user_data_cloud_init.args, {
-            branch = "TM-1185/nomis-web12-manual-build"
-          })
-        })
-        tags = merge(local.ec2_instances.web12.tags, {
-          nomis-environment = "qa11g"
-        })
-      })
-
-      qa11g-nomis-web12-c = merge(local.ec2_instances.web12, {
-        config = merge(local.ec2_instances.web12.config, {
-          availability_zone = "eu-west-2b"
-          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
-            "Ec2Qa11GWeblogicPolicy",
-          ])
-        })
-        user_data_cloud_init = merge(local.ec2_instances.web12.user_data_cloud_init, {
-          args = merge(local.ec2_instances.web12.user_data_cloud_init.args, {
-            branch = "TM-1259/nomis/web12c-reporting-fixes"
+            branch = "main"
           })
         })
         tags = merge(local.ec2_instances.web12.tags, {

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -252,60 +252,6 @@ locals {
         })
       })
 
-      t1-nomis-db-1-b = merge(local.ec2_instances.db, {
-        config = merge(local.ec2_instances.db.config, {
-          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          availability_zone = "eu-west-2b"
-          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicy",
-          ])
-        })
-        ebs_volumes = merge(local.ec2_instances.db.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 700 }
-          flash = { total_size = 50 }
-        })
-        instance = merge(local.ec2_instances.db.instance, {
-          disable_api_termination = true
-        })
-        tags = merge(local.ec2_instances.db.tags, {
-          description         = "for testing oracle19c upgrade"
-          instance-scheduling = "skip-scheduling"
-          nomis-environment   = "t1"
-          oracle-sids         = ""
-        })
-      })
-
-      t1-nomis-db-1-c = merge(local.ec2_instances.db, {
-        config = merge(local.ec2_instances.db.config, {
-          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
-          availability_zone = "eu-west-2c"
-          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
-            "Ec2T1DatabasePolicy",
-          ])
-        })
-        ebs_volumes = merge(local.ec2_instances.db.ebs_volumes, {
-          "/dev/sdb" = { label = "app", size = 100 }
-          "/dev/sdc" = { label = "app", size = 100 }
-        })
-        ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 700 }
-          flash = { total_size = 50 }
-        })
-        instance = merge(local.ec2_instances.db.instance, {
-          disable_api_termination = true
-        })
-        tags = merge(local.ec2_instances.db.tags, {
-          description         = "for testing oracle19c upgrade"
-          instance-scheduling = "skip-scheduling"
-          nomis-environment   = "t1"
-          oracle-sids         = ""
-        })
-      })
-
       t1-nomis-db-2-a = merge(local.ec2_instances.db, {
         cloudwatch_metric_alarms = merge(
           local.cloudwatch_metric_alarms.db,

--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -279,6 +279,33 @@ locals {
         })
       })
 
+      t1-nomis-db-1-c = merge(local.ec2_instances.db, {
+        config = merge(local.ec2_instances.db.config, {
+          ami_name          = "nomis_rhel_7_9_oracledb_11_2_release_2023-07-02T00-00-39.521Z"
+          availability_zone = "eu-west-2c"
+          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
+            "Ec2T1DatabasePolicy",
+          ])
+        })
+        ebs_volumes = merge(local.ec2_instances.db.ebs_volumes, {
+          "/dev/sdb" = { label = "app", size = 100 }
+          "/dev/sdc" = { label = "app", size = 100 }
+        })
+        ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
+          data  = { total_size = 700 }
+          flash = { total_size = 50 }
+        })
+        instance = merge(local.ec2_instances.db.instance, {
+          disable_api_termination = true
+        })
+        tags = merge(local.ec2_instances.db.tags, {
+          description         = "for testing oracle19c upgrade"
+          instance-scheduling = "skip-scheduling"
+          nomis-environment   = "t1"
+          oracle-sids         = ""
+        })
+      })
+
       t1-nomis-db-2-a = merge(local.ec2_instances.db, {
         cloudwatch_metric_alarms = merge(
           local.cloudwatch_metric_alarms.db,


### PR DESCRIPTION
Updated branch for qa11g-nomis-web12-b as this is now built from code.
Remove dev-nomis-web19 ASGs, no longer in use (Syscon - Vinny).
Remove t1-nomis-db-1-b, no longer in use (DBAs - Jason).

Already applied