### PR TITLE
Add onecrown host aliases to cadet template

### DIFF
--- a/terraform/environments/analytical-platform-compute/actions-runner/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/actions-runner/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl
@@ -30,3 +30,12 @@ hostAliases:
   - ip: "10.168.1.16"
     hostnames:
       - "mi-synapse-dev-ondemand.sql.azuresynapse.net"
+  - ip: "10.168.5.16"
+    hostnames:
+      - "mi-synapse-prod.sql.azuresynapse.net"
+  - ip: "10.168.5.17"
+    hostnames:
+      - "mi-synapse-prod-ondemand.sql.azuresynapse.net"
+  - ip: "10.168.5.18"
+    hostnames:
+      - "mi-synapse-prod.dev.azuresynapse.net"


### PR DESCRIPTION
This PR is tracked upstream by [#7851](https://github.com/ministryofjustice/analytical-platform/issues/7851) in the analytical-platform repository.

This PR introduces further host aliases for OneCrown endpoints.