### PR TITLE
Update strategy to default to plan_apply action on main

### DIFF
--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -237,6 +237,31 @@ jobs:
             done
           done < envlist.json
 
+          # --------------------------------------------------------------------
+          # 5.1. On main: ensure all component/environment pairs are included with plan_apply
+          # --------------------------------------------------------------------
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "On main: ensuring all component/environment pairs are included with plan_apply."
+            while IFS= read -r envobj; do
+              for comp in $COMPONENTS; do
+                target=$(echo "$envobj" | jq -r '.target')
+                pair="${comp}_${target}"
+
+                if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
+                  continue
+                fi
+
+                seen_pairs+=("$pair")
+                if [ "$firstEntry" = true ]; then
+                  firstEntry=false
+                else
+                  echo "," >> final-list.json
+                fi
+                echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
+              done
+            done < envlist.json
+          fi
+          
           # Ensure the JSON array is properly closed.
           echo "]" >> final-list.json
 


### PR DESCRIPTION
## Issue
Reported in the ask channel here: https://mojdt.slack.com/archives/C01A7QK5VM1/p1749220739931139
I've also had some direct comms from users who want to reinstate the previous strategy behaviour.

## Changes
I've added a step to the new strategy (to replicate the behaviour of the previous strategy) so when running the pipeline from main branch the matrix is populated with a `plan_apply` action for all environments.