### PR TITLE
TM-1378: Update-mp-dns-severs

### DIFF
--- a/terraform/modules/baseline_presets/route53.tf
+++ b/terraform/modules/baseline_presets/route53.tf
@@ -19,19 +19,25 @@ locals {
     azure-fixngo-devtest-domain = {
       domain_name = "azure.noms.root"
       target_ips = flatten([
-        var.ip_addresses.azure_fixngo_ips.devtest.domain_controllers,
         var.ip_addresses.mp_ips.ad_fixngo_azure_domain_controllers,
+        var.ip_addresses.azure_fixngo_ips.devtest.domain_controllers,
       ])
       rule_type = "FORWARD"
     }
     azure-fixngo-production-domain = {
       domain_name = "azure.hmpp.root"
-      target_ips  = var.ip_addresses.azure_fixngo_ips.prod.domain_controllers
+      target_ips = flatten([
+        var.ip_addresses.mp_ips.ad_fixngo_hmpp_domain_controllers,
+        var.ip_addresses.azure_fixngo_ips.prod.domain_controllers,
+      ])
       rule_type   = "FORWARD"
     }
     infra-int-domain-hmpp-forest-trust = {
       domain_name = "infra.int"
-      target_ips  = var.ip_addresses.azure_fixngo_ips.prod.domain_controllers
+      target_ips = flatten([
+        var.ip_addresses.mp_ips.ad_fixngo_hmpp_domain_controllers,
+        var.ip_addresses.azure_fixngo_ips.prod.domain_controllers,
+      ])
       rule_type   = "FORWARD"
     }
   }

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -2,21 +2,29 @@ locals {
 
   azure_fixngo_ip = {
     # Prod Domain Controllers
-    PCMCW0011 = "10.40.128.196"
-    PCMCW0012 = "10.40.0.133"
+    AD-HMPP-DC-A = "10.27.136.5"
+    AD-HMPP-DC-B = "10.27.137.5"
+    PCMCW0011    = "10.40.128.196"
+    PCMCW0012    = "10.40.0.133"
 
     # DevTest Domain Controllers
-    MGMCW0002 = "10.102.0.196"
+    AD-AZURE-DC-A = "10.20.104.5"
+    AD-AZURE-DC-B = "10.20.106.5"
+    MGMCW0002     = "10.102.0.196"
   }
 
   azure_fixngo_ips = {
     devtest = {
       domain_controllers = [
+        local.azure_fixngo_ip.AD-AZURE-DC-A,
+        local.azure_fixngo_ip.AD-AZURE-DC-B,
         local.azure_fixngo_ip.MGMCW0002,
       ]
     }
     prod = {
       domain_controllers = [
+        local.azure_fixngo_ip.AD-HMPP-DC-A,
+        local.azure_fixngo_ip.AD-HMPP-DC-B,
         local.azure_fixngo_ip.PCMCW0011,
         local.azure_fixngo_ip.PCMCW0012,
       ]

--- a/terraform/modules/ip_addresses/azure_fixngo.tf
+++ b/terraform/modules/ip_addresses/azure_fixngo.tf
@@ -2,29 +2,21 @@ locals {
 
   azure_fixngo_ip = {
     # Prod Domain Controllers
-    AD-HMPP-DC-A = "10.27.136.5"
-    AD-HMPP-DC-B = "10.27.137.5"
     PCMCW0011    = "10.40.128.196"
     PCMCW0012    = "10.40.0.133"
 
     # DevTest Domain Controllers
-    AD-AZURE-DC-A = "10.20.104.5"
-    AD-AZURE-DC-B = "10.20.106.5"
     MGMCW0002     = "10.102.0.196"
   }
 
   azure_fixngo_ips = {
     devtest = {
       domain_controllers = [
-        local.azure_fixngo_ip.AD-AZURE-DC-A,
-        local.azure_fixngo_ip.AD-AZURE-DC-B,
         local.azure_fixngo_ip.MGMCW0002,
       ]
     }
     prod = {
       domain_controllers = [
-        local.azure_fixngo_ip.AD-HMPP-DC-A,
-        local.azure_fixngo_ip.AD-HMPP-DC-B,
         local.azure_fixngo_ip.PCMCW0011,
         local.azure_fixngo_ip.PCMCW0012,
       ]


### PR DESCRIPTION
Updating DNS severs to point to MP homed servers in preference to AZ.



