### PR TITLE
DPR2-2072: Set max_standby_streaming_delay and max_standby_archive_delay to -1

### DIFF
--- a/terraform/environments/digital-prison-reporting/dpr_rds_db.tf
+++ b/terraform/environments/digital-prison-reporting/dpr_rds_db.tf
@@ -36,6 +36,16 @@ module "dpr_rds_parameter_group" {
       name         = "max_slot_wal_keep_size"
       value        = "40000"
       apply_method = "immediate"
+    },
+    {
+      name         = "max_standby_streaming_delay"
+      value        = "-1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "max_standby_archive_delay"
+      value        = "-1"
+      apply_method = "immediate"
     }
   ]
 


### PR DESCRIPTION
This PR sets max_standby_streaming_delay and max_standby_archive_delay to -1 to retest the read-replica issue.