### PR TITLE
Centralise secrets for `generate-dependabot-file.yml` file

### DIFF
--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -21,22 +21,36 @@ permissions:
   pull-requests: write
 
 jobs:
-  create-and-commit-dependabot-file:    
+  fetch-secrets:
+        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
+        secrets:
+          MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  create-and-commit-dependabot-file:
     runs-on: ubuntu-latest
+    needs: fetch-secrets   
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - name: Generate file
-        run: bash ./scripts/generate-dependabot-file.sh
-        
-      - name: Set up git user
-        run: bash ./scripts/git-setup.sh
-
-      - name: Commit and Create PR with Signed Commit
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c1e0b8a7db1410268afe2f3377b5d82b09a1b336 # v3.2.4
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "Automated Update: Dependabot File"
-          pr_body: "This PR updates the Dependabot configuration file."
+          slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Test
+        run: exit 1 
+
+      # - name: Generate file
+      #   run: bash ./scripts/generate-dependabot-file.sh
+        
+      # - name: Set up git user
+      #   run: bash ./scripts/git-setup.sh
+
+      # - name: Commit and Create PR with Signed Commit
+      #   uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     pr_title: "Automated Update: Dependabot File"
+      #     pr_body: "This PR updates the Dependabot configuration file."
 
       - name: Slack failure notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v1.26.0
@@ -44,6 +58,6 @@ jobs:
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -39,21 +39,19 @@ jobs:
         with:
           slack_webhook_url: ${{ needs.fetch-secrets.outputs.slack_webhook_url }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
-      - name: Test
-        run: exit 1 
 
-      # - name: Generate file
-      #   run: bash ./scripts/generate-dependabot-file.sh
+      - name: Generate file
+        run: bash ./scripts/generate-dependabot-file.sh
         
-      # - name: Set up git user
-      #   run: bash ./scripts/git-setup.sh
+      - name: Set up git user
+        run: bash ./scripts/git-setup.sh
 
-      # - name: Commit and Create PR with Signed Commit
-      #   uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     pr_title: "Automated Update: Dependabot File"
-      #     pr_body: "This PR updates the Dependabot configuration file."
+      - name: Commit and Create PR with Signed Commit
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "Automated Update: Dependabot File"
+          pr_body: "This PR updates the Dependabot configuration file."
 
       - name: Slack failure notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v1.26.0

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Slack failure notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v1.26.0
         with:
+          webhook-type: incoming-webhook
           payload: |
             {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: ${{ failure() }}

--- a/.github/workflows/generate-dependabot-file.yml
+++ b/.github/workflows/generate-dependabot-file.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   fetch-secrets:
         uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@3f9fb1af00462c69c806640652ddf41292963615 # v3.2.5
+        permissions:
+          id-token: write
+          contents: read
         secrets:
           MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
## Issue 
https://github.com/ministryofjustice/modernisation-platform/issues/10126

## What's Changed?
I've updated the `generate-dependabot-file.yml` workflow to fetch secrets from aws using the central action.