### PR TITLE
Tm/tm 1257/build test instance in preprod

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -73,6 +73,7 @@ locals {
           description         = "Test instance from pp-cafm-a-11-a"
           instance-scheduling = "skip-scheduling"
         })
+        cloudwatch_metric_alarms = null
       })
 
       # database servers

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -57,7 +57,7 @@ locals {
       })
 
       # test instance, not for use
-      pp-test-a-21-a = merge(local.ec2_instances.app, {
+      pp-test-a-11-a = merge(local.ec2_instances.app, {
         config = merge(local.ec2_instances.app.config, {
           ami_name          = "pp-cafm-a-11-upgrade-test"
           availability_zone = "eu-west-2a"
@@ -70,7 +70,7 @@ locals {
           instance_type           = "t3.large"
         })
         tags = merge(local.ec2_instances.app.tags, {
-          description         = "Test instance"
+          description         = "Test instance from pp-cafm-a-11-a"
           instance-scheduling = "skip-scheduling"
         })
       })

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -56,8 +56,8 @@ locals {
         })
       })
 
-      # test instance, not for use
-      pp-test-a-11-a = merge(local.ec2_instances.app, {
+      # test instance, not for use 
+      pp-cafm-a-19-a = merge(local.ec2_instances.app, {
         config = merge(local.ec2_instances.app.config, {
           ami_name          = "pp-cafm-a-11-upgrade-test"
           availability_zone = "eu-west-2a"
@@ -70,7 +70,7 @@ locals {
           instance_type           = "t3.large"
         })
         tags = merge(local.ec2_instances.app.tags, {
-          description         = "Test instance from pp-cafm-a-11-a"
+          description         = "Test instance ami from pp-cafm-a-11-a"
           instance-scheduling = "skip-scheduling"
         })
         cloudwatch_metric_alarms = null

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -56,6 +56,25 @@ locals {
         })
       })
 
+      # test instance, not for use
+      pp-test-a-21-a = merge(local.ec2_instances.app, {
+        config = merge(local.ec2_instances.app.config, {
+          ami_name          = "pp-cafm-a-11-upgrade-test"
+          availability_zone = "eu-west-2a"
+        })
+        ebs_volumes = {
+          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
+        }
+        instance = merge(local.ec2_instances.app.instance, {
+          disable_api_termination = false
+          instance_type           = "t3.large"
+        })
+        tags = merge(local.ec2_instances.app.tags, {
+          description         = "Test instance"
+          instance-scheduling = "skip-scheduling"
+        })
+      })
+
       # database servers
       pp-cafm-db-a = merge(local.ec2_instances.db, {
         config = merge(local.ec2_instances.db.config, {


### PR DESCRIPTION
- build upgrade test instance pp-cafm-a-19-a in plantefm preproduction based on snapshot ami
- we can attach a Server 2019 installation drive to this as a volume and run the upgrade test entirely independently from the application and the rest of the setup 
- less risk