### PR TITLE
🔧  EKS Compute: update helm charts

### DIFF
--- a/terraform/environments/analytical-platform-compute/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/helm-charts-system.tf
@@ -71,7 +71,7 @@ resource "helm_release" "amazon_prometheus_proxy" {
   name       = "amazon-prometheus-proxy"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  version    = "75.2.0"
+  version    = "75.3.0"
   namespace  = kubernetes_namespace.aws_observability.metadata[0].name
   values = [
     templatefile(
@@ -188,7 +188,7 @@ resource "helm_release" "external_dns" {
   name       = "external-dns"
   repository = "https://kubernetes-sigs.github.io/external-dns"
   chart      = "external-dns"
-  version    = "1.16.1"
+  version    = "1.17.0"
   namespace  = kubernetes_namespace.external_dns.metadata[0].name
   values = [
     templatefile(
@@ -283,7 +283,7 @@ resource "helm_release" "external_secrets" {
   name       = "external-secrets"
   repository = "https://charts.external-secrets.io"
   chart      = "external-secrets"
-  version    = "0.16.2"
+  version    = "0.18.0"
   namespace  = kubernetes_namespace.external_secrets.metadata[0].name
   values = [
     templatefile(


### PR DESCRIPTION
Prior to updating the cluster these helm charts are being brought to their latest version. Preparation for the upgrade to `external-secrets` was done in [this](https://github.com/ministryofjustice/modernisation-platform-environments/pull/11113/files) PR. 

The latest [release](https://github.com/external-secrets/external-secrets/releases/tag/v0.18.0) of `external-secrets` mentions 'Potential Breaking Changes' but does not go any further so I am proceeding with caution.

Edit: applied to Development locally and re-ran plans, now appear with [no changes](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/15730557436/job/44331429416?pr=11127#step:13:734) as expected so I believe this can proceed to production. 

Applied to Test environment as well. 

### Helm Chart Version Changes

- **aws-observability**
  - `75.2.0` → `75.3.0`

- **external-dns**
  - `1.16.1` → `1.17.0`

- **external-secrets**
  - `0.16.2` → `0.18.0`