### PR TITLE
TM-1376: csr: remove domain SG

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -28,7 +28,7 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["domain", "app", "jumpserver", "ad-join", "ec2-windows"]
+        vpc_security_group_ids = ["app", "jumpserver", "ad-join", "ec2-windows"]
       }
       route53_records = {
         create_external_record = true
@@ -140,7 +140,7 @@ locals {
         tags = {
           backup-plan = "daily-and-weekly"
         }
-        vpc_security_group_ids = ["domain", "web", "jumpserver", "ad-join", "ec2-windows"]
+        vpc_security_group_ids = ["web", "jumpserver", "ad-join", "ec2-windows"]
       }
       route53_records = {
         create_external_record = true


### PR DESCRIPTION
The domain security group has been replaced with ad-join which has some additional rules for the MP DCs. Has already been tested + applied on a single prod server without issue.