### PR TITLE
TM-1425: oasys: improve iowait alarm

### DIFF
--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -235,6 +235,14 @@ locals {
       })
 
       pd-oasys-db-a = merge(local.ec2_instances.db19c, {
+        cloudwatch_metric_alarms = merge(local.ec2_instances.db19c.cloudwatch_metric_alarms, {
+          cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["cpu-iowait-high"], {
+            evaluation_periods  = "15"
+            datapoints_to_alarm = "15"
+            threshold           = "50"
+            alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 15 minutes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
+          })
+        })
         config = merge(local.ec2_instances.db19c.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.db19c.config.instance_profile_policies, [
@@ -262,9 +270,14 @@ locals {
       })
 
       pd-oasys-db-b = merge(local.ec2_instances.db19c, {
-        cloudwatch_metric_alarms = merge(
-          local.cloudwatch_metric_alarms.db,
-        )
+        cloudwatch_metric_alarms = merge(local.cloudwatch_metric_alarms.db, {
+          cpu-iowait-high = merge(module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux["cpu-iowait-high"], {
+            evaluation_periods  = "15"
+            datapoints_to_alarm = "15"
+            threshold           = "50"
+            alarm_description   = "Triggers if the amount of CPU time spent waiting for I/O to complete is continually high for 15 minutes. See https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/4325900634"
+          })
+        })
         config = merge(local.ec2_instances.db19c.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.db19c.config.instance_profile_policies, [


### PR DESCRIPTION
Align with nomis thresholds.
Disable out of hours as scheduled DB activity at weekend will trigger it with these reduced thresholds.
As agreed with DBAs (Karen)