### PR TITLE
Add default strategy for manually running pieplines

### DIFF
--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -78,9 +78,9 @@ jobs:
 
           echo "Discovered components (folders with platform_backend.tf): $COMPONENTS"
 
-          # --------------------------------------------------------------------
-          # 4. Build the final matrix by checking each component independently.
-          # --------------------------------------------------------------------
+          # ----------------------------------------------------------------------------
+          # 4. Build the matrix by checking for changes in each component independently.
+          # ----------------------------------------------------------------------------
           echo "[" > final-list.json
           firstEntry=true
 
@@ -155,9 +155,9 @@ jobs:
             done
           done < envlist.json
 
-          # --------------------------------------------------------------------
+          # ----------------------------------------------------------------
           # 5. Detect changes in the "modules" folder and update the matrix.
-          # --------------------------------------------------------------------
+          # ----------------------------------------------------------------
 
           # Check for changes in the modules directory.
           modules_dir="terraform/environments/${{ inputs.application }}/modules"
@@ -237,62 +237,65 @@ jobs:
             done
           done < envlist.json
 
-          # --------------------------------------------------------------------
-          # 5.1. On main: ensure all component/environment pairs are included with plan_apply,
-          # else ensure dev/test envs for all components are run as plan_apply and preprd/prod run as plan.
-          # --------------------------------------------------------------------
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "On main: ensuring all component/environment pairs are included with plan_apply."
-            while IFS= read -r envobj; do
-              for comp in $COMPONENTS; do
-                target=$(echo "$envobj" | jq -r '.target')
-                pair="${comp}_${target}"
+          # ----------------------------------------------------------------------------------------------------------------
+          # 6. If manually triggered: on main branch, ensure all component/environment pairs are included with plan_apply.
+          #    On feature branch, ensure all dev/test components are included with plan_apply,
+          #    and prod/preprod components are included with plan.
+          # ---------------------------------------------------------------------------------------------------------------
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+              echo "Manually triggered on main: ensuring all component/environment pairs are included with plan_apply."
+              while IFS= read -r envobj; do
+                for comp in $COMPONENTS; do
+                  target=$(echo "$envobj" | jq -r '.target')
+                  pair="${comp}_${target}"
 
-                if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
-                  continue
-                fi
+                  if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
+                    continue
+                  fi
 
-                seen_pairs+=("$pair")
-                if [ "$firstEntry" = true ]; then
-                  firstEntry=false
-                else
-                  echo "," >> final-list.json
-                fi
-                echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
-              done
-            done < envlist.json
-          else
-            echo "Not main: ensuring all component/environment pairs are included with plan or plan_apply as appropriate."
-            while IFS= read -r envobj; do
-              for comp in $COMPONENTS; do
-                target=$(echo "$envobj" | jq -r '.target')
-                pair="${comp}_${target}"
-
-                if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
-                  continue
-                fi
-
-                seen_pairs+=("$pair")
-                if [ "$firstEntry" = true ]; then
-                  firstEntry=false
-                else
-                  echo "," >> final-list.json
-                fi
-                # Use plan for preprod/prod, plan_apply otherwise
-                if [[ "$target" =~ preprod|prod ]]; then
-                  echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan"}' >> final-list.json
-                else
+                  seen_pairs+=("$pair")
+                  if [ "$firstEntry" = true ]; then
+                    firstEntry=false
+                  else
+                    echo "," >> final-list.json
+                  fi
                   echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
-                fi
-              done
-            done < envlist.json
+                done
+              done < envlist.json
+            else
+              echo "Manually triggered not on main: ensuring all component/environment pairs are included with plan or plan_apply as appropriate."
+              while IFS= read -r envobj; do
+                for comp in $COMPONENTS; do
+                  target=$(echo "$envobj" | jq -r '.target')
+                  pair="${comp}_${target}"
+
+                  if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
+                    continue
+                  fi
+
+                  seen_pairs+=("$pair")
+                  if [ "$firstEntry" = true ]; then
+                    firstEntry=false
+                  else
+                    echo "," >> final-list.json
+                  fi
+                  # Use plan for preprod/prod, plan_apply otherwise
+                  if [[ "$target" =~ preprod|prod ]]; then
+                    echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan"}' >> final-list.json
+                  else
+                    echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
+                  fi
+                done
+              done < envlist.json
+            fi
           fi
           
           # Ensure the JSON array is properly closed.
           echo "]" >> final-list.json
 
           # --------------------------------------------------------------------
-          # 6. Wrap the JSON array in a matrix object.
+          # 7. Wrap the JSON array in a matrix object.
           # --------------------------------------------------------------------
           echo -n '{"include":' > matrix.out
           cat final-list.json >> matrix.out
@@ -303,7 +306,7 @@ jobs:
           echo "$matrix"
 
           # --------------------------------------------------------------------
-          # 7. Output the matrix for subsequent jobs.
+          # 8. Output the matrix for subsequent jobs.
           # --------------------------------------------------------------------
           echo 'matrix<<EOF' >> $GITHUB_OUTPUT
           echo "${matrix}" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable_terraform_components_strategy.yml
+++ b/.github/workflows/reusable_terraform_components_strategy.yml
@@ -238,7 +238,8 @@ jobs:
           done < envlist.json
 
           # --------------------------------------------------------------------
-          # 5.1. On main: ensure all component/environment pairs are included with plan_apply
+          # 5.1. On main: ensure all component/environment pairs are included with plan_apply,
+          # else ensure dev/test envs for all components are run as plan_apply and preprd/prod run as plan.
           # --------------------------------------------------------------------
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             echo "On main: ensuring all component/environment pairs are included with plan_apply."
@@ -258,6 +259,31 @@ jobs:
                   echo "," >> final-list.json
                 fi
                 echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
+              done
+            done < envlist.json
+          else
+            echo "Not main: ensuring all component/environment pairs are included with plan or plan_apply as appropriate."
+            while IFS= read -r envobj; do
+              for comp in $COMPONENTS; do
+                target=$(echo "$envobj" | jq -r '.target')
+                pair="${comp}_${target}"
+
+                if [[ " ${seen_pairs[@]} " =~ " ${pair} " ]]; then
+                  continue
+                fi
+
+                seen_pairs+=("$pair")
+                if [ "$firstEntry" = true ]; then
+                  firstEntry=false
+                else
+                  echo "," >> final-list.json
+                fi
+                # Use plan for preprod/prod, plan_apply otherwise
+                if [[ "$target" =~ preprod|prod ]]; then
+                  echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan"}' >> final-list.json
+                else
+                  echo -n "$envobj" | jq --arg comp "$comp" '. + {"component": $comp, "action": "plan_apply"}' >> final-list.json
+                fi
               done
             done < envlist.json
           fi


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10126

## What's Changed?
I've updated the strategy so that it behaves like the previous strategy when the pipeline is triggered manually i.e.
on main, it triggers `plan_apply` to all components/envs,
on feature branch, it triggers `plan_apply` to all components for dev/test and `plan` to all components for preprod/prod.

After receiving feedback from users, they want the ability to use this logic when they manually running pipelines because in certain circumstances they'll be making changes to a module that doesn't live in the root folder for the application they want to test it on.