### PR TITLE
🧑‍🏭 Update MWAA worker configuration

### DIFF
--- a/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
@@ -6,8 +6,12 @@ locals {
 
       /* MWAA */
       airflow_version                 = "2.10.3"
-      airflow_environment_class       = "mw1.small"
+      airflow_environment_class       = "mw1.medium"
       airflow_webserver_instance_name = "Development"
+      airflow_max_workers             = 10
+      airflow_min_workers             = 2
+      airflow_schedulers              = 2
+      airflow_celery_worker_autoscale = "7,0"
     }
     test = {
       /* Route53 */
@@ -17,6 +21,10 @@ locals {
       airflow_version                 = "2.10.3"
       airflow_environment_class       = "mw1.medium"
       airflow_webserver_instance_name = "Test"
+      airflow_max_workers             = 10
+      airflow_min_workers             = 2
+      airflow_schedulers              = 2
+      airflow_celery_worker_autoscale = "7,0"
     }
     production = {
       /* Route53 */
@@ -26,6 +34,10 @@ locals {
       airflow_version                 = "2.10.3"
       airflow_environment_class       = "mw1.medium"
       airflow_webserver_instance_name = "Production"
+      airflow_max_workers             = 10
+      airflow_min_workers             = 2
+      airflow_schedulers              = 2
+      airflow_celery_worker_autoscale = "7,0"
     }
   }
 }

--- a/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
@@ -15,9 +15,9 @@ resource "aws_mwaa_environment" "main" {
   plugins_s3_path                = "plugins.zip"
   plugins_s3_object_version      = module.airflow_plugins_object.s3_object_version_id
 
-  max_workers = 2
-  min_workers = 1
-  schedulers  = 2
+  max_workers = local.environment_configuration.airflow_max_workers
+  min_workers = local.environment_configuration.airflow_min_workers
+  schedulers  = local.environment_configuration.airflow_schedulers
 
   webserver_access_mode = "PRIVATE_ONLY"
 
@@ -33,6 +33,7 @@ resource "aws_mwaa_environment" "main" {
     "webserver.warn_deployment_exposure" = 0
     "webserver.base_url"                 = "airflow.${local.environment_configuration.route53_zone}"
     "webserver.instance_name"            = local.environment_configuration.airflow_webserver_instance_name
+    "celery.worker_autoscale"            = local.environment_configuration.airflow_celery_worker_autoscale
   }
 
   network_configuration {


### PR DESCRIPTION
## Context

We've had a couple of support issues raised:

- https://github.com/ministryofjustice/data-platform-support/issues/1327
- https://github.com/ministryofjustice/data-platform-support/issues/1343

Where it has been reported that workflows are not running as expected, and are not providing any logs.

Originally we suspected this might've been an issue with EKS and Karpenter, but after investigating the Kubernetes logs, the API server never receives a request at the time of failure.

Myself and @jhpyke reviewed the Airflow control plane logs, and the workers appear to fail around the time the workflows fail. We can see that the worker does not emit a "warm shutdown" message like we'd expect to see if a worker was scaling down.

We raised this AWS (175095753100221), and they explained:

> As you have provided the screenshot of the logs, I was not able to see any error in that but I got the timestamps for the task failure and I have checked the metrics for the worker and found that at the same time you worker CPU utilization increased to more than 99% and then it disappeared because due to overload worker got shut down. This explains why you were able to see the “warm shutdown” error in the worker log. I have also attached the screenshot for your reference.
> 
> It seems like there are some specific task/tasks are running at same time and some of them are using high worker resources, which is making worker overwhelmed. I can see some more occurrences of this same high CPU utilization for other timestamps also.
> 
> To mitigate this issue we can try adding the parameter “celery.worker_autoscale” – The maximum and minimum number of tasks that can run concurrently on any worker. You can keep the maximum value less than what a worker class type can handle and minimum to zero.
> `celery.worker_autoscale = 7,0`

This can be observed here: https://observability.analytical-platform.service.justice.gov.uk/goto/-FKORXPHR?orgId=1

## Proposed Changes

- Sets `airflow_environment_class` to `mw1.medium`
  - 10 concurrent tasks (by default)
  - Workers: 2 vCPU 4GB RAM each
- Sets `airflow_max_workers` to `10`
- Sets `airflow_min_workers` to `2`
- Sets `airflow_celery_worker_autoscale` to `7,0`
  - This allows for up to 70 concurrent tasks in the cluster 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>