### PR TITLE
🚰 Data Engineering Data Lake state access 

### DIFF
--- a/terraform/environments/analytical-platform-common/ecr-repositories.tf
+++ b/terraform/environments/analytical-platform-common/ecr-repositories.tf
@@ -3,7 +3,7 @@ module "analytical_platform_jml_report_ecr_repository" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/ecr/aws"
-  version = "2.3.1"
+  version = "2.4.0"
 
   repository_name            = "analytical-platform-jml-report"
   repository_encryption_type = "KMS"

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -115,7 +115,7 @@ module "analytical_platform_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.2"
+  version = "5.58.0"
 
   name_prefix = "analytical-platform-terraform"
 
@@ -163,11 +163,77 @@ module "analytical_platform_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.52.2"
+  version = "5.58.0"
 
   name_prefix = "analytical-platform-github-actions"
 
   policy = data.aws_iam_policy_document.analytical_platform_github_actions.json
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "data_engineering_github_actions" {
+  statement {
+    sid       = "AllowAssumeRole"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = [module.analytical_platform_terraform_iam_role.iam_role_arn]
+  }
+}
+
+module "data_engineering_github_actions_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.58.0"
+
+  name_prefix = "data-engineering-github-actions"
+
+  policy = data.aws_iam_policy_document.data_engineering_github_actions.json
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "data_engineering_terraform" {
+  statement {
+    sid    = "AllowKMS"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = [module.terraform_s3_kms.key_arn]
+  }
+  statement {
+    sid       = "AllowS3List"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [module.terraform_bucket.s3_bucket_arn]
+  }
+  statement {
+    sid    = "AllowS3Write"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = ["${module.terraform_bucket.s3_bucket_arn}/data-engineering/*"]
+  }
+}
+
+module "data_engineering_terraform_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.58.0"
+
+  name_prefix = "data-engineering-terraform"
+
+  policy = data.aws_iam_policy_document.data_engineering_terraform.json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -172,7 +172,7 @@ module "analytical_platform_github_actions_iam_policy" {
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "data_engineering_github_actions" {
+data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions" {
   statement {
     sid       = "AllowAssumeRole"
     effect    = "Allow"
@@ -181,21 +181,21 @@ data "aws_iam_policy_document" "data_engineering_github_actions" {
   }
 }
 
-module "data_engineering_github_actions_iam_policy" {
+module "data_engineering_datalake_access_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "5.58.0"
 
-  name_prefix = "data-engineering-github-actions"
+  name_prefix = "data-engineering-datalake-access-github-actions"
 
-  policy = data.aws_iam_policy_document.data_engineering_github_actions.json
+  policy = data.aws_iam_policy_document.data_engineering_datalake_access_github_actions.json
 
   tags = local.tags
 }
 
-data "aws_iam_policy_document" "data_engineering_terraform" {
+data "aws_iam_policy_document" "data_engineering_datalake_access_terraform" {
   statement {
     sid    = "AllowKMS"
     effect = "Allow"
@@ -220,20 +220,20 @@ data "aws_iam_policy_document" "data_engineering_terraform" {
       "s3:GetObject",
       "s3:PutObject"
     ]
-    resources = ["${module.terraform_bucket.s3_bucket_arn}/data-engineering/*"]
+    resources = ["${module.terraform_bucket.s3_bucket_arn}/data-engineering-datalake-access/*"]
   }
 }
 
-module "data_engineering_terraform_iam_policy" {
+module "data_engineering_datalake_access_terraform_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "5.58.0"
 
-  name_prefix = "data-engineering-terraform"
+  name_prefix = "data-engineering-datalake-access-terraform"
 
-  policy = data.aws_iam_policy_document.data_engineering_terraform.json
+  policy = data.aws_iam_policy_document.data_engineering_datalake_access_terraform.json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -174,10 +174,13 @@ module "analytical_platform_github_actions_iam_policy" {
 
 data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions" {
   statement {
-    sid       = "AllowAssumeRole"
-    effect    = "Allow"
-    actions   = ["sts:AssumeRole"]
-    resources = [module.data_engineering_datalake_access_terraform_iam_role.iam_role_arn]
+    sid     = "AllowAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    resources = [
+      module.data_engineering_datalake_access_terraform_iam_role.iam_role_arn,
+      "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-engineering-datalake-access"
+    ]
   }
 }
 

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions"
     sid       = "AllowAssumeRole"
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
-    resources = [module.analytical_platform_terraform_iam_role.iam_role_arn]
+    resources = [module.data_engineering_datalake_access_terraform_iam_role.iam_role_arn]
   }
 }
 

--- a/terraform/environments/analytical-platform-common/iam-roles.tf
+++ b/terraform/environments/analytical-platform-common/iam-roles.tf
@@ -24,7 +24,7 @@ module "analytical_platform_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.52.2"
+  version = "5.58.0"
 
   name = "analytical-platform-github-actions"
 
@@ -42,7 +42,7 @@ module "analytical_platform_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.2"
+  version = "5.58.0"
 
   create_role = true
 
@@ -52,6 +52,43 @@ module "analytical_platform_terraform_iam_role" {
   trusted_role_arns = [module.analytical_platform_github_actions_iam_role.arn]
 
   custom_role_policy_arns = [module.analytical_platform_terraform_iam_policy.arn]
+
+  tags = local.tags
+}
+
+module "data_engineering_github_actions_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.58.0"
+
+  name = "data-engineering-github-actions"
+
+  subjects = ["ministryofjustice/data-engineering-datalake-access:*"]
+
+  policies = {
+    data_engineering_github_actions = module.data_engineering_github_actions_iam_policy.arn
+  }
+
+  tags = local.tags
+}
+
+module "data_engineering_terraform_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.58.0"
+
+  create_role = true
+
+  role_name         = "data-engineering-terraform"
+  role_requires_mfa = false
+
+  trusted_role_arns = [module.data_engineering_github_actions_iam_role.arn]
+
+  custom_role_policy_arns = [module.data_engineering_terraform_iam_policy.arn]
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-common/iam-roles.tf
+++ b/terraform/environments/analytical-platform-common/iam-roles.tf
@@ -56,25 +56,25 @@ module "analytical_platform_terraform_iam_role" {
   tags = local.tags
 }
 
-module "data_engineering_github_actions_iam_role" {
+module "data_engineering_datalake_access_github_actions_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "5.58.0"
 
-  name = "data-engineering-github-actions"
+  name = "data-engineering-datalake-access-github-actions"
 
-  subjects = ["ministryofjustice/data-engineering-datalake-access:*"]
+  subjects = ["moj-analytical-services/data-engineering-datalake-access:*"]
 
   policies = {
-    data_engineering_github_actions = module.data_engineering_github_actions_iam_policy.arn
+    data_engineering_github_actions = module.data_engineering_datalake_access_github_actions_iam_policy.arn
   }
 
   tags = local.tags
 }
 
-module "data_engineering_terraform_iam_role" {
+module "data_engineering_datalake_access_terraform_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
@@ -83,12 +83,12 @@ module "data_engineering_terraform_iam_role" {
 
   create_role = true
 
-  role_name         = "data-engineering-terraform"
+  role_name         = "data-engineering-datalake-access-terraform"
   role_requires_mfa = false
 
-  trusted_role_arns = [module.data_engineering_github_actions_iam_role.arn]
+  trusted_role_arns = [module.data_engineering_datalake_access_github_actions_iam_role.arn]
 
-  custom_role_policy_arns = [module.data_engineering_terraform_iam_policy.arn]
+  custom_role_policy_arns = [module.data_engineering_datalake_access_terraform_iam_policy.arn]
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-common/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-common/s3-buckets.tf
@@ -3,7 +3,7 @@ module "terraform_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.6.1"
+  version = "4.10.1"
 
   bucket = "mojap-common-${local.environment}-tfstate"
 


### PR DESCRIPTION
## Proposed Changes

- Creates IAM policy and role to allow https://github.com/moj-analytical-services/data-engineering-datalake-access write state to `${module.terraform_bucket.s3_bucket_arn}/data-engineering-datalake-access/*` 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>