### PR TITLE
TM-1376: planetfm: test removal of domain SG

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -31,7 +31,7 @@ locals {
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
           instance_type           = "t3.xlarge"
-          vpc_security_group_ids  = ["domain", "app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
+          vpc_security_group_ids  = ["app", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.app.tags, {
           ami              = "pd-cafm-a-10-b"
@@ -176,7 +176,7 @@ locals {
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true
           instance_type           = "r6i.4xlarge"
-          vpc_security_group_ids  = ["domain", "database", "jumpserver", "ad-join"]
+          vpc_security_group_ids  = ["database", "jumpserver", "ad-join"]
         })
         tags = merge(local.ec2_instances.db.tags, {
           ami              = "pd-cafm-db-b"
@@ -215,7 +215,7 @@ locals {
         instance = merge(local.ec2_instances.web.instance, {
           disable_api_termination = true
           instance_type           = "t3.2xlarge"
-          vpc_security_group_ids  = ["domain", "web", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
+          vpc_security_group_ids  = ["web", "jumpserver", "remotedesktop_sessionhost", "ad-join"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami              = "pd-cafm-w-36-b"


### PR DESCRIPTION
Test removal of domain SG on one of each server type. This has been replaced by ad-join SG.