### PR TITLE
DPR2-2072: Create test rds database

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -185,7 +185,21 @@
       "redshift_table_expiry_days": 7,
       "enable_s3_data_migrate_lambda": true,
       "create_postgres_load_generator_job": true,
-      "enable_probation_discovery_node": true
+      "enable_probation_discovery_node": true,
+      "dpr_rds_db": {
+        "enable": false,
+        "create_replica": false,
+        "engine": "postgres",
+        "engine_version": "16.8",
+        "init_size": "158",
+        "max_size": "1000",
+        "name": "testdatabase",
+        "db_identifier": "test-database",
+        "inst_class": "db.t4g.large",
+        "user": "postgres",
+        "store_type": "gp3",
+        "parameter_group": "default:postgres-16"
+      }
     },
     "test": {
       "project_short_id": "dpr",
@@ -265,8 +279,7 @@
         "dps-calc-rel-date",
         "dps-prison-reg",
         "dps-personal-rela",
-        "dps-organisations",
-        "dps-testing"
+        "dps-organisations"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -356,7 +369,21 @@
       "redshift_table_expiry_days": 7,
       "enable_s3_data_migrate_lambda": true,
       "create_postgres_load_generator_job": true,
-      "enable_probation_discovery_node": false
+      "enable_probation_discovery_node": false,
+      "dpr_rds_db": {
+        "enable": true,
+        "create_replica": true,
+        "engine": "postgres",
+        "engine_version": "16.8",
+        "init_size": "158",
+        "max_size": "1000",
+        "name": "testdatabase",
+        "db_identifier": "test-database",
+        "inst_class": "db.t4g.large",
+        "user": "postgres",
+        "store_type": "gp3",
+        "parameter_group": "default:postgres-16"
+      }
     },
     "preproduction": {
       "project_short_id": "dpr",
@@ -543,7 +570,21 @@
       "redshift_table_expiry_days": 7,
       "enable_s3_data_migrate_lambda": true,
       "create_postgres_load_generator_job": false,
-      "enable_probation_discovery_node": false
+      "enable_probation_discovery_node": false,
+      "dpr_rds_db": {
+        "enable": false,
+        "create_replica": false,
+        "engine": "postgres",
+        "engine_version": "16.8",
+        "init_size": "158",
+        "max_size": "1000",
+        "name": "testdatabase",
+        "db_identifier": "test-database",
+        "inst_class": "db.t4g.large",
+        "user": "postgres",
+        "store_type": "gp3",
+        "parameter_group": "default:postgres-16"
+      }
     },
     "production": {
       "project_short_id": "dpr",
@@ -728,7 +769,21 @@
       "redshift_table_expiry_days": 1,
       "enable_s3_data_migrate_lambda": false,
       "create_postgres_load_generator_job": false,
-      "enable_probation_discovery_node": false
+      "enable_probation_discovery_node": false,
+      "dpr_rds_db": {
+        "enable": false,
+        "create_replica": false,
+        "engine": "postgres",
+        "engine_version": "16.8",
+        "init_size": "158",
+        "max_size": "1000",
+        "name": "testdatabase",
+        "db_identifier": "test-database",
+        "inst_class": "db.t4g.large",
+        "user": "postgres",
+        "store_type": "gp3",
+        "parameter_group": "default:postgres-16"
+      }
     }
   }
 }

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -187,18 +187,19 @@
       "create_postgres_load_generator_job": true,
       "enable_probation_discovery_node": true,
       "dpr_rds_db": {
-        "enable": false,
-        "create_replica": false,
+        "enable": true,
+        "create_replica": true,
         "engine": "postgres",
         "engine_version": "16.8",
         "init_size": "158",
         "max_size": "1000",
         "name": "testdatabase",
-        "db_identifier": "test-database",
+        "db_identifier": "test-database-alt",
         "inst_class": "db.t4g.large",
         "user": "postgres",
         "store_type": "gp3",
-        "parameter_group": "default:postgres-16"
+        "parameter_group_family": "postgres16",
+        "parameter_group_name": "with-pglogical"
       }
     },
     "test": {
@@ -382,7 +383,8 @@
         "inst_class": "db.t4g.large",
         "user": "postgres",
         "store_type": "gp3",
-        "parameter_group": "default:postgres-16"
+        "parameter_group_family": "postgres16",
+        "parameter_group_name": "with-pglogical"
       }
     },
     "preproduction": {
@@ -583,7 +585,8 @@
         "inst_class": "db.t4g.large",
         "user": "postgres",
         "store_type": "gp3",
-        "parameter_group": "default:postgres-16"
+        "parameter_group_family": "postgres16",
+        "parameter_group_name": "with-pglogical"
       }
     },
     "production": {
@@ -782,7 +785,8 @@
         "inst_class": "db.t4g.large",
         "user": "postgres",
         "store_type": "gp3",
-        "parameter_group": "default:postgres-16"
+        "parameter_group_family": "postgres16",
+        "parameter_group_name": "with-pglogical"
       }
     }
   }

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -127,6 +127,19 @@ data "aws_secretsmanager_secret_version" "dps" {
   depends_on = [aws_secretsmanager_secret.dps]
 }
 
+# DPR Secret
+data "aws_secretsmanager_secret" "test_db" {
+  count = local.is_dev_or_test ? 1 : 0
+
+  name = "external/${local.project}-dps-test-db-source-secrets"
+}
+
+data "aws_secretsmanager_secret_version" "test_db" {
+  count = local.is_dev_or_test ? 1 : 0
+
+  secret_id = data.aws_secretsmanager_secret.test_db[0].id
+}
+
 # AWS _IAM_ Policy
 data "aws_iam_policy" "rds_full_access" {
   #checkov:skip=CKV_AWS_275:Disallow policies from using the AWS AdministratorAccess policy

--- a/terraform/environments/digital-prison-reporting/dpr_rds_db.tf
+++ b/terraform/environments/digital-prison-reporting/dpr_rds_db.tf
@@ -1,0 +1,34 @@
+# DPR RDS Database Instance
+module "dpr_rds_db" {
+  source = "./modules/rds/postgres"
+
+  count = local.is_dev_or_test ? 1 : 0
+
+  enable_rds         = local.enable_dpr_rds_db
+  create_rds_replica = local.create_rds_replica
+  engine             = local.dpr_rds_engine
+  engine_version     = local.dpr_rds_engine_version
+  allocated_size     = local.dpr_rds_init_size
+  max_allocated_size = local.dpr_rds_max_size
+  subnets            = local.dpr_subnets
+  vpc_id             = local.dpr_vpc
+  kms                = local.rds_kms_arn
+  name               = local.dpr_rds_db_identifier
+  db_name            = local.dpr_rds_name
+  db_instance_class  = local.dpr_rds_inst_class
+  master_user        = jsondecode(data.aws_secretsmanager_secret_version.test_db[0].secret_string)["user"]
+  storage_type       = local.dpr_rds_store_type
+  parameter_group    = local.dpr_rds_parameter_group
+  ca_cert_identifier = "rds-ca-rsa2048-g1" # Expiry on June 16, 2026
+  license_model      = "postgresql-license"
+
+  tags = merge(
+    local.all_tags,
+    {
+      Resource_Group = "RDS"
+      Jira           = "DPR2-2072"
+      Resource_Type  = "RDS Instance"
+      Name           = local.dpr_rds_name
+    }
+  )
+}

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,7 +1,8 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
-  dpr_test_connection_string            = try("jdbc:postgresql://${module.dpr_rds_db[0].rds_host}:5432/postgres", "")
+
+  dpr_test_connection_string = try("jdbc:postgresql://${module.dpr_rds_db[0].rds_host}:${module.dpr_rds_db[0].rds_port}/${jsondecode(data.aws_secretsmanager_secret_version.test_db[0].secret_string)["db_name"]}", "")
 
   dps_endpoint = {
     for item in local.dps_domains_list :

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -1,6 +1,7 @@
 locals {
   operational_db_jdbc_connection_string = "jdbc:postgresql://${module.aurora_operational_db.rds_cluster_endpoints["static"]}:${local.operational_db_port}/${local.operational_db_default_database}"
   nomis_jdbc_connection_string          = "jdbc:oracle:thin:@${local.nomis_host}:${local.nomis_port}/${local.nomis_service_name}"
+  dpr_test_connection_string            = try("jdbc:postgresql://${module.dpr_rds_db[0].rds_host}:5432/postgres", "")
 
   dps_endpoint = {
     for item in local.dps_domains_list :
@@ -68,6 +69,24 @@ resource "aws_glue_connection" "glue_dps_connection" {
     JDBC_CONNECTION_URL    = local.dps_connection_string[each.value]
     JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
     SECRET_ID              = aws_secretsmanager_secret.dps[each.value].name
+  }
+
+  physical_connection_requirements {
+    availability_zone      = data.aws_subnet.private_subnets_a.availability_zone
+    security_group_id_list = [aws_security_group.glue_job_connection_sg.id]
+    subnet_id              = data.aws_subnet.private_subnets_a.id
+  }
+}
+
+resource "aws_glue_connection" "glue_dpr_test_connection" {
+  count           = (local.create_glue_connection && local.is_dev_or_test) ? 1 : 0
+  name            = "${local.project}-dps-test-db-connection"
+  connection_type = "JDBC"
+
+  connection_properties = {
+    JDBC_CONNECTION_URL    = local.dpr_test_connection_string
+    JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
+    SECRET_ID              = aws_secretsmanager_secret.dpr-test[0].name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -112,6 +112,20 @@ locals {
   enable_slack_alerts     = local.application_data.accounts[local.environment].enable_slack_alerts
   enable_pagerduty_alerts = local.application_data.accounts[local.environment].enable_pagerduty_alerts
 
+  # DPR RDS Database
+  enable_dpr_rds_db       = local.application_data.accounts[local.environment].dpr_rds_db.enable
+  create_rds_replica      = local.application_data.accounts[local.environment].dpr_rds_db.create_replica
+  dpr_rds_engine          = local.application_data.accounts[local.environment].dpr_rds_db.engine
+  dpr_rds_engine_version  = local.application_data.accounts[local.environment].dpr_rds_db.engine_version
+  dpr_rds_init_size       = local.application_data.accounts[local.environment].dpr_rds_db.init_size
+  dpr_rds_max_size        = local.application_data.accounts[local.environment].dpr_rds_db.max_size
+  dpr_rds_name            = local.application_data.accounts[local.environment].dpr_rds_db.name
+  dpr_rds_db_identifier   = local.application_data.accounts[local.environment].dpr_rds_db.db_identifier
+  dpr_rds_inst_class      = local.application_data.accounts[local.environment].dpr_rds_db.inst_class
+  dpr_rds_user            = local.application_data.accounts[local.environment].dpr_rds_db.user
+  dpr_rds_store_type      = local.application_data.accounts[local.environment].dpr_rds_db.store_type
+  dpr_rds_parameter_group = local.application_data.accounts[local.environment].dpr_rds_db.parameter_group
+
   # Domain Builder, Variables
   dpr_vpc                        = data.aws_vpc.shared.id
   dpr_subnets                    = [data.aws_subnet.private_subnets_a.id, data.aws_subnet.private_subnets_b.id, data.aws_subnet.private_subnets_c.id]

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -113,18 +113,19 @@ locals {
   enable_pagerduty_alerts = local.application_data.accounts[local.environment].enable_pagerduty_alerts
 
   # DPR RDS Database
-  enable_dpr_rds_db       = local.application_data.accounts[local.environment].dpr_rds_db.enable
-  create_rds_replica      = local.application_data.accounts[local.environment].dpr_rds_db.create_replica
-  dpr_rds_engine          = local.application_data.accounts[local.environment].dpr_rds_db.engine
-  dpr_rds_engine_version  = local.application_data.accounts[local.environment].dpr_rds_db.engine_version
-  dpr_rds_init_size       = local.application_data.accounts[local.environment].dpr_rds_db.init_size
-  dpr_rds_max_size        = local.application_data.accounts[local.environment].dpr_rds_db.max_size
-  dpr_rds_name            = local.application_data.accounts[local.environment].dpr_rds_db.name
-  dpr_rds_db_identifier   = local.application_data.accounts[local.environment].dpr_rds_db.db_identifier
-  dpr_rds_inst_class      = local.application_data.accounts[local.environment].dpr_rds_db.inst_class
-  dpr_rds_user            = local.application_data.accounts[local.environment].dpr_rds_db.user
-  dpr_rds_store_type      = local.application_data.accounts[local.environment].dpr_rds_db.store_type
-  dpr_rds_parameter_group = local.application_data.accounts[local.environment].dpr_rds_db.parameter_group
+  enable_dpr_rds_db              = local.application_data.accounts[local.environment].dpr_rds_db.enable
+  create_rds_replica             = local.application_data.accounts[local.environment].dpr_rds_db.create_replica
+  dpr_rds_engine                 = local.application_data.accounts[local.environment].dpr_rds_db.engine
+  dpr_rds_engine_version         = local.application_data.accounts[local.environment].dpr_rds_db.engine_version
+  dpr_rds_init_size              = local.application_data.accounts[local.environment].dpr_rds_db.init_size
+  dpr_rds_max_size               = local.application_data.accounts[local.environment].dpr_rds_db.max_size
+  dpr_rds_name                   = local.application_data.accounts[local.environment].dpr_rds_db.name
+  dpr_rds_db_identifier          = local.application_data.accounts[local.environment].dpr_rds_db.db_identifier
+  dpr_rds_inst_class             = local.application_data.accounts[local.environment].dpr_rds_db.inst_class
+  dpr_rds_user                   = local.application_data.accounts[local.environment].dpr_rds_db.user
+  dpr_rds_store_type             = local.application_data.accounts[local.environment].dpr_rds_db.store_type
+  dpr_rds_parameter_group_family = local.application_data.accounts[local.environment].dpr_rds_db.parameter_group_family
+  dpr_rds_parameter_group_name   = local.application_data.accounts[local.environment].dpr_rds_db.parameter_group_name
 
   # Domain Builder, Variables
   dpr_vpc                        = data.aws_vpc.shared.id
@@ -138,7 +139,7 @@ locals {
   rds_dbuilder_store_type        = "gp2"
   rds_dbuilder_init_size         = 10
   rds_dbuilder_max_size          = 50
-  rds_dbuilder_parameter_group   = "postgres14"
+  rds_dbuilder_parameter_group   = "default.postgres14"
   rds_dbuilder_port              = 5432
   rds_dbuilder_user              = "domain_builder"
   enable_dbuilder_lambda         = local.application_data.accounts[local.environment].enable_domain_builder_lambda

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1123,7 +1123,7 @@ module "generate_test_postgres_data" {
   enable_continuous_log_filter = false
   project_id                   = local.project
   aws_kms_key                  = local.s3_kms_arn
-  connections                  = ["dpr-dps-testing-connection"]
+  connections                  = ["${local.project}-dps-test-db-connection"]
 
   execution_class             = "STANDARD"
   worker_type                 = "G.1X"
@@ -1148,7 +1148,7 @@ module "generate_test_postgres_data" {
     "--class"                                  = "uk.gov.justice.digital.job.generator.PostgresLoadGeneratorJob"
     "--dpr.aws.region"                         = local.account_region
     "--dpr.log.level"                          = local.glue_job_common_log_level
-    "--dpr.test.database.secret.id"            = "external/dpr-dps-testing-source-secrets"
+    "--dpr.test.database.secret.id"            = "external/dpr-dps-test-db-source-secrets"
     "--dpr.test.data.batch.size"               = 5
     "--dpr.test.data.parallelism"              = 100
     "--dpr.test.data.inter.batch.delay.millis" = 2000

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/outputs.tf
@@ -146,34 +146,6 @@ output "security_group_id" {
 }
 
 ################################################################################
-# Cluster Parameter Group
-################################################################################
-
-output "db_cluster_parameter_group_arn" {
-  description = "The ARN of the DB cluster parameter group created"
-  value       = try(aws_rds_cluster_parameter_group.this[0].arn, null)
-}
-
-output "db_cluster_parameter_group_id" {
-  description = "The ID of the DB cluster parameter group created"
-  value       = try(aws_rds_cluster_parameter_group.this[0].id, null)
-}
-
-################################################################################
-# DB Parameter Group
-################################################################################
-
-output "db_parameter_group_arn" {
-  description = "The ARN of the DB parameter group created"
-  value       = try(aws_db_parameter_group.this[0].arn, null)
-}
-
-output "db_parameter_group_id" {
-  description = "The ID of the DB parameter group created"
-  value       = try(aws_db_parameter_group.this[0].id, null)
-}
-
-################################################################################
 # CloudWatch Log Group
 ################################################################################
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/aws-aurora/variables.tf
@@ -367,7 +367,11 @@ variable "ca_cert_identifier" {
 variable "db_parameter_group_name" {
   description = "The name of the DB parameter group"
   type        = string
-  default     = null
+}
+
+variable "db_cluster_parameter_group_name" {
+  description = "The name of the DB cluster parameter group"
+  type        = string
 }
 
 variable "instances_use_identifier_prefix" {
@@ -604,80 +608,6 @@ variable "security_group_tags" {
   description = "Additional tags for the security group"
   type        = map(string)
   default     = {}
-}
-
-################################################################################
-# Cluster Parameter Group
-################################################################################
-
-variable "create_db_cluster_parameter_group" {
-  description = "Determines whether a cluster parameter should be created or use existing"
-  type        = bool
-  default     = false
-}
-
-variable "db_cluster_parameter_group_name" {
-  description = "The name of the DB cluster parameter group"
-  type        = string
-  default     = null
-}
-
-variable "db_cluster_parameter_group_use_name_prefix" {
-  description = "Determines whether the DB cluster parameter group name is used as a prefix"
-  type        = bool
-  default     = true
-}
-
-variable "db_cluster_parameter_group_description" {
-  description = "The description of the DB cluster parameter group. Defaults to \"Managed by Terraform\""
-  type        = string
-  default     = null
-}
-
-variable "db_cluster_parameter_group_family" {
-  description = "The family of the DB cluster parameter group"
-  type        = string
-  default     = ""
-}
-
-variable "db_cluster_parameter_group_parameters" {
-  description = "A list of DB cluster parameters to apply. Note that parameters may differ from a family to an other"
-  type        = list(map(string))
-  default     = []
-}
-
-################################################################################
-# DB Parameter Group
-################################################################################
-
-variable "create_db_parameter_group" {
-  description = "Determines whether a DB parameter should be created or use existing"
-  type        = bool
-  default     = false
-}
-
-variable "db_parameter_group_use_name_prefix" {
-  description = "Determines whether the DB parameter group name is used as a prefix"
-  type        = bool
-  default     = true
-}
-
-variable "db_parameter_group_description" {
-  description = "The description of the DB parameter group. Defaults to \"Managed by Terraform\""
-  type        = string
-  default     = null
-}
-
-variable "db_parameter_group_family" {
-  description = "The family of the DB parameter group"
-  type        = string
-  default     = ""
-}
-
-variable "db_parameter_group_parameters" {
-  description = "A list of DB parameters to apply. Note that parameters may differ from a family to an other"
-  type        = list(map(string))
-  default     = []
 }
 
 ################################################################################

--- a/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/main.tf
@@ -1,0 +1,28 @@
+################################################################################
+# Cluster Parameter Group
+################################################################################
+
+resource "aws_rds_cluster_parameter_group" "this" {
+  count = var.create_db_cluster_parameter_group ? 1 : 0
+
+  name        = var.db_cluster_parameter_group_use_name_prefix ? null : var.db_cluster_parameter_group_name
+  name_prefix = var.db_cluster_parameter_group_use_name_prefix ? "${var.db_cluster_parameter_group_name}-" : null
+  description = var.db_cluster_parameter_group_description
+  family      = var.db_cluster_parameter_group_family
+
+  dynamic "parameter" {
+    for_each = var.db_cluster_parameter_group_parameters
+
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = try(parameter.value.apply_method, "immediate")
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/outputs.tf
@@ -1,0 +1,18 @@
+################################################################################
+# Cluster Parameter Group
+################################################################################
+
+output "db_cluster_parameter_group_arn" {
+  description = "The ARN of the DB cluster parameter group created"
+  value       = try(aws_rds_cluster_parameter_group.this[0].arn, null)
+}
+
+output "db_cluster_parameter_group_id" {
+  description = "The ID of the DB cluster parameter group created"
+  value       = try(aws_rds_cluster_parameter_group.this[0].id, null)
+}
+
+output "db_cluster_parameter_group_name" {
+  description = "The Name of the DB cluster parameter group created"
+  value       = try(aws_rds_cluster_parameter_group.this[0].name, null)
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/variables.tf
@@ -1,0 +1,43 @@
+################################################################################
+# Cluster Parameter Group
+################################################################################
+
+variable "create_db_cluster_parameter_group" {
+  description = "Determines whether a cluster parameter should be created or use existing"
+  type        = bool
+  default     = false
+}
+
+variable "db_cluster_parameter_group_name" {
+  description = "The name of the DB cluster parameter group"
+  type        = string
+}
+
+variable "db_cluster_parameter_group_use_name_prefix" {
+  description = "Determines whether the DB cluster parameter group name is used as a prefix"
+  type        = bool
+  default     = true
+}
+
+variable "db_cluster_parameter_group_description" {
+  description = "The description of the DB cluster parameter group. Defaults to \"Managed by Terraform\""
+  type        = string
+  default     = null
+}
+
+variable "db_cluster_parameter_group_family" {
+  description = "The family of the DB cluster parameter group"
+  type        = string
+  default     = ""
+}
+
+variable "db_cluster_parameter_group_parameters" {
+  description = "A list of DB cluster parameters to apply. Note that parameters may differ from a family to an other"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "tags" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/cluster_parameter_group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.10"
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/main.tf
@@ -1,0 +1,28 @@
+################################################################################
+# DB Parameter Group
+################################################################################
+
+resource "aws_db_parameter_group" "parameter_group" {
+  count = var.create_db_parameter_group ? 1 : 0
+
+  name        = var.db_parameter_group_use_name_prefix ? null : var.db_parameter_group_name
+  name_prefix = var.db_parameter_group_use_name_prefix ? "${var.db_parameter_group_name}-" : null
+  description = var.db_parameter_group_description
+  family      = var.db_parameter_group_family
+
+  dynamic "parameter" {
+    for_each = var.db_parameter_group_parameters
+
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = try(parameter.value.apply_method, "immediate")
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/outputs.tf
@@ -1,0 +1,17 @@
+################################################################################
+# DB Parameter Group
+################################################################################
+output "db_parameter_group_arn" {
+  description = "The ARN of the DB parameter group created"
+  value       = try(aws_db_parameter_group.parameter_group[0].arn, null)
+}
+
+output "parameter_group_id" {
+  value       = try(aws_db_parameter_group.parameter_group[0].id, null)
+  description = "The ID of the DB parameter group created"
+}
+
+output "parameter_group_name" {
+  value       = try(aws_db_parameter_group.parameter_group[0].name, null)
+  description = "The name of the parameter group created"
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/variables.tf
@@ -1,0 +1,44 @@
+################################################################################
+# DB Parameter Group
+################################################################################
+
+variable "create_db_parameter_group" {
+  description = "Determines whether a DB parameter should be created or use existing"
+  type        = bool
+  default     = false
+}
+
+variable "db_parameter_group_name" {
+  description = "The name of the DB parameter group"
+  type        = string
+  default     = null
+}
+
+variable "db_parameter_group_use_name_prefix" {
+  description = "Determines whether the DB parameter group name is used as a prefix"
+  type        = bool
+  default     = true
+}
+
+variable "db_parameter_group_description" {
+  description = "The description of the DB parameter group. Defaults to \"Managed by Terraform\""
+  type        = string
+  default     = null
+}
+
+variable "db_parameter_group_family" {
+  description = "The family of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
+variable "db_parameter_group_parameters" {
+  description = "A list of DB parameters to apply. Note that parameters may differ from a family to an other"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "tags" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/parameter_group/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+    random = {
+      version = ">= 3.0.0"
+      source  = "hashicorp/random"
+    }
+
+  }
+  required_version = "~> 1.10"
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/main.tf
@@ -54,6 +54,7 @@ resource "aws_db_instance" "default" {
   engine                  = var.engine
   engine_version          = var.engine_version
   instance_class          = var.db_instance_class
+  parameter_group_name    = var.parameter_group
   username                = var.master_user
   password                = data.aws_secretsmanager_secret_version.password.secret_string
   storage_type            = var.storage_type
@@ -61,15 +62,23 @@ resource "aws_db_instance" "default" {
   maintenance_window      = var.maintenance_window
   backup_window           = var.backup_window
   backup_retention_period = var.back_up_period
-  vpc_security_group_ids  = [aws_security_group.rds[0].id, aws_security_group.ec2_sec_group[0].id, ]
-  skip_final_snapshot     = true
+  vpc_security_group_ids  = [aws_security_group.rds[0].id, aws_security_group.rds_ec2_sec_group[0].id, ]
+  skip_final_snapshot     = var.skip_final_snapshot
   kms_key_id              = var.kms
-  storage_encrypted       = true
-  apply_immediately       = true
+  storage_encrypted       = var.storage_encrypted
+  apply_immediately       = var.apply_immediately
   allocated_storage       = var.allocated_size
   max_allocated_storage   = var.max_allocated_size
   ca_cert_identifier      = var.ca_cert_identifier
-  multi_az                = false
+  multi_az                = var.multi_az
+  monitoring_interval     = var.monitoring_interval
+  deletion_protection     = var.deletion_protection
+
+  auto_minor_version_upgrade            = var.auto_minor_version_upgrade
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_kms_key_id       = var.performance_insights_kms_key_id
+  performance_insights_retention_period = var.performance_insights_retention_period
+
   tags = merge(
     var.tags,
     {
@@ -77,24 +86,47 @@ resource "aws_db_instance" "default" {
       Name          = "${var.name}-rds"
     }
   )
+
+  depends_on = [aws_security_group.rds[0], aws_security_group.rds_ec2_sec_group[0]]
 }
 
 resource "aws_db_instance" "replica" {
+  #checkov:skip=CKV_AWS_129: "Ensure that respective logs of Amazon Relational Database Service (Amazon RDS) are enabled"
+  #checkov:skip=CKV_AWS_79: "Ensure Instance Metadata Service Version 1 is not enabled"
+
   count = (var.enable_rds && var.create_rds_replica) ? 1 : 0
 
   replicate_source_db     = aws_db_instance.default[0].identifier
-  backup_retention_period = 7
+  parameter_group_name    = aws_db_instance.default[0].parameter_group_name
+  backup_retention_period = aws_db_instance.default[0].backup_retention_period
   identifier              = "${var.name}-replica"
-  instance_class          = var.db_instance_class
-  vpc_security_group_ids  = [aws_security_group.rds[0].id, aws_security_group.ec2_sec_group[0].id, ]
-  skip_final_snapshot     = true
+  instance_class          = aws_db_instance.default[0].instance_class
+  vpc_security_group_ids  = [aws_security_group.rds[0].id, aws_security_group.rds_ec2_sec_group[0].id, ]
+  skip_final_snapshot     = aws_db_instance.default[0].skip_final_snapshot
   kms_key_id              = var.kms
-  storage_encrypted       = true
-  apply_immediately       = true
+  storage_encrypted       = aws_db_instance.default[0].storage_encrypted
+  apply_immediately       = aws_db_instance.default[0].apply_immediately
   max_allocated_storage   = var.max_allocated_size
   ca_cert_identifier      = var.ca_cert_identifier
-  copy_tags_to_snapshot   = true
-  multi_az                = false
+  copy_tags_to_snapshot   = aws_db_instance.default[0].copy_tags_to_snapshot
+  multi_az                = aws_db_instance.default[0].multi_az
+  monitoring_interval     = aws_db_instance.default[0].monitoring_interval
+  deletion_protection     = aws_db_instance.default[0].deletion_protection
+
+  auto_minor_version_upgrade            = aws_db_instance.default[0].auto_minor_version_upgrade
+  performance_insights_enabled          = aws_db_instance.default[0].performance_insights_enabled
+  performance_insights_kms_key_id       = aws_db_instance.default[0].performance_insights_kms_key_id
+  performance_insights_retention_period = aws_db_instance.default[0].performance_insights_retention_period
+
+  tags = merge(
+    var.tags,
+    {
+      Resource_Type = "rds"
+      Name          = "${var.name}-rds"
+    }
+  )
+
+  depends_on = [aws_db_instance.default[0], aws_security_group.rds[0], aws_security_group.rds_ec2_sec_group[0]]
 }
 
 resource "random_password" "password" {

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/outputs.tf
@@ -7,3 +7,8 @@ output "rds_host" {
   description = "RDS Host Endpoint"
   value       = try(aws_db_instance.default[0].address, "")
 }
+
+output "rds_port" {
+  description = "RDS port"
+  value       = try(aws_db_instance.default[0].port, "")
+}

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
@@ -24,38 +24,62 @@ resource "aws_security_group" "rds" {
 }
 
 # EC2 Security Group
-resource "aws_security_group" "ec2_sec_group" {
+resource "aws_security_group" "rds_ec2_sec_group" {
   count = var.enable_rds ? 1 : 0
 
-  name        = "${var.name}-ec2-sgroup"
-  description = "RDS EC2 security group"
+  name        = "${var.name}-rds-ec2-sgroup"
+  description = "RDS to EC2 security group"
   vpc_id      = data.aws_vpc.dpr.id
   tags        = var.tags
 }
 
-resource "aws_security_group_rule" "ingress_traffic" {
+resource "aws_security_group_rule" "ingress_traffic_block_1" {
   count = var.enable_rds ? 1 : 0
 
   type              = "ingress"
-  description       = "RDS EC2 security group rule to allow incoming connections from EC2 instances to RDS"
+  description       = "Security group rule to allow incoming connections between ports 0-21"
   protocol          = "tcp"
   from_port         = 0
-  to_port           = 65535
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.ec2_sec_group[0].id
+  to_port           = 21
+  cidr_blocks       = [data.aws_vpc.dpr.cidr_block, ]
+  security_group_id = aws_security_group.rds_ec2_sec_group[0].id
 }
 
-resource "aws_security_group_rule" "egress_traffic" {
-  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
+resource "aws_security_group_rule" "ingress_traffic_block_2" {
   count = var.enable_rds ? 1 : 0
 
-  type              = "egress"
-  description       = "RDS EC2 security group rule to allow outgoing connections from RDS to EC2 instances"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.ec2_sec_group[0].id
+  type              = "ingress"
+  description       = "Security group rule to allow incoming connections between ports 23-79"
+  protocol          = "tcp"
+  from_port         = 23
+  to_port           = 79
+  cidr_blocks       = [data.aws_vpc.dpr.cidr_block, ]
+  security_group_id = aws_security_group.rds_ec2_sec_group[0].id
+}
+
+
+resource "aws_security_group_rule" "ingress_traffic_block_3" {
+  count = var.enable_rds ? 1 : 0
+
+  type              = "ingress"
+  description       = "Security group rule to allow incoming connections between ports 81-3388"
+  protocol          = "tcp"
+  from_port         = 81
+  to_port           = 3388
+  cidr_blocks       = [data.aws_vpc.dpr.cidr_block, ]
+  security_group_id = aws_security_group.rds_ec2_sec_group[0].id
+}
+
+resource "aws_security_group_rule" "ingress_traffic_block_4" {
+  count = var.enable_rds ? 1 : 0
+
+  type              = "ingress"
+  description       = "Security group rule to allow incoming connections between ports 3390-65535"
+  protocol          = "tcp"
+  from_port         = 3390
+  to_port           = 65535
+  cidr_blocks       = [data.aws_vpc.dpr.cidr_block, ]
+  security_group_id = aws_security_group.rds_ec2_sec_group[0].id
 }
 
 resource "aws_security_group_rule" "rule" {

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/sg.tf
@@ -23,6 +23,41 @@ resource "aws_security_group" "rds" {
   )
 }
 
+# EC2 Security Group
+resource "aws_security_group" "ec2_sec_group" {
+  count = var.enable_rds ? 1 : 0
+
+  name        = "${var.name}-ec2-sgroup"
+  description = "RDS EC2 security group"
+  vpc_id      = data.aws_vpc.dpr.id
+  tags        = var.tags
+}
+
+resource "aws_security_group_rule" "ingress_traffic" {
+  count = var.enable_rds ? 1 : 0
+
+  type              = "ingress"
+  description       = "RDS EC2 security group rule to allow incoming connections from EC2 instances to RDS"
+  protocol          = "tcp"
+  from_port         = 0
+  to_port           = 65535
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ec2_sec_group[0].id
+}
+
+resource "aws_security_group_rule" "egress_traffic" {
+  #checkov:skip=CKV_AWS_382: "Ensure no security groups allow egress from 0.0.0.0:0 to port -1"
+  count = var.enable_rds ? 1 : 0
+
+  type              = "egress"
+  description       = "RDS EC2 security group rule to allow outgoing connections from RDS to EC2 instances"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ec2_sec_group[0].id
+}
+
 resource "aws_security_group_rule" "rule" {
   #checkov:skip=CKV_AWS_23: "Ensure every security group and rule has a description"
 

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/variables.tf
@@ -52,9 +52,21 @@ variable "back_up_period" {
   default     = 1
 }
 
+variable "skip_final_snapshot" {
+  type        = bool
+  description = "Flag to skip the final snapshot"
+  default     = true
+}
+
 variable "parameter_group" {
   type        = string
   description = "Parameter_group"
+}
+
+variable "backup_retention_period" {
+  type        = number
+  description = "The backup retention period of the RDS instance"
+  default     = 7
 }
 
 variable "storage_type" {
@@ -80,6 +92,54 @@ variable "kms" {
   default     = ""
 }
 
+variable "storage_encrypted" {
+  type        = bool
+  description = "Flag to encrypt the storage"
+  default     = true
+}
+
+variable "apply_immediately" {
+  type        = bool
+  description = "Flag to apply changes immediately"
+  default     = true
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "Flag to allow Multi-AZ"
+  default     = false
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Ensure deletion protection"
+  default     = false
+}
+
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  description = "Allow automatic minor version upgrades"
+  default     = true
+}
+
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "Enable performance insights"
+  default     = false
+}
+
+variable "performance_insights_kms_key_id" {
+  type        = string
+  description = "KMS key for the performance insights"
+  default     = null
+}
+
+variable "performance_insights_retention_period" {
+  type        = number
+  description = "Performance insights retention period"
+  default     = 0
+}
+
 variable "allocated_size" {
   type        = string
   description = "Allocated Storage"
@@ -90,6 +150,12 @@ variable "ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance"
   type        = string
   default     = null
+}
+
+variable "monitoring_interval" {
+  description = "The monitoring interval for the DB instance"
+  type        = number
+  default     = 0
 }
 
 variable "max_allocated_size" {

--- a/terraform/environments/digital-prison-reporting/modules/rds/postgres/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/rds/postgres/variables.tf
@@ -16,6 +16,24 @@ variable "db_name" {
   description = "RDS Identifier"
 }
 
+variable "engine" {
+  type = string
+  description = "RDS Engine"
+  default = "postgres"
+}
+
+variable "engine_version" {
+  type        = string
+  description = "RDS Engine Version"
+  default     = null
+}
+
+variable "license_model" {
+  type        = string
+  description = "License Model"
+  default     = null
+}
+
 variable "backup_window" {
   type        = string
   description = "Backup window"
@@ -90,4 +108,10 @@ variable "master_user" {
   type        = string
   description = "Default Super User,"
   default     = "domain_builder"
+}
+
+variable "create_rds_replica" {
+  type        = bool
+  description = "Whether to create the RDS replica. Set to `false` to prevent the RDS replica from being created"
+  default     = false
 }

--- a/terraform/environments/digital-prison-reporting/operational_datastore.tf
+++ b/terraform/environments/digital-prison-reporting/operational_datastore.tf
@@ -4,6 +4,15 @@ locals {
 
   name = "${local.project}-operational-db"
 
+  create_db_parameter_group         = true
+  create_db_cluster_parameter_group = true
+
+  parameter_group_name         = "${local.name}-instance"
+  cluster_parameter_group_name = null
+
+  db_cluster_parameter_group_name = try(coalesce(local.cluster_parameter_group_name, local.name), null)
+  db_parameter_group_name         = try(coalesce(local.parameter_group_name, local.name), null)
+
   operational_db_tags = merge(
     local.all_tags,
     {
@@ -19,7 +28,68 @@ locals {
 }
 
 ################################################################################
-# Operationa DB - RDS Aurora Cluster
+# Operational DB - Parameter Group
+################################################################################
+module "operational_db_parameter_group" {
+  source = "./modules/rds/parameter_group"
+
+  create_db_parameter_group      = local.create_db_parameter_group
+  db_parameter_group_name        = "${local.name}-instance"
+  db_parameter_group_family      = "aurora-postgresql16"
+  db_parameter_group_description = "${local.name} DB parameter group"
+  db_parameter_group_parameters = [
+    {
+      name         = "log_min_duration_statement"
+      value        = 4000
+      apply_method = "immediate"
+    },
+    {
+      name         = "shared_preload_libraries"
+      value        = "pg_stat_statements,pg_cron"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "cron.database_name"
+      value        = local.operational_db_default_database
+      apply_method = "pending-reboot"
+    }
+  ]
+
+  tags = merge(
+    local.operational_db_tags,
+    {
+      Resource_Type  = "RDS Parameter Group"
+    }
+  )
+}
+
+################################################################################
+# Operationa DB - Cluster Parameter Group
+################################################################################
+module "operational_db_cluster_parameter_group" {
+  source = "./modules/rds/cluster_parameter_group"
+
+  create_db_cluster_parameter_group      = local.create_db_cluster_parameter_group
+  db_cluster_parameter_group_name        = local.db_cluster_parameter_group_name
+  db_cluster_parameter_group_family      = "aurora-postgresql16"
+  db_cluster_parameter_group_description = "${local.name} cluster parameter group"
+
+  db_cluster_parameter_group_parameters = [
+    {
+      name         = "log_min_duration_statement"
+      value        = 4000
+      apply_method = "immediate"
+    },
+    {
+      name         = "rds.force_ssl"
+      value        = 1
+      apply_method = "immediate"
+    }
+  ]
+}
+
+################################################################################
+# Operational DB - RDS Aurora Cluster
 ################################################################################
 
 module "aurora_operational_db" {
@@ -64,45 +134,11 @@ module "aurora_operational_db" {
   apply_immediately   = true
   skip_final_snapshot = true
 
-  create_db_cluster_parameter_group      = true
   create_db_subnet_group                 = true
   subnets                                = local.dpr_subnets
-  db_cluster_parameter_group_family      = "aurora-postgresql16"
-  db_cluster_parameter_group_description = "${local.name} cluster parameter group"
-  db_cluster_parameter_group_parameters = [
-    {
-      name         = "log_min_duration_statement"
-      value        = 4000
-      apply_method = "immediate"
-    },
-    {
-      name         = "rds.force_ssl"
-      value        = 1
-      apply_method = "immediate"
-    }
-  ]
 
-  create_db_parameter_group      = true
-  db_parameter_group_name        = "${local.name}-instance"
-  db_parameter_group_family      = "aurora-postgresql16"
-  db_parameter_group_description = "${local.name} DB parameter group"
-  db_parameter_group_parameters = [
-    {
-      name         = "log_min_duration_statement"
-      value        = 4000
-      apply_method = "immediate"
-    },
-    {
-      name         = "shared_preload_libraries"
-      value        = "pg_stat_statements,pg_cron"
-      apply_method = "pending-reboot"
-    },
-    {
-      name         = "cron.database_name"
-      value        = local.operational_db_default_database
-      apply_method = "pending-reboot"
-    }
-  ]
+  db_parameter_group_name         = local.create_db_parameter_group ? module.operational_db_parameter_group.parameter_group_id : local.db_parameter_group_name
+  db_cluster_parameter_group_name = local.create_db_cluster_parameter_group ? module.operational_db_cluster_parameter_group.db_cluster_parameter_group_id : local.db_cluster_parameter_group_name
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
   create_cloudwatch_log_group     = true
@@ -112,4 +148,6 @@ module "aurora_operational_db" {
   db_cluster_activity_stream_mode       = "async"
 
   tags = local.operational_db_tags
+
+  depends_on = [module.operational_db_cluster_parameter_group, module.operational_db_parameter_group]
 }

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -583,3 +583,33 @@ resource "aws_secretsmanager_secret_version" "dpr_windows_rdp_credentials" {
     ignore_changes = [secret_string, ]
   }
 }
+
+# Nomis Test Source Secrets (for Unit Test)
+resource "aws_secretsmanager_secret" "dpr-test" {
+  #checkov:skip=CKV2_AWS_57: "Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
+  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
+  count = local.is_dev_or_test ? 1 : 0
+
+  name = "external/${local.project}-dps-test-db-source-secrets"
+
+  tags = merge(
+    local.all_tags,
+    {
+      Name          = "external/${local.project}-dps-test-db-source-secrets"
+      Resource_Type = "Secrets"
+      Jira          = "DPR2-2072"
+    }
+  )
+}
+
+# PlaceHolder Secrets
+resource "aws_secretsmanager_secret_version" "dpr-test" {
+  count = local.is_dev_or_test ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.dpr-test[0].id
+  secret_string = jsonencode(local.dps_secrets_placeholder) # Uses the DPS secret placeholder format
+
+  lifecycle {
+    ignore_changes = [secret_string, ]
+  }
+}


### PR DESCRIPTION
This PR:
- Creates a test RDS database in the dev and test environments for the purpose of reproducing the read replica issue for AWS support to take a look at.
- Extracts the parameter group and cluster parameter group to their own modules
- Creates the secrets for the test database