### PR TITLE
DMET-prisons: Lake formation permissions/versions

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -13,19 +13,6 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
     ]
   )
 
-  # Ensure permissions are null to avoid LF being
-  create_database_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = []
-    principal   = "IAM_ALLOWED_PRINCIPALS"
-  }
-
-  create_table_default_permissions {
-    # These settings should replicate current behaviour: LakeFormation is Ignored
-    permissions = []
-    principal   = "IAM_ALLOWED_PRINCIPALS"
-  }
-
   parameters = {
     "CROSS_ACCOUNT_VERSION" = "4"
   }


### PR DESCRIPTION
**Objective**: Default permissions for IAMPRINCIPALS causes Lake Formation (tag based access cross-account) not to work properly.

Removing this default setting avoids this issue.

Also need to update to CROSS ACCOUNT VERSION 4.

Similar approach to: https://github.com/ministryofjustice/modernisation-platform-environments/blob/dmet-prison-remove-default-lf-settings/terraform/environments/electronic-monitoring-data/lake_formation.tf