### PR TITLE
DPR2-1499: Rename antivirus check ECR repository as per github repository name for the image

### DIFF
--- a/terraform/environments/digital-prison-reporting/ecr.tf
+++ b/terraform/environments/digital-prison-reporting/ecr.tf
@@ -1,7 +1,8 @@
 # Used to store our custom clamav S3 scanner image for File Transfer In/Push
 resource "aws_ecr_repository" "file_transfer_in_clamav_scanner" {
-  name                 = "${local.project}-images-${local.env}/hmpps-data-hub-clamav-s3-scanner"
-  image_tag_mutability = "IMMUTABLE"
+  #checkov:skip=CKV_AWS_51:Ensure ECR Image Tags are immutable - we explicitly want to use a mutable latest tag to manage versions in the image repo
+  name                 = "${local.project}-images-${local.env}/hmpps-dpr-landing-zone-antivirus-check"
+  image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
- Rename the ECR repository so it is consistent with the github repository that manages the container image
- Allow mutable tags so we can have a latest version tag for the container image, as we do for jars used in lambdas