### PR TITLE
🕵️ Enable AWS Network Flow Monitoring Agent

### DIFF
--- a/terraform/environments/analytical-platform-compute/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/eks-cluster.tf
@@ -63,6 +63,10 @@ module "eks" {
     aws-guardduty-agent = {
       addon_version = local.environment_configuration.eks_cluster_addon_versions.aws_guardduty_agent
     }
+    aws-network-flow-monitoring-agent = {
+      addon_version            = local.environment_configuration.eks_cluster_addon_versions.aws_network_flow_monitoring_agent
+      service_account_role_arn = module.aws_cloudwatch_network_flow_monitor_iam_role.iam_role_arn
+    }
     eks-pod-identity-agent = {
       addon_version = local.environment_configuration.eks_cluster_addon_versions.eks_pod_identity_agent
     }

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -23,14 +23,15 @@ locals {
       eks_cluster_version = "1.33"
       eks_node_version    = "1.41.0-bc3ad241"
       eks_cluster_addon_versions = {
-        coredns                   = "v1.12.1-eksbuild.2"
-        kube_proxy                = "v1.33.0-eksbuild.2"
-        aws_ebs_csi_driver        = "v1.44.0-eksbuild.1"
-        aws_efs_csi_driver        = "v2.1.8-eksbuild.1"
-        aws_guardduty_agent       = "v1.10.0-eksbuild.2"
-        eks_pod_identity_agent    = "v1.3.7-eksbuild.2"
-        eks_node_monitoring_agent = "v1.3.0-eksbuild.2"
-        vpc_cni                   = "v1.19.5-eksbuild.3"
+        coredns                           = "v1.12.1-eksbuild.2"
+        kube_proxy                        = "v1.33.0-eksbuild.2"
+        aws_ebs_csi_driver                = "v1.44.0-eksbuild.1"
+        aws_efs_csi_driver                = "v2.1.8-eksbuild.1"
+        aws_guardduty_agent               = "v1.10.0-eksbuild.2"
+        aws_network_flow_monitoring_agent = "v1.0.2-eksbuild.5"
+        eks_pod_identity_agent            = "v1.3.7-eksbuild.2"
+        eks_node_monitoring_agent         = "v1.3.0-eksbuild.2"
+        vpc_cni                           = "v1.19.5-eksbuild.3"
       }
 
       /* Data Engineering Airflow */
@@ -67,14 +68,15 @@ locals {
       eks_cluster_version = "1.33"
       eks_node_version    = "1.41.0-bc3ad241"
       eks_cluster_addon_versions = {
-        coredns                   = "v1.12.1-eksbuild.2"
-        kube_proxy                = "v1.33.0-eksbuild.2"
-        aws_ebs_csi_driver        = "v1.44.0-eksbuild.1"
-        aws_efs_csi_driver        = "v2.1.8-eksbuild.1"
-        aws_guardduty_agent       = "v1.10.0-eksbuild.2"
-        eks_pod_identity_agent    = "v1.3.7-eksbuild.2"
-        eks_node_monitoring_agent = "v1.3.0-eksbuild.2"
-        vpc_cni                   = "v1.19.5-eksbuild.3"
+        coredns                           = "v1.12.1-eksbuild.2"
+        kube_proxy                        = "v1.33.0-eksbuild.2"
+        aws_ebs_csi_driver                = "v1.44.0-eksbuild.1"
+        aws_efs_csi_driver                = "v2.1.8-eksbuild.1"
+        aws_guardduty_agent               = "v1.10.0-eksbuild.2"
+        aws_network_flow_monitoring_agent = "v1.0.2-eksbuild.5"
+        eks_pod_identity_agent            = "v1.3.7-eksbuild.2"
+        eks_node_monitoring_agent         = "v1.3.0-eksbuild.2"
+        vpc_cni                           = "v1.19.5-eksbuild.3"
       }
 
       /* Data Engineering Airflow */
@@ -111,15 +113,17 @@ locals {
       eks_cluster_version = "1.33"
       eks_node_version    = "1.41.0-bc3ad241"
       eks_cluster_addon_versions = {
-        coredns                   = "v1.12.1-eksbuild.2"
-        kube_proxy                = "v1.33.0-eksbuild.2"
-        aws_ebs_csi_driver        = "v1.44.0-eksbuild.1"
-        aws_efs_csi_driver        = "v2.1.8-eksbuild.1"
-        aws_guardduty_agent       = "v1.10.0-eksbuild.2"
-        eks_pod_identity_agent    = "v1.3.7-eksbuild.2"
-        eks_node_monitoring_agent = "v1.3.0-eksbuild.2"
-        vpc_cni                   = "v1.19.5-eksbuild.3"
+        coredns                           = "v1.12.1-eksbuild.2"
+        kube_proxy                        = "v1.33.0-eksbuild.2"
+        aws_ebs_csi_driver                = "v1.44.0-eksbuild.1"
+        aws_efs_csi_driver                = "v2.1.8-eksbuild.1"
+        aws_guardduty_agent               = "v1.10.0-eksbuild.2"
+        aws_network_flow_monitoring_agent = "v1.0.2-eksbuild.5"
+        eks_pod_identity_agent            = "v1.3.7-eksbuild.2"
+        eks_node_monitoring_agent         = "v1.3.0-eksbuild.2"
+        vpc_cni                           = "v1.19.5-eksbuild.3"
       }
+
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-prod-execution-role"
 

--- a/terraform/environments/analytical-platform-compute/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/iam-roles.tf
@@ -214,3 +214,26 @@ module "analytical_platform_ui_service_role" {
   }
   tags = local.tags
 }
+
+module "aws_cloudwatch_network_flow_monitor_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.58.0"
+
+  role_name_prefix = "aws-cloudwatch-network-flow-monitor"
+
+  role_policy_arns = {
+    CloudWatchNetworkFlowMonitorAgentPublishPolicy = "arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy"
+  }
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["amazon-network-flow-monitor:aws-network-flow-monitor-agent-service-account"]
+    }
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
## Proposed Changes

- Enables [EKS AWS Network Flow Monitor Agent add-on](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-kubernetes-eks.html)

## Notes

I had to manually initialise CloudWatch Network Flow Monitor in the console as there isn't a Terraform resource for it _yet_

- https://github.com/hashicorp/terraform-provider-aws/issues/40890

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>