### PR TITLE
WIP on TM/TM-1329/windows-bip-server-onr-preprod

### DIFF
--- a/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/oasys-national-reporting/locals_ec2_instances.tf
@@ -318,7 +318,7 @@ locals {
       }
       instance = {
         disable_api_termination      = false
-        instance_type                = "r4.2xlarge" # Memory optimised 8 vCPU, 61 GiB RAM
+        instance_type                = "r6i.2xlarge" # Memory optimised 8 vCPU, 64 GiB RAM
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids       = ["private-jumpserver"]

--- a/terraform/environments/oasys-national-reporting/locals_preproduction.tf
+++ b/terraform/environments/oasys-national-reporting/locals_preproduction.tf
@@ -178,24 +178,24 @@ locals {
       })
 
       # Temporary windows BIP server for migration only
-      pp-win-bip-1 = merge(local.ec2_instances.windows_bip, {
-        config = merge(local.ec2_instances.windows_bip.config, {
-          ami_name          = "hmpps_windows_server_2022_release_2025-06-02T00-00-40.444Z"
-          availability_zone = "eu-west-2a"
-          instance_profile_policies = concat(local.ec2_instances.windows_bip.config.instance_profile_policies, [
-            "Ec2SecretPolicy",
-          ])
-          user_data_raw = base64encode(templatefile(
-            "./templates/user-data-onr-bip-pwsh.yaml.tftpl", {
-              branch = "TM/TM-1329/windows-bip-server-onr-preprod"
-            }
-          ))
-        })
-        tags = merge(local.ec2_instances.windows_bip.tags, {
-          oasys-national-reporting-environment = "pp"
-          domain-name                          = "azure.hmpp.root"
-        })
-      })
+      # pp-win-bip-1 = merge(local.ec2_instances.windows_bip, {
+      #   config = merge(local.ec2_instances.windows_bip.config, {
+      #     ami_name          = "hmpps_windows_server_2022_release_2025-06-02T00-00-40.444Z"
+      #     availability_zone = "eu-west-2a"
+      #     instance_profile_policies = concat(local.ec2_instances.windows_bip.config.instance_profile_policies, [
+      #       "Ec2SecretPolicy",
+      #     ])
+      #     user_data_raw = base64encode(templatefile(
+      #       "./templates/user-data-onr-bip-pwsh.yaml.tftpl", {
+      #         branch = "TM/TM-1329/windows-bip-server-onr-preprod"
+      #       }
+      #     ))
+      #   })
+      #   tags = merge(local.ec2_instances.windows_bip.tags, {
+      #     oasys-national-reporting-environment = "pp"
+      #     domain-name                          = "azure.hmpp.root"
+      #   })
+      # })
     }
 
     fsx_windows = {

--- a/terraform/environments/oasys-national-reporting/templates/user-data-onr-bip-pwsh.yaml.tftpl
+++ b/terraform/environments/oasys-national-reporting/templates/user-data-onr-bip-pwsh.yaml.tftpl
@@ -4,6 +4,15 @@
 # See C:\Windows\System32\config\systemprofile\AppData\Local\Temp\EC2Launch* for script output
 version: 1.0 # version 1.0 is required as this executes AFTER the SSM Agent is running
 tasks:
+  - task: executeScript
+    inputs:
+      - frequency: once
+        type: powershell
+        runAs: admin
+        content: |-
+          # Wait for EBS volumes to be attached
+          Write-Output "Waiting 30 seconds for EBS volumes to attach..."
+          Start-Sleep -Seconds 30
   - task: initializeVolume
     inputs:
       initialize: devices


### PR DESCRIPTION
- destroy instance
- use newer instance type 
  - better EBS/NVME integration so disk initialization doesn't fail
  - add timeout so disk attach (it's large) can complete before initialization attempt
  - newer instance == better memory bandwidth