### PR TITLE
TM-1320: oasys: simplify SGs

### DIFF
--- a/terraform/environments/oasys/locals.tf
+++ b/terraform/environments/oasys/locals.tf
@@ -38,6 +38,7 @@ locals {
       enable_business_unit_kms_cmks               = true
       enable_ec2_cloud_watch_agent                = true
       enable_ec2_oracle_enterprise_managed_server = true
+      enable_ec2_security_groups                  = true
       enable_ec2_self_provision                   = true
       enable_ec2_session_manager_cloudwatch_logs  = true
       enable_ec2_ssm_agent_update                 = true

--- a/terraform/environments/oasys/locals_ec2_instances.tf
+++ b/terraform/environments/oasys/locals_ec2_instances.tf
@@ -19,7 +19,7 @@ locals {
         disable_api_termination = false
         instance_type           = "t3.xlarge"
         key_name                = "ec2-user"
-        vpc_security_group_ids  = ["bip"]
+        vpc_security_group_ids  = ["bip", "ec2-linux"]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -69,7 +69,7 @@ locals {
         instance_type                = "r6i.4xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
-        vpc_security_group_ids       = ["data"]
+        vpc_security_group_ids       = ["data", "ec2-linux", "oem-agent"]
         tags = {
           backup-plan = "daily-and-weekly"
         }
@@ -130,7 +130,7 @@ locals {
         instance_type                = "r6i.4xlarge"
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
-        vpc_security_group_ids       = ["data"]
+        vpc_security_group_ids       = ["data", "ec2-linux", "oem-agent"]
         tags = {
           backup-plan = "daily-and-weekly"
         }

--- a/terraform/environments/oasys/locals_security_groups.tf
+++ b/terraform/environments/oasys/locals_security_groups.tf
@@ -24,10 +24,6 @@ locals {
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc, # "172.20.0.0/16"
       module.ip_addresses.moj_cidr.aws_data_engineering_dev,
     ])
-    oracle_oem_agent = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.devtest,
-      module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ])
     http7xxx = flatten([
       "10.0.0.0/8",
     ])
@@ -68,10 +64,6 @@ locals {
       "10.40.37.0/24", # pp prison nomis
       module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
       module.ip_addresses.moj_cidr.aws_data_engineering_stage,
-    ])
-    oracle_oem_agent = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
     http7xxx = flatten([
       "10.0.0.0/8",
@@ -117,10 +109,6 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.moj_cidr.aws_data_engineering_prod,
     ])
-    oracle_oem_agent = flatten([
-      module.ip_addresses.azure_fixngo_cidrs.prod,
-      module.ip_addresses.mp_cidr[module.environment.vpc_name],
-    ])
     http7xxx = flatten([
       "10.0.0.0/8",
       module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
@@ -135,28 +123,6 @@ locals {
   security_group_cidrs = local.security_group_cidrs_by_environment[local.environment]
 
   security_groups = {
-    private = {
-      description = "Security group for private subnet"
-      ingress = {
-        all-within-subnet = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
-      }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
-    }
     private_lb = {
       description = "Security group for internal load balancer"
       ingress = {
@@ -253,58 +219,31 @@ locals {
     }
     private_web = {
       description = "Security group for web servers"
-      ingress = {
-        all-within-subnet = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
-        http8080 = {
-          description     = "Allow http8080 ingress"
-          from_port       = 0
-          to_port         = 8080
-          protocol        = "tcp"
-          cidr_blocks     = local.security_group_cidrs.https_internal
-          security_groups = ["private_lb", "public_lb", "public_lb_2"]
-        }
-      }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
+      ingress = merge(
+        module.baseline_presets.security_groups["ec2-linux"].ingress,
+        {
+          http8080 = {
+            description     = "Allow http8080 ingress"
+            from_port       = 0
+            to_port         = 8080
+            protocol        = "tcp"
+            cidr_blocks     = local.security_group_cidrs.https_internal
+            security_groups = ["private_lb", "public_lb", "public_lb_2"]
+          }
+      })
+      egress = merge(
+        module.baseline_presets.security_groups["ec2-linux"].egress,
+      )
     }
     data = {
       description = "Security group for data subnet"
       ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         icmp = {
           description = "Allow icmp ingress"
           from_port   = -1
           to_port     = -1
           protocol    = "icmp"
           cidr_blocks = local.security_group_cidrs.icmp
-        }
-        ssh = {
-          description     = "Allow ssh ingress"
-          from_port       = "22"
-          to_port         = "22"
-          protocol        = "TCP"
-          cidr_blocks     = local.security_group_cidrs.ssh
-          security_groups = []
         }
         http8080 = {
           description = "Allow http 8080 ingress"
@@ -329,35 +268,11 @@ locals {
             "private_web",
           ]
         }
-        oracle3872 = {
-          description = "Allow oem agent ingress"
-          from_port   = "3872"
-          to_port     = "3872"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-      }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
       }
     }
     bip = {
       description = "Security group for bip"
       ingress = {
-        all-within-subnet = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
         http7001 = {
           description     = "Allow http7001 ingress"
           from_port       = 7001
@@ -383,17 +298,6 @@ locals {
           cidr_blocks     = local.security_group_cidrs.http7xxx
         }
       }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
-        }
-      }
     }
-
   }
 }

--- a/terraform/environments/oasys/main.tf
+++ b/terraform/environments/oasys/main.tf
@@ -96,6 +96,12 @@ module "baseline" {
     lookup(local.baseline_environment_specific, "cloudwatch_log_groups", {}),
   )
 
+  data_firehoses = merge(
+    module.baseline_presets.data_firehoses,
+    lookup(local.baseline_all_environments, "data_firehoses", {}),
+    lookup(local.baseline_environment_specific, "data_firehoses", {}),
+  )
+
   ec2_autoscaling_groups = merge(
     lookup(local.baseline_all_environments, "ec2_autoscaling_groups", {}),
     lookup(local.baseline_environment_specific, "ec2_autoscaling_groups", {}),
@@ -196,6 +202,7 @@ module "baseline" {
   )
 
   security_groups = merge(
+    module.baseline_presets.security_groups,
     lookup(local.baseline_all_environments, "security_groups", {}),
     lookup(local.baseline_environment_specific, "security_groups", {}),
   )


### PR DESCRIPTION
Align Oasys Security Groups with other DSO apps:
- use baseline SGs for egress, self and OEM rules
- remove SSH (confirmed via FlowLogs that it's unused)