### PR TITLE
doubled volume size to help with Centurion extraction

### DIFF
--- a/terraform/environments/electronic-monitoring-data/bastion_linux.tf
+++ b/terraform/environments/electronic-monitoring-data/bastion_linux.tf
@@ -191,7 +191,7 @@ module "zip_bastion" {
   subnet_set    = local.subnet_set
   environment   = local.environment
   region        = "eu-west-2"
-  volume_size   = 250
+  volume_size   = 500
   # tags
   tags_common = local.tags
   tags_prefix = terraform.workspace


### PR DESCRIPTION
Attempts to extract the Centurion data using an EC2 instance with the 7zz linux package have failed because there just isn't enough memory. Want to pursue a higher memory option for this task.

Error documented on ticket: https://dsdmoj.atlassian.net/browse/ELM-3502
