### PR TITLE
dmet-prisons-364 - provide permissions for AP share on all glue datab…

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -165,6 +165,21 @@
       "enable_dbt_k8s_secrets": true,
       "dpr_generic_athena_workgroup": true,
       "analytics_generic_athena_workgroup": true,
+      "analytical_platform_share": [
+        {
+          "target_account_name": "analytical-platform-data-production",
+          "target_account_id": "593291632749",
+          "assume_account_name": "analytical-platform-management-production",
+          "assume_account_id": "042130406152",
+          "data_locations": ["dpr-structured-historical-development"],
+          "resource_shares": [
+            {
+              "glue_database": "*",
+              "glue_tables": ["*"]
+            }
+          ]
+        }
+      ],
       "redshift_table_expiry_days": 7,
       "enable_s3_data_migrate_lambda": true,
       "create_postgres_load_generator_job": true,


### PR DESCRIPTION
Ticket: https://github.com/moj-analytical-services/dmet-prisons/issues/364

To set up the DPR development account 'AP share' role which will be used by the AP https://github.com/ministryofjustice/analytical-platform/tree/main/terraform/aws/analytical-platform-data-production/lakeformation-external-data