### PR TITLE
Add CCMS production DNS

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-r53.tf
+++ b/terraform/environments/ccms-ebs/ccms-r53.tf
@@ -13,6 +13,20 @@ resource "aws_route53_record" "external" {
   }
 }
 
+## Prod Network Loadbalancer
+resource "aws_route53_record" "prod_ebs_nlb" {
+  provider = aws.core-network-services
+  count    = local.is-production ? 1 : 0
+  zone_id  = data.aws_route53_zone.legalservices.zone_id
+  name     = "ccmsebs.legalservices.gov.uk"
+  type     = "A"
+  alias {
+    name                   = aws_lb.ebsapps_nlb.dns_name
+    zone_id                = aws_lb.ebsapps_nlb.zone_id
+    evaluate_target_health = true
+  }
+}
+
 # Prod LB EBS Apps DNS
 resource "aws_route53_record" "prod_ebsapp_lb" {
   count    = local.is-production ? 1 : 0

--- a/terraform/environments/ccms-ebs/member-data.tf
+++ b/terraform/environments/ccms-ebs/member-data.tf
@@ -212,3 +212,9 @@ data "aws_route53_zone" "application_zone" {
   name         = "ccms-ebs.service.justice.gov.uk."
   private_zone = false
 }
+
+data "aws_route53_zone" "legalservices" {
+  provider     = aws.core-network-services
+  name         = "legalservices.gov.uk"
+  private_zone = false
+}


### PR DESCRIPTION
This DNS record currently sits in the LAA Production hosted zone, and points to the 3 EIPs attached to the NLB.

This adds in a new alias record to the new legalservices.gov.uk hosted zone in MP which will replace the LAA production hosted zone.