### PR TITLE
Pin chatbot version to v5.X

### DIFF
--- a/terraform/environments/ccms-edrms/chatbot.tf
+++ b/terraform/environments/ccms-edrms/chatbot.tf
@@ -3,7 +3,7 @@
 
 module "template" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
 
   slack_channel_id = data.aws_secretsmanager_secret_version.slack_channel_id.secret_string
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:cloudwatch-slack-alerts"]

--- a/terraform/environments/ccms-edrms/chatbot.tf
+++ b/terraform/environments/ccms-edrms/chatbot.tf
@@ -3,7 +3,7 @@
 
 module "template" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
 
   slack_channel_id = data.aws_secretsmanager_secret_version.slack_channel_id.secret_string
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:cloudwatch-slack-alerts"]

--- a/terraform/environments/ccms-edrms/chatbot.tf
+++ b/terraform/environments/ccms-edrms/chatbot.tf
@@ -3,7 +3,7 @@
 
 module "template" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?=ref@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
 
   slack_channel_id = data.aws_secretsmanager_secret_version.slack_channel_id.secret_string
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:cloudwatch-slack-alerts"]

--- a/terraform/environments/ccms-edrms/chatbot.tf
+++ b/terraform/environments/ccms-edrms/chatbot.tf
@@ -3,7 +3,7 @@
 
 module "template" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=@73280f80ce8a4557cec3a76ee56eb913452ca9aa" # v2.0.0
 
   slack_channel_id = data.aws_secretsmanager_secret_version.slack_channel_id.secret_string
   sns_topic_arns   = ["arn:aws:sns:eu-west-2:${local.environment_management.account_ids[terraform.workspace]}:cloudwatch-slack-alerts"]
@@ -11,4 +11,3 @@ module "template" {
   application_name = local.application_name
 
 }
-


### PR DESCRIPTION
pinning chatbox version to v5.X as latest runs are trying to use v6.0 and failing: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/16420592952/job/46397865977