### PR TITLE
DPR2-1925: Fix DMS notification event pattern

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/pipeline-lambda/lambda.tf
@@ -40,12 +40,7 @@ module "step_function_notification_lambda_trigger" {
 
   trigger_event_pattern = jsonencode(
     {
-      "source" : ["aws.dms"],
-      "detail-type" : ["DMS Replication Task State Change"],
-      "type" : ["REPLICATION_TASK"],
-      "detail" : {
-        "eventType" : ["REPLICATION_TASK_STOPPED", "REPLICATION_TASK_FAILED"]
-      }
+      "source" : ["aws.dms"]
     }
   )
 }


### PR DESCRIPTION
This PR broadens the eventbridge pattern match to trigger on all DMS events.
This is temporary and will allow inspecting the event which gets emitted when the `snapshot too old error` happens.