### PR TITLE
TM-1320: csr security group db tidyup

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_development.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_development.tf
@@ -40,7 +40,11 @@ locals {
           instance_type                = "t3.medium"
           key_name                     = "ec2-user"
           metadata_options_http_tokens = "required"
-          vpc_security_group_ids       = ["database"]
+          vpc_security_group_ids = [
+            "database",
+            "ec2-linux",
+            "oem-agent",
+          ]
         }
         user_data_cloud_init = {
           args = {

--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -87,7 +87,11 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["database"]
+        vpc_security_group_ids = [
+          "database",
+          "ec2-linux",
+          "oem-agent",
+        ]
       }
       route53_records = {
         create_external_record = true

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -130,13 +130,6 @@ locals {
     web = {
       description = "New security group for web-servers"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         http_web = {
           description     = "80: http allow ingress"
           from_port       = 80
@@ -205,27 +198,16 @@ locals {
           security_groups = ["app", "database"]
         }
       }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
     }
 
     app = {
       description = "New security group for application servers"
       ingress = {
-        all-from-self = {
-          description     = "Allow all ingress to self"
+        all-from-web = {
+          description     = "Allow all ingress from web"
           from_port       = 0
           to_port         = 0
           protocol        = -1
-          self            = true
           security_groups = ["web"]
         }
         rpc_tcp_app2 = {
@@ -262,16 +244,6 @@ locals {
           to_port         = 65535
           protocol        = "TCP"
           security_groups = ["web", "database"]
-          # NOTE: csr_clientaccess will need to be added here to cidr_blocks
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
         }
       }
     }
@@ -469,50 +441,6 @@ locals {
     database = {
       description = "New security group for database servers"
       ingress = {
-        all-from-self = {
-          description     = "Allow all ingress to self"
-          from_port       = 0
-          to_port         = 0
-          protocol        = -1
-          self            = true
-          security_groups = ["web", "app"]
-        }
-        # IMPORTANT: check if an 'allow all from load-balancer' rule is required
-        echo_core_tcp_db = {
-          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port   = 7
-          to_port     = 7
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        echo_core_udp_db = {
-          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port   = 7
-          to_port     = 7
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        ssh-db = {
-          description = "22: SSH allow ingress"
-          from_port   = 22
-          to_port     = 22
-          protocol    = "tcp"
-          cidr_blocks = local.security_group_cidrs.ssh
-        }
-        rpc_tcp_db = {
-          description = "135: TCP MS-RPC AD connect ingress from Azure DC and Jumpserver"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
-        rpc_udp_db = {
-          description = "135: UDP MS-RPC AD connect ingress from Azure DC and Jumpserver"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
         oracle_1521_db = {
           description     = "Allow oracle database 1521 ingress"
           from_port       = "1521"
@@ -520,29 +448,6 @@ locals {
           protocol        = "TCP"
           cidr_blocks     = local.security_group_cidrs.oracle_db
           security_groups = ["web", "app"]
-        }
-        oracleoem_3872_db = {
-          description = "Allow oem agent ingress"
-          from_port   = "3872"
-          to_port     = "3872"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        rpc_dynamic_tcp_db = {
-          description = "49152-65535: TCP Dynamic Port range"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
         }
       }
     }

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -78,7 +78,7 @@ locals {
   security_groups = {
 
     load-balancer = {
-      description = "Security group for load-balancer"
+      description = "New security group for load-balancer"
       ingress = {
         all-from-self = {
           description = "Allow all ingress to self"
@@ -128,7 +128,7 @@ locals {
     }
 
     web = {
-      description = "Security group for web-servers"
+      description = "New security group for web-servers"
       ingress = {
         http_web = {
           description     = "80: http allow ingress"
@@ -201,7 +201,7 @@ locals {
     }
 
     app = {
-      description = "Security group for application servers"
+      description = "New security group for application servers"
       ingress = {
         all-from-web = {
           description     = "Allow all ingress from web"
@@ -439,7 +439,7 @@ locals {
     }
 
     database = {
-      description = "Security group for database servers"
+      description = "New security group for database servers"
       ingress = {
         oracle_1521_db = {
           description     = "Allow oracle database 1521 ingress"

--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -78,7 +78,7 @@ locals {
   security_groups = {
 
     load-balancer = {
-      description = "New security group for load-balancer"
+      description = "Security group for load-balancer"
       ingress = {
         all-from-self = {
           description = "Allow all ingress to self"
@@ -128,7 +128,7 @@ locals {
     }
 
     web = {
-      description = "New security group for web-servers"
+      description = "Security group for web-servers"
       ingress = {
         http_web = {
           description     = "80: http allow ingress"
@@ -201,7 +201,7 @@ locals {
     }
 
     app = {
-      description = "New security group for application servers"
+      description = "Security group for application servers"
       ingress = {
         all-from-web = {
           description     = "Allow all ingress from web"
@@ -439,7 +439,7 @@ locals {
     }
 
     database = {
-      description = "New security group for database servers"
+      description = "Security group for database servers"
       ingress = {
         oracle_1521_db = {
           description     = "Allow oracle database 1521 ingress"

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -5,6 +5,7 @@ locals {
     var.options.enable_hmpps_domain ? ["rdp-from-gateways"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-linux"] : [],
     var.options.enable_ec2_security_groups ? ["ec2-windows"] : [],
+    var.options.enable_ec2_security_groups && var.options.enable_ec2_oracle_enterprise_managed_server ? ["oem-agent"] : [],
   ])
 
   ad_netbios_name = contains(["development", "test"], var.environment.environment) ? "azure" : "hmpp"
@@ -174,6 +175,57 @@ locals {
           to_port     = 0
           protocol    = "-1"
           cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+
+    oem-agent = {
+      description = "Security group for EC2s with Oracle OEM agent"
+
+      ingress = {
+        icmp = {
+          description = "Allow ICMP ingress from OEM"
+          protocol    = "ICMP"
+          from_port   = 8
+          to_port     = 0
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+        }
+        echo = {
+          description = "Allow echo from OEM"
+          protocol    = "TCP"
+          from_port   = 7
+          to_port     = 7
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+        }
+        ssh = {
+          description = "Allow SSH from OEM"
+          from_port   = 22
+          to_port     = 22
+          protocol    = "tcp"
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+        }
+        oracle-db-1521 = {
+          description = "Allow oracle database 1521 ingress from OEM"
+          from_port   = "1521"
+          to_port     = "1521"
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+        }
+        oem-agent-3872 = {
+          description = "Allow oem agent ingress from OEM"
+          from_port   = "3872"
+          to_port     = "3872"
+          protocol    = "TCP"
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress to OEM"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
         }
       }
     }

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -188,35 +188,35 @@ locals {
           protocol    = "ICMP"
           from_port   = 8
           to_port     = 0
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
         echo = {
           description = "Allow echo from OEM"
           protocol    = "TCP"
           from_port   = 7
           to_port     = 7
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
         ssh = {
           description = "Allow SSH from OEM"
           from_port   = 22
           to_port     = 22
           protocol    = "tcp"
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
         oracle-db-1521 = {
           description = "Allow oracle database 1521 ingress from OEM"
           from_port   = "1521"
           to_port     = "1521"
           protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
         oem-agent-3872 = {
           description = "Allow oem agent ingress from OEM"
           from_port   = "3872"
           to_port     = "3872"
           protocol    = "TCP"
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
       }
       egress = {
@@ -225,7 +225,7 @@ locals {
           from_port   = 0
           to_port     = 0
           protocol    = "-1"
-          cidr_blocks = var.ip_addresses.mp_cidr[var.environment.vpc_name],
+          cidr_blocks = [var.ip_addresses.mp_cidr[var.environment.vpc_name]],
         }
       }
     }


### PR DESCRIPTION
Tighten DB Security group for CSR:
- add oem-agent SG to baseline as this is common across all environments
- tightened oem-agent rules as access from azure no longer required
- removed duplicate rules from web and app