### PR TITLE
🔒 Prepare for ESO v1.17.0

### DIFF
--- a/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-external-secrets.tf
@@ -4,7 +4,7 @@ resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_se
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-token-apc-self-hosted-runners"
@@ -37,7 +37,7 @@ resource "kubernetes_manifest" "actions_runners_token_moj_apc_self_hosted_runner
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-token-moj-apc-self-hosted-runners"
@@ -70,7 +70,7 @@ resource "kubernetes_manifest" "actions_runners_github_app_apc_self_hosted_runne
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-github-app-apc-self-hosted-runners"

--- a/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-external-secrets.tf
@@ -4,7 +4,7 @@ resource "kubernetes_manifest" "dashboard_service_app_secrets_secret" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "dashboard-service-app-secrets"

--- a/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-external-secrets.tf
@@ -2,7 +2,7 @@ resource "kubernetes_manifest" "ui_sentry_dsn_external_secret" {
   #checkov:skip=CKV_SECRET_6:secretKey is a reference to the key in the secret
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "ui-sentry-dsn"
@@ -32,7 +32,7 @@ resource "kubernetes_manifest" "ui_azure_external_secret" {
   #checkov:skip=CKV_SECRET_6:secretKey is a reference to the key in the secret
 
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "ui-azure-secrets"

--- a/terraform/environments/analytical-platform-compute/kubernetes-secret-stores.tf
+++ b/terraform/environments/analytical-platform-compute/kubernetes-secret-stores.tf
@@ -1,6 +1,6 @@
-resource "kubernetes_manifest" "secretstore_sample" {
+resource "kubernetes_manifest" "eso_secretstore_data_production" {
   manifest = {
-    "apiVersion" = "external-secrets.io/v1beta1"
+    "apiVersion" = "external-secrets.io/v1"
     "kind"       = "SecretStore"
     "metadata" = {
       "namespace" = kubernetes_namespace.mwaa.metadata[0].name
@@ -22,4 +22,9 @@ resource "kubernetes_manifest" "secretstore_sample" {
       }
     }
   }
+}
+
+moved {
+  from = kubernetes_manifest.secretstore_sample
+  to   = kubernetes_manifest.eso_secretstore_data_production
 }


### PR DESCRIPTION
## Proposed Changes

- Corrects a reference to Analytical Platform Data Production secret store
- [External Secrets Operator v1.17.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) introduces a breaking change 😱 

> v0.17.0 Stops serving v1beta1 apis. You need to update your manifests from v1beta1 to v1 prior to updating from v0.16 to v0.17.
> 
> The only change needed is upgrading your manifests to v1 (i.e. removing the beta1 from v1beta1).
> 
> Be sure to do that to all your manifests prior to bumping to v0.17.0! v0.16.2 already supports v1 so this process should be smooth.
> 

## Notes

Due to the API version being changed, Terraform wants to **recreate** ESO resources and cannot in-place upgrade. For `*SecretStore`, this should result in minimal to no downtime, but `Secret` will recreate secrets, but this _shouldn't_ be an issue, as

- Running pods will retain their existing secrets via environment variables
- New pods will get the recreated secret- 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>