### PR TITLE
fix: disable scale down on ec2 and rds

### DIFF
--- a/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
+++ b/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
@@ -12,7 +12,10 @@ resource "aws_autoscaling_group" "cluster-scaling-group-managed" {
     id      = aws_launch_template.ec2-launch-template-managed.id
     version = "$Latest"
   }
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db
@@ -31,7 +34,10 @@ resource "aws_autoscaling_group" "cluster-scaling-group-admin" {
     id      = aws_launch_template.ec2-launch-template-admin.id
     version = "$Latest"
   }
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -60,7 +60,10 @@ resource "aws_db_instance" "soa_db" {
     "audit",
     "listener"
   ]
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   timeouts {
     create = "40m"
     delete = "40m"


### PR DESCRIPTION
Disables ec2 and rds overnight halting in NP environments as per `https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/environments/instance-scheduling.html` for `laa-ccms-soa`