### PR TITLE
Switch AWSManagedGroupRules to Monitoring mode

### DIFF
--- a/terraform/environments/xhibit-portal/xhibit-waf.tf
+++ b/terraform/environments/xhibit-portal/xhibit-waf.tf
@@ -7,11 +7,11 @@ module "waf" {
 
   managed_rule_actions = {
     AWSManagedRulesKnownBadInputsRuleSet = true
-    AWSManagedRulesCommonRuleSet         = true
+    AWSManagedRulesCommonRuleSet         = false
     AWSManagedRulesSQLiRuleSet           = true
     AWSManagedRulesLinuxRuleSet          = true
-    AWSManagedRulesAnonymousIpList       = true
-    AWSManagedRulesBotControlRuleSet     = true
+    AWSManagedRulesAnonymousIpList       = false
+    AWSManagedRulesBotControlRuleSet     = false
   }
   
   core_logging_account_id = local.environment_management.account_ids["core-logging-production"]


### PR DESCRIPTION
We had issues regarding blocking AWSManagedGroupRules so we need to switch them to Monitoring mode. 