### PR TITLE
🐺 Disable `ACMEHTTP01IngressPathTypeExact` in cert-manager

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/src/helm/values/cert-manager/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/cluster/src/helm/values/cert-manager/values.yml.tftpl
@@ -1,6 +1,10 @@
 ---
 installCRDs: true
 
+config:
+  featureGates:
+    ACMEHTTP01IngressPathTypeExact: false
+
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: ${eks_role_arn}


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytical-platform/issues/8147

## Proposed Changes

- As per [Cert Manager 1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes), disabling `ACMEHTTP01IngressPathTypeExact` to resolve a bug with NGINX Ingress

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>