### PR TITLE
TM-1376: hmpps-domain-services: add alltoself rule

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_security_groups.tf
+++ b/terraform/environments/hmpps-domain-services/locals_security_groups.tf
@@ -41,6 +41,13 @@ locals {
     rd-session-host = {
       description = "Security group for RD Session Hosts"
       ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
         rpc-from-rds = {
           description     = "Allow RPC from remote desktop connection broker"
           from_port       = 135
@@ -83,6 +90,13 @@ locals {
     rdgw = {
       description = "Security group for Remote Desktop Gateways"
       ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
         http-from-lb = {
           description = "Allow http ingress"
           from_port   = 80
@@ -116,6 +130,13 @@ locals {
     rds = {
       description = "Security group for Remote Desktop Services (ConnectionBroker and RDWeb)"
       ingress = {
+        all-from-self = {
+          description = "Allow all ingress to self"
+          from_port   = 0
+          to_port     = 0
+          protocol    = -1
+          self        = true
+        }
         http-from-lb = {
           description = "Allow http ingress"
           from_port   = 80


### PR DESCRIPTION
Just adding this back in as the one in the baseline ec2-linux is too permissive