### PR TITLE
first draft of new security group layout

### DIFF
--- a/terraform/environments/electronic-monitoring-data/dms_security_groups.tf
+++ b/terraform/environments/electronic-monitoring-data/dms_security_groups.tf
@@ -65,8 +65,8 @@ resource "aws_security_group_rule" "dms_to_s3_egress" {
   type              = "egress"
   cidr_blocks       = data.aws_ip_ranges.london_s3.cidr_blocks
   protocol          = "tcp"
-  from_port         = each.value
-  to_port           = each.value
+  from_port         = 433
+  to_port           = 433
   description       = "Allow DMS to communicate with S3 over HTTPS"
 }
 


### PR DESCRIPTION
![Screenshot 2025-05-28 at 17 12 40](https://github.com/user-attachments/assets/6991435f-ff23-4d07-9048-c3a24210c92b)
IF I understand the ask correctly, this is the terraform configuration visualised which includes
- paired ingress and egress traffic between rds and glue on ports 433 and 1433
- self-referencing rule within RDS to allow egress traffic from RDS to itself (does this need limiting - not 100% on why this is needed)
- and egress rule from dms to s3 on the S3 cidr ports