### PR TITLE
TM-1320: hmpps: remove decommissioned Azure DCs from IP address list

### DIFF
--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -4,8 +4,6 @@ locals {
     # Prod Domain Controllers
     PCMCW0011 = "10.40.128.196"
     PCMCW0012 = "10.40.0.133"
-    pcmcw1011 = "10.40.144.196"
-    pcmcw1012 = "10.40.64.133"
 
     # DevTest Domain Controllers
     MGMCW0002 = "10.102.0.196"
@@ -21,8 +19,6 @@ locals {
       domain_controllers = [
         local.azure_fixngo_ip.PCMCW0011,
         local.azure_fixngo_ip.PCMCW0012,
-        local.azure_fixngo_ip.pcmcw1011,
-        local.azure_fixngo_ip.pcmcw1012,
       ]
     }
   }
@@ -46,8 +42,6 @@ locals {
 
     noms_prod_domain_controller_PCMCW0011 = "10.40.128.196/32"
     noms_prod_domain_controller_PCMCW0012 = "10.40.0.133/32"
-    noms_prod_domain_controller_pcmcw1011 = "10.40.144.196/32"
-    noms_prod_domain_controller_pcmcw1012 = "10.40.64.133/32"
 
     noms_devtest_domain_controller_MGMCW0002 = "10.102.0.196/32"
   }
@@ -194,8 +188,6 @@ locals {
     prod_domain_controllers = [
       local.azure_fixngo_cidr.noms_prod_domain_controller_PCMCW0011,
       local.azure_fixngo_cidr.noms_prod_domain_controller_PCMCW0012,
-      local.azure_fixngo_cidr.noms_prod_domain_controller_pcmcw1011,
-      local.azure_fixngo_cidr.noms_prod_domain_controller_pcmcw1012,
     ]
 
     prod_jumpservers = [


### PR DESCRIPTION
Zap DCs from ip address module. This will cause a change in Security Groups in some accounts, e.g. CSR