### PR TITLE
remove pp-cafm-a-19-a as it's not reachable

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -56,26 +56,6 @@ locals {
         })
       })
 
-      # test instance, not for use 
-      pp-cafm-a-19-a = merge(local.ec2_instances.app, {
-        config = merge(local.ec2_instances.app.config, {
-          ami_name          = "pp-cafm-a-11-upgrade-test"
-          availability_zone = "eu-west-2a"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-        }
-        instance = merge(local.ec2_instances.app.instance, {
-          disable_api_termination = false
-          instance_type           = "t3.large"
-        })
-        tags = merge(local.ec2_instances.app.tags, {
-          description         = "Test instance ami from pp-cafm-a-11-a"
-          instance-scheduling = "skip-scheduling"
-        })
-        cloudwatch_metric_alarms = null
-      })
-
       # database servers
       pp-cafm-db-a = merge(local.ec2_instances.db, {
         config = merge(local.ec2_instances.db.config, {


### PR DESCRIPTION
- instance has become un-reachable via SSO or domain credentials
- remove this and re-do based on an instance ami that has been REMOVED from the domain first