### PR TITLE
csr: remove unused fsx security group

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_security_groups.tf
@@ -208,50 +208,5 @@ locals {
         }
       }
     }
-    fsx_windows = {
-      description = "Security group for fsx windows"
-      ingress = {
-        all-from-self = {
-          description = "Allow all ingress to self"
-          from_port   = 0
-          to_port     = 0
-          protocol    = -1
-          self        = true
-        }
-        netbios_fsx = {
-          description = "139: NetBIOS Session Service"
-          from_port   = 139
-          to_port     = 139
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-        smb_fsx = {
-          description = "445: Directory Services SMB file sharing"
-          from_port   = 445
-          to_port     = 445
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-        winrm_fsx = {
-          description = "5985-5986: WinRM 2.0 (Microsoft Windows Remote Management)"
-          from_port   = 5985
-          to_port     = 5986
-          protocol    = "TCP"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-      }
-      egress = {
-        all = {
-          description = "Allow all traffic outbound"
-          from_port   = 0
-          to_port     = 0
-          protocol    = "-1"
-          cidr_blocks = ["0.0.0.0/0"]
-        }
-      }
-    }
   }
 }
-
-
-


### PR DESCRIPTION
CSR FSX has been zapped so can now get rid of the associated SG