### PR TITLE
TM-1376: csr: tighten database SG

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -425,42 +425,6 @@ locals {
           self            = true
           security_groups = ["web", "app"]
         }
-        # IMPORTANT: check if an 'allow all from load-balancer' rule is required
-        echo_core_tcp_db = {
-          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port   = 7
-          to_port     = 7
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        echo_core_udp_db = {
-          description = "7: Allow ingress from port 7 oem agent echo" # Not sure what this is
-          from_port   = 7
-          to_port     = 7
-          protocol    = "UDP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        ssh-db = {
-          description = "22: SSH allow ingress"
-          from_port   = 22
-          to_port     = 22
-          protocol    = "tcp"
-          cidr_blocks = local.security_group_cidrs.ssh
-        }
-        rpc_tcp_db = {
-          description = "135: TCP MS-RPC AD connect ingress from Azure DC and Jumpserver"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
-        rpc_udp_db = {
-          description = "135: UDP MS-RPC AD connect ingress from Azure DC and Jumpserver"
-          from_port   = 135
-          to_port     = 135
-          protocol    = "UDP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
         oracle_1521_db = {
           description     = "Allow oracle database 1521 ingress"
           from_port       = "1521"
@@ -468,29 +432,6 @@ locals {
           protocol        = "TCP"
           cidr_blocks     = local.security_group_cidrs.oracle_db
           security_groups = ["web", "app"]
-        }
-        oracleoem_3872_db = {
-          description = "Allow oem agent ingress"
-          from_port   = "3872"
-          to_port     = "3872"
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.oracle_oem_agent
-        }
-        rpc_dynamic_tcp_db = {
-          description = "49152-65535: TCP Dynamic Port range"
-          from_port   = 49152
-          to_port     = 65535
-          protocol    = "TCP"
-          cidr_blocks = concat(local.security_group_cidrs.jumpservers, local.security_group_cidrs.domain_controllers)
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
         }
       }
     }


### PR DESCRIPTION
Remove duplicate or unnecessary rules from CSR database SG. No need for RPC as it's linux box.  SSH is too open. OEM covered by oem-agent SG.