### PR TITLE
TM-1320: planetfm security group tidyup v1

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals.tf
+++ b/terraform/environments/corporate-staff-rostering/locals.tf
@@ -28,6 +28,7 @@ locals {
       enable_business_unit_kms_cmks               = true
       enable_ec2_cloud_watch_agent                = true
       enable_ec2_oracle_enterprise_managed_server = true
+      enable_ec2_security_groups                  = true
       enable_ec2_self_provision                   = true
       enable_ec2_session_manager_cloudwatch_logs  = true
       enable_ec2_ssm_agent_update                 = true

--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -101,9 +101,9 @@ locals {
           key_name                     = "ec2-user"
           metadata_options_http_tokens = "required"
           vpc_security_group_ids = [
-            "ad-join",
-            "rdp-from-gateways",
             "web",
+            "ad-join",
+            "ec2-windows",
           ]
         }
         tags = {
@@ -153,9 +153,9 @@ locals {
           key_name                     = "ec2-user"
           metadata_options_http_tokens = "required"
           vpc_security_group_ids = [
-            "ad-join",
-            "rdp-from-gateways",
             "web",
+            "ad-join",
+            "ec2-windows",
           ]
         }
         tags = {

--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -29,10 +29,9 @@ locals {
           backup-plan = "daily-and-weekly"
         }
         vpc_security_group_ids = [
-          "ad-join",
           "app",
-          "remote-management",
-          "rdp-from-gateways",
+          "ad-join",
+          "ec2-windows",
         ]
       }
       route53_records = {
@@ -146,10 +145,9 @@ locals {
           backup-plan = "daily-and-weekly"
         }
         vpc_security_group_ids = [
-          "ad-join",
           "web",
-          "remote-management",
-          "rdp-from-gateways",
+          "ad-join",
+          "ec2-windows",
         ]
       }
       route53_records = {

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -589,59 +589,5 @@ locals {
         }
       }
     }
-
-    remote-management = {
-      description = "Security group for managing windows servers remotely"
-      ingress = {
-        rpc-from-jumpservers = {
-          description = "135: TCP MS-RPC AD connect ingress from jumpservers"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-        smb-from-jumpserver = {
-          description = "445: TCP SMB ingress from jumpservers"
-          from_port   = 445
-          to_port     = 445
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-        rdp-from-jumpservers = {
-          description = "3389: Allow RDP ingress from jumpservers"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-        winrm-from-jumpservers = {
-          description = "5985-6: Allow WinRM ingress from jumpservers"
-          from_port   = 5985
-          to_port     = 5986
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-        rpc-dynamic_from-jumpservers = {
-          description = "49152-65535: TCP Dynamic Port range from jumpservers"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-      }
-      egress = {
-        all-to-jumpservers = {
-          description = "Allow all egress to jumpservers"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = local.security_group_cidrs.jumpservers
-        }
-      }
-    }
-
   }
 }
-
-
-

--- a/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_autoscaling_groups.tf
@@ -90,9 +90,8 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
           "ad-join",
-          "rdp-from-gateways",
+          "ec2-windows",
           "rd-session-host",
         ]
         tags = {
@@ -149,10 +148,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
           "rdgw",
           "ad-join",
-          "rdp-from-gateways",
+          "ec2-windows",
         ]
         tags = {
           patch-manager = "group2"
@@ -213,10 +211,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
-          "ad-join",
-          "rdp-from-gateways",
           "rds",
+          "ad-join",
+          "ec2-windows",
         ]
         tags = {
           patch-manager = "group2"

--- a/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
+++ b/terraform/environments/hmpps-domain-services/locals_ec2_instances.tf
@@ -35,9 +35,8 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
           "ad-join",
-          "rdp-from-gateways",
+          "ec2-windows",
           "rd-session-host",
         ]
       }
@@ -91,10 +90,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
-          "ad-join",
-          "rdp-from-gateways",
           "rdgw",
+          "ad-join",
+          "ec2-windows",
         ]
       }
       ebs_volumes = {
@@ -137,10 +135,9 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "ec2-windows",
-          "ad-join",
-          "rdp-from-gateways",
           "rds",
+          "ad-join",
+          "ec2-windows",
         ]
       }
       ebs_volumes = {

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -32,6 +32,7 @@ locals {
       enable_backup_plan_daily_and_weekly        = true
       enable_business_unit_kms_cmks              = true
       enable_ec2_cloud_watch_agent               = true
+      enable_ec2_security_groups                 = true
       enable_ec2_self_provision                  = true
       enable_ec2_session_manager_cloudwatch_logs = true
       enable_ec2_ssm_agent_update                = true

--- a/terraform/environments/planetfm/locals_ec2_instances.tf
+++ b/terraform/environments/planetfm/locals_ec2_instances.tf
@@ -26,8 +26,11 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
-
+        vpc_security_group_ids = [
+          "app",
+          "ad-join",
+          "ec2-windows",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -67,8 +70,11 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["domain", "database", "jumpserver"]
-
+        vpc_security_group_ids = [
+          "database",
+          "ad-join",
+          "ec2-windows",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -110,8 +116,11 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["domain", "web", "jumpserver", "remotedesktop_sessionhost"]
-
+        vpc_security_group_ids = [
+          "web",
+          "ad-join",
+          "ec2-windows",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }

--- a/terraform/environments/planetfm/locals_security_groups.tf
+++ b/terraform/environments/planetfm/locals_security_groups.tf
@@ -9,7 +9,12 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.devtest_domain_controllers,
       module.ip_addresses.mp_cidrs.ad_fixngo_azure_domain_controllers,
     ])
+    # consolodate below in future PR
     jumpservers = module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers
+    jumpservers2 = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name]
+    ])
     remotedesktop_gateways = flatten([
       module.ip_addresses.azure_fixngo_cidrs.devtest_jumpservers,
       module.ip_addresses.mp_cidr[module.environment.vpc_name]
@@ -26,7 +31,12 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod_domain_controllers,
       # module.ip_addresses.mp_cidrs.ad_fixngo_hmpp_domain_controllers, # hits rule limit, remove azure DCs first
     ])
+    # consolodate below in future PR
     jumpservers = module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers
+    jumpservers2 = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name]
+    ])
     remotedesktop_gateways = flatten([
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
       module.ip_addresses.mp_cidr[module.environment.vpc_name]
@@ -82,19 +92,12 @@ locals {
     web = {
       description = "Security group for Windows Web Servers"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         http_web = {
           description     = "80: Allow HTTP ingress from LB"
           from_port       = 80
           to_port         = 80
           protocol        = "TCP"
-          cidr_blocks     = ["10.40.129.64/26"] # noms mgmt live jumpservers
+          cidr_blocks     = local.security_group_cidrs.jumpserver2
           security_groups = ["loadbalancer"]
         }
         https_web = {
@@ -104,55 +107,17 @@ locals {
           protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
-        rdp_tcp_web = {
-          description = "3389: Allow RDP TCP ingress from jumpserver"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-        rdp_udp_web = {
-          description = "3389: Allow RDP UDP ingress from jumpserver"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
-        }
       }
     }
     app = {
       description = "Security group for Windows App Servers"
       ingress = {
-        all-from-self = {
-          description     = "Allow all ingress to self"
+        all-from-web = {
+          description     = "Allow all ingress from web"
           from_port       = 0
           to_port         = 0
           protocol        = -1
-          self            = true
           security_groups = ["web"]
-        }
-        rdp_tcp_app = {
-          description = "3389: Allow RDP UDP ingress from jumpserver"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-        rdp_udp_app = {
-          description = "3389: Allow RDP UDP ingress from jumpserver"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
         }
         web_access_cafm_5504 = {
           description     = "All web access inbound on 5504"
@@ -160,33 +125,23 @@ locals {
           to_port         = 5504
           protocol        = "TCP"
           security_groups = ["database", "loadbalancer"]
-          cidr_blocks     = local.security_group_cidrs.enduserclient # NOTE: this may need to change at some point
+          cidr_blocks     = local.security_group_cidrs.enduserclient
         }
         cafm_licensing_7071 = {
           description = "All CAFM licensing inbound on 7071"
           from_port   = 7071
           to_port     = 7071
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient # NOTE: this may need to change at some point
+          cidr_blocks = local.security_group_cidrs.enduserclient
         }
         cafm_licensing_7073 = {
           description = "All CAFM licensing inbound on 7073"
           from_port   = 7073
           to_port     = 7073
           protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient # NOTE: this may need to change at some point
+          cidr_blocks = local.security_group_cidrs.enduserclient
         }
       }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
-        }
-      }
-
     }
     domain = {
       description = "Common Windows security group for fixngo domain(s) access from Jumpservers and Azure DCs"
@@ -453,19 +408,24 @@ locals {
       }
     }
     database = {
-      # FIXME: note - this may still need Winrm and Winrm https ports adding
       description = "Security group for WINDOWS SQL database servers"
       ingress = {
-        all-from-self = {
-          description     = "Allow all ingress to self"
+        all-from-app = {
+          description     = "Allow all ingress from app"
           from_port       = 0
           to_port         = 0
           protocol        = -1
-          self            = true
-          security_groups = ["web", "app"]
+          security_groups = ["app"]
+        }
+        all-from-web = {
+          description     = "Allow all ingress from web"
+          from_port       = 0
+          to_port         = 0
+          protocol        = -1
+          security_groups = ["web"]
         }
         http_enduser_db = {
-          description = "80: HTTP ingress for end-users" # Try to remove this later as it's not part of the Azure rule set
+          description = "80: HTTP ingress for end-users"
           from_port   = 80
           to_port     = 80
           protocol    = "TCP"
@@ -492,27 +452,6 @@ locals {
           protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
-        smb_udp_445_enduser = {
-          description = "445: UDP SMB ingress from enduserclient"
-          from_port   = 445
-          to_port     = 445
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-        rdp_tcp_db = {
-          description = "3389: Allow RDP TCP ingress from azure jumpservers"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-        rdp_udp_db = {
-          description = "3389: Allow RDP UDP ingress from azure jumpservers"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
         sql_tcp_1433_enduser = {
           description = "1433: Allow SQL Server TCP ingress from enduserclient for authentication"
           from_port   = 1433
@@ -525,13 +464,6 @@ locals {
           from_port   = 1434
           to_port     = 1434
           protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-        winrm_tcp_db = {
-          description = "5985-5986: Allow WinRM from CAFM servers and other clients"
-          from_port   = 5985
-          to_port     = 5986
-          protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
         cafm_licensing_7071_db = {
@@ -548,28 +480,12 @@ locals {
           protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
-        rpc_dynamic_udp_db = {
-          description = "49152-65535: UDP Dynamic Port range"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
         rpc_dynamic_tcp_db = {
           description = "49152-65535: TCP Dynamic Port range"
           from_port   = 49152
           to_port     = 65535
           protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
         }
       }
     }

--- a/terraform/environments/planetfm/locals_security_groups.tf
+++ b/terraform/environments/planetfm/locals_security_groups.tf
@@ -97,7 +97,7 @@ locals {
           from_port       = 80
           to_port         = 80
           protocol        = "TCP"
-          cidr_blocks     = local.security_group_cidrs.jumpserver2
+          cidr_blocks     = local.security_group_cidrs.jumpservers2
           security_groups = ["loadbalancer"]
         }
         https_web = {

--- a/terraform/environments/planetfm/main.tf
+++ b/terraform/environments/planetfm/main.tf
@@ -96,6 +96,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_log_groups", {}),
   )
 
+  data_firehoses = merge(
+    module.baseline_presets.data_firehoses,
+    lookup(local.baseline_all_environments, "data_firehoses", {}),
+    lookup(local.baseline_environment_specific, "data_firehoses", {}),
+  )
+
   ec2_autoscaling_groups = merge(
     lookup(local.baseline_all_environments, "ec2_autoscaling_groups", {}),
     lookup(local.baseline_environment_specific, "ec2_autoscaling_groups", {}),
@@ -196,6 +202,7 @@ module "baseline" {
   )
 
   security_groups = merge(
+    module.baseline_presets.security_groups,
     lookup(local.baseline_all_environments, "security_groups", {}),
     lookup(local.baseline_environment_specific, "security_groups", {}),
   )

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -98,6 +98,56 @@ locals {
           protocol    = -1
           self        = true
         }
+        rpc-from-jumpservers = {
+          description = "Allow RPC from jumpservers"
+          from_port   = 135
+          to_port     = 135
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        smb-from-jumpserver = {
+          description = "Allow SMB from jumpservers"
+          from_port   = 445
+          to_port     = 445
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        rdp-from-jumpservers = {
+          description = "Allow RDP from jumpservers"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        winrm-from-jumpservers = {
+          description = "Allow WinRM from jumpservers"
+          from_port   = 5985
+          to_port     = 5986
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        rpc-dynamic_from-jumpservers = {
+          description = "Allow RPC dynamic from jumpservers"
+          from_port   = 49152
+          to_port     = 65535
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
       }
       egress = {
         all = {

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -89,77 +89,81 @@ locals {
     ec2-windows = {
       description = "Security group for windows EC2s"
 
-      ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
-        rpc-from-jumpservers = {
-          description = "Allow RPC from jumpservers"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        smb-from-jumpserver = {
-          description = "Allow SMB from jumpservers"
-          from_port   = 445
-          to_port     = 445
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        rdp-tcp-from-jumpservers = {
-          description = "Allow RDP TCP from jumpservers"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        rdp-udp-from-jumpservers = {
-          description = "Allow RDP UDP from jumpservers"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        winrm-from-jumpservers = {
-          description = "Allow WinRM from jumpservers"
-          from_port   = 5985
-          to_port     = 5986
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        rpc-dynamic_from-jumpservers = {
-          description = "Allow RPC dynamic from jumpservers"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-      }
+      ingress = merge(
+        {
+          all-from-self = {
+            description = "Allow all ingress to self"
+            from_port   = 0
+            to_port     = 0
+            protocol    = -1
+            self        = true
+          }
+        },
+        var.options.enable_hmpps_domain ? {
+          rpc-from-jumpservers = {
+            description = "Allow RPC from jumpservers"
+            from_port   = 135
+            to_port     = 135
+            protocol    = "TCP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+          smb-from-jumpserver = {
+            description = "Allow SMB from jumpservers"
+            from_port   = 445
+            to_port     = 445
+            protocol    = "TCP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+          rdp-tcp-from-jumpservers = {
+            description = "Allow RDP TCP from jumpservers"
+            from_port   = 3389
+            to_port     = 3389
+            protocol    = "TCP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+          rdp-udp-from-jumpservers = {
+            description = "Allow RDP UDP from jumpservers"
+            from_port   = 3389
+            to_port     = 3389
+            protocol    = "UDP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+          winrm-from-jumpservers = {
+            description = "Allow WinRM from jumpservers"
+            from_port   = 5985
+            to_port     = 5986
+            protocol    = "TCP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+          rpc-dynamic_from-jumpservers = {
+            description = "Allow RPC dynamic from jumpservers"
+            from_port   = 49152
+            to_port     = 65535
+            protocol    = "TCP"
+            cidr_blocks = flatten([
+              var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+              var.ip_addresses.mp_cidr[var.environment.vpc_name],
+            ])
+          }
+        } : {}
+      )
       egress = {
         all = {
           # allow all since internal resources are protected by inbound SGs

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -187,7 +187,7 @@ locals {
           to_port     = 3389
           protocol    = "TCP"
           cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
           ])
         }
@@ -197,7 +197,7 @@ locals {
           to_port     = 3389
           protocol    = "UDP"
           cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
           ])
         }

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -2,6 +2,7 @@ locals {
 
   security_groups_filter = flatten([
     var.options.enable_hmpps_domain ? ["ad-join"] : [],
+    var.options.enable_hmpps_domain ? ["rdp-from-gateways"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-linux"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-windows"] : [],
   ])
@@ -173,6 +174,32 @@ locals {
           to_port     = 0
           protocol    = "-1"
           cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+
+    rdp-from-gateways = {
+      description = "Security group to allow RDP from ${local.ad_netbios_name} remote desktop gateways"
+      ingress = {
+        rpd-tcp = {
+          description = "Allow TCP RDP from Remote Desktop Gateways"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "TCP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        rdp-udp = {
+          description = "Allow UDP RDP from Remote Desktop Gateways"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "UDP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
         }
       }
     }

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -2,7 +2,6 @@ locals {
 
   security_groups_filter = flatten([
     var.options.enable_hmpps_domain ? ["ad-join"] : [],
-    var.options.enable_hmpps_domain ? ["rdp-from-gateways"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-linux"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-windows"] : [],
   ])
@@ -118,12 +117,24 @@ locals {
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
           ])
         }
-        rdp-from-jumpservers = {
-          description = "Allow RDP from jumpservers"
+        rdp-tcp-from-jumpservers = {
+          description = "Allow RDP TCP from jumpservers"
           from_port   = 3389
           to_port     = 3389
           protocol    = "TCP"
           cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
+            var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          ])
+        }
+        rdp-udp-from-jumpservers = {
+          description = "Allow RDP UDP from jumpservers"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "UDP"
+          cidr_blocks = flatten([
+            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rdgateways,
             var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].jumpservers,
             var.ip_addresses.mp_cidr[var.environment.vpc_name],
           ])
@@ -158,32 +169,6 @@ locals {
           to_port     = 0
           protocol    = "-1"
           cidr_blocks = ["0.0.0.0/0"]
-        }
-      }
-    }
-
-    rdp-from-gateways = {
-      description = "Security group to allow RDP from ${local.ad_netbios_name} remote desktop gateways"
-      ingress = {
-        rpd-tcp = {
-          description = "Allow TCP RDP from Remote Desktop Gateways"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
-        }
-        rdp-udp = {
-          description = "Allow UDP RDP from Remote Desktop Gateways"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = flatten([
-            var.ip_addresses.active_directory_cidrs[local.ad_netbios_name].rd_gateways,
-            var.ip_addresses.mp_cidr[var.environment.vpc_name],
-          ])
         }
       }
     }

--- a/terraform/modules/ip_addresses/active_directory.tf
+++ b/terraform/modules/ip_addresses/active_directory.tf
@@ -9,7 +9,12 @@ locals {
         local.mp_cidrs.ad_fixngo_azure_domain_controllers
       )
 
-      rd_gateways = concat(
+      jumpservers = concat(
+        local.azure_fixngo_cidrs.devtest_jumpservers,
+        # MP jumpservers are in ASGs so could be any IP in hmpps VPC
+      )
+
+      rdgateways = concat(
         local.azure_fixngo_cidrs.devtest_rdgateways,
         # MP gateways are in ASGs so could be any IP in hmpps VPC
       )
@@ -22,7 +27,12 @@ locals {
         local.mp_cidrs.ad_fixngo_hmpp_domain_controllers
       )
 
-      rd_gateways = concat(
+      jumpservers = concat(
+        local.azure_fixngo_cidrs.prod_jumpservers,
+        # MP jumpservers are in ASGs so could be any IP in hmpps VPC
+      )
+
+      rdgateways = concat(
         local.azure_fixngo_cidrs.prod_rdgateways,
         # MP gateways are in ASGs so could be any IP in hmpps VPC
       )


### PR DESCRIPTION
More Security Group simplification. Some of the rules were too wide, e.g. WINRM fron 10.0.0.0/8.

- use baseline ec2-windows/ec2-linux SGs for common rules, e.g. RDP and remote management of windows servers. This will replace remote-management SG in CSR and rdp-from-gateways in baseline.
- enable the baseline SGs in PlanetFM (ad-join and ec2-windows)
- remove unnecessary/duplicate rules from PlanetFM web/app/database SGs. Mainly unnecessary UDP rules, and rules already covered by ad-join/ec2-windows.

Agreed with Glenn to deploy in preproduction this afternoon.