### PR TITLE
Create service role for Acquisitive Crime

### DIFF
--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -128,10 +128,10 @@ module "acquisitive_crime_assumable_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.48.0"
 
-  trusted_role_arns = concat(
+  trusted_role_arns = flatten([
     data.aws_iam_roles.mod_plat_roles.arns,
     [var.cloud-platform-crime-matching-iam-dev],
-  )
+  ])
 
   create_role       = true
   role_requires_mfa = false

--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -125,7 +125,7 @@ module "cmt_front_end_assumable_role" {
 module "acquisitive_crime_assumable_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-  count   = local.environment_shorthand == "dev" || local.environment_shorthand == "test" ? 1 : 0
+  count   = local.is-development || local.is-test ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.48.0"
 
@@ -285,6 +285,7 @@ resource "aws_iam_role_policy_attachment" "specials_role_standard_athena_access"
 }
 
 resource "aws_iam_role_policy_attachment" "standard_athena_access_ac" {
+  count      = local.is-development || local.is-test ? 1 : 0
   policy_arn = aws_iam_policy.standard_athena_access.arn
   role       = module.acquisitive_crime_assumable_role[0].iam_role_name
 }

--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -2,14 +2,12 @@ locals {
   env_ = "${local.environment_shorthand}_"
   iam-dev = local.environment_shorthand == "dev" ? [
     var.cloud-platform-iam-dev,
-    var.cloud-platform-crime-matching-iam-dev
   ] : null
 
   iam-test = local.environment_shorthand == "test" ? [
     var.cloud-platform-iam-dev,
     var.cloud-platform-iam-preprod,
     var.cloud-platform-iam-prod,
-    var.cloud-platform-crime-matching-iam-dev
   ] : null
 
   iam-preprod = local.environment_shorthand == "preprod" ? [
@@ -120,6 +118,25 @@ module "cmt_front_end_assumable_role" {
   role_requires_mfa = false
 
   role_name = "cmt_read_emds_data_${local.environment_shorthand}"
+
+  tags = local.tags
+}
+
+module "acquisitive_crime_assumable_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.48.0"
+
+  trusted_role_arns = concat(
+    data.aws_iam_roles.mod_plat_roles.arns,
+    [var.cloud-platform-crime-matching-iam-dev],
+  )
+
+  create_role       = true
+  role_requires_mfa = false
+
+  role_name = "ac_read_emds_data_${local.environment_shorthand}"
 
   tags = local.tags
 }
@@ -264,4 +281,9 @@ resource "aws_iam_role_policy_attachment" "standard_athena_access" {
 resource "aws_iam_role_policy_attachment" "specials_role_standard_athena_access" {
   policy_arn = aws_iam_policy.standard_athena_access.arn
   role       = module.specials_cmt_front_end_assumable_role.iam_role_name
+}
+
+resource "aws_iam_role_policy_attachment" "standard_athena_access_ac" {
+  policy_arn = aws_iam_policy.standard_athena_access.arn
+  role       = module.acquisitive_crime_assumable_role.iam_role_name
 }

--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -125,6 +125,7 @@ module "cmt_front_end_assumable_role" {
 module "acquisitive_crime_assumable_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  count   = local.environment_shorthand == "dev" || local.environment_shorthand == "test" ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.48.0"
 
@@ -285,5 +286,5 @@ resource "aws_iam_role_policy_attachment" "specials_role_standard_athena_access"
 
 resource "aws_iam_role_policy_attachment" "standard_athena_access_ac" {
   policy_arn = aws_iam_policy.standard_athena_access.arn
-  role       = module.acquisitive_crime_assumable_role.iam_role_name
+  role       = module.acquisitive_crime_assumable_role[0].iam_role_name
 }


### PR DESCRIPTION
Previously, AC were piggy-backing on the role for cmt. Here we create a new role for them to use so that we can more finely control the permissions granted to them. We also remove their access to the old role.