### PR TITLE
TM-1320: ndh: restore prod security groups to fix drift

### DIFF
--- a/terraform/environments/nomis-data-hub/locals_preproduction.tf
+++ b/terraform/environments/nomis-data-hub/locals_preproduction.tf
@@ -88,5 +88,7 @@ locals {
     secretsmanager_secrets = {
       "/ndh/pp" = local.secretsmanager_secrets.ndh
     }
+
+    security_groups = local.security_groups_old
   }
 }

--- a/terraform/environments/nomis-data-hub/locals_production.tf
+++ b/terraform/environments/nomis-data-hub/locals_production.tf
@@ -129,5 +129,7 @@ locals {
       "/ndh/pd" = local.secretsmanager_secrets.ndh
       "/ndh/dr" = local.secretsmanager_secrets.ndh
     }
+
+    security_groups = local.security_groups_old
   }
 }

--- a/terraform/environments/nomis-data-hub/locals_security_groups.tf
+++ b/terraform/environments/nomis-data-hub/locals_security_groups.tf
@@ -79,4 +79,223 @@ locals {
       }
     }
   }
+
+  #### OLD RULES - TO BE REMOVED AFTER CUTOVER
+  security_group_cidrs_old = {
+    https = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.azure_fixngo_cidrs.internet_egress,
+      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
+      module.ip_addresses.moj_cidrs.trusted_moj_enduser_internal,
+    ])
+    oracle_db = flatten([
+      module.ip_addresses.azure_fixngo_cidrs.prod,
+      module.ip_addresses.moj_cidr.aws_cloud_platform_vpc,
+    ])
+    http8555 = flatten([
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+    tcp7222 = flatten([
+      module.ip_addresses.mp_cidr[module.environment.vpc_name],
+    ])
+  }
+  security_groups_old = {
+    public = {
+      description = "Security group for public subnet"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        https = {
+          description = "Allow https ingress"
+          from_port   = 443
+          to_port     = 443
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs_old.https
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    private = {
+      description = "Security group for private subnet"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http8080 = {
+          description     = "Allow http8080 ingress"
+          from_port       = 8080
+          to_port         = 8080
+          protocol        = "tcp"
+          security_groups = ["public"]
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    management_server = {
+      description = "Security group for management server"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    ndh_app = {
+      description = "Security group for ndh app"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http8080 = {
+          description     = "Allow http8080 ingress"
+          from_port       = 8080
+          to_port         = 8080
+          protocol        = "tcp"
+          security_groups = ["management_server"]
+        }
+        http8555 = { # from oasys
+          description = "Allow http8555 ingress"
+          from_port   = 8555
+          to_port     = 8555
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs_old.http8555
+        }
+        tcp-ems = {
+          description     = "Allow all ems ingress"
+          from_port       = 0
+          to_port         = 65535
+          protocol        = "tcp"
+          security_groups = ["ndh_ems"]
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    ndh_ems = {
+      description = "Security group for ndh ems"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        http8080 = {
+          description     = "Allow http8080 ingress"
+          from_port       = 8080
+          to_port         = 8080
+          protocol        = "tcp"
+          security_groups = ["management_server"]
+        }
+        tcp7222 = { # from nomis (XTAG)
+          description = "Allow port 7222 ingress"
+          from_port   = 7222
+          to_port     = 7222
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs_old.tcp7222
+        }
+        tcp7224 = {
+          description = "Allow port 7224 ingress"
+          from_port   = 7224
+          to_port     = 7224
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs_old.tcp7222
+        }
+        tcp-app = {
+          description     = "Allow all app ingress"
+          from_port       = 0
+          to_port         = 65535
+          protocol        = "tcp"
+          security_groups = ["ndh_app"]
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    data = {
+      description = "Security group for data subnet"
+      ingress = {
+        all-within-subnet = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
+        oracle1521 = {
+          description     = "Allow oracle database 1521 ingress"
+          from_port       = "1521"
+          to_port         = "1521"
+          protocol        = "tcp"
+          cidr_blocks     = local.security_group_cidrs_old.oracle_db
+          security_groups = ["private"]
+        }
+      }
+      egress = {
+        all = {
+          description = "Allow all egress"
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Taking extra care over new security group rules which are applied up to test.
To avoid any chance of error, add the new rules to the EC2s before removing the old ones. To do this, need to restore the old prod rules into the code.