### PR TITLE
TM-1376: csr: add additional ad-join SG

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -28,7 +28,7 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["domain", "app", "jumpserver"]
+        vpc_security_group_ids = ["domain", "app", "jumpserver", "ad-join", "ec2-windows"]
       }
       route53_records = {
         create_external_record = true
@@ -83,7 +83,7 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["database"]
+        vpc_security_group_ids = ["database", "oem-agent", "ec2-linux"]
       }
       route53_records = {
         create_external_record = true
@@ -140,7 +140,7 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["domain", "web", "jumpserver"]
+        vpc_security_group_ids = ["domain", "web", "jumpserver", "ad-join", "ec2-windows"]
       }
       route53_records = {
         create_external_record = true


### PR DESCRIPTION
Add baseline security groups (ad-join, oracle-oem, ec2-linux, ec2-windows) to existing EC2 instances. This will fix access to Mod Platform DCs.
Subsequent PRs will tidy up duplicate/unused rules.