### PR TITLE
Remove nomis-combine-reporting-development from items in modernisation-platform-environments

### DIFF
--- a/terraform/environments/nomis-combined-reporting/platform_locals.tf
+++ b/terraform/environments/nomis-combined-reporting/platform_locals.tf
@@ -12,7 +12,6 @@ locals {
   is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
   is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
-  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
   # Merge tags from the environment json file with additional ones
   tags = merge(


### PR DESCRIPTION
This is to remove all versions of the development sections from the information on here.
It will tidy up any issues found and clear any issues.

This does NOT remove the information on the PagerDuty section. Changes on PagerDuty will be undertaken manually.