### PR TITLE
fix: disable ec2 and rds shutdown for ccms-soa

### DIFF
--- a/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
+++ b/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
@@ -12,7 +12,10 @@ resource "aws_autoscaling_group" "cluster-scaling-group-managed" {
     id      = aws_launch_template.ec2-launch-template-managed.id
     version = "$Latest"
   }
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db
@@ -31,7 +34,10 @@ resource "aws_autoscaling_group" "cluster-scaling-group-admin" {
     id      = aws_launch_template.ec2-launch-template-admin.id
     version = "$Latest"
   }
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db

--- a/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
+++ b/terraform/environments/laa-ccms-soa/ec2_autoscaling.tf
@@ -12,10 +12,11 @@ resource "aws_autoscaling_group" "cluster-scaling-group-managed" {
     id      = aws_launch_template.ec2-launch-template-managed.id
     version = "$Latest"
   }
-  tags = merge(
-    local.tags,
-    { instance-scheduling = "skip-scheduling" }
-  )
+  tag {
+    key                 = "instance-scheduling"
+    value               = "skip-scheduling"
+    propagate_at_launch = true
+  }
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db
@@ -34,10 +35,11 @@ resource "aws_autoscaling_group" "cluster-scaling-group-admin" {
     id      = aws_launch_template.ec2-launch-template-admin.id
     version = "$Latest"
   }
-  tags = merge(
-    local.tags,
-    { instance-scheduling = "skip-scheduling" }
-  )
+  tag {
+    key                 = "instance-scheduling"
+    value               = "skip-scheduling"
+    propagate_at_launch = true
+  }
   depends_on = [
     aws_efs_file_system.storage,
     aws_db_instance.soa_db

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -54,7 +54,10 @@ resource "aws_db_instance" "soa_db" {
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
   option_group_name       = aws_db_option_group.soa_oracle_19.id
-
+  tags = merge(
+    local.tags,
+    { instance-scheduling = "skip-scheduling" }
+  )
   enabled_cloudwatch_logs_exports = [
     "alert",
     "audit",


### PR DESCRIPTION
Disables ec2 and rds overnight halting in NP environments as per `https://user-guide.modernisation-platform.service.justice.gov.uk/concepts/environments/instance-scheduling.html` for `laa-ccms-soa`