### PR TITLE
Set Alarms to Insufficient Data when Re-Enabled to Allow Re-Evaluation

### DIFF
--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "19:59"
-      end_time        = "06:00"
+      start_time      = "12:40"
+      end_time        = "13:10"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "11:00"
-      end_time        = "11:30"
+      start_time      = "14:30"
+      end_time        = "15:00"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "12:45"
-      end_time        = "13:00"
+      start_time      = "13:15"
+      end_time        = "13:30"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "09:50"
-      end_time        = "10:20"
+      start_time      = "11:00"
+      end_time        = "11:30"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "12:25"
-      end_time        = "13:35"
+      start_time      = "12:45"
+      end_time        = "13:00"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "14:30"
-      end_time        = "15:00"
+      start_time      = "15:30"
+      end_time        = "16:00"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "13:20"
-      end_time        = "13:55"
+      start_time      = "13:50"
+      end_time        = "14:20"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "13:50"
-      end_time        = "14:20"
+      start_time      = "09:50"
+      end_time        = "10:20"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "08:10"
-      end_time        = "08:40"
+      start_time      = "19:59"
+      end_time        = "06:45"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "12:40"
-      end_time        = "13:10"
+      start_time      = "12:25"
+      end_time        = "13:35"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "15:30"
-      end_time        = "16:00"
+      start_time      = "08:10"
+      end_time        = "08:40"
       disable_weekend = true
     }
   }

--- a/terraform/environments/delius-core/locals_development.tf
+++ b/terraform/environments/delius-core/locals_development.tf
@@ -146,8 +146,8 @@ locals {
     is-production = false
     # Times must be specified in UTC
     disable_latency_alarms = {
-      start_time      = "13:15"
-      end_time        = "13:30"
+      start_time      = "13:20"
+      end_time        = "13:55"
       disable_weekend = true
     }
   }

--- a/terraform/modules/schedule_alarms_lambda/lambda/alarm_scheduler.py
+++ b/terraform/modules/schedule_alarms_lambda/lambda/alarm_scheduler.py
@@ -100,7 +100,10 @@ def lambda_handler(event, context):
                     cloudwatch.enable_alarm_actions(AlarmNames=batch)
                     # We put newly re-enabled alarms into INSUFFICIENT_DATA state to force a re-evaulation.
                     # A new PagerDuty notification will be sent for any which go into ALARM state on re-evaluation.
-                    cloudwatch.set_alarm_state(AlarmNames=batch,StateValue='INSUFFICIENT_DATA',StateReason='Re-evaluate alarm after AlarmActions re-enabled')
+                    # Unfortunately there is no batching of alarms for the set_alarm_state API so we need to
+                    # loop through each one individually.
+                    for alarm in batch:
+                       cloudwatch.set_alarm_state(AlarmName=alarm,StateValue='INSUFFICIENT_DATA',StateReason='Re-evaluate alarm after AlarmActions re-enabled')
                     logger.info(f"Enabled {len(batch)} alarms")
                 else:
                     raise ValueError(f"Invalid action: {action}")

--- a/terraform/modules/schedule_alarms_lambda/lambda/alarm_scheduler.py
+++ b/terraform/modules/schedule_alarms_lambda/lambda/alarm_scheduler.py
@@ -98,6 +98,9 @@ def lambda_handler(event, context):
                     logger.info(f"Disabled {len(batch)} alarms")
                 elif action == "ENABLE":
                     cloudwatch.enable_alarm_actions(AlarmNames=batch)
+                    # We put newly re-enabled alarms into INSUFFICIENT_DATA state to force a re-evaulation.
+                    # A new PagerDuty notification will be sent for any which go into ALARM state on re-evaluation.
+                    cloudwatch.set_alarm_state(AlarmNames=batch,StateValue='INSUFFICIENT_DATA',StateReason='Re-evaluate alarm after AlarmActions re-enabled')
                     logger.info(f"Enabled {len(batch)} alarms")
                 else:
                     raise ValueError(f"Invalid action: {action}")

--- a/terraform/modules/schedule_alarms_lambda/main.tf
+++ b/terraform/modules/schedule_alarms_lambda/main.tf
@@ -92,6 +92,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch" {
       "cloudwatch:DescribeAlarms",
       "cloudwatch:DisableAlarmActions",
       "cloudwatch:EnableAlarmActions",
+      "cloudwatch:SetAlarmState",
     ]
     resources = ["arn:aws:cloudwatch:*:*:alarm:*"]
   }


### PR DESCRIPTION
If alarms triggered out-of-hours are still in effect this will allow a PagerDuty notification to be sent.