### PR TITLE
MAAT Sec Groups - Prevent Prod env being blocked.

### DIFF
--- a/terraform/environments/maatdb/application_variables.json
+++ b/terraform/environments/maatdb/application_variables.json
@@ -59,11 +59,11 @@
       "license_model": "license-included",
       "performance_insights_enabled": true,
       "performance_insights_retention_period": 31,
-      "snapshot_arn": "la1jkamurh6jd9a-shutdown",
+      "snapshot_arn": "maatdb-22may20250936-finalsnapshot",
       "deletion_protection": false,
       "cloud_platform_cidr": "172.20.0.0/16",
       "manual_added_cidr": "10.221.0.0/16",
-      "ecs_cluster_sec_group_id": "sg-056a1a203c91700ea",
+      "ecs_cluster_sec_group_id": "",
       "mlra_ecs_cluster_sec_group_id": "sg-0faa8fe022ea7e3aa"
     }
   }

--- a/terraform/environments/maatdb/modules/rds/rds.tf
+++ b/terraform/environments/maatdb/modules/rds/rds.tf
@@ -136,7 +136,7 @@ resource "aws_db_instance" "appdb1" {
   multi_az                              = var.multi_az
   username                              = var.username
   password                              = random_password.rds_password.result
-  vpc_security_group_ids                = [aws_security_group.cloud_platform_sec_group.id, aws_security_group.bastion_sec_group.id, aws_security_group.vpc_sec_group.id, aws_security_group.mlra_ecs_sec_group.id]
+  vpc_security_group_ids                = var.environment == "development" ? [aws_security_group.cloud_platform_sec_group.id, aws_security_group.bastion_sec_group.id, aws_security_group.vpc_sec_group[0].id, aws_security_group.mlra_ecs_sec_group.id] : [aws_security_group.cloud_platform_sec_group.id, aws_security_group.bastion_sec_group.id, aws_security_group.mlra_ecs_sec_group.id]
   skip_final_snapshot                   = false
   final_snapshot_identifier             = "${var.application_name}-${formatdate("DDMMMYYYYhhmm", timestamp())}-finalsnapshot"
   parameter_group_name                  = aws_db_parameter_group.parameter_group_19.name
@@ -192,6 +192,7 @@ resource "aws_security_group" "cloud_platform_sec_group" {
 
 # Access fromm MAAT Application
 resource "aws_security_group" "vpc_sec_group" {
+  count = var.environment == "development" ? 1:0
   name        = "ecs-sec-group"
   description = "RDS Access with the shared vpc"
   vpc_id      = var.vpc_shared_id


### PR DESCRIPTION
Interim change to ensure all can be built and ready for when the maat production sec groups are known.