### PR TITLE
dmet-prisons: add AP repo to DPR AP share role

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -916,7 +916,9 @@ data "aws_iam_policy_document" "ap_assume_role" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:ministryofjustice/data-engineering-datalake-access:ref:refs/heads/*"]
+      values = ["repo:ministryofjustice/data-engineering-datalake-access:ref:refs/heads/*",
+        "repo:ministryofjustice/analytical-platform:ref:refs/heads/*"
+      ]
     }
   }
 }


### PR DESCRIPTION
The share role cannot be used when called from the AP repo see [here](https://github.com/ministryofjustice/analytical-platform/actions/runs/16146982122/job/45568356875#step:13:31)