### PR TITLE
DHS-336: Order IAM policies alphabetically

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/dms_dps/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_dps/iam.tf
@@ -111,8 +111,8 @@ resource "aws_iam_role_policy" "dmsoperatorpolicy" {
                 "s3:GetBucketLocation"
             ],
             "Resource": [
-                "arn:aws:s3::*:dpr-*/*",
-                "arn:aws:s3::*:dpr-*"
+                "arn:aws:s3::*:dpr-*",
+                "arn:aws:s3::*:dpr-*/*"
             ]
         },
         {

--- a/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/dms_s3_v2/iam.tf
@@ -109,8 +109,8 @@ resource "aws_iam_policy" "dms-operator-s3-policy" {
                 "s3:GetBucketLocation"
             ],
             "Resource": [
-                "arn:aws:s3::*:dpr-*/*",
-                "arn:aws:s3::*:dpr-*"
+                "arn:aws:s3::*:dpr-*",
+                "arn:aws:s3::*:dpr-*/*"
             ]
         },
         {

--- a/terraform/environments/digital-prison-reporting/modules/ec2/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/ec2/iam.tf
@@ -98,8 +98,8 @@ data "aws_iam_policy_document" "dms" {
       "s3:GetBucketLocation",
     ]
     resources = [
-      "arn:aws:s3:::dpr-*/*",
-      "arn:aws:s3:::dpr-*"
+      "arn:aws:s3:::dpr-*",
+      "arn:aws:s3:::dpr-*/*"
     ]
   }
 

--- a/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/glue_job/main.tf
@@ -92,26 +92,25 @@ data "aws_iam_policy_document" "extra-policy-document" {
 
   statement {
     actions = [
-      "s3:GetObject",
       "s3:DeleteObject",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:ListBucket",
-      "s3:PutObject",
-      "s3:GetBucketLocation",
-      "s3:GetBucketLocation"
+      "s3:PutObject"
     ]
     resources = [
-      "arn:aws:s3:::${var.project_id}-*/*",
-      "arn:aws:s3:::${var.project_id}-*"
+      "arn:aws:s3:::${var.project_id}-*",
+      "arn:aws:s3:::${var.project_id}-*/*"
     ]
   }
   # https://docs.aws.amazon.com/glue/latest/dg/monitor-continuous-logging-enable.html#monitor-continuous-logging-encrypt-log-data
   statement {
     actions = [
+      "logs:AssociateKmsKey",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:AssociateKmsKey"
+      "logs:PutLogEvents"
     ]
     resources = [
       "arn:aws:logs:*:*:/aws-glue/*"
@@ -119,11 +118,11 @@ data "aws_iam_policy_document" "extra-policy-document" {
   }
   statement {
     actions = [
+      "cloudwatch:PutMetricData",
       "glue:*",
-      "iam:ListRolePolicies",
       "iam:GetRole",
       "iam:GetRolePolicy",
-      "cloudwatch:PutMetricData",
+      "iam:ListRolePolicies",
       "sqs:*" # Needs Fixing
     ]
     resources = [
@@ -132,10 +131,10 @@ data "aws_iam_policy_document" "extra-policy-document" {
   }
   statement {
     actions = [
-      "dms:DescribeTableStatistics",
       "dms:DescribeReplicationTasks",
-      "dms:StopReplicationTask",
-      "dms:ModifyReplicationTask"
+      "dms:DescribeTableStatistics",
+      "dms:ModifyReplicationTask",
+      "dms:StopReplicationTask"
     ]
     resources = [
       "arn:aws:dms:${var.region}:${var.account}:*:*"
@@ -147,8 +146,8 @@ data "aws_iam_policy_document" "extra-policy-document" {
       "kinesis:DescribeStream",
       "kinesis:GetRecords",
       "kinesis:GetShardIterator",
-      "kinesis:SubscribeToShard",
-      "kinesis:ListShards"
+      "kinesis:ListShards",
+      "kinesis:SubscribeToShard"
     ]
     resources = [
       "arn:aws:kinesis:${var.region}:${var.account}:stream/${var.project_id}-*"
@@ -166,11 +165,11 @@ data "aws_iam_policy_document" "extra-policy-document" {
   }
   statement {
     actions = [
-      "kms:Encrypt*",
       "kms:Decrypt*",
-      "kms:ReEncrypt*",
+      "kms:DescribeKey",
+      "kms:Encrypt*",
       "kms:GenerateDataKey*",
-      "kms:DescribeKey"
+      "kms:ReEncrypt*"
     ]
     resources = [
       "arn:aws:kms:*:${var.account}:key/*"
@@ -179,16 +178,16 @@ data "aws_iam_policy_document" "extra-policy-document" {
   statement {
     actions = [
       "dynamodb:BatchGet*",
-      "dynamodb:DescribeStream",
-      "dynamodb:DescribeTable",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
       "dynamodb:BatchWrite*",
       "dynamodb:CreateTable",
       "dynamodb:Delete*",
-      "dynamodb:Update*",
-      "dynamodb:PutItem"
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:Update*"
     ]
     resources = [
       "arn:aws:dynamodb:${var.region}:${var.account}:table/dpr-*"

--- a/terraform/environments/digital-prison-reporting/modules/lambdas/generic/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/lambdas/generic/iam.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "lambda_execution" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:PutLogEvents",
+      "logs:PutLogEvents"
     ]
   }
 
@@ -42,8 +42,8 @@ data "aws_iam_policy_document" "lambda_execution" {
     resources = ["*"]
 
     actions = [
-      "xray:PutTraceSegments",
       "xray:PutTelemetryRecords",
+      "xray:PutTraceSegments"
     ]
   }
 
@@ -59,11 +59,11 @@ data "aws_iam_policy_document" "lambda_execution" {
     resources = ["*"]
 
     actions = [
-      "ec2:DescribeNetworkInterfaces",
+      "ec2:AttachNetworkInterface",
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
       "ec2:DescribeInstances",
-      "ec2:AttachNetworkInterface"
+      "ec2:DescribeNetworkInterfaces"
     ]
   }
 

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -84,8 +84,8 @@ resource "aws_iam_policy" "s3_read_access_policy" {
           "s3:Get*",
         ],
         "Resource" : [
-          "arn:aws:s3:::${local.project}-*/*",
-          "arn:aws:s3:::${local.project}-*"
+          "arn:aws:s3:::${local.project}-*",
+          "arn:aws:s3:::${local.project}-*/*"
         ]
       }
     ]
@@ -119,8 +119,8 @@ resource "aws_iam_policy" "s3_read_write_policy" {
           "s3:*Object",
         ],
         "Resource" : [
-          "arn:aws:s3:::${local.project}-*/*",
-          "arn:aws:s3:::${local.project}-*"
+          "arn:aws:s3:::${local.project}-*",
+          "arn:aws:s3:::${local.project}-*/*"
         ]
       }
     ]
@@ -138,8 +138,8 @@ resource "aws_iam_policy" "s3_all_object_actions_policy" {
         "Action" : ["s3:*Object"],
         "Effect" : "Allow",
         "Resource" : [
-          "arn:aws:s3:::${local.project}-*/*",
-          "arn:aws:s3:::${local.project}-*"
+          "arn:aws:s3:::${local.project}-*",
+          "arn:aws:s3:::${local.project}-*/*"
         ]
       }
     ]
@@ -321,12 +321,12 @@ data "aws_iam_policy_document" "redshift-additional-policy" {
   }
   statement {
     actions = [
+      "logs:AssociateKmsKey",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:AssociateKmsKey",
       "logs:DescribeLogStreams",
       "logs:GetLogEvents",
+      "logs:PutLogEvents",
       "logs:PutRetentionPolicy"
     ]
     resources = [
@@ -957,9 +957,9 @@ data "aws_iam_policy_document" "eventbridge_execution_assume_policy_document" {
       type = "Service"
 
       identifiers = [
+        "lambda.amazonaws.com",
         "scheduler.amazonaws.com",
-        "states.amazonaws.com",
-        "lambda.amazonaws.com"
+        "states.amazonaws.com"
       ]
     }
   }


### PR DESCRIPTION
This PR orders the IAM policies used by the DPR in ascending alphabetical order. This reduces the unnecessary terraform diffs which are created as a result of the difference in the to-be applied ordering and the resulting ordering of the policies.