### PR TITLE
TM: fix missing default variable in baseline module

### DIFF
--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -172,6 +172,7 @@ variable "data_firehoses" {
     destination_http_secret_name                 = optional(string)
     destination_http_endpoint_ssm_parameter_name = string
   }))
+  default = {}
 }
 
 variable "ec2_autoscaling_groups" {


### PR DESCRIPTION
Missing a default value for new firehose variable