### PR TITLE
add secrets to ccms-ebs for storing ftp third party credentials

### DIFF
--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -68,7 +68,7 @@ env:
   WORKSPACE_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
   ENVIRONMENT_MANAGEMENT: "${{ secrets.modernisation_platform_environments }}"
   GITHUB_TOKEN: "${{ secrets.pipeline_github_token }}"
-  TF_LOG: "DEBUG"
+  TF_LOG: "TRACE"
 
 concurrency:
   group: ${{ inputs.application }}-${{ inputs.environment }}

--- a/.github/workflows/reusable_terraform_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_plan_apply.yml
@@ -68,6 +68,7 @@ env:
   WORKSPACE_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
   ENVIRONMENT_MANAGEMENT: "${{ secrets.modernisation_platform_environments }}"
   GITHUB_TOKEN: "${{ secrets.pipeline_github_token }}"
+  TF_LOG: "DEBUG"
 
 concurrency:
   group: ${{ inputs.application }}-${{ inputs.environment }}

--- a/terraform/environments/ccms-ebs/ccms-ebs-ftp.tf
+++ b/terraform/environments/ccms-ebs/ccms-ebs-ftp.tf
@@ -1,0 +1,29 @@
+### secrets for ftp user and password
+resource "aws_secretsmanager_secret" "ftp_password" {
+  name        = lower(format("laa-ccms-ebs-ftp-password-%s",local.environment))
+  description = "A secret for storing ftp server password"
+}
+
+resource "aws_secretsmanager_secret" "ftp_user" {
+  name        = lower(format("laa-ccms-ebs-ftp-user-%s",local.environment))
+  description = "A secret for storing ftp server user"
+}
+
+
+
+
+#### bucket for laa-ccms-inbound for storing files from lambda
+resource "aws_s3_bucket" "inbound_bucket" {
+  bucket = lower(format("laa-ccms-inbound-%s-mp",local.environment))  # ccms inbound bucket
+
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "secure_bucket_encryption" {
+  bucket = aws_s3_bucket.inbound_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
+++ b/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
@@ -16,11 +16,6 @@ locals {
     "LAA-ftp-1stlocate-ccms-inbound",
     "LAA-ftp-rossendales-nct-inbound-product"
   ]
-  base_buckets = ["laa-ccms-inbound", "laa-ccms-outbound", "laa-ccms-ftp-lambda"]
-
-  bucket_names = [
-    for name in local.base_buckets : "${name}-${local.environment}-mp"
-  ]
 }
 
 

--- a/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
+++ b/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
@@ -1,0 +1,32 @@
+locals {
+    secret_names = [
+    "LAA-ftp-allpay-inbound-ccms",
+    "LAA-ftp-tdx-inbound-ccms-agencyassigmen",
+    "LAA-ftp-rossendales-ccms-csv-inbound",
+    "LAA-ftp-rossendales-maat-inbound",
+    "LAA-ftp-tdx-inbound-ccms-activity",
+    "LAA-ftp-tdx-inbound-ccms-transaction",
+    "LAA-ftp-tdx-inbound-ccms-livelist",
+    "LAA-ftp-tdx-inbound-ccms-multiplefiles",
+    "LAA-ftp-rossendales-ccms-inbound",
+    "LAA-ftp-tdx-inbound-ccms-agencyrecallre",
+    "LAA-ftp-tdx-inbound-ccms-nonfinancialup",
+    "LAA-ftp-tdx-inbound-ccms-exceptionnotif",
+    "LAA-ftp-eckoh-inbound-ccms",
+    "LAA-ftp-1stlocate-ccms-inbound",
+    "LAA-ftp-rossendales-nct-inbound-product"
+  ]
+  base_buckets = ["laa-ccms-inbound", "laa-ccms-outbound", "laa-ccms-ftp-lambda"]
+
+  bucket_names = [
+    for name in local.base_buckets : "${name}-${local.environment}-mp"
+  ]
+}
+
+
+### secrets for ftp user and password
+resource "aws_secretsmanager_secret" "secrets" {
+  for_each = toset(local.secret_names)
+
+  name = "${each.value}-${local.environment}"
+}

--- a/terraform/environments/ccms-ebs/versions.tf
+++ b/terraform/environments/ccms-ebs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 5.0, != 5.86.0, != 5.99.0"
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
this pr is for adding secrets manager for storing ftp third party credentials, to be consumed by lambda's created for inbound and outbound ftp transfers.