### PR TITLE
♻️ Optimise and Secure Athena Pipeline

### DIFF
--- a/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
@@ -131,7 +131,11 @@ resource "aws_glue_crawler" "github_auditlog" {
   })
 
   recrawl_policy {
-    recrawl_behavior = "CRAWL_EVERYTHING"
+    recrawl_behavior = "CRAWL_NEW_FOLDERS_ONLY"
+  }
+  schema_change_policy {
+    delete_behavior = "LOG"
+    update_behavior = "LOG"
   }
   schedule = "cron(0 7 * * ? *)"
   tags     = local.tags

--- a/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy" "glue_github_auditlog_policy" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ],
-        Resource = "*"
+        Resource = "arn:aws:logs:${local.aws_region}:${local.account_id}:log-group:/aws-glue/crawlers:*"
       },
       {
         Sid    = "AllowKMSEncryptDecrypt",

--- a/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
@@ -23,7 +23,7 @@ resource "aws_athena_workgroup" "github_auditlog" {
 
     enforce_workgroup_configuration    = true
     publish_cloudwatch_metrics_enabled = true
-    bytes_scanned_cutoff_per_query     = 1000000000 # 1GB
+    bytes_scanned_cutoff_per_query     = 10000000000 # 10GB
     requester_pays_enabled             = false
   }
 

--- a/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
@@ -116,6 +116,14 @@ resource "aws_glue_crawler" "github_auditlog" {
 
   s3_target {
     path = "s3://${module.github-cloudtrail-auditlog.github_auditlog_s3bucket}/"
+    exclusions = [
+      "2024/*",
+      "2025/01/*",
+      "2025/02/*",
+      "2025/03/*",
+      "2025/04/*",
+      "2025/05/*",
+    ]
   }
 
   configuration = jsonencode({

--- a/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
+++ b/terraform/environments/operations-engineering/audit_log_streaming_github_athena.tf
@@ -14,6 +14,11 @@ resource "aws_athena_workgroup" "github_auditlog" {
   configuration {
     result_configuration {
       output_location = "s3://${module.github_audit_log_athena_results.bucket.id}/results/"
+
+      encryption_configuration {
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = data.aws_kms_key.github_auditlog.arn
+      }
     }
 
     enforce_workgroup_configuration    = true

--- a/terraform/environments/operations-engineering/locals.tf
+++ b/terraform/environments/operations-engineering/locals.tf
@@ -1,1 +1,8 @@
 #### This file can be used to store locals specific to the member account ####
+locals {
+  oidc_provider = "token.actions.githubusercontent.com"
+  account_id    = local.environment_management.account_ids[terraform.workspace]
+  aws_region    = data.aws_region.current.name
+}
+
+

--- a/terraform/environments/operations-engineering/oidc.tf
+++ b/terraform/environments/operations-engineering/oidc.tf
@@ -1,8 +1,3 @@
-locals {
-  oidc_provider = "token.actions.githubusercontent.com"
-  account_id    = local.environment_management.account_ids[terraform.workspace]
-}
-
 resource "aws_iam_openid_connect_provider" "github" {
   url = "https://oidc-configuration.audit-log.githubusercontent.com"
 
@@ -38,3 +33,4 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy_document" {
     }
   }
 }
+


### PR DESCRIPTION
## 👀 Purpose

- To optimise the Glue Crawler and Athena to reduce cost
- To harden some of the infrastructure to address some security alerts

## ♻️ What's changed

- Refactor Crawler Policy to New Folders Only & Add Exclusions For Scanned Folders - this has reduced the crawl time from 2 hours to 1 minute
- Add Additional Bytes Cutoff - since Athena has to scan all the 2025 data, we need a larger cutoff to allow the queries to run
- Encrypt Athena Results with KMS Keys

## 📝 Notes

- Athena queries will continue to be slow, we're using the raw data so the partitions are awful. It'd require more work to set up a pipeline to better partition the data, so leaving this for now.
- Trivy alerts are for other files in this folder, to look at separately.