### PR TITLE
TM-1320: nomis: restore prod security groups to fix drift

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -676,5 +676,7 @@ locals {
       "/oracle/database/DRCNMAUD" = local.secretsmanager_secrets.db
       "/oracle/database/DRMIS"    = local.secretsmanager_secrets.db_mis
     }
+
+    security_groups = local.security_groups_old
   }
 }

--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -171,4 +171,252 @@ locals {
       }
     }
   }
+
+  ##### OLD - to be removed after prod cutover #####
+
+  security_group_cidrs_old = {
+    icmp = flatten([
+      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc
+    ])
+    ssh = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+    https = flatten([
+      "10.0.0.0/8", # too many end-user addresses to list
+      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
+    ])
+    http7xxx = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+    oracle_db = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
+      module.ip_addresses.moj_cidr.aws_analytical_platform_aggregate,
+      module.ip_addresses.moj_cidr.aws_xsiam_prod_vpc,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+    oracle_oem_agent = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+    remotedesktop_gateways = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod_jumpservers,
+      module.ip_addresses.mp_cidr[module.environment.vpc_name]
+    ])
+  }
+  security_groups_old = {
+    private-lb = {
+      description = "Security group for internal load balancer"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http = {
+          description = "Allow http ingress"
+          from_port   = 80
+          to_port     = 80
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.https
+        }
+        https = {
+          description = "Allow https ingress"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.https
+        }
+        http7001 = {
+          description = "Allow http7001 ingress"
+          from_port   = 7001
+          to_port     = 7001
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.http7xxx
+        }
+        http7777 = {
+          description = "Allow http7777 ingress"
+          from_port   = 7777
+          to_port     = 7777
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.http7xxx
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
+    private-web = {
+      description = "Security group for web servers"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        ssh = {
+          description = "Allow ssh ingress"
+          from_port   = "22"
+          to_port     = "22"
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.ssh
+        }
+        oracle3872 = {
+          description = "Allow oem agent ingress"
+          from_port   = "3872"
+          to_port     = "3872"
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.oracle_oem_agent
+        }
+        http7001 = {
+          description = "Allow http7001 ingress"
+          from_port   = 7001
+          to_port     = 7001
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+            "private-lb",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.http7xxx
+        },
+        http7777 = {
+          description = "Allow http7777 ingress"
+          from_port   = 7777
+          to_port     = 7777
+          protocol    = "tcp"
+          security_groups = [
+            "private-jumpserver",
+            "private-lb",
+          ]
+          cidr_blocks = local.security_group_cidrs_old.http7xxx
+        },
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
+    private-jumpserver = {
+      description = "Security group for jumpservers"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        rdp_tcp_web = {
+          description = "3389: Allow RDP TCP ingress"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.remotedesktop_gateways
+        }
+        rdp_udp_web = {
+          description = "3389: Allow RDP UDP ingress"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "UDP"
+          cidr_blocks = local.security_group_cidrs_old.remotedesktop_gateways
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
+
+    data-db = {
+      description = "Security group for databases"
+      ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        icmp = {
+          description = "Allow icmp ingress"
+          from_port   = -1
+          to_port     = -1
+          protocol    = "icmp"
+          cidr_blocks = local.security_group_cidrs_old.icmp
+        }
+        ssh = {
+          description = "Allow ssh ingress"
+          from_port   = "22"
+          to_port     = "22"
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.ssh
+        }
+        oracle1521 = {
+          description = "Allow oracle database 1521 ingress"
+          from_port   = "1521"
+          to_port     = "1521"
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.oracle_db
+          security_groups = [
+            "private-jumpserver",
+            "private-web",
+          ]
+        }
+        oracle3872 = {
+          description = "Allow oem agent ingress"
+          from_port   = "3872"
+          to_port     = "3872"
+          protocol    = "TCP"
+          cidr_blocks = local.security_group_cidrs_old.oracle_oem_agent
+        }
+      }
+      egress = {
+        all = {
+          description     = "Allow all egress"
+          from_port       = 0
+          to_port         = 0
+          protocol        = "-1"
+          cidr_blocks     = ["0.0.0.0/0"]
+          security_groups = []
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Taking extra care over new security group rules which are applied up to preprod.
To avoid any chance of error, add the new rules to the EC2s before removing the old ones. To do this, need to restore the old prod rules into the code.