### PR TITLE
Dmet prisons 400/setup OIDC on datalake repo

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -191,6 +191,10 @@ data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions"
       module.data_engineering_datalake_access_terraform_iam_role.iam_role_arn,
       "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-engineering-datalake-access",
       "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-test"]}:role/analytical-platform-data-production-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-development"]}:role/analytical-platform-data-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-test"]}:role/analytical-platform-data-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-preproduction"]}:role/analytical-platform-data-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-production"]}:role/analytical-platform-data-share-role",
     ]
   }
 }

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -191,10 +191,10 @@ data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions"
       module.data_engineering_datalake_access_terraform_iam_role.iam_role_arn,
       "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/data-engineering-datalake-access",
       "arn:aws:iam::${local.environment_management.account_ids["electronic-monitoring-data-test"]}:role/analytical-platform-data-production-share-role",
-      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-development"]}:role/analytical-platform-data-share-role",
-      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-test"]}:role/analytical-platform-data-share-role",
-      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-preproduction"]}:role/analytical-platform-data-share-role",
-      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-production"]}:role/analytical-platform-data-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-development"]}:role/analytical-platform-data-production-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-test"]}:role/analytical-platform-data-production-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-preproduction"]}:role/analytical-platform-data-production-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["digital-prison-reporting-production"]}:role/analytical-platform-data-production-share-role",
     ]
   }
 }


### PR DESCRIPTION

## Context:

We need to enable the data-engineering-datalake-access repository to access all DPR environments (dev, test, preprod, prod) via appropriate IAM roles and policies. This is already in place for Electronic Monitoring (EM).

There are two IAM roles involved:

[data-engineering-datalake-access-github-actions](https://github.com/ministryofjustice/modernisation-platform-environments/blob/4e0b8b06cf6a764707e9e6c403dcfcdfa6762d48/terraform/environments/analytical-platform-common/iam-roles.tf#L59-L75) – used by GitHub Actions

[data-engineering-datalake-access-terraform](https://github.com/ministryofjustice/modernisation-platform-environments/blob/4e0b8b06cf6a764707e9e6c403dcfcdfa6762d48/terraform/environments/analytical-platform-common/iam-roles.tf#L77-L94) – used for Terraform provisioning

We want these roles to be able to assume the DPR share role:
analytical-platform-data-production-share-role

## what this PR does

Allows assuming the DPR share role in all four accounts (dev/test/preprod/prod)
