### PR TITLE
TM-1376: csr: cleanup unnecessary terraform

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_production.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_production.tf
@@ -318,7 +318,6 @@ locals {
         }
         instance = merge(local.ec2_instances.web.instance, {
           instance_type          = "m5.4xlarge"
-          vpc_security_group_ids = ["web", "ad-join", "ec2-windows"]
         })
         tags = merge(local.ec2_instances.web.tags, {
           ami           = "pd-csr-w-2-b"


### PR DESCRIPTION
Missed this in previous PR. This was only used in testing - can get rid now