### PR TITLE
TM-1325: baseline: fix for trusted principals

### DIFF
--- a/terraform/environments/hmpps-oem/locals_secretsmanager.tf
+++ b/terraform/environments/hmpps-oem/locals_secretsmanager.tf
@@ -45,7 +45,7 @@ locals {
       ]
       principals = {
         type        = "AWS"
-        identifiers = ["hmpps-oem-${local.environment}"]
+        identifiers = [module.environment.account_root_arns["hmpps-oem-${local.environment}"]]
       }
       resources = ["*"]
     }

--- a/terraform/modules/baseline/iam_roles.tf
+++ b/terraform/modules/baseline/iam_roles.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "assume_role" {
         for_each = statement.value.principals != null ? [statement.value.principals] : []
         content {
           type        = principals.value.type
-          identifiers = [for identifier in principals.value.identifiers : try(var.environment.account_root_arns[identifier], identifier)]
+          identifiers = principals.value.identifiers
         }
       }
       dynamic "condition" {

--- a/terraform/modules/baseline/secretsmanager.tf
+++ b/terraform/modules/baseline/secretsmanager.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "secretsmanager_secret_policy" {
         for_each = statement.value.principals != null ? [statement.value.principals] : []
         content {
           type        = principals.value.type
-          identifiers = [for identifier in principals.value.identifiers : try(var.environment.account_root_arns[identifier], identifier)]
+          identifiers = principals.value.identifiers
         }
       }
       dynamic "condition" {

--- a/terraform/modules/baseline_presets/iam_roles.tf
+++ b/terraform/modules/baseline_presets/iam_roles.tf
@@ -18,7 +18,7 @@ locals {
         actions = ["sts:AssumeRole"]
         principals = {
           type        = "AWS"
-          identifiers = ["core-shared-services-production"]
+          identifiers = [var.environment.account_root_arns["core-shared-services-production"]]
         }
       }]
       policy_attachments = [
@@ -81,7 +81,9 @@ locals {
         actions = ["sts:AssumeRole"]
         principals = {
           type        = "AWS"
-          identifiers = var.options.cloudwatch_metric_oam_links
+          identifiers = [
+            for identifier in coalesce(var.options.cloudwatch_metric_oam_links, []) : var.environment.account_root_arns[identifier]
+          ]
         }
       }]
       policy_attachments = [


### PR DESCRIPTION
Remove unnecessary code in baseline re converting principal identifiers - this is causing a problem with the xsiam integration. Ran plans across all accounts and there are no plan changes with this.