### PR TITLE
dmet-prisons: remove default permissions for IAMPRINCIPALS (causes LF…

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -3,6 +3,9 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
     [for share in local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn],
     data.aws_iam_session_context.current.issuer_arn,
 
+    # Make the cross-account runner used by create-a-derived table LF admin
+    aws_iam_role.dataapi_cross_role.arn,
+
     # Make Data engineer role a LF admin
     try(one(data.aws_iam_roles.data_engineering_roles.arns), []),
 
@@ -20,30 +23,30 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 }
 
 # Give the cadet cross-account role LF data access
-resource "aws_iam_role_policy_attachment" "dataapi_cross_role_lake_formation_data_access" {
-  role       = aws_iam_role.dataapi_cross_role.name
-  policy_arn = aws_iam_policy.lake_formation_data_access.arn
-}
+# resource "aws_iam_role_policy_attachment" "dataapi_cross_role_lake_formation_data_access" {
+#   role       = aws_iam_role.dataapi_cross_role.name
+#   policy_arn = aws_iam_policy.lake_formation_data_access.arn
+# }
 
 # Give the cadet cross-account role data location access
 # structured and working are required
-resource "aws_lakeformation_permissions" "data_location_access_structured_historical" {
-  principal   = aws_iam_role.dataapi_cross_role.arn
-  permissions = ["DATA_LOCATION_ACCESS"]
+# resource "aws_lakeformation_permissions" "data_location_access_structured_historical" {
+#   principal   = aws_iam_role.dataapi_cross_role.arn
+#   permissions = ["DATA_LOCATION_ACCESS"]
 
-  data_location {
-    arn = "arn:aws:s3:::${local.project}-structured-historical-${local.environment}"
-  }
-}
+#   data_location {
+#     arn = "arn:aws:s3:::${local.project}-structured-historical-${local.environment}"
+#   }
+# }
 
-resource "aws_lakeformation_permissions" "data_location_access_working" {
-  principal   = aws_iam_role.dataapi_cross_role.arn
-  permissions = ["DATA_LOCATION_ACCESS"]
+# resource "aws_lakeformation_permissions" "data_location_access_working" {
+#   principal   = aws_iam_role.dataapi_cross_role.arn
+#   permissions = ["DATA_LOCATION_ACCESS"]
 
-  data_location {
-    arn = "arn:aws:s3:::${local.project}-working-${local.environment}"
-  }
-}
+#   data_location {
+#     arn = "arn:aws:s3:::${local.project}-working-${local.environment}"
+#   }
+# }
 
 # Create the 'domain' tag with values
 resource "aws_lakeformation_lf_tag" "domain_tag" {

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -81,3 +81,23 @@ resource "aws_lakeformation_permissions" "sensitive_grant" {
     values = aws_lakeformation_lf_tag.sensitive_tag.values
   }
 }
+
+
+resource "aws_lakeformation_permissions" "de_role_prisons_and_non_sensitive" {
+  principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
+  permissions = ["DESCRIBE", "SELECT"]
+
+  lf_tag_policy {
+    resource_type = "TABLE"
+
+    expression {
+      key    = "domain"
+      values = ["prisons"]
+    }
+
+    expression {
+      key    = "sensitive"
+      values = ["false", "true", "data_linking"]
+    }
+  }
+}

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -30,23 +30,23 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 
 # Give the cadet cross-account role data location access
 # structured and working are required
-# resource "aws_lakeformation_permissions" "data_location_access_structured_historical" {
-#   principal   = aws_iam_role.dataapi_cross_role.arn
-#   permissions = ["DATA_LOCATION_ACCESS"]
+resource "aws_lakeformation_permissions" "data_location_access_structured_historical" {
+  principal   = aws_iam_role.dataapi_cross_role.arn
+  permissions = ["DATA_LOCATION_ACCESS"]
 
-#   data_location {
-#     arn = "arn:aws:s3:::${local.project}-structured-historical-${local.environment}"
-#   }
-# }
+  data_location {
+    arn = "arn:aws:s3:::${local.project}-structured-historical-${local.environment}"
+  }
+}
 
-# resource "aws_lakeformation_permissions" "data_location_access_working" {
-#   principal   = aws_iam_role.dataapi_cross_role.arn
-#   permissions = ["DATA_LOCATION_ACCESS"]
+resource "aws_lakeformation_permissions" "data_location_access_working" {
+  principal   = aws_iam_role.dataapi_cross_role.arn
+  permissions = ["DATA_LOCATION_ACCESS"]
 
-#   data_location {
-#     arn = "arn:aws:s3:::${local.project}-working-${local.environment}"
-#   }
-# }
+  data_location {
+    arn = "arn:aws:s3:::${local.project}-working-${local.environment}"
+  }
+}
 
 # Create the 'domain' tag with values
 resource "aws_lakeformation_lf_tag" "domain_tag" {

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -82,6 +82,26 @@ resource "aws_lakeformation_permissions" "sensitive_grant" {
   }
 }
 
+# Give DE role the actual tag
+resource "aws_lakeformation_permissions" "grant_tag_domain_de_role" {
+  principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
+  permissions = ["DESCRIBE", "ASSOCIATE"]
+
+  lf_tag {
+    key    = aws_lakeformation_lf_tag.domain_tag.key
+    values = ["prisons", "probation", "electronic-monitoring"]
+  }
+}
+
+resource "aws_lakeformation_permissions" "grant_tag_sensitive_de_role" {
+  principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
+  permissions = ["DESCRIBE", "ASSOCIATE"]
+
+  lf_tag {
+    key    = aws_lakeformation_lf_tag.sensitive_tag.key
+    values = ["false", "true", "data_linking"]
+  }
+}
 
 resource "aws_lakeformation_permissions" "de_role_prisons_and_non_sensitive" {
   principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -4,7 +4,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
     data.aws_iam_session_context.current.issuer_arn,
 
     # Make the cross-account runner used by create-a-derived table LF admin
-    aws_iam_role.dataapi_cross_role.arn,
+    # aws_iam_role.dataapi_cross_role.arn,
 
     # Make Data engineer role a LF admin
     try(one(data.aws_iam_roles.data_engineering_roles.arns), []),
@@ -23,10 +23,10 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
 }
 
 # Give the cadet cross-account role LF data access
-# resource "aws_iam_role_policy_attachment" "dataapi_cross_role_lake_formation_data_access" {
-#   role       = aws_iam_role.dataapi_cross_role.name
-#   policy_arn = aws_iam_policy.lake_formation_data_access.arn
-# }
+resource "aws_iam_role_policy_attachment" "dataapi_cross_role_lake_formation_data_access" {
+  role       = aws_iam_role.dataapi_cross_role.name
+  policy_arn = aws_iam_policy.lake_formation_data_access.arn
+}
 
 # Give the cadet cross-account role data location access
 # structured and working are required

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -13,18 +13,10 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
     ]
   )
 
-  # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_data_lake_settings#principal
-  create_database_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = ["ALL"]
-    principal   = "IAM_ALLOWED_PRINCIPALS"
+  parameters = {
+    "CROSS_ACCOUNT_VERSION" = "4"
   }
 
-  create_table_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = ["ALL"]
-    principal   = "IAM_ALLOWED_PRINCIPALS"
-  }
 }
 
 # Give the cadet cross-account role LF data access
@@ -86,5 +78,3 @@ resource "aws_lakeformation_permissions" "sensitive_grant" {
     values = aws_lakeformation_lf_tag.sensitive_tag.values
   }
 }
-
-

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -101,3 +101,15 @@ resource "aws_lakeformation_permissions" "de_role_prisons_and_non_sensitive" {
     }
   }
 }
+
+
+resource "aws_lakeformation_permissions" "table_permissions_2" {
+
+  principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
+  permissions = ["DESCRIBE"]
+
+  table {
+    name          = "dev_model_2_tag"
+    database_name = "dpr_ap_integration_test_tag2_dev_dbt"
+  }
+}

--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -103,6 +103,15 @@ resource "aws_lakeformation_permissions" "grant_tag_sensitive_de_role" {
   }
 }
 
+resource "aws_lakeformation_permissions" "de_role_db_describe" {
+  principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = "dpr_ap_integration_test_tag2_dev_dbt"
+  }
+}
+
 resource "aws_lakeformation_permissions" "de_role_prisons_and_non_sensitive" {
   principal   = "arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-data-eng_499410b42334a7d7"
   permissions = ["DESCRIBE", "SELECT"]

--- a/terraform/environments/digital-prison-reporting/lake_formation_cadet_runner.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation_cadet_runner.tf
@@ -1,0 +1,28 @@
+resource "aws_lakeformation_permissions" "dataapi_cross_role_db_access" {
+  for_each = toset([
+    "dpr_ap_integration_test_tag2_dev_dbt",
+    "dpr_ap_integration_test_newtag_dev_dbt"
+  ])
+
+  principal   = aws_iam_role.dataapi_cross_role.arn
+  permissions = ["ALL"]
+
+  database {
+    name = each.key
+  }
+}
+
+resource "aws_lakeformation_permissions" "dataapi_cross_role_table_access" {
+  for_each = toset([
+    "dpr_ap_integration_test_tag2_dev_dbt",
+    "dpr_ap_integration_test_newtag_dev_dbt"
+  ])
+
+  principal   = aws_iam_role.dataapi_cross_role.arn
+  permissions = ["ALL"]
+
+  table {
+    database_name = each.key
+    wildcard      = true
+  }
+}

--- a/terraform/environments/digital-prison-reporting/lake_formation_cadet_runner.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation_cadet_runner.tf
@@ -26,3 +26,4 @@ resource "aws_lakeformation_permissions" "dataapi_cross_role_table_access" {
     wildcard      = true
   }
 }
+


### PR DESCRIPTION
Objective: Default permissions for IAMPRINCIPALS causes Lake Formation (tag based access cross-account) not to work properly.

Removing this default setting avoids this issue.

Also need to update to CROSS ACCOUNT VERSION 4.

Similar approach to: https://github.com/ministryofjustice/modernisation-platform-environments/blob/dmet-prison-remove-default-lf-settings/terraform/environments/electronic-monitoring-data/lake_formation.tf