### PR TITLE
TM-1296: nomis: allow xsiam access to db

### DIFF
--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -51,6 +51,7 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       module.ip_addresses.moj_cidr.aws_analytical_platform_aggregate,
+      module.ip_addresses.moj_cidr.aws_xsiam_prod_vpc,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     oracle_oem_agent = flatten([

--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -20,8 +20,6 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.devtest,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       module.ip_addresses.moj_cidr.aws_analytical_platform_aggregate,
-      module.ip_addresses.azure_studio_hosting_cidrs.devtest,
-      module.ip_addresses.azure_nomisapi_cidrs.devtest,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     oracle_oem_agent = flatten([
@@ -53,8 +51,6 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
       module.ip_addresses.moj_cidr.aws_analytical_platform_aggregate,
-      module.ip_addresses.azure_studio_hosting_cidrs.prod,
-      module.ip_addresses.azure_nomisapi_cidrs.prod,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     oracle_oem_agent = flatten([

--- a/terraform/modules/ip_addresses/moj.tf
+++ b/terraform/modules/ip_addresses/moj.tf
@@ -69,6 +69,7 @@ locals {
     aws_data_engineering_dev          = "172.24.0.0/16"
     aws_data_engineering_prod         = "172.25.0.0/16"
     aws_data_engineering_stage        = "172.26.0.0/16"
+    aws_xsiam_prod_vpc                = "10.180.96.0/22"
   }
 
   moj_cidrs = {


### PR DESCRIPTION
On request from MIP team.
Also removing access from StudioHosting/NomisAPI as those environments have been deleted and IP ranges re-allocated.