### PR TITLE
Update shield/waf module external data source 

### DIFF
--- a/terraform/modules/shield_advanced/shield.tf
+++ b/terraform/modules/shield_advanced/shield.tf
@@ -12,7 +12,7 @@ data "external" "shield_protections" {
 data "external" "shield_waf" {
   program = [
     "bash", "-c",
-    "aws wafv2 list-web-acls --scope REGIONAL --output json | jq -c '{arn: .WebACLs[] | select(.Name | contains(\"FMManagedWebACL\")) | .ARN, name: .WebACLs[] | select(.Name | contains(\"FMManagedWebACL\")) | .Name}'"
+    "aws wafv2 list-web-acls --scope REGIONAL --output json | jq -c '[.WebACLs[] | select(.Name | startswith(\"FMManagedWebACL\"))] | sort_by(.Name) | .[0] | {arn: .ARN, name: .Name}'"
   ]
 }
 


### PR DESCRIPTION
## Issue

Reported in Slack [here](https://mojdt.slack.com/archives/C01A7QK5VM1/p1750257845896729)

For some reason in all the ppud environments the AWS Firewall Manager service created duplicate WebACLs on 5th June. I've rasied a ticket with AWS to confirm why which is on-going.

## What's changed?

For now, I've updated the external data source command to filter on only the first webacl with name matching `FMManagedWebACL`
It's not ideal but it should allow ppud to run their deployments again and based on some testing of an account that doesnt have the duplicate webacl e.g. equip it works there too.