### PR TITLE
TM-1376: planetfm: add AD join security group

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -31,7 +31,7 @@ locals {
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
           instance_type           = "t3.xlarge"
-          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.app.tags, {
           ami              = "pd-cafm-a-10-b"
@@ -57,7 +57,7 @@ locals {
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
           instance_type           = "t3.xlarge"
-          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.app.tags, {
           ami              = "pd-cafm-a-11-a"
@@ -83,7 +83,7 @@ locals {
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
           instance_type           = "t3.xlarge"
-          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.app.tags, {
           ami              = "pd-cafm-a-12-b"
@@ -109,7 +109,7 @@ locals {
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
           instance_type           = "t3.xlarge"
-          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.app.tags, {
           ami              = "pd-cafm-a-13-a"
@@ -143,7 +143,7 @@ locals {
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
           instance_type           = "r6i.4xlarge"
-          vpc_security_group_ids  = ["domain", "database", "jumpserver"]
+          vpc_security_group_ids  = ["domain", "database", "jumpserver", "ad-join"]
         })
         tags = merge(local.ec2_instances.db.tags, {
           ami              = "pd-cafm-db-a"
@@ -176,7 +176,7 @@ locals {
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
           instance_type           = "r6i.4xlarge"
-          vpc_security_group_ids  = ["domain", "database", "jumpserver"]
+          vpc_security_group_ids  = ["domain", "database", "jumpserver", "ad-join"]
         })
         tags = merge(local.ec2_instances.db.tags, {
           ami              = "pd-cafm-db-b"
@@ -215,7 +215,7 @@ locals {
         instance = merge(local.ec2_instances.web.instance, {
           disable_api_termination = true
           instance_type           = "t3.2xlarge"
-          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami              = "pd-cafm-w-36-b"
@@ -253,7 +253,7 @@ locals {
         instance = merge(local.ec2_instances.web.instance, {
           disable_api_termination = true
           instance_type           = "t3.2xlarge"
-          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami              = "pd-cafm-w-37-a"
@@ -279,7 +279,7 @@ locals {
         instance = merge(local.ec2_instances.web.instance, {
           disable_api_termination = true
           instance_type           = "t3.large"
-          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost"]
+          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami              = "pd-cafm-w-38-b"


### PR DESCRIPTION
Add additional ad-join group which will replace the domain one. This allows IPs from MP domain controllers whereas existing rule only allows azure DCs.