### PR TITLE
Add IAM user and access policies for S3 and Rekognition

### DIFF
--- a/terraform/environments/hmpps-esupervision/data.tf
+++ b/terraform/environments/hmpps-esupervision/data.tf
@@ -1,1 +1,0 @@
-data "aws_caller_identity" "current" {}

--- a/terraform/environments/hmpps-esupervision/data.tf
+++ b/terraform/environments/hmpps-esupervision/data.tf
@@ -1,1 +1,1 @@
-#### This file can be used to store data specific to the member account ####
+data "aws_caller_identity" "current" {}

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy" "rekognition_read" {
 
 resource "aws_iam_user_policy_attachment" "rekognition_rekognition" {
   user = aws_iam_user.rekognition_user.name
-  policy_arn = data.aws_iam_policy.rekognition_read
+  policy_arn = data.aws_iam_policy.rekognition_read.arn
 }
 
 resource "aws_iam_user_policy_attachment" "rekognition_s3" {

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "rekognition_s3_policy_document" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
+      "s3:DeleteObject"
     ]
     resources = ["${aws_s3_bucket.rekognition_bucket.arn}/*"]
   }

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -1,0 +1,51 @@
+resource "aws_iam_user" "rekognition_user" {
+  name = "rekognition"
+}
+
+data "aws_iam_policy_document" "rekognition_s3_policy_document" {
+  statement {
+    sid = "LocateUserBuckets"
+    effect = "Allow"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation"
+    ]
+    resources = ["arn:aws:s3:::*"]
+  }
+
+  statement {
+    sid = "RekognitionBucketList"
+    effect = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.rekognition_bucket.arn]
+  }
+
+  statement {
+    sid = "RekognitionBucketCRUDOperations"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.rekognition_bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "rekognition_s3_policy" {
+  name = "rekognition_uploads_bucket_access"
+  policy = data.aws_iam_policy_document.rekognition_s3_policy_document.json
+}
+
+data "aws_iam_policy" "rekognition_read" {
+  name = "AmazonRekognitionReadOnlyAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "rekognition_rekognition" {
+  user = aws_iam_user.rekognition_user.name
+  policy_arn = data.aws_iam_policy.rekognition_read
+}
+
+resource "aws_iam_user_policy_attachment" "rekognition_s3" {
+  user = aws_iam_user.rekognition_user.name
+  policy_arn = aws_iam_policy.rekognition_s3_policy.arn
+}

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -49,3 +49,21 @@ resource "aws_iam_user_policy_attachment" "rekognition_s3" {
   user = aws_iam_user.rekognition_user.name
   policy_arn = aws_iam_policy.rekognition_s3_policy.arn
 }
+
+# access key
+resource "aws_iam_access_key" "rekognition_user_access_key" {
+  user = aws_iam_user.rekognition_user.name
+}
+
+# store access key secret
+resource "aws_secretsmanager_secret" "rekognition_user_access_key" {
+  name = "rekognition-user-access-key"
+}
+
+resource "aws_secretsmanager_secret_version" "rekognition_user_access_key_value" {
+  secret_id     = aws_secretsmanager_secret.rekognition_user_access_key.id
+  secret_string = jsonencode({
+    aws_access_key_id = aws_iam_access_key.rekognition_user_access_key.id
+    aws_secret_access_key = aws_iam_access_key.rekognition_user_access_key.secret
+  })
+}

--- a/terraform/environments/hmpps-esupervision/s3.tf
+++ b/terraform/environments/hmpps-esupervision/s3.tf
@@ -2,6 +2,20 @@ resource "aws_s3_bucket" "rekognition_bucket" {
   bucket = local.rekog_s3_bucket_name
 }
 
+resource "aws_s3_bucket_cors_configuration" "rekognition_bucket_cors" {
+  bucket = aws_s3_bucket.rekognition_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT"]
+    // TODO: restrict to known environments
+    // need to allow for dev
+    allowed_origins = ["*"]
+    expose_headers = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
 resource "aws_kms_key" "rekognition_encryption_key" {
   description = "Encryption key for rekognition image uploads bucket"
   deletion_window_in_days = 30


### PR DESCRIPTION
Add IAM user to HMPPS esupervision environments. Add a policy granting the user access to the rekognition uploads bucket and attach the managed read-only policy for rekognition.