### PR TITLE
TM-1320: tighten hmpps-domain-services SGs part 1

### DIFF
--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1026,7 +1026,7 @@ variable "security_groups" {
   description = "map of security groups and associated rules to create where key is the name of the group"
   type = map(object({
     description = string
-    ingress = map(object({
+    ingress = optional(map(object({
       description     = optional(string)
       from_port       = number
       to_port         = number
@@ -1035,8 +1035,8 @@ variable "security_groups" {
       cidr_blocks     = optional(list(string))
       self            = optional(bool)
       prefix_list_ids = optional(list(string))
-    }))
-    egress = map(object({
+    })), [])
+    egress = optional(map(object({
       description     = optional(string)
       from_port       = number
       to_port         = number
@@ -1045,7 +1045,7 @@ variable "security_groups" {
       cidr_blocks     = optional(list(string))
       self            = optional(bool)
       prefix_list_ids = optional(list(string))
-    }))
+    })), [])
     tags = optional(map(string), {})
   }))
   default = {}

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1035,7 +1035,7 @@ variable "security_groups" {
       cidr_blocks     = optional(list(string))
       self            = optional(bool)
       prefix_list_ids = optional(list(string))
-    })), [])
+    })), {})
     egress = optional(map(object({
       description     = optional(string)
       from_port       = number
@@ -1045,7 +1045,7 @@ variable "security_groups" {
       cidr_blocks     = optional(list(string))
       self            = optional(bool)
       prefix_list_ids = optional(list(string))
-    })), [])
+    })), {})
     tags = optional(map(string), {})
   }))
   default = {}

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -1,15 +1,15 @@
 locals {
 
   security_groups_filter = flatten([
-    var.options.enable_hmpps_domain ? ["ad_join"] : [],
-    var.options.enable_hmpps_domain ? ["rdp_from_gateways"] : [],
+    var.options.enable_hmpps_domain ? ["ad-join"] : [],
+    var.options.enable_hmpps_domain ? ["rdp-from-gateways"] : [],
   ])
 
   ad_netbios_name = contains(["development", "test"], var.environment.environment) ? "azure" : "hmpp"
 
   security_groups = {
 
-    ad_join = {
+    ad-join = {
       description = "Security group for resources that need to join the ${local.ad_netbios_name} active directory domain"
       ingress = {
         icmp = {
@@ -35,135 +35,32 @@ locals {
         }
       }
       egress = {
-        icmp = {
-          description = "Allow ICMP egress"
-          from_port   = 8
-          to_port     = 0
-          protocol    = "ICMP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        dns_udp = {
-          description = "Allow DNS UDP egress"
-          from_port   = 53
-          to_port     = 53
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        dns_tcp = {
-          description = "Allow DNS TCP egress"
-          from_port   = 53
-          to_port     = 53
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        kerberos_udp = {
-          description = "Allow Kerberos UDP egress"
-          from_port   = 88
-          to_port     = 88
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        kerberos_tcp = {
-          description = "Allow Kerberos TCP egress"
-          from_port   = 88
-          to_port     = 88
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        ntp_udp = {
-          description = "Allow NTP UDP egress"
-          from_port   = 123
-          to_port     = 123
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        rpc_tcp = {
-          description = "Allow RPC TCP egress"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        netbios_udp = {
-          description = "Allow Netbios UDP egress"
-          from_port   = 137
-          to_port     = 139
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        netbios_tcp = {
-          description = "Allow Netbios TCP egress"
-          from_port   = 137
-          to_port     = 139
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        ldap_udp = {
-          description = "Allow Ldap UDP egress"
-          from_port   = 389
-          to_port     = 389
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        ldap_tcp = {
-          description = "Allow Ldap TCP egress"
-          from_port   = 389
-          to_port     = 389
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        smb_tcp = {
-          description = "Allow SMB TCP egress"
-          from_port   = 445
-          to_port     = 445
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        kerberos_password_change_udp = {
-          description = "Allow Kerberos Password Change UDP egress"
-          from_port   = 464
-          to_port     = 464
-          protocol    = "UDP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        kerberos_password_change_tcp = {
-          description = "Allow Kerberos Password Change TCP egress"
-          from_port   = 464
-          to_port     = 464
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        ldaps_tcp = {
-          description = "Allow Ldaps TCP egress"
-          from_port   = 636
-          to_port     = 636
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        ldap_global_catalog_tcp = {
-          description = "Allow Ldaps Global Catalog TCP egress"
-          from_port   = 3268
-          to_port     = 3269
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        adws_tcp = {
-          description = "Allow ADWS TCP egress"
-          from_port   = 9389
-          to_port     = 9389
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
-        }
-        rpc_tcp_dynamic2 = {
-          description = "Allow RPC dynamic port range"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+        all = {
+          # Ideally, we'd lock down to specific ports but we exceed maximum number of rules for SG
+          # Ports required:
+          #  - ICMP
+          #  - DNS         tcp/53 udp/53
+          #  - Kerberos    tcp/88 udp/88
+          #  - NTP         udp/123
+          #  - RPC         tcp/135
+          #  - Netbios     udp/137 udp/138 tcp/139
+          #  - LDAP        tcp/389 udp/389
+          #  - SMB         tcp/445
+          #  - Kerberos    tcp/464 udp/464 (Password Change)
+          #  - LDAPs       tcp/636
+          #  - LDAP GC     tcp/3268 tcp/3269 (Global Catalog for Cross Domain)
+          #  - ADWS        tcp/9389
+          #  - RPD Dynamic tcp/49152 - tcp/65536
+          description     = "Allow all egress to DCs"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].domain_controllers
+          security_groups = []
         }
       }
     }
-    rdp_from_gateways = {
+    rdp-from-gateways = {
       description = "Security group to allow RDP from ${local.ad_netbios_name} remote desktop gateways"
       ingress = {
         rpd-tcp = {

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -68,20 +68,20 @@ locals {
           from_port   = 3389
           to_port     = 3389
           protocol    = "TCP"
-          cidr_blocks = concat(
+          cidr_blocks = flatten([
             var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          )
+          ])
         }
         rdp-udp = {
           description = "Allow UDP RDP from Remote Desktop Gateways"
           from_port   = 3389
           to_port     = 3389
           protocol    = "UDP"
-          cidr_blocks = concat(
+          cidr_blocks = flatten([
             var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          )
+          ])
         }
       }
     }

--- a/terraform/modules/ip_addresses/active_directory.tf
+++ b/terraform/modules/ip_addresses/active_directory.tf
@@ -1,12 +1,17 @@
 locals {
 
-  # active directory
+  # active directory
   active_directory_cidrs = {
     # azure.noms.root
     azure = {
       domain_controllers = concat(
         local.azure_fixngo_cidrs.devtest_domain_controllers,
         local.mp_cidrs.ad_fixngo_azure_domain_controllers
+      )
+
+      rd_gateways = concat(
+        local.azure_fixngo_cidrs.devtest_rdgateways,
+        # MP gateways are in ASGs so could be any IP in hmpps VPC
       )
     }
 
@@ -15,6 +20,11 @@ locals {
       domain_controllers = concat(
         local.azure_fixngo_cidrs.prod_domain_controllers,
         local.mp_cidrs.ad_fixngo_hmpp_domain_controllers
+      )
+
+      rd_gateways = concat(
+        local.azure_fixngo_cidrs.prod_rdgateways,
+        # MP gateways are in ASGs so could be any IP in hmpps VPC
       )
     }
   }

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -42,8 +42,10 @@ locals {
 
     noms_prod_domain_controller_PCMCW0011 = "10.40.128.196/32"
     noms_prod_domain_controller_PCMCW0012 = "10.40.0.133/32"
+    noms_prod_rdgateway_PDMRW0001         = "10.40.128.133/32"
 
     noms_devtest_domain_controller_MGMCW0002 = "10.102.0.196/32"
+    noms_devtest_rdgateway_MGMRW0001         = "10.102.0.132/32"
   }
 
   noms_live_subnet = {
@@ -165,6 +167,10 @@ locals {
       local.noms_mgmt_subnet.nomsmgmt_remoteaccess,
     ]
 
+    devtest_rdgateways = [
+      local.azure_fixngo_cidr.noms_devtest_rdgateway_MGMRW0001,
+    ]
+
     devtest_oasys_db = [
       local.noms_test_subnet.t1_oasys_clientaccess,
       local.noms_test_subnet.t2_oasys_clientaccess,
@@ -193,6 +199,10 @@ locals {
     prod_jumpservers = [
       local.noms_mgmt_live_subnet.noms_mgmt_live_jumpservers,
       local.noms_mgmt_live_subnet.noms_mgmt_live_remoteaccess,
+    ]
+
+    prod_rdgateways = [
+      local.azure_fixngo_cidr.noms_prod_rdgateway_PDMRW0001,
     ]
 
     prod_oasys_db = [

--- a/terraform/modules/ip_addresses/moj.tf
+++ b/terraform/modules/ip_addresses/moj.tf
@@ -32,7 +32,7 @@ locals {
       "194.33.197.0/25"
     ]
 
-    # Ian Norris: for sites that don't go through prisma
+    # Ian Norris: for sites that don't go through prisma
     vodafone_dia_networks = [
       "194.33.200.0/21",
       "194.33.216.0/23",


### PR DESCRIPTION
Some more prep & fixes in order to tighten SGs in hmpps-domain-services:
- use dashes instead of underscores in naming to be consistent with SGs elsewhere
- simplified outbound rules to avoid running into maximum number of rules limit
- added rdp from rdgateway SG
- whitespace fixes