### PR TITLE
Fix issue with Grafana role not allowed to do kms

### DIFF
--- a/terraform/environments/coat/observability_platform.tf
+++ b/terraform/environments/coat/observability_platform.tf
@@ -45,6 +45,16 @@ data "aws_iam_policy_document" "grafana_athena_full_access_policy" {
   }
 
   statement {
+    Effect = "Allow"
+
+    Action = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    Resource = module.cur_s3_kms.key_arn
+  }
+
+  statement {
     effect = "Allow"
 
     actions = [

--- a/terraform/environments/coat/observability_platform.tf
+++ b/terraform/environments/coat/observability_platform.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "grafana_athena_full_access_policy" {
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    Resource = module.cur_s3_kms.key_arn
+    resources = ["*"]
   }
 
   statement {

--- a/terraform/environments/coat/observability_platform.tf
+++ b/terraform/environments/coat/observability_platform.tf
@@ -45,9 +45,9 @@ data "aws_iam_policy_document" "grafana_athena_full_access_policy" {
   }
 
   statement {
-    Effect = "Allow"
+    effect = "Allow"
 
-    Action = [
+    actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]


### PR DESCRIPTION
The datasource is set up correctly for the dashboard but querying the data is unsuccessful

` Message: com.amazonaws.services.s3.model.AmazonS3Exception: User: arn:aws:sts::xxxx:assumed-role/observability-platform/xxxx is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:eu-west-2:xxx:key/x because no identity-based policy allows the kms:Decrypt action `

This PR tries to fix it