### PR TITLE
Add SES for yjaf networking account

### DIFF
--- a/terraform/environments/youth-justice-networking/data.tf
+++ b/terraform/environments/youth-justice-networking/data.tf
@@ -1,2 +1,4 @@
 #### This file can be used to store data specific to the member account ####
 data "aws_availability_zones" "available" {}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/environments/youth-justice-networking/data.tf
+++ b/terraform/environments/youth-justice-networking/data.tf
@@ -1,4 +1,2 @@
 #### This file can be used to store data specific to the member account ####
 data "aws_availability_zones" "available" {}
-
-data "aws_caller_identity" "current" {}

--- a/terraform/environments/youth-justice-networking/ses.tf
+++ b/terraform/environments/youth-justice-networking/ses.tf
@@ -1,0 +1,55 @@
+resource "aws_ses_domain_identity" "yjb" {
+  domain = "yjb.gov.uk"
+}
+
+resource "aws_ses_domain_dkim" "yjb" {
+  domain = aws_ses_domain_identity.yjb.domain
+}
+
+resource "aws_iam_user" "ses_smtp_user" {
+  name = "ses-smtp-user"
+}
+
+resource "aws_iam_policy" "ses_smtp_send_policy" {
+  name        = "ses-smtp-send-policy"
+  description = "Allow sending email via SES for yjb.gov.uk"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ses:SendRawEmail"
+        Resource = aws_ses_domain_identity.yjb.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "ses_smtp_user_attach" {
+  user       = aws_iam_user.ses_smtp_user.name
+  policy_arn = aws_iam_policy.ses_smtp_send_policy.arn
+}
+
+resource "aws_iam_access_key" "ses_smtp_user" {
+  user = aws_iam_user.ses_smtp_user.name
+}
+
+resource "aws_secretsmanager_secret" "ses_smtp" {
+  name = "ses-smtp-credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "ses_smtp_version" {
+  secret_id = aws_secretsmanager_secret.ses_smtp.id
+  secret_string = jsonencode({
+    smtp_username = aws_iam_access_key.ses_smtp_user.id
+    smtp_password = aws_iam_access_key.ses_smtp_user.ses_smtp_password_v4
+  })
+}
+
+output "ses_verification_token" {
+  value = aws_ses_domain_identity.yjb.verification_token
+}
+
+output "ses_dkim_tokens" {
+  value = aws_ses_domain_dkim.yjb.dkim_tokens
+}

--- a/terraform/environments/youth-justice-networking/ses.tf
+++ b/terraform/environments/youth-justice-networking/ses.tf
@@ -45,11 +45,3 @@ resource "aws_secretsmanager_secret_version" "ses_smtp_version" {
     smtp_password = aws_iam_access_key.ses_smtp_user.ses_smtp_password_v4
   })
 }
-
-output "ses_verification_token" {
-  value = aws_ses_domain_identity.yjb.verification_token
-}
-
-output "ses_dkim_tokens" {
-  value = aws_ses_domain_dkim.yjb.dkim_tokens
-}


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10594

## What's Changed?
Adds SES domain `yjb.gov.uk` which will generate some verifiction records which I will separately associate with the hosted zone in https://github.com/ministryofjustice/dns/blob/main/hostedzones/yjb.gov.uk.yaml

It also adds an smtp iam user to be used by ses and stores the access keys in secrets manager. 
