### PR TITLE
DPR2-2043: Ignore tickle lambda alert when data is insufficient

### DIFF
--- a/terraform/environments/digital-prison-reporting/metric_alarms.tf
+++ b/terraform/environments/digital-prison-reporting/metric_alarms.tf
@@ -127,6 +127,8 @@ module "dpr_postgres_tickle_function_failure_alarm" {
   period              = local.period_postgres_tickle_function_failure_alarm
   unit                = "Count"
 
+  treat_missing_data  = "notBreaching"
+
   namespace   = "AWS/Lambda"
   metric_name = "Errors"
   statistic   = "Maximum"


### PR DESCRIPTION
This PR
- Ignores the tickle lambda alert when there is insufficient data