### PR TITLE
DPR2-1925: Fix DMS event pattern

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
@@ -42,7 +42,10 @@ module "step_function_notification_lambda_trigger" {
     {
       "source" : ["aws.dms"],
       "detail-type" : ["DMS Replication Task State Change"],
-      "eventId" : ["DMS-EVENT-0079", "DMS-EVENT-0078"] # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html
+      "type" : ["REPLICATION_TASK"],
+      "detail" : {
+        "eventType" : ["REPLICATION_TASK_STOPPED", "REPLICATION_TASK_FAILED"]
+      }
     }
   )
 }

--- a/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
@@ -42,9 +42,7 @@ module "step_function_notification_lambda_trigger" {
     {
       "source" : ["aws.dms"],
       "detail-type" : ["DMS Replication Task State Change"],
-      "detail" : {
-        "eventId" : ["DMS-EVENT-0079", "DMS-EVENT-0078"] # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html
-      }
+      "eventId" : ["DMS-EVENT-0079", "DMS-EVENT-0078"] # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html
     }
   )
 }

--- a/terraform/environments/digital-prison-reporting/notifications.tf
+++ b/terraform/environments/digital-prison-reporting/notifications.tf
@@ -91,6 +91,7 @@ module "dms_failure_state_rule" {
   event_pattern = <<PATTERN
 {
   "source": ["aws.dms"],
+  "type": ["REPLICATION_TASK"],
   "detail": {
     "category": ["Failure"]
   }


### PR DESCRIPTION
This PR:
- Restricts the DMS alerts to only replication task failures
- Modifies the eventbridge pattern to ensure the pipeline notification lambda is triggered for replication task stoppage and failure events