### PR TITLE
Secrets version error fix

### DIFF
--- a/terraform/environments/maatdb/ftp_lambda.tf
+++ b/terraform/environments/maatdb/ftp_lambda.tf
@@ -7,7 +7,11 @@
 locals {
 
   decoded_ftp_secret = try(
-    jsondecode(data.aws_secretsmanager_secret_version.ftp_jobs_secret_version.secret_string),
+    jsondecode(
+      length(data.aws_secretsmanager_secret_version.ftp_jobs_secret_version) > 0 ?
+      data.aws_secretsmanager_secret_version.ftp_jobs_secret_version[0].secret_string :
+      "{}"
+    ),
     []
   )
 

--- a/terraform/environments/maatdb/ftp_secrets.tf
+++ b/terraform/environments/maatdb/ftp_secrets.tf
@@ -53,5 +53,6 @@ resource "aws_secretsmanager_secret_version" "ftp_jobs_secret_values" {
 }
 
 data "aws_secretsmanager_secret_version" "ftp_jobs_secret_version" {
+  count     = local.build_ftp ? 1 : 0
   secret_id = aws_secretsmanager_secret.ftp_jobs_secret.id
 }

--- a/terraform/environments/maatdb/ftp_secrets.tf
+++ b/terraform/environments/maatdb/ftp_secrets.tf
@@ -40,13 +40,17 @@
 # ]
 
 resource "aws_secretsmanager_secret" "ftp_jobs_secret" {
-  #checkov:skip=CKV2_AWS_57:"This is will be fixed at a later date"
+  #checkov:skip=CKV2_AWS_57:"This will be fixed at a later date"
   #checkov:skip=CKV_AWS_149:"To be added later."
   name = "${local.application_name}-${local.environment}-ftp-endpoint"
 }
 
-# Create blank versions so that the locals do not error:
-
+resource "aws_secretsmanager_secret_version" "ftp_jobs_secret_values" {
+  secret_id     = aws_secretsmanager_secret.ftp_jobs_secret.id
+  secret_string = jsonencode({
+    organisation_id = "CHANGE_ME_IN_THE_CONSOLE"
+  })
+}
 
 data "aws_secretsmanager_secret_version" "ftp_jobs_secret_version" {
   secret_id = aws_secretsmanager_secret.ftp_jobs_secret.id


### PR DESCRIPTION
This fixes an issue whereby the data call getting the latest ftp secrets was failing to resolve if the version did not exist - which it would do at initial plan & apply.