### PR TITLE
Add Secrets Manager read access to node4 policy

### DIFF
--- a/terraform/environments/long-term-storage/s3.tf
+++ b/terraform/environments/long-term-storage/s3.tf
@@ -31,6 +31,16 @@ data "aws_iam_policy_document" "node4_s3_read_write_policy" {
       "${aws_s3_bucket.ospt_transfer.arn}/*"
     ]
   }
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+
+    resources = [
+      aws_secretsmanager_secret.s3_user_secret.arn
+    ]
+  }
 }
 
 # Policies


### PR DESCRIPTION
This PR updates the node4 policy document to include read permissions (`GetSecretValue` and `DescribeSecret`) for the `s3-user-credentials` secret in AWS Secrets Manager. [#issue](https://github.com/ministryofjustice/modernisation-platform/issues/10561)