### PR TITLE
Add new S3 bucket for storing XDR agent installer

### DIFF
--- a/terraform/environments/maat/artifacts.tf
+++ b/terraform/environments/maat/artifacts.tf
@@ -1,5 +1,5 @@
 module "artifacts-s3" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
 
   providers = {
     aws.bucket-replication = aws

--- a/terraform/environments/maat/athena.tf
+++ b/terraform/environments/maat/athena.tf
@@ -5,7 +5,7 @@ locals {
 
 ### Setup S3 Bucket for Athena Queries ###
 module "s3-bucket-athena-queries-output" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
 
   bucket_prefix      = "athena-query-s3-bucket"
   versioning_enabled = false

--- a/terraform/environments/maat/locals.tf
+++ b/terraform/environments/maat/locals.tf
@@ -35,7 +35,5 @@ locals {
   lbs_domain_type_main   = [for k, v in local.lbs_domain_types : v.type if k == local.cloudfront_domain]
   lbs_domain_type_sub    = [for k, v in local.lbs_domain_types : v.type if k != "modernisation-platform.service.justice.gov.uk"]
 
-
-
-
+  xdr_tags = join(", ", upper(local.application_name), upper(local.environment), upper(var.networking[0].business-unit))
 }

--- a/terraform/environments/maat/locals.tf
+++ b/terraform/environments/maat/locals.tf
@@ -35,5 +35,5 @@ locals {
   lbs_domain_type_main   = [for k, v in local.lbs_domain_types : v.type if k == local.cloudfront_domain]
   lbs_domain_type_sub    = [for k, v in local.lbs_domain_types : v.type if k != "modernisation-platform.service.justice.gov.uk"]
 
-  xdr_tags = join(", ", upper(local.application_name), upper(local.environment), upper(var.networking[0].business-unit))
+  xdr_tags = join(", ", [upper(local.application_name), upper(local.environment), upper(var.networking[0].business-unit)])
 }

--- a/terraform/environments/maat/maat-cw.tf
+++ b/terraform/environments/maat/maat-cw.tf
@@ -465,7 +465,7 @@ module "maat_pagerduty_core_alerts" {
   depends_on = [
     aws_sns_topic.maat_alerting_topic
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=v2.0.0"
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4"
   sns_topics                = [aws_sns_topic.maat_alerting_topic.name]
   pagerduty_integration_key = local.maat_pagerduty_integration_keys[local.maat_pagerduty_integration_key_name]
 }

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -43,7 +43,7 @@ if [[ -f ${xdr_tar} ]]; then
   fi
 
   sudo yum install -y ${xdr_dir}/*.rpm
-  sudo /opt/traps/bin/cytool endpoint_tags add ${xdr_tags}
+  sudo /opt/traps/bin/cytool endpoint_tags add "${xdr_tags}"
 
 else
   echo "XDR agent download failed" >&2

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -28,24 +28,21 @@ sudo systemctl start awslogsd
 sudo systemctl enable awslogsd.service
 
 # Install XDR agent stored in S3 bucket
-XDR_DIR="/tmp/cortex-agent"
-XDR_TAR="/tmp/cortex-agent.tar.gz"
+aws s3 cp "s3://${XDR_BUCKET}/cortex-agent.tar.gz" ${XDR_TAR}
 
-aws s3 cp "s3://${xdr_bucket}/cortex-agent.tar.gz" \${XDR_TAR}
+if [[ -f ${XDR_TAR} ]]; then
+  mkdir -p ${XDR_DIR}
+  tar -xzf ${XDR_TAR} -C ${XDR_DIR}
 
-if [[ -f \${XDR_TAR} ]]; then
-  mkdir -p \${XDR_DIR}
-  tar -xzf \${XDR_TAR} -C \${XDR_DIR}
-
-  if [[ -f \${XDR_DIR}/cortex.conf ]]; then
+  if [[ -f ${XDR_DIR}/cortex.conf ]]; then
     sudo mkdir -p /etc/panw
-    sudo cp \${XDR_DIR}/cortex.conf /etc/panw/
+    sudo cp ${XDR_DIR}/cortex.conf /etc/panw/
   else
     echo "Missing cortex.conf in extracted archive" >&2
     exit 1
   fi
 
-  sudo yum install -y \${XDR_DIR}/*.rpm
+  sudo yum install -y ${XDR_DIR}/*.rpm
 else
   echo "XDR agent download failed" >&2
   exit 1

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -26,3 +26,13 @@ chmod 644 /etc/awslogs/awslogs.conf
 sed -i 's/^region = .*/region = eu-west-2/g' /etc/awslogs/awscli.conf
 chkconfig awslogs on
 service awslogs restart
+
+# Install XDC agent stored in S3 bucket
+aws s3 cp s3://${xdr_bucket}/cortex.rpm /tmp/cortex.rpm
+
+if [[ -f /tmp/cortex.rpm ]]; then
+    yum install -y /tmp/cortex.rpm
+else
+    echo "XDR agent download failed" >&2
+    exit 1
+fi

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -31,21 +31,21 @@ sudo systemctl enable awslogsd.service
 XDR_DIR="/tmp/cortex-agent"
 XDR_TAR="/tmp/cortex-agent.tar.gz"
 
-aws s3 cp "s3://${xdr_bucket}/cortex-agent.tar.gz" "${XDR_TAR}"
+aws s3 cp "s3://${xdr_bucket}/cortex-agent.tar.gz" \${XDR_TAR}
 
-if [[ -f "${XDR_TAR}" ]]; then
-  mkdir -p "${XDR_DIR}"
-  tar -xzf "${XDR_TAR}" -C "${XDR_DIR}"
+if [[ -f \${XDR_TAR} ]]; then
+  mkdir -p \${XDR_DIR}
+  tar -xzf \${XDR_TAR} -C \${XDR_DIR}
 
-  if [[ -f "${XDR_DIR}/cortex.conf" ]]; then
+  if [[ -f \${XDR_DIR}/cortex.conf ]]; then
     sudo mkdir -p /etc/panw
-    sudo cp "${XDR_DIR}/cortex.conf" /etc/panw/
+    sudo cp \${XDR_DIR}/cortex.conf /etc/panw/
   else
     echo "Missing cortex.conf in extracted archive" >&2
     exit 1
   fi
 
-  sudo yum install -y "${XDR_DIR}"/*.rpm
+  sudo yum install -y \${XDR_DIR}/*.rpm
 else
   echo "XDR agent download failed" >&2
   exit 1

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -43,6 +43,8 @@ if [[ -f ${xdr_tar} ]]; then
   fi
 
   sudo yum install -y ${xdr_dir}/*.rpm
+  sudo /opt/traps/bin/cytool endpoint_tags add ${xdr_tags}
+
 else
   echo "XDR agent download failed" >&2
   exit 1

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -24,8 +24,8 @@ EOF
 chmod 644 /etc/awslogs/awslogs.conf
 # Change region
 sed -i 's/^region = .*/region = eu-west-2/g' /etc/awslogs/awscli.conf
-chkconfig awslogs on
-service awslogs restart
+sudo systemctl start awslogsd
+sudo systemctl enable awslogsd.service
 
 # Install XDC agent stored in S3 bucket
 aws s3 cp s3://${xdr_bucket}/cortex.rpm /tmp/cortex.rpm

--- a/terraform/environments/maat/maat-ec2-user-data.sh
+++ b/terraform/environments/maat/maat-ec2-user-data.sh
@@ -28,21 +28,21 @@ sudo systemctl start awslogsd
 sudo systemctl enable awslogsd.service
 
 # Install XDR agent stored in S3 bucket
-aws s3 cp "s3://${XDR_BUCKET}/cortex-agent.tar.gz" ${XDR_TAR}
+aws s3 cp "s3://${xdr_bucket}/cortex-agent.tar.gz" ${xdr_tar}
 
-if [[ -f ${XDR_TAR} ]]; then
-  mkdir -p ${XDR_DIR}
-  tar -xzf ${XDR_TAR} -C ${XDR_DIR}
+if [[ -f ${xdr_tar} ]]; then
+  mkdir -p ${xdr_dir}
+  tar -xzf ${xdr_tar} -C ${xdr_dir}
 
-  if [[ -f ${XDR_DIR}/cortex.conf ]]; then
+  if [[ -f ${xdr_dir}/cortex.conf ]]; then
     sudo mkdir -p /etc/panw
-    sudo cp ${XDR_DIR}/cortex.conf /etc/panw/
+    sudo cp ${xdr_dir}/cortex.conf /etc/panw/
   else
     echo "Missing cortex.conf in extracted archive" >&2
     exit 1
   fi
 
-  sudo yum install -y ${XDR_DIR}/*.rpm
+  sudo yum install -y ${xdr_dir}/*.rpm
 else
   echo "XDR agent download failed" >&2
   exit 1

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -155,8 +155,9 @@ resource "aws_launch_template" "maat_ec2_launch_template" {
     maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group,
     app_ecs_cluster    = aws_ecs_cluster.maat_ecs_cluster.name,
     xdr_bucket         = module.xdr-agent-s3.bucket.id,
-    xdr_dir            ="/tmp/cortex-agent",
-    xdr_tar            ="/tmp/cortex-agent.tar.gz"
+    xdr_dir            = "/tmp/cortex-agent",
+    xdr_tar            = "/tmp/cortex-agent.tar.gz",
+    xdr_tags           = local.xdr_tags
   }))
 
   tag_specifications {

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -256,18 +256,18 @@ resource "aws_security_group_rule" "maat_sg_rule_outbound" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks = ["0.0.0.0/0"]
   description       = "This rule is needed for the ECS agent to reach the ECS API endpoints"
   security_group_id = aws_security_group.maat_ecs_security_group.id
 }
 
 resource "aws_security_group_rule" "maat_to_maatdb_sg_rule_outbound" {
-  type              = "egress"
-  from_port         = 1521
-  to_port           = 1521
-  protocol          = "tcp"
-  description       = "This rule is needed for the ECS agent to reach the ECS API endpoints"
-  security_group_id = aws_security_group.maat_ecs_security_group.id
+  type                     = "egress"
+  from_port                = 1521
+  to_port                  = 1521
+  protocol                 = "tcp"
+  description              = "This rule is needed for the ECS agent to reach the ECS API endpoints"
+  security_group_id        = aws_security_group.maat_ecs_security_group.id
   source_security_group_id = local.application_data.accounts[local.environment].maatdb_rds_sec_group_id
 }
 
@@ -338,7 +338,7 @@ resource "aws_cloudwatch_metric_alarm" "maat_ec2_high_cpu_alarm" {
   threshold           = local.application_data.accounts[local.environment].maat_ec2_cpu_scaling_up_threshold
   unit                = "Percent"
   comparison_operator = "GreaterThanThreshold"
-  alarm_actions       = [aws_autoscaling_policy.maat_ec2_scaling_up_policy.arn]
+  alarm_actions = [aws_autoscaling_policy.maat_ec2_scaling_up_policy.arn]
 
   dimensions = {
     ClusterName = aws_ecs_cluster.maat_ecs_cluster.name
@@ -357,7 +357,7 @@ resource "aws_cloudwatch_metric_alarm" "maat_ec2_low_cpu_alarm" {
   threshold           = local.application_data.accounts[local.environment].maat_ec2_cpu_scaling_down_threshold
   unit                = "Percent"
   comparison_operator = "LessThanThreshold"
-  alarm_actions       = [aws_autoscaling_policy.maat_ec2_scaling_down_policy.arn]
+  alarm_actions = [aws_autoscaling_policy.maat_ec2_scaling_down_policy.arn]
 
   dimensions = {
     ClusterName = aws_ecs_cluster.maat_ecs_cluster.name
@@ -525,32 +525,32 @@ resource "aws_iam_role_policy_attachment" "maat_ecs_tasks_role_policy_attachment
 #### ECS TASK DEFINITION -------
 
 resource "aws_ecs_task_definition" "maat_ecs_task_definition" {
-  family             = "${local.application_name}-ecs-task-definition"
+  family = "${local.application_name}-ecs-task-definition"
   execution_role_arn = aws_iam_role.maat_ec2_instance_role.arn
   # task_role_arn            = aws_iam_role.maat_ec2_instance_role.arn
 
   container_definitions = templatefile("maat-task-definition.json",
     {
-      maat_docker_image_tag      = local.application_data.accounts[local.environment].maat_docker_image_tag
-      xray_docker_image_tag      = local.application_data.accounts[local.environment].xray_docker_image_tag
-      region                     = local.application_data.accounts[local.environment].region
-      sentry_env                 = local.environment
-      maat_orch_base_url         = local.application_data.accounts[local.environment].maat_orch_base_url
-      maat_orch_oauth_url        = local.application_data.accounts[local.environment].maat_orch_oauth_url
-      maat_db_url                = local.application_data.accounts[local.environment].maat_db_url
-      maat_caa_oauth_url         = local.application_data.accounts[local.environment].maat_caa_oauth_url
-      maat_bc_endpoint_url       = local.application_data.accounts[local.environment].maat_bc_endpoint_url
-      maat_mlra_url              = local.application_data.accounts[local.environment].maat_mlra_url
-      maat_caa_base_url          = local.application_data.accounts[local.environment].maat_caa_base_url
-      ecr_url                    = "${local.environment_management.account_ids["core-shared-services-production"]}.dkr.ecr.eu-west-2.amazonaws.com/maat-ecr-repo"
-      maat_ecs_log_group         = local.application_data.accounts[local.environment].maat_ecs_log_group
-      maat_aws_stream_prefix     = local.application_data.accounts[local.environment].maat_aws_stream_prefix
-      env_account_region         = local.env_account_region
-      env_account_id             = local.env_account_id
-      app_log_level              = local.application_data.accounts[local.environment].app_log_level
-      maat_ats_oauth_url         = local.application_data.accounts[local.environment].maat_ats_oauth_url
-      maat_ats_endpoint          = local.application_data.accounts[local.environment].maat_ats_endpoint
-      maat_ats_base_url          = local.application_data.accounts[local.environment].maat_ats_base_url
+      maat_docker_image_tag  = local.application_data.accounts[local.environment].maat_docker_image_tag
+      xray_docker_image_tag  = local.application_data.accounts[local.environment].xray_docker_image_tag
+      region                 = local.application_data.accounts[local.environment].region
+      sentry_env             = local.environment
+      maat_orch_base_url     = local.application_data.accounts[local.environment].maat_orch_base_url
+      maat_orch_oauth_url    = local.application_data.accounts[local.environment].maat_orch_oauth_url
+      maat_db_url            = local.application_data.accounts[local.environment].maat_db_url
+      maat_caa_oauth_url     = local.application_data.accounts[local.environment].maat_caa_oauth_url
+      maat_bc_endpoint_url   = local.application_data.accounts[local.environment].maat_bc_endpoint_url
+      maat_mlra_url          = local.application_data.accounts[local.environment].maat_mlra_url
+      maat_caa_base_url      = local.application_data.accounts[local.environment].maat_caa_base_url
+      ecr_url                = "${local.environment_management.account_ids["core-shared-services-production"]}.dkr.ecr.eu-west-2.amazonaws.com/maat-ecr-repo"
+      maat_ecs_log_group     = local.application_data.accounts[local.environment].maat_ecs_log_group
+      maat_aws_stream_prefix = local.application_data.accounts[local.environment].maat_aws_stream_prefix
+      env_account_region     = local.env_account_region
+      env_account_id         = local.env_account_id
+      app_log_level          = local.application_data.accounts[local.environment].app_log_level
+      maat_ats_oauth_url     = local.application_data.accounts[local.environment].maat_ats_oauth_url
+      maat_ats_endpoint      = local.application_data.accounts[local.environment].maat_ats_endpoint
+      maat_ats_base_url      = local.application_data.accounts[local.environment].maat_ats_base_url
 
     }
   )
@@ -670,9 +670,9 @@ resource "aws_cloudwatch_log_group" "maat_ecs_cloudwatch_log_group" {
 #### ECS Service ------
 
 resource "aws_ecs_service" "maat_ecs_service" {
-  name            = "${local.application_name}-ecs-service"
-  cluster         = aws_ecs_cluster.maat_ecs_cluster.id
-  desired_count   = local.application_data.accounts[local.environment].maat_ecs_service_desired_count
+  name          = "${local.application_name}-ecs-service"
+  cluster       = aws_ecs_cluster.maat_ecs_cluster.id
+  desired_count = local.application_data.accounts[local.environment].maat_ecs_service_desired_count
   task_definition = aws_ecs_task_definition.maat_ecs_task_definition.arn
   # iam_role                          = aws_iam_role.maat_ecs_service_role.arn
   depends_on = [aws_lb_listener.external, aws_lb_listener.maat_internal_lb_https_listener]
@@ -683,13 +683,13 @@ resource "aws_ecs_service" "maat_ecs_service" {
   }
 
   load_balancer {
-    container_name   = upper(local.application_name)
+    container_name = upper(local.application_name)
     container_port   = 8080
     target_group_arn = aws_lb_target_group.external.arn
   }
 
   load_balancer {
-    container_name   = upper(local.application_name)
+    container_name = upper(local.application_name)
     container_port   = 8080
     target_group_arn = aws_lb_target_group.maat_internal_lb_target_group.arn
   }
@@ -721,7 +721,7 @@ resource "aws_cloudwatch_metric_alarm" "maat_ecs_high_cpu_alarm" {
   threshold           = 70
   unit                = "Percent"
   comparison_operator = "GreaterThanThreshold"
-  alarm_actions       = [aws_appautoscaling_policy.maat_ecs_scaling_up_policy.arn]
+  alarm_actions = [aws_appautoscaling_policy.maat_ecs_scaling_up_policy.arn]
 
   dimensions = {
     ClusterName = aws_ecs_cluster.maat_ecs_cluster.name
@@ -741,7 +741,7 @@ resource "aws_cloudwatch_metric_alarm" "maat_ecs_low_cpu_alarm" {
   threshold           = 20
   unit                = "Percent"
   comparison_operator = "LessThanThreshold"
-  alarm_actions       = [aws_appautoscaling_policy.maat_ecs_scaling_down_policy.arn]
+  alarm_actions = [aws_appautoscaling_policy.maat_ecs_scaling_down_policy.arn]
 
   dimensions = {
     ClusterName = aws_ecs_cluster.maat_ecs_cluster.name

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -72,8 +72,8 @@ resource "aws_iam_policy" "maat_ec2_instance_role_policy" {
           "s3:GetObject"
         ],
         Resource = [
-          "arn:aws:s3:::${module.xdr-agent-s3.bucket_name}",
-          "arn:aws:s3:::${module.xdr-agent-s3.bucket_name}/*"
+          "arn:aws:s3:::${module.xdr-agent-s3.bucket.id}",
+          "arn:aws:s3:::${module.xdr-agent-s3.bucket.id}/*"
         ]
       }
     ]

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -154,7 +154,9 @@ resource "aws_launch_template" "maat_ec2_launch_template" {
   user_data = base64encode(templatefile("maat-ec2-user-data.sh", {
     maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group,
     app_ecs_cluster    = aws_ecs_cluster.maat_ecs_cluster.name,
-    xdr_bucket         = module.xdr-agent-s3.bucket.id
+    xdr_bucket         = module.xdr-agent-s3.bucket.id,
+    xdr_dir            ="/tmp/cortex-agent",
+    xdr_tar            ="/tmp/cortex-agent.tar.gz"
   }))
 
   tag_specifications {

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -66,6 +66,16 @@ resource "aws_iam_policy" "maat_ec2_instance_role_policy" {
         ]
         Resource = "*"
       },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject"
+        ],
+        Resource = [
+          "arn:aws:s3:::${module.xdr-agent-s3.bucket_name}",
+          "arn:aws:s3:::${module.xdr-agent-s3.bucket_name}/*"
+        ]
+      }
     ]
   })
 }

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -152,7 +152,10 @@ resource "aws_launch_template" "maat_ec2_launch_template" {
   }
 
   user_data = base64encode(templatefile("maat-ec2-user-data.sh", {
-  maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group, app_ecs_cluster = aws_ecs_cluster.maat_ecs_cluster.name }))
+    maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group,
+    app_ecs_cluster    = aws_ecs_cluster.maat_ecs_cluster.name,
+    xdr_bucket         = module.xdr-agent-s3.bucket.id
+  }))
 
   tag_specifications {
     resource_type = "instance"

--- a/terraform/environments/maat/maat-ext-lb.tf
+++ b/terraform/environments/maat/maat-ext-lb.tf
@@ -13,7 +13,7 @@ locals {
 
 module "lb-s3-access-logs" {
   count  = local.existing_bucket_name == "" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
 
   providers = {
     aws.bucket-replication = aws

--- a/terraform/environments/maat/s3_xdr_agent_bucket.tf
+++ b/terraform/environments/maat/s3_xdr_agent_bucket.tf
@@ -22,11 +22,11 @@ module "xdr-agent-s3" {
       }
 
       expiration = {
-        days = 90
+        days = 120
       }
 
       noncurrent_version_expiration = {
-        days = 90
+        days = 120
       }
     }
   ]

--- a/terraform/environments/maat/s3_xdr_agent_bucket.tf
+++ b/terraform/environments/maat/s3_xdr_agent_bucket.tf
@@ -1,5 +1,5 @@
 module "xdr-agent-s3" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
 
   providers = {
     aws.bucket-replication = aws

--- a/terraform/environments/maat/s3_xdr_agent_bucket.tf
+++ b/terraform/environments/maat/s3_xdr_agent_bucket.tf
@@ -1,0 +1,35 @@
+module "xdr-agent-s3" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1"
+
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  bucket_prefix       = "${local.application_name}-xdr-agent"
+  replication_enabled = false
+  versioning_enabled  = false
+  force_destroy       = false
+
+  lifecycle_rule = [
+    {
+      id      = "xdr-agent-cleanup"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "xdr"
+        autoclean = "true"
+      }
+
+      expiration = {
+        days = 90
+      }
+
+      noncurrent_version_expiration = {
+        days = 90
+      }
+    }
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
This PR introduces functionality to securely install and configure the Cortex XDR agent on EC2 instances used in our ECS cluster. Key changes include:

📦 XDR Agent S3 Bucket
Created an S3 bucket (via the Modernisation Platform Terraform S3 module) to store the Cortex XDR agent installation files.

- Bucket name is dynamically generated from the application name.
- Versioning is disabled and `force_destroy` is off to avoid accidental deletion.
- A lifecycle rule deletes files after 90 days.
- Shared tags are applied for consistency.

🔐 EC2 IAM Policy
- Granted `s3:GetObject` permission to the EC2 instance role.


⚙️ User Data Script
Updated the EC2 launch template user data to:

- Download the Cortex XDR agent archive from S3.
- Extract and install the RPMs.
- Copy the required `cortex.conf` (containing the distribution ID) to `/etc/panw`.
- Used `systemctl` to correctly start the `awslogs` service (previous attempts using `chkconfig` failed on Amazon Linux 2).