### PR TITLE
DPR2-1925: Shorten ingestion/reload of large pipelines by removing maintenance steps

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/ingestion-pipeline/pipeline.tf
@@ -257,7 +257,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : "Run Compaction Job on Structured Zone"
+      "Next" : var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.run_compaction_job_on_structured_zone.StepName
     }
   }
 
@@ -333,7 +333,7 @@ locals {
         "NumberOfWorkers" : var.retention_curated_num_workers,
         "WorkerType" : var.retention_curated_worker_type
       },
-      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : (var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.resume_dms_replication_task.StepName)
+      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName
     }
   }
 
@@ -500,10 +500,6 @@ module "data_ingestion_pipeline" {
         (local.set_dms_cdc_replication_task_start_time.StepName) : local.set_dms_cdc_replication_task_start_time.StepDefinition,
         (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
         (local.archive_raw_data.StepName) : local.archive_raw_data.StepDefinition,
-        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
-        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
-        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
-        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
         (local.start_dms_cdc_replication_task.StepName) : local.start_dms_cdc_replication_task.StepDefinition,
         (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
         (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,

--- a/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
+++ b/terraform/environments/digital-prison-reporting/modules/domains/reload-pipeline/pipeline.tf
@@ -389,7 +389,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : local.run_compaction_job_on_structured_zone.StepName
+      "Next" : var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.run_compaction_job_on_structured_zone.StepName
     }
   }
 
@@ -465,7 +465,7 @@ locals {
         "NumberOfWorkers" : var.retention_curated_num_workers,
         "WorkerType" : var.retention_curated_worker_type
       },
-      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : (var.split_pipeline ? local.start_dms_cdc_replication_task.StepName : local.resume_dms_replication_task.StepName)
+      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName
     }
   }
 
@@ -644,10 +644,6 @@ module "reload_pipeline" {
         (local.move_reload_diffs_toDelete_to_archive_bucket.StepName) : local.move_reload_diffs_toDelete_to_archive_bucket.StepDefinition,
         (local.move_reload_diffs_toUpdate_to_archive_bucket.StepName) : local.move_reload_diffs_toUpdate_to_archive_bucket.StepDefinition,
         (local.empty_raw_data.StepName) : local.empty_raw_data.StepDefinition,
-        (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
-        (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
-        (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
-        (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
         (local.start_dms_cdc_replication_task.StepName) : local.start_dms_cdc_replication_task.StepDefinition,
         (local.start_glue_streaming_job.StepName) : local.start_glue_streaming_job.StepDefinition,
         (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,


### PR DESCRIPTION
This PR:
- Shortens the time between the completion of the Full-Load task and the start of the CDC task in the ingestion/reload pipelines by removing the compaction and vacuum steps. The compaction and maintenance steps will be eventually executed when the maintenance pipeline runs during the night.
- This will reduce the chance of the redo logs getting overwritten before the the CDC task starts