### PR TITLE
DPR2-2029: Archive raw files during the maintenance pipeline

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/pipeline.tf
@@ -108,6 +108,17 @@ module "maintenance_pipeline" {
             "NumberOfWorkers" : var.retention_curated_num_workers,
             "WorkerType" : var.retention_curated_worker_type
           },
+          "Next" : "Archive Raw Data"
+        },
+        "Archive Raw Data" : {
+          "Type" : "Task",
+          "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+          "Parameters" : {
+            "JobName" : var.glue_archive_job,
+            "Arguments" : {
+              "--dpr.raw.file.retention.period.amount" : "0"
+            }
+          },
           "Next" : "Resume DMS Replication Task"
         },
         "Resume DMS Replication Task" : {

--- a/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/maintenance-pipeline/variables.tf
@@ -80,6 +80,11 @@ variable "stop_dms_task_job" {
   type        = string
 }
 
+variable "glue_archive_job" {
+  description = "Name of the glue job which archives the raw data"
+  type        = string
+}
+
 variable "compaction_structured_worker_type" {
   description = "(Optional) Worker type to use for the compaction job in structured zone"
   type        = string


### PR DESCRIPTION
This PR:
- Archives all the raw files during the maintenance window to reduce the performance impact on the spark streaming jobs when listing many files