### PR TITLE
TM-1376: csr: replace domain SG test

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -317,7 +317,8 @@ locals {
           "/dev/sdd"  = { type = "gp3", size = 112 }
         }
         instance = merge(local.ec2_instances.web.instance, {
-          instance_type = "m5.4xlarge"
+          instance_type          = "m5.4xlarge"
+          vpc_security_group_ids = ["web", "jumpserver", "ad-join", "ec2-windows"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami           = "pd-csr-w-2-b"


### PR DESCRIPTION
Remove the "domain" Security Group from single prod server. If OK, separate PR will remove from the other servers. This has been replaced with ad-join SG which also allows MP DCs.