### PR TITLE
Fixes to RDS - Glue ingress/egress

### DIFF
--- a/terraform/environments/electronic-monitoring-data/server_backups.tf
+++ b/terraform/environments/electronic-monitoring-data/server_backups.tf
@@ -129,24 +129,14 @@ resource "aws_vpc_security_group_ingress_rule" "db_ipv4_lb" {
   cidr_ipv4 = "209.35.83.77/32"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "db_glue_access" {
+resource "aws_vpc_security_group_egress_rule" "db_outbound" {
 
   security_group_id            = aws_security_group.db.id
-  description                  = "glue"
-  ip_protocol                  = "tcp"
-  from_port                    = 1433
-  to_port                      = 1433
   referenced_security_group_id = aws_security_group.db.id
-}
-
-resource "aws_vpc_security_group_egress_rule" "db_glue_access" {
-
-  security_group_id            = aws_security_group.db.id
-  description                  = "glue"
   ip_protocol                  = "tcp"
   from_port                    = 0
   to_port                      = 65535
-  referenced_security_group_id = aws_security_group.db.id
+  description                  = "RDS Database -----[All ports]-----+ RDS Database"
 }
 
 resource "aws_db_subnet_group" "db" {


### PR DESCRIPTION
initial draft of fix for ingress and egress rules, only minor reformatting.

- Glue only needs an ingress self-referencing rule. 
- RDS only needs an egress self-referencing rule.
- There needs to be an ingress rule defined on the DB security group to allow traffic FROM Glue
- There needs to be an egress rule defined on the Glue security group to allow traffic TO the DB