### PR TITLE
TM-1320: add tightened dc security group via baseline

### DIFF
--- a/terraform/environments/hmpps-domain-services/main.tf
+++ b/terraform/environments/hmpps-domain-services/main.tf
@@ -96,6 +96,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_log_groups", {}),
   )
 
+  data_firehoses = merge(
+    module.baseline_presets.data_firehoses,
+    lookup(local.baseline_all_environments, "data_firehoses", {}),
+    lookup(local.baseline_environment_specific, "data_firehoses", {}),
+  )
+
   ec2_autoscaling_groups = merge(
     lookup(local.baseline_all_environments, "ec2_autoscaling_groups", {}),
     lookup(local.baseline_environment_specific, "ec2_autoscaling_groups", {}),
@@ -196,6 +202,7 @@ module "baseline" {
   )
 
   security_groups = merge(
+    module.baseline_presets.security_groups,
     lookup(local.baseline_all_environments, "security_groups", {}),
     lookup(local.baseline_environment_specific, "security_groups", {}),
   )

--- a/terraform/modules/baseline_presets/outputs.tf
+++ b/terraform/modules/baseline_presets/outputs.tf
@@ -166,6 +166,13 @@ output "secretsmanager_secrets" {
   }
 }
 
+output "security_groups" {
+  description = "Map of common security_groupss to create"
+  value = {
+    for key, value in local.security_groups : key => value if contains(local.security_groups_filter, key)
+  }
+}
+
 output "ssm_associations" {
   description = "Map of common ssm associations to create"
   value = {

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -1,0 +1,166 @@
+locals {
+
+  security_groups_filter = flatten([
+    var.options.enable_hmpps_domain ? ["domain_controllers"] : []
+  ])
+
+  ad_netbios_name = contains(["development", "test"], var.environment.environment) ? "azure" : "hmpp"
+
+  security_groups = {
+
+    domain_controllers = {
+      description = "Security group for Domain Controllers"
+      ingress = {
+        icmp = {
+          description = "Allow ICMP ingress"
+          protocol    = "ICMP"
+          from_port   = 8
+          to_port     = 0
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        rpc_tcp = {
+          description = "Allow RPC ingress"
+          from_port   = 135
+          to_port     = 135
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        rpc_tcp_dynamic2 = {
+          description = "Allow RPC dynamic port range"
+          from_port   = 49152
+          to_port     = 65535
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+      }
+      egress = {
+        icmp = {
+          description = "Allow ICMP egress"
+          from_port   = 8
+          to_port     = 0
+          protocol    = "ICMP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        dns_udp = {
+          description = "Allow DNS UDP egress"
+          from_port   = 53
+          to_port     = 53
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        dns_tcp = {
+          description = "Allow DNS TCP egress"
+          from_port   = 53
+          to_port     = 53
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        kerberos_udp = {
+          description = "Allow Kerberos UDP egress"
+          from_port   = 88
+          to_port     = 88
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        kerberos_tcp = {
+          description = "Allow Kerberos TCP egress"
+          from_port   = 88
+          to_port     = 88
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        ntp_udp = {
+          description = "Allow NTP UDP egress"
+          from_port   = 123
+          to_port     = 123
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        rpc_tcp = {
+          description = "Allow RPC TCP egress"
+          from_port   = 135
+          to_port     = 135
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        netbios_udp = {
+          description = "Allow Netbios UDP egress"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        netbios_tcp = {
+          description = "Allow Netbios TCP egress"
+          from_port   = 137
+          to_port     = 139
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        ldap_udp = {
+          description = "Allow Ldap UDP egress"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        ldap_tcp = {
+          description = "Allow Ldap TCP egress"
+          from_port   = 389
+          to_port     = 389
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        smb_tcp = {
+          description = "Allow SMB TCP egress"
+          from_port   = 445
+          to_port     = 445
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        kerberos_password_change_udp = {
+          description = "Allow Kerberos Password Change UDP egress"
+          from_port   = 464
+          to_port     = 464
+          protocol    = "UDP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        kerberos_password_change_tcp = {
+          description = "Allow Kerberos Password Change TCP egress"
+          from_port   = 464
+          to_port     = 464
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        ldaps_tcp = {
+          description = "Allow Ldaps TCP egress"
+          from_port   = 636
+          to_port     = 636
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        ldap_global_catalog_tcp = {
+          description = "Allow Ldaps Global Catalog TCP egress"
+          from_port   = 3268
+          to_port     = 3269
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        adws_tcp = {
+          description = "Allow ADWS TCP egress"
+          from_port   = 9389
+          to_port     = 9389
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+        rpc_tcp_dynamic2 = {
+          description = "Allow RPC dynamic port range"
+          from_port   = 49152
+          to_port     = 65535
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/ip_addresses/active_directory.tf
+++ b/terraform/modules/ip_addresses/active_directory.tf
@@ -1,0 +1,21 @@
+locals {
+
+  # active directory
+  active_directory_cidrs = {
+    # azure.noms.root
+    azure = {
+      domain_controllers = concat(
+        local.azure_fixngo_cidrs.devtest_domain_controllers,
+        local.mp_cidrs.ad_fixngo_azure_domain_controllers
+      )
+    }
+
+    # azure.hmpp.root
+    hmpp = {
+      domain_controllers = concat(
+        local.azure_fixngo_cidrs.prod_domain_controllers,
+        local.mp_cidrs.ad_fixngo_hmpp_domain_controllers
+      )
+    }
+  }
+}

--- a/terraform/modules/ip_addresses/outputs.tf
+++ b/terraform/modules/ip_addresses/outputs.tf
@@ -28,6 +28,11 @@ output "mp_cidrs" {
   description = "Modernisation Platform cidrs: map(list(string))"
 }
 
+output "active_directory_cidrs" {
+  value       = local.active_directory_cidrs
+  description = "Active Directory cidrs: map(list(string))"
+}
+
 output "azure_fixngo_ip" {
   value       = local.azure_fixngo_ip
   description = "Azure FixNGo ips: map(string)"


### PR DESCRIPTION
Some of the SG rules are too wide and have unnecessary rules in, and it's generally Azure and DC related SGs. Adding a new DC security group via baseline which can be added as needed. Used AWS flow logs to figure out which ports are actually used.