### PR TITLE
TM-1320: ncr: security group fix

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_lbs.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_lbs.tf
@@ -2,55 +2,6 @@ locals {
 
   lbs = {
 
-    private = {
-      access_logs                      = true
-      drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
-      enable_cross_zone_load_balancing = true
-      enable_delete_protection         = false
-      force_destroy_bucket             = true
-      idle_timeout                     = 3600
-      internal_lb                      = true
-      load_balancer_type               = "application"
-      security_groups                  = ["lb"]
-      subnets                          = module.environment.subnets["private"].ids
-
-      instance_target_groups = {
-        http-7777 = {
-          port     = 7777
-          protocol = "HTTP"
-          health_check = {
-            enabled             = true
-            healthy_threshold   = 3
-            interval            = 30
-            matcher             = "200-399"
-            path                = "/keepalive.htm"
-            port                = 7777
-            timeout             = 5
-            unhealthy_threshold = 5
-          }
-          stickiness = {
-            enabled = true
-            type    = "lb_cookie"
-          }
-        }
-      }
-      listeners = {
-        http-7777 = {
-          port     = 7777
-          protocol = "HTTP"
-
-          default_action = {
-            type = "fixed-response"
-            fixed_response = {
-              content_type = "text/plain"
-              message_body = "Not implemented"
-              status_code  = "501"
-            }
-          }
-        }
-      }
-    }
-
     public = {
       access_logs                      = true
       drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935

--- a/terraform/environments/nomis-combined-reporting/locals_lbs.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_lbs.tf
@@ -2,6 +2,55 @@ locals {
 
   lbs = {
 
+    private = {
+      access_logs                      = true
+      drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935
+      enable_cross_zone_load_balancing = true
+      enable_delete_protection         = false
+      force_destroy_bucket             = true
+      idle_timeout                     = 3600
+      internal_lb                      = true
+      load_balancer_type               = "application"
+      security_groups                  = ["lb"]
+      subnets                          = module.environment.subnets["private"].ids
+
+      instance_target_groups = {
+        http-7777 = {
+          port     = 7777
+          protocol = "HTTP"
+          health_check = {
+            enabled             = true
+            healthy_threshold   = 3
+            interval            = 30
+            matcher             = "200-399"
+            path                = "/keepalive.htm"
+            port                = 7777
+            timeout             = 5
+            unhealthy_threshold = 5
+          }
+          stickiness = {
+            enabled = true
+            type    = "lb_cookie"
+          }
+        }
+      }
+      listeners = {
+        http-7777 = {
+          port     = 7777
+          protocol = "HTTP"
+
+          default_action = {
+            type = "fixed-response"
+            fixed_response = {
+              content_type = "text/plain"
+              message_body = "Not implemented"
+              status_code  = "501"
+            }
+          }
+        }
+      }
+    }
+
     public = {
       access_logs                      = true
       drop_invalid_header_fields       = false # https://me.sap.com/notes/0003348935

--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -167,7 +167,7 @@ locals {
         mount_targets = [{
           subnet_name        = "private"
           availability_zones = ["eu-west-2a"]
-          security_groups    = ["bip"]
+          security_groups    = ["efs"]
         }]
         tags = {
           backup      = "false"

--- a/terraform/environments/nomis-combined-reporting/locals_production.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_production.tf
@@ -238,7 +238,7 @@ locals {
         mount_targets = [{
           subnet_name        = "private"
           availability_zones = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
-          security_groups    = ["bip"]
+          security_groups    = ["efs"]
         }]
         tags = {
           backup      = "false"

--- a/terraform/environments/nomis-combined-reporting/locals_security_groups.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_security_groups.tf
@@ -4,6 +4,9 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.devtest,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
+    enduserclient_internal = [
+      "10.0.0.0/8"
+    ]
     enduserclient_public1 = flatten([
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
     ])
@@ -27,6 +30,9 @@ locals {
       module.ip_addresses.azure_fixngo_cidrs.prod,
       module.ip_addresses.mp_cidr[module.environment.vpc_name],
     ])
+    enduserclient_internal = [
+      "10.0.0.0/8"
+    ]
     enduserclient_public1 = flatten([
       module.ip_addresses.moj_cidrs.trusted_moj_digital_staff_public,
     ])
@@ -56,6 +62,46 @@ locals {
   security_groups = {
     lb = {
       description = "Security group for public subnet"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
+        http7777 = {
+          description = "Allow http7777 ingress"
+          from_port   = 7777
+          to_port     = 7777
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs.http7xxx
+        }
+        https = {
+          description = "Allow https ingress"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs.enduserclient_internal
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
     }
     public-lb = {
       description = "Security group for public load balancer"
@@ -157,7 +203,7 @@ locals {
           to_port         = 7010
           protocol        = "tcp"
           cidr_blocks     = local.security_group_cidrs.http7xxx
-          security_groups = ["public-lb", "public-lb-2"]
+          security_groups = ["lb", "public-lb", "public-lb-2"]
         }
         http7777 = {
           description     = "Allow http7777 ingress"
@@ -165,7 +211,7 @@ locals {
           to_port         = 7777
           protocol        = "tcp"
           cidr_blocks     = local.security_group_cidrs.http7xxx
-          security_groups = ["public-lb", "public-lb-2"]
+          security_groups = ["lb", "public-lb", "public-lb-2"]
         }
         http8005 = {
           description     = "Allow http8005 ingress"
@@ -173,7 +219,7 @@ locals {
           to_port         = 8005
           protocol        = "tcp"
           cidr_blocks     = local.security_group_cidrs.http7xxx
-          security_groups = ["public-lb", "public-lb-2"]
+          security_groups = ["lb", "public-lb", "public-lb-2"]
         }
         http8443 = {
           description     = "Allow http8443 ingress"
@@ -181,7 +227,7 @@ locals {
           to_port         = 8443
           protocol        = "tcp"
           cidr_blocks     = local.security_group_cidrs.http7xxx
-          security_groups = ["public-lb", "public-lb-2"]
+          security_groups = ["lb", "public-lb", "public-lb-2"]
         }
       }
     }

--- a/terraform/environments/nomis-combined-reporting/locals_security_groups.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_security_groups.tf
@@ -127,6 +127,27 @@ locals {
         }
       }
     }
+    efs = {
+      description = "Security group for EFS"
+      ingress = {
+        nfs = {
+          description     = "Allow http7010 ingress"
+          from_port       = 2049
+          to_port         = 2049
+          protocol        = "tcp"
+          security_groups = ["bip", "web"]
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress to bip and web"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          security_groups = ["bip", "web"]
+        }
+      }
+    }
     web = {
       description = "Security group for tomcat web servers"
       ingress = {

--- a/terraform/environments/nomis-combined-reporting/locals_test.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_test.tf
@@ -132,7 +132,7 @@ locals {
         mount_targets = [{
           subnet_name        = "private"
           availability_zones = ["eu-west-2a"]
-          security_groups    = ["bip"]
+          security_groups    = ["efs"]
         }]
         tags = {
           backup      = "false"


### PR DESCRIPTION
Add security group fix for EFS fileshare.
Also adding internal-LB rules back in as LB still exists, although not in use. But will remove that separately