### PR TITLE
Correcting variable names for more clarity on exchange rates

### DIFF
--- a/terraform/environments/coat/secrets.tf
+++ b/terraform/environments/coat/secrets.tf
@@ -1,5 +1,5 @@
 #### This file can be used to store secrets specific to the member account ####
-resource "aws_ssm_parameter" "gbp_exchange_rate_up_to_april" {
+resource "aws_ssm_parameter" "gbp_exchange_rate_up_to_april_2024" {
   # checkov:skip=CKV_AWS_337: Standard KMS is fine
   name  = "/currency_rates/up_to_30-04-2024/gbp"
   type  = "SecureString"
@@ -10,7 +10,7 @@ resource "aws_ssm_parameter" "gbp_exchange_rate_up_to_april" {
   }
 }
 
-resource "aws_ssm_parameter" "gbp_exchange_rate_april_to_may" {
+resource "aws_ssm_parameter" "gbp_exchange_rate_may_2024_to_april_2025" {
   # checkov:skip=CKV_AWS_337: Standard KMS is fine
   name  = "/currency_rates/01-05-2024_to_30-04-2025/gbp"
   type  = "SecureString"
@@ -21,9 +21,9 @@ resource "aws_ssm_parameter" "gbp_exchange_rate_april_to_may" {
   }
 }
 
-resource "aws_ssm_parameter" "gbp_exchange_rate_may" {
+resource "aws_ssm_parameter" "gbp_exchange_rate_may_2025_to_april_2026" {
   # checkov:skip=CKV_AWS_337: Standard KMS is fine
-  name  = "/currency_rates/01-05-2025_onwards/gbp"
+  name  = "/currency_rates/01-05-2025_to_30-04-2026/gbp"
   type  = "SecureString"
   value = "[]" # or use a dummy like '[]'
 


### PR DESCRIPTION
Changing SSM Parameter names to match the namespaces for more clarity in future changes to exchange rates