### PR TITLE
Add missing prefix to app environment variables

### DIFF
--- a/terraform/environments/mlra/task_definition.json
+++ b/terraform/environments/mlra/task_definition.json
@@ -47,15 +47,15 @@
         "value": "${region}"
       },
       {
-        "name": "MAAT_API_END_POINT",
+        "name": "APP_MAAT_API_END_POINT",
         "value": "${maat_api_end_point}"
       },
       {
-        "name": "MAAT_API_OAUTH_SCOPE",
+        "name": "APP_MAAT_API_OAUTH_SCOPE",
         "value": "${maat_api_oauth_scope}"
       },
       {
-        "name": "MAAT_API_OAUTH_URL",
+        "name": "APP_MAAT_API_OAUTH_URL",
         "value": "${maat_api_oauth_url}"
       },
       {


### PR DESCRIPTION
This PR adds the missing `APP_` prefix to new environment variables for the MAAT API. MLRA is currently failing to send
requests to the MAAT API because it is expecting the prefixed environment variables which do not exist.