### PR TITLE
Update TF state mgmt job to use centralised secrets

### DIFF
--- a/.github/workflows/terraform-state-management.yml
+++ b/.github/workflows/terraform-state-management.yml
@@ -47,9 +47,6 @@ on:
         default: "root"
         description: "Component (Optional: subfolder in 'terraform/environments/<application>' if present)"
 
-env:
-  ENVIRONMENT_MANAGEMENT: "${{ secrets.modernisation_platform_environments }}"
-
 permissions:
   id-token: write
   contents: read
@@ -159,8 +156,14 @@ jobs:
           echo -e "$SUMMARY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+  fetch-secrets:
+        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+        secrets:
+          MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
   approve_operation:
-    needs: request_operation
+    needs: [request_operation, fetch-secrets]
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.application }}-${{ github.event.inputs.workspace }}
     steps:
@@ -175,6 +178,12 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ github.event.inputs.branch_name }}
+
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@c46848c0f17b1550dcf8ecffa0cdad8f0fc858ef # v3.2.3
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10126

## What's Changed?

I've updated the `terraform-state-management.yml` workflow to use centralised AWS secrets.

## Testing

See the following workflow run where I've tested a state unlock for sprinkler..
https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/15679883659