### PR TITLE
TM: nomis: remove cloudwatch xsiam integration

### DIFF
--- a/terraform/environments/nomis/locals_preproduction.tf
+++ b/terraform/environments/nomis/locals_preproduction.tf
@@ -7,8 +7,7 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      enable_xsiam_cloudwatch_integration = true
-      enable_xsiam_s3_integration         = true
+      enable_xsiam_s3_integration = true
       route53_resolver_rules = {
         outbound-data-and-private-subnets = ["azure-fixngo-domain", "infra-int-domain"]
       }

--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -8,8 +8,7 @@ locals {
 
   baseline_presets_production = {
     options = {
-      enable_xsiam_cloudwatch_integration = true
-      enable_xsiam_s3_integration         = true
+      enable_xsiam_s3_integration = true
       route53_resolver_rules = {
         outbound-data-and-private-subnets = ["azure-fixngo-domain", "infra-int-domain"]
       }


### PR DESCRIPTION
The XSIAM cortex cloudwatch integration is no longer required as we have agents running on the hosts instead.