### PR TITLE
AP Compute: EKS Upgrade Test/Dev `1.32` -> `1.33`

### DIFF
--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -20,7 +20,7 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
-      eks_cluster_version = "1.32"
+      eks_cluster_version = "1.33"
       eks_node_version    = "1.40.0-807acc8b"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.14"
@@ -63,7 +63,7 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.32"
+      eks_cluster_version = "1.33"
       eks_node_version    = "1.40.0-807acc8b"
       eks_cluster_addon_versions = {
         coredns                = "v1.11.4-eksbuild.14"


### PR DESCRIPTION
This PR supersedes [this](https://github.com/ministryofjustice/modernisation-platform-environments/pull/11112) PR.

Upgrades EKS Cluster in Development and Test environments in `analytical-platform-compute-development` and `analytical-platform-compute-test` from 1.32 to 1.33. 