### PR TITLE
TM-1376: csr: remove jumpserver SG test

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -318,7 +318,7 @@ locals {
         }
         instance = merge(local.ec2_instances.web.instance, {
           instance_type          = "m5.4xlarge"
-          vpc_security_group_ids = ["web", "jumpserver", "ad-join", "ec2-windows"]
+          vpc_security_group_ids = ["web", "ad-join", "ec2-windows"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami           = "pd-csr-w-2-b"


### PR DESCRIPTION
Remove JumpServer security group on a single prod server. The jumpserver SG rules are either not needed or duplicate, but removing on one server only as a precaution.