### PR TITLE
🔧 CD Bedrock: Update Terraform Modules

### DIFF
--- a/terraform/environments/analytical-platform-compute/central-digital-bedrock/versions.tf
+++ b/terraform/environments/analytical-platform-compute/central-digital-bedrock/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     dns = {


### PR DESCRIPTION
This PR contributes to https://github.com/ministryofjustice/analytical-platform/issues/8066

This PR updates the central-digital-bedrock component.