### PR TITLE
TM-1320: nomis sg tweaks

### DIFF
--- a/terraform/environments/nomis/locals.tf
+++ b/terraform/environments/nomis/locals.tf
@@ -28,6 +28,7 @@ locals {
       enable_business_unit_kms_cmks               = true
       enable_ec2_cloud_watch_agent                = true
       enable_ec2_oracle_enterprise_managed_server = true
+      enable_ec2_security_groups                  = true
       enable_ec2_self_provision                   = true
       enable_ec2_session_manager_cloudwatch_logs  = true
       enable_ec2_ssm_agent_update                 = true

--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -103,7 +103,6 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
         vpc_security_group_ids = [
-          "private-jumpserver",
           "ad-join",
           "ec2-windows",
         ]

--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -23,13 +23,10 @@ locals {
         subnet_name = "private"
       }
       instance = {
-        disable_api_termination = false
-        instance_type           = "t3.medium"
-        key_name                = "ec2-user"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        disable_api_termination      = false
+        instance_type                = "t3.medium"
+        key_name                     = "ec2-user"
+        vpc_security_group_ids       = ["private-web"]
         metadata_options_http_tokens = "required"
       }
       user_data_cloud_init = {
@@ -102,10 +99,7 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids = [
-          "ad-join",
-          "ec2-windows",
-        ]
+        vpc_security_group_ids       = ["private-jumpserver"]
       }
       tags = {
         backup                          = "false"
@@ -192,13 +186,10 @@ locals {
         "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
       }
       instance = {
-        disable_api_termination = false
-        instance_type           = "t3.large"
-        key_name                = "ec2-user"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        disable_api_termination      = false
+        instance_type                = "t3.large"
+        key_name                     = "ec2-user"
+        vpc_security_group_ids       = ["private-web"]
         metadata_options_http_tokens = "required"
       }
       lb_target_groups = {
@@ -277,13 +268,10 @@ locals {
         "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
       }
       instance = {
-        disable_api_termination = false
-        instance_type           = "t3.large"
-        key_name                = "ec2-user"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        disable_api_termination      = false
+        instance_type                = "t3.large"
+        key_name                     = "ec2-user"
+        vpc_security_group_ids       = ["private-web"]
         metadata_options_http_tokens = "required"
       }
       lb_target_groups = {

--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -23,10 +23,13 @@ locals {
         subnet_name = "private"
       }
       instance = {
-        disable_api_termination      = false
-        instance_type                = "t3.medium"
-        key_name                     = "ec2-user"
-        vpc_security_group_ids       = ["private-web"]
+        disable_api_termination = false
+        instance_type           = "t3.medium"
+        key_name                = "ec2-user"
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
         metadata_options_http_tokens = "required"
       }
       user_data_cloud_init = {
@@ -99,7 +102,11 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["private-jumpserver"]
+        vpc_security_group_ids = [
+          "private-jumpserver",
+          "ad-join",
+          "ec2-windows",
+        ]
       }
       tags = {
         backup                          = "false"
@@ -186,10 +193,13 @@ locals {
         "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
       }
       instance = {
-        disable_api_termination      = false
-        instance_type                = "t3.large"
-        key_name                     = "ec2-user"
-        vpc_security_group_ids       = ["private-web"]
+        disable_api_termination = false
+        instance_type           = "t3.large"
+        key_name                = "ec2-user"
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
         metadata_options_http_tokens = "required"
       }
       lb_target_groups = {
@@ -268,10 +278,13 @@ locals {
         "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
       }
       instance = {
-        disable_api_termination      = false
-        instance_type                = "t3.large"
-        key_name                     = "ec2-user"
-        vpc_security_group_ids       = ["private-web"]
+        disable_api_termination = false
+        instance_type           = "t3.large"
+        key_name                = "ec2-user"
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
         metadata_options_http_tokens = "required"
       }
       lb_target_groups = {

--- a/terraform/environments/nomis/locals_ec2_instances.tf
+++ b/terraform/environments/nomis/locals_ec2_instances.tf
@@ -23,10 +23,7 @@ locals {
         instance_type                = "t3.medium"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        vpc_security_group_ids       = ["private-web"]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -229,10 +226,7 @@ locals {
         instance_type                = "t2.xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        vpc_security_group_ids       = ["private-web"]
       }
       route53_records = {
         create_internal_record = true
@@ -281,11 +275,7 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
-
+        vpc_security_group_ids       = ["private-web"]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -327,10 +317,7 @@ locals {
         disable_api_termination = false
         instance_type           = "t2.large"
         key_name                = "ec2-user"
-        vpc_security_group_ids = [
-          "private-web",
-          "ec2-linux",
-        ]
+        vpc_security_group_ids  = ["private-web"]
       }
       user_data_cloud_init = {
         args = {

--- a/terraform/environments/nomis/locals_ec2_instances.tf
+++ b/terraform/environments/nomis/locals_ec2_instances.tf
@@ -23,7 +23,10 @@ locals {
         instance_type                = "t3.medium"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["private-web"]
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -88,7 +91,11 @@ locals {
         instance_type                = "r6i.xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional"
-        vpc_security_group_ids       = ["data-db"]
+        vpc_security_group_ids = [
+          "data-db",
+          "ec2-linux",
+          "oem-agent",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -162,7 +169,11 @@ locals {
         instance_type                = "r6i.xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional"
-        vpc_security_group_ids       = ["data-db"]
+        vpc_security_group_ids = [
+          "data-db",
+          "ec2-linux",
+          "oem-agent",
+        ]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -218,7 +229,10 @@ locals {
         instance_type                = "t2.xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional"
-        vpc_security_group_ids       = ["private-web"]
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
       }
       route53_records = {
         create_internal_record = true
@@ -267,7 +281,10 @@ locals {
         instance_type                = "t3.large"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "required"
-        vpc_security_group_ids       = ["private-web"]
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
 
         tags = {
           backup-plan = "daily-and-weekly"
@@ -310,7 +327,10 @@ locals {
         disable_api_termination = false
         instance_type           = "t2.large"
         key_name                = "ec2-user"
-        vpc_security_group_ids  = ["private-web"]
+        vpc_security_group_ids = [
+          "private-web",
+          "ec2-linux",
+        ]
       }
       user_data_cloud_init = {
         args = {

--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -113,49 +113,53 @@ locals {
         }
       }
     }
+
+    # ideally would attach ec2-linux to EC2 as well but they are in an
+    # ASG, so just merge the rules instead
     private-web = {
       description = "Security group for web servers"
-      ingress = {
-        http7001 = {
-          description = "Allow http7001 ingress"
-          from_port   = 7001
-          to_port     = 7001
-          protocol    = "tcp"
-          security_groups = [
-            "private-lb",
-          ]
-          cidr_blocks = local.security_group_cidrs.http7xxx
-        },
-        http7777 = {
-          description = "Allow http7777 ingress"
-          from_port   = 7777
-          to_port     = 7777
-          protocol    = "tcp"
-          security_groups = [
-            "private-lb",
-          ]
-          cidr_blocks = local.security_group_cidrs.http7xxx
-        },
-      }
+      ingress = merge(
+        module.baseline_presets.security_groups["ec2-linux"].ingress,
+        {
+          http7001 = {
+            description = "Allow http7001 ingress"
+            from_port   = 7001
+            to_port     = 7001
+            protocol    = "tcp"
+            security_groups = [
+              "private-lb",
+            ]
+            cidr_blocks = local.security_group_cidrs.http7xxx
+          }
+          http7777 = {
+            description = "Allow http7777 ingress"
+            from_port   = 7777
+            to_port     = 7777
+            protocol    = "tcp"
+            security_groups = [
+              "private-lb",
+            ]
+            cidr_blocks = local.security_group_cidrs.http7xxx
+          }
+        }
+      )
+      egress = merge(
+        module.baseline_presets.security_groups["ec2-linux"].egress,
+      )
     }
+
+    # ideally would attach ec2-linux to EC2 as well but they are in an
+    # ASG, so just merge the rules instead
     private-jumpserver = {
       description = "Security group for jumpservers"
-      ingress = {
-        rdp_tcp_web = {
-          description = "3389: Allow RDP TCP ingress"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-        rdp_udp_web = {
-          description = "3389: Allow RDP UDP ingress"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
-        }
-      }
+      ingress = merge(
+        module.baseline_presets.security_groups["ec2-windows"].ingress,
+        module.baseline_presets.security_groups["ad-join"].ingress,
+      )
+      egress = merge(
+        module.baseline_presets.security_groups["ec2-windows"].egress,
+        module.baseline_presets.security_groups["ad-join"].egress,
+      )
     }
 
     data-db = {

--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -4,10 +4,6 @@ locals {
     icmp = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
     ])
-    ssh = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.devtest,
-      module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ])
     https = flatten([
       "10.0.0.0/8", # too many end-user addresses to list
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
@@ -23,7 +19,6 @@ locals {
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     oracle_oem_agent = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.devtest,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     remotedesktop_gateways = flatten([
@@ -34,10 +29,6 @@ locals {
   security_group_cidrs_preprod_prod = {
     icmp = flatten([
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
-    ])
-    ssh = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     https = flatten([
       "10.0.0.0/8", # too many end-user addresses to list
@@ -55,7 +46,6 @@ locals {
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     oracle_oem_agent = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     remotedesktop_gateways = flatten([
@@ -88,9 +78,6 @@ locals {
           from_port   = 80
           to_port     = 80
           protocol    = "tcp"
-          security_groups = [
-            "private-jumpserver",
-          ]
           cidr_blocks = local.security_group_cidrs.https
         }
         https = {
@@ -98,9 +85,6 @@ locals {
           from_port   = 443
           to_port     = 443
           protocol    = "tcp"
-          security_groups = [
-            "private-jumpserver",
-          ]
           cidr_blocks = local.security_group_cidrs.https
         }
         http7001 = {
@@ -108,9 +92,6 @@ locals {
           from_port   = 7001
           to_port     = 7001
           protocol    = "tcp"
-          security_groups = [
-            "private-jumpserver",
-          ]
           cidr_blocks = local.security_group_cidrs.http7xxx
         }
         http7777 = {
@@ -118,9 +99,6 @@ locals {
           from_port   = 7777
           to_port     = 7777
           protocol    = "tcp"
-          security_groups = [
-            "private-jumpserver",
-          ]
           cidr_blocks = local.security_group_cidrs.http7xxx
         }
       }
@@ -138,34 +116,12 @@ locals {
     private-web = {
       description = "Security group for web servers"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
-        ssh = {
-          description = "Allow ssh ingress"
-          from_port   = "22"
-          to_port     = "22"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.ssh
-        }
-        oracle3872 = {
-          description = "Allow oem agent ingress"
-          from_port   = "3872"
-          to_port     = "3872"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
         http7001 = {
           description = "Allow http7001 ingress"
           from_port   = 7001
           to_port     = 7001
           protocol    = "tcp"
           security_groups = [
-            "private-jumpserver",
             "private-lb",
           ]
           cidr_blocks = local.security_group_cidrs.http7xxx
@@ -176,33 +132,15 @@ locals {
           to_port     = 7777
           protocol    = "tcp"
           security_groups = [
-            "private-jumpserver",
             "private-lb",
           ]
           cidr_blocks = local.security_group_cidrs.http7xxx
         },
       }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
     }
     private-jumpserver = {
       description = "Security group for jumpservers"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         rdp_tcp_web = {
           description = "3389: Allow RDP TCP ingress"
           from_port   = 3389
@@ -218,41 +156,17 @@ locals {
           cidr_blocks = local.security_group_cidrs.remotedesktop_gateways
         }
       }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
     }
 
     data-db = {
       description = "Security group for databases"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         icmp = {
           description = "Allow icmp ingress"
           from_port   = -1
           to_port     = -1
           protocol    = "icmp"
           cidr_blocks = local.security_group_cidrs.icmp
-        }
-        ssh = {
-          description = "Allow ssh ingress"
-          from_port   = "22"
-          to_port     = "22"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.ssh
         }
         oracle1521 = {
           description = "Allow oracle database 1521 ingress"
@@ -261,26 +175,8 @@ locals {
           protocol    = "TCP"
           cidr_blocks = local.security_group_cidrs.oracle_db
           security_groups = [
-            "private-jumpserver",
             "private-web",
           ]
-        }
-        oracle3872 = {
-          description = "Allow oem agent ingress"
-          from_port   = "3872"
-          to_port     = "3872"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-      }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
         }
       }
     }

--- a/terraform/environments/nomis/main.tf
+++ b/terraform/environments/nomis/main.tf
@@ -202,6 +202,7 @@ module "baseline" {
   )
 
   security_groups = merge(
+    module.baseline_presets.security_groups,
     lookup(local.baseline_all_environments, "security_groups", {}),
     lookup(local.baseline_environment_specific, "security_groups", {}),
   )

--- a/terraform/modules/baseline_presets/security_groups.tf
+++ b/terraform/modules/baseline_presets/security_groups.tf
@@ -38,7 +38,7 @@ locals {
         }
       }
       egress = {
-        all = {
+        all-to-dc = {
           # Ideally, we'd lock down to specific ports but we exceed maximum number of rules for SG
           # Ports required:
           #  - ICMP
@@ -220,7 +220,7 @@ locals {
         }
       }
       egress = {
-        all = {
+        all-to-oem = {
           description = "Allow all egress to OEM"
           from_port   = 0
           to_port     = 0


### PR DESCRIPTION
Tighten Nomis SG rules
- remove ssh
- remove OEM agent from web tier as it was never used
- use baseline SGs for common rules: ad-join, oem-agent, ec2-linux, ec2-windows