### PR TITLE
Fix SMTP user policy

### DIFF
--- a/terraform/environments/youth-justice-networking/ses.tf
+++ b/terraform/environments/youth-justice-networking/ses.tf
@@ -21,7 +21,7 @@ resource "aws_iam_policy" "ses_smtp_send_policy" {
       {
         Effect   = "Allow"
         Action   = "ses:SendRawEmail"
-        Resource = aws_ses_domain_identity.yjb.arn
+        Resource = "arn:aws:ses:eu-west-2:${data.aws_caller_identity.current.account_id}:identity/*"
       }
     ]
   })


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10594

## Changes

Allows SMTP user to send to any verified identity within the account. Previously it only allowed sending to yjb.gov.uk which was not intended.