### PR TITLE
:wrench: Analytical Platform Compute Development: Patch EKS Add-ons + EKS Node version

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -21,7 +21,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
       eks_cluster_version = "1.33"
-      eks_node_version    = "1.42.0-5ed157861"
+      eks_node_version    = "1.42.0-5ed15786"
       eks_cluster_addon_versions = {
         kube_proxy                        = "v1.33.0-eksbuild.2"
         aws_efs_csi_driver                = "v2.1.9-eksbuild.1"


### PR DESCRIPTION
> [!NOTE]  
> Already applied to development environment

This PR patches EKS Add Ons as well as EKS Node versions in the `analytical-platform-compute-development` EKS Cluster.

This PR makes use of [this](https://github.com/ministryofjustice/analytical-platform/pull/8158) script and forms part of [this](https://github.com/ministryofjustice/analytical-platform/issues/8049) piece of work.

### :chart_with_upwards_trend: Addon version changes:

| Addon                             | Previous Version         | Updated Version          |
|----------------------------------|---------------------------|---------------------------|
| `coredns`                         | `v1.12.1-eksbuild.2`      | `v1.12.2-eksbuild.4`      |
| `aws_ebs_csi_driver`             | `v1.44.0-eksbuild.1`      | `v1.45.0-eksbuild.2`      |
| `aws_efs_csi_driver`            | `v2.1.8-eksbuild.1`       | `v2.1.9-eksbuild.1`       |
| `aws_network_flow_monitoring_agent` | `v1.0.2-eksbuild.5`   | `v1.0.2-eksbuild.6`       |
| `eks_pod_identity_agent`        | `v1.3.7-eksbuild.2`       | `v1.3.8-eksbuild.2`       |
| `vpc_cni`                         | `v1.19.6-eksbuild.1`      | `v1.19.6-eksbuild.7`      |

EKS Node version: 
`1.41.0-bc3ad241` -> `1.42.0-5ed15786`
