### PR TITLE
🪵 Send Route 53 Resolver logs to Core Logging to Enable MIP/SOC Integration

### DIFF
--- a/terraform/environments/analytical-platform-compute/data.tf
+++ b/terraform/environments/analytical-platform-compute/data.tf
@@ -108,3 +108,9 @@ data "aws_s3_bucket" "mwaa_bucket" {
   bucket = "mojap-compute-${local.environment}-mwaa"
 }
 
+data "aws_route53_resolver_query_log_config" "core_logging_s3" {
+  filter {
+    name   = "Name"
+    values = ["core-logging-rlq-s3"]
+  }
+}

--- a/terraform/environments/analytical-platform-compute/route53-resolver-query-logging.tf
+++ b/terraform/environments/analytical-platform-compute/route53-resolver-query-logging.tf
@@ -1,0 +1,4 @@
+resource "aws_route53_resolver_query_log_config_association" "core_logging_s3" {
+  resolver_query_log_config_id = data.aws_route53_resolver_query_log_config.core_logging_s3.id
+  resource_id                  = module.vpc.vpc_id
+}

--- a/terraform/environments/analytical-platform-ingestion/data.tf
+++ b/terraform/environments/analytical-platform-ingestion/data.tf
@@ -49,3 +49,10 @@ data "aws_secretsmanager_secret_version" "datasync_exclude_path" {
 data "aws_secretsmanager_secret_version" "datasync_include_paths" {
   secret_id = module.datasync_include_paths_secret.secret_id
 }
+
+data "aws_route53_resolver_query_log_config" "core_logging_s3" {
+  filter {
+    name   = "Name"
+    values = ["core-logging-rlq-s3"]
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-query-logging.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-query-logging.tf
@@ -7,3 +7,13 @@ resource "aws_route53_resolver_query_log_config_association" "connected_vpc" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.connected_vpc.id
   resource_id                  = module.connected_vpc.vpc_id
 }
+
+resource "aws_route53_resolver_query_log_config_association" "core_logging_s3_connected_vpc" {
+  resolver_query_log_config_id = data.aws_route53_resolver_query_log_config.core_logging_s3.id
+  resource_id                  = module.connected_vpc.vpc_id
+}
+
+resource "aws_route53_resolver_query_log_config_association" "core_logging_s3_isolated_vpc" {
+  resolver_query_log_config_id = data.aws_route53_resolver_query_log_config.core_logging_s3.id
+  resource_id                  = module.isolated_vpc.vpc_id
+}


### PR DESCRIPTION
## Proposed Changes

- Enables Route 53 Resolver Query logging, and sends them to Modernisation Platform's Core Logging 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>