### PR TITLE
Define S3 bucket for rekognition uploads for HMPPS esupervision

### DIFF
--- a/terraform/environments/hmpps-esupervision/locals.tf
+++ b/terraform/environments/hmpps-esupervision/locals.tf
@@ -1,1 +1,3 @@
-#### This file can be used to store locals specific to the member account ####
+locals {
+  rekog_s3_bucket_name = "${terraform.workspace}-rekognition-uploads"
+}

--- a/terraform/environments/hmpps-esupervision/s3.tf
+++ b/terraform/environments/hmpps-esupervision/s3.tf
@@ -2,13 +2,27 @@ resource "aws_s3_bucket" "rekognition_bucket" {
   bucket = local.rekog_s3_bucket_name
 }
 
+resource "aws_kms_key" "rekognition_encryption_key" {
+  description = "Encryption key for rekognition image uploads bucket"
+  deletion_window_in_days = 30
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "rekognition_bucket_encryption_configuration" {
   bucket = aws_s3_bucket.rekognition_bucket.id
 
   rule {
     bucket_key_enabled = true
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = aws_kms_key.rekognition_encryption_key.arn
+      sse_algorithm = "aws:kms"
     }
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "rekognition_bucket_policy" {
+  bucket = aws_s3_bucket.rekognition_bucket.id
+  block_public_policy = true
+  block_public_acls = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
 }

--- a/terraform/environments/hmpps-esupervision/s3.tf
+++ b/terraform/environments/hmpps-esupervision/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "rekognition_bucket" {
+  bucket = local.rekog_s3_bucket_name
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "rekognition_bucket_encryption_configuration" {
+  bucket = aws_s3_bucket.rekognition_bucket.id
+
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}


### PR DESCRIPTION
Define an S3 bucket to be used for rekognition image uploads for the e-supervision application. Objects in the bucket are encrypted using AES256.