### PR TITLE
DPR2-1925: Add job to create the CDC DMS task

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-jobs/variables.tf
@@ -671,7 +671,6 @@ variable "glue_create_reload_diff_job_spark_event_logs" {
   description = "(Optional) Specifies an Amazon S3 path to a bucket that can be used as a Spark Event Logs directory for the job."
 }
 
-
 variable "s3_kms_arn" {
   type        = string
   default     = ""

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -26,7 +26,7 @@ locals {
           "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
         }
       },
-      "Next" : local.stop_dms_replication_task.StepName
+      "Next" : var.split_pipeline ? local.stop_dms_cdc_replication_task.StepName : local.stop_dms_replication_task.StepName
     }
   }
 
@@ -42,6 +42,21 @@ locals {
         }
       },
       "Next" : var.batch_only ? local.update_hive_tables.StepName : local.stop_glue_streaming_job.StepName
+    }
+  }
+
+  stop_dms_cdc_replication_task = {
+    "StepName" : "Stop DMS CDC Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.stop_dms_task_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.cdc_replication_task_id
+        }
+      },
+      "Next" : local.stop_glue_streaming_job.StepName
     }
   }
 
@@ -147,6 +162,22 @@ locals {
     }
   }
 
+  set_dms_cdc_replication_task_start_time = {
+    "StepName" : "Set DMS CDC Replication Task Start Time",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.set_cdc_dms_start_time_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.replication_task_id,
+          "--dpr.cdc.dms.replication.task.id" : var.cdc_replication_task_id
+        }
+      },
+      "Next" : local.run_glue_batch_job.StepName
+    }
+  }
+
   start_dms_replication_task = {
     "StepName" : "Start DMS Replication Task",
     "StepDefinition" : {
@@ -169,6 +200,7 @@ locals {
       "Parameters" : {
         "Payload" : {
           "token.$" : "$$.Task.Token",
+          "ignoreDmsTaskFailure" : var.pipeline_notification_lambda_function_ignore_dms_failure,
           "replicationTaskArn" : var.dms_replication_task_arn
         },
         "FunctionName" : var.pipeline_notification_lambda_function
@@ -186,7 +218,7 @@ locals {
           "BackoffRate" : 2
         }
       ],
-      "Next" : local.run_glue_batch_job.StepName
+      "Next" : var.split_pipeline ? local.set_dms_cdc_replication_task_start_time.StepName : local.run_glue_batch_job.StepName
     }
   }
 
@@ -301,7 +333,20 @@ locals {
         "NumberOfWorkers" : var.retention_curated_num_workers,
         "WorkerType" : var.retention_curated_worker_type
       },
-      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName
+      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : (var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.resume_dms_replication_task.StepName)
+    }
+  }
+
+  start_dms_cdc_replication_task = {
+    "StepName" : "Start DMS CDC Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_cdc_replication_task_arn,
+        "StartReplicationTaskType" : "start-replication"
+      },
+      "Next" : local.start_glue_streaming_job.StepName
     }
   }
 
@@ -436,7 +481,37 @@ module "data_ingestion_pipeline" {
         (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
       }
     }
-    ) : jsonencode(
+    ) : var.split_pipeline ? jsonencode(
+    {
+      "Comment" : "Data Ingestion Pipeline Step Function (With Separated Full-Load and CDC Tasks)",
+      "StartAt" : local.deactivate_archive_trigger.StepName,
+      "States" : {
+        (local.deactivate_archive_trigger.StepName) : local.deactivate_archive_trigger.StepDefinition,
+        (local.stop_archive_job.StepName) : local.stop_archive_job.StepDefinition,
+        (local.stop_dms_cdc_replication_task.StepName) : local.stop_dms_cdc_replication_task.StepDefinition,
+        (local.stop_glue_streaming_job.StepName) : local.stop_glue_streaming_job.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_archive_structured_and_curated_data.StepName) : local.empty_raw_archive_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.set_dms_cdc_replication_task_start_time.StepName) : local.set_dms_cdc_replication_task_start_time.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.archive_raw_data.StepName) : local.archive_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.start_dms_cdc_replication_task.StepName) : local.start_dms_cdc_replication_task.StepDefinition,
+        (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.reactivate_archive_trigger.StepName) : local.reactivate_archive_trigger.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition,
+      }
+    }
+  ) : jsonencode(
     {
       "Comment" : "Data Ingestion Pipeline Step Function",
       "StartAt" : local.deactivate_archive_trigger.StepName,

--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/variables.tf
@@ -11,6 +11,17 @@ variable "batch_only" {
   default     = false
 }
 
+variable "split_pipeline" {
+  description = "Determines if the pipeline is split into a Full-Load and a separate CDC tasks, True or False?"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.batch_only ? var.split_pipeline == false : true
+    error_message = "split_pipeline can only be 'true' when batch_only = false"
+  }
+}
+
 variable "data_ingestion_pipeline" {
   description = "Name for Data Ingestion Pipeline"
   type        = string
@@ -37,14 +48,50 @@ variable "dms_replication_task_arn" {
   type        = string
 }
 
+variable "dms_cdc_replication_task_arn" {
+  description = "ARN of the CDC replication task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.dms_cdc_replication_task_arn != null : var.dms_cdc_replication_task_arn == null
+    error_message = "dms_cdc_replication_task_arn is only allowed when split_pipeline = true"
+  }
+}
+
 variable "replication_task_id" {
   description = "ID of the replication task"
   type        = string
 }
 
+variable "cdc_replication_task_id" {
+  description = "ID of the CDC replication task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.cdc_replication_task_id != null : var.cdc_replication_task_id == null
+    error_message = "cdc_replication_task_id is only allowed when split_pipeline = true"
+  }
+}
+
 variable "pipeline_notification_lambda_function" {
   description = "Pipeline Notification Lambda Name"
   type        = string
+}
+
+variable "pipeline_notification_lambda_function_ignore_dms_failure" {
+  description = "Pipeline notification lambda function ignores DMS task failures"
+  type        = bool
+  default     = false
+}
+
+variable "set_cdc_dms_start_time_job" {
+  description = "Name of the Glue job which sets the start time of the CDC DMS task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.set_cdc_dms_start_time_job != null : var.set_cdc_dms_start_time_job == null
+    error_message = "set_cdc_dms_start_time_job is only allowed when split_pipeline = true"
+  }
 }
 
 variable "glue_reporting_hub_batch_jobname" {

--- a/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
@@ -43,7 +43,7 @@ module "step_function_notification_lambda_trigger" {
       "source" : ["aws.dms"],
       "detail-type" : ["DMS Replication Task State Change"],
       "detail" : {
-        "eventId" : ["DMS-EVENT-0079"] # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html
+        "eventId" : ["DMS-EVENT-0079", "DMS-EVENT-0078"] # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html
       }
     }
   )

--- a/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.10"
+}

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -26,7 +26,22 @@ locals {
           "--dpr.stop.glue.instance.job.name" : var.glue_archive_job
         }
       },
-      "Next" : local.stop_dms_replication_task.StepName
+      "Next" : var.split_pipeline ? local.stop_dms_cdc_replication_task.StepName : local.stop_dms_replication_task.StepName
+    }
+  }
+
+  stop_dms_cdc_replication_task = {
+    "StepName" : "Stop DMS CDC Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.stop_dms_task_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.cdc_replication_task_id
+        }
+      },
+      "Next" : local.check_all_pending_files_have_been_processed.StepName
     }
   }
 
@@ -207,6 +222,7 @@ locals {
       "Parameters" : {
         "Payload" : {
           "token.$" : "$$.Task.Token",
+          "ignoreDmsTaskFailure" : var.pipeline_notification_lambda_function_ignore_dms_failure,
           "replicationTaskArn" : var.dms_replication_task_arn
         },
         "FunctionName" : var.pipeline_notification_lambda_function
@@ -224,6 +240,22 @@ locals {
           "BackoffRate" : 2
         }
       ],
+      "Next" : var.split_pipeline ? local.set_dms_cdc_replication_task_start_time.StepName : local.run_glue_batch_job.StepName
+    }
+  }
+
+  set_dms_cdc_replication_task_start_time = {
+    "StepName" : "Set DMS CDC Replication Task Start Time",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.set_cdc_dms_start_time_job,
+        "Arguments" : {
+          "--dpr.dms.replication.task.id" : var.replication_task_id,
+          "--dpr.cdc.dms.replication.task.id" : var.cdc_replication_task_id
+        }
+      },
       "Next" : local.run_glue_batch_job.StepName
     }
   }
@@ -433,7 +465,20 @@ locals {
         "NumberOfWorkers" : var.retention_curated_num_workers,
         "WorkerType" : var.retention_curated_worker_type
       },
-      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName
+      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : (var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.resume_dms_replication_task.StepName)
+    }
+  }
+
+  start_dms_cdc_replication_task = {
+    "StepName" : "Start DMS CDC Replication Task",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::aws-sdk:databasemigration:startReplicationTask",
+      "Parameters" : {
+        "ReplicationTaskArn" : var.dms_cdc_replication_task_arn,
+        "StartReplicationTaskType" : "start-replication"
+      },
+      "Next" : local.start_glue_streaming_job.StepName
     }
   }
 
@@ -573,7 +618,44 @@ module "reload_pipeline" {
         (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
       }
     }
-    ) : jsonencode(
+    ) : var.split_pipeline ? jsonencode(
+    {
+      "Comment" : "Reload Pipeline Step Function (With Separated Full-Load and CDC Tasks)",
+      "StartAt" : local.deactivate_archive_trigger.StepName,
+      "States" : {
+        (local.deactivate_archive_trigger.StepName) : local.deactivate_archive_trigger.StepDefinition,
+        (local.stop_archive_job.StepName) : local.stop_archive_job.StepDefinition,
+        (local.stop_dms_cdc_replication_task.StepName) : local.stop_dms_cdc_replication_task.StepDefinition,
+        (local.check_all_pending_files_have_been_processed.StepName) : local.check_all_pending_files_have_been_processed.StepDefinition,
+        (local.stop_glue_streaming_job.StepName) : local.stop_glue_streaming_job.StepDefinition,
+        (local.archive_remaining_raw_files.StepName) : local.archive_remaining_raw_files.StepDefinition,
+        (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+        (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+        (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+        (local.empty_raw_structured_and_curated_data.StepName) : local.empty_raw_structured_and_curated_data.StepDefinition,
+        (local.start_dms_replication_task.StepName) : local.start_dms_replication_task.StepDefinition,
+        (local.invoke_dms_state_control_lambda.StepName) : local.invoke_dms_state_control_lambda.StepDefinition,
+        (local.set_dms_cdc_replication_task_start_time.StepName) : local.set_dms_cdc_replication_task_start_time.StepDefinition,
+        (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+        (local.delete_existing_reload_diffs.StepName) : local.delete_existing_reload_diffs.StepDefinition,
+        (local.run_create_reload_diff_batch_job.StepName) : local.run_create_reload_diff_batch_job.StepDefinition,
+        (local.move_reload_diffs_toInsert_to_archive_bucket.StepName) : local.move_reload_diffs_toInsert_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toDelete_to_archive_bucket.StepName) : local.move_reload_diffs_toDelete_to_archive_bucket.StepDefinition,
+        (local.move_reload_diffs_toUpdate_to_archive_bucket.StepName) : local.move_reload_diffs_toUpdate_to_archive_bucket.StepDefinition,
+        (local.empty_raw_data.StepName) : local.empty_raw_data.StepDefinition,
+        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+        (local.start_dms_cdc_replication_task.StepName) : local.start_dms_cdc_replication_task.StepDefinition,
+        (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
+        (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+        (local.reactivate_archive_trigger.StepName) : local.reactivate_archive_trigger.StepDefinition,
+        (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
+      }
+    }
+  ) : jsonencode(
     {
       "Comment" : "Reload Pipeline Step Function",
       "StartAt" : local.deactivate_archive_trigger.StepName,

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/variables.tf
@@ -10,6 +10,17 @@ variable "batch_only" {
   default     = false
 }
 
+variable "split_pipeline" {
+  description = "Determines if the pipeline is split into a Full-Load and a separate CDC tasks, True or False?"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.batch_only ? var.split_pipeline == false : true
+    error_message = "split_pipeline can only be 'true' when batch_only = false"
+  }
+}
+
 variable "reload_pipeline" {
   description = "Name for the Reload Pipeline"
   type        = string
@@ -86,6 +97,26 @@ variable "dms_replication_task_arn" {
   type        = string
 }
 
+variable "dms_cdc_replication_task_arn" {
+  description = "ARN of the CDC replication task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.dms_cdc_replication_task_arn != null : var.dms_cdc_replication_task_arn == null
+    error_message = "dms_cdc_replication_task_arn is only allowed when split_pipeline = true"
+  }
+}
+
+variable "cdc_replication_task_id" {
+  description = "ID of the CDC replication task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.cdc_replication_task_id != null : var.cdc_replication_task_id == null
+    error_message = "cdc_replication_task_id is only allowed when split_pipeline = true"
+  }
+}
+
 variable "replication_task_id" {
   description = "ID of the replication task"
   type        = string
@@ -94,6 +125,22 @@ variable "replication_task_id" {
 variable "pipeline_notification_lambda_function" {
   description = "Pipeline Notification Lambda Name"
   type        = string
+}
+
+variable "pipeline_notification_lambda_function_ignore_dms_failure" {
+  description = "Pipeline notification lambda function ignores DMS task failures"
+  type        = bool
+  default     = false
+}
+
+variable "set_cdc_dms_start_time_job" {
+  description = "Name of the Glue job which sets the start time of the CDC DMS task"
+  type        = string
+
+  validation {
+    condition     = var.split_pipeline == true ? var.set_cdc_dms_start_time_job != null : var.set_cdc_dms_start_time_job == null
+    error_message = "set_cdc_dms_start_time_job is only allowed when split_pipeline = true"
+  }
 }
 
 variable "glue_reporting_hub_batch_jobname" {

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -134,7 +134,8 @@ data "aws_iam_policy_document" "extra-policy-document" {
     actions = [
       "dms:DescribeTableStatistics",
       "dms:DescribeReplicationTasks",
-      "dms:StopReplicationTask"
+      "dms:StopReplicationTask",
+      "dms:ModifyReplicationTask"
     ]
     resources = [
       "arn:aws:dms:${var.region}:${var.account}:*:*"


### PR DESCRIPTION
This PR:
- Creates a common Glue job for setting the start-time of a DMS task
- Adds permissions to allow the Glue job mentioned above modify a DMS task
- Modifies the ingestion and reload pipelines to support domains where the CDC task is separate from the Full-Load task