### PR TITLE
Revert "temporarily skip AWS provider version 5.99.0"

### DIFF
--- a/terraform/environments/delius-core/versions.tf
+++ b/terraform/environments/delius-core/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0, != 5.99.0"
+      version = "~> 5.0, != 5.86.0"
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform-environments#10854

A fix has now been included in patch release 5.99.1