### PR TITLE
🔧 Analytical Platform Compute Production: Patch EKS Add-ons + EKS Node Version

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -128,8 +128,8 @@ locals {
         coredns                           = "v1.12.2-eksbuild.4"
         eks_pod_identity_agent            = "v1.3.8-eksbuild.2"
         aws_guardduty_agent               = "v1.10.0-eksbuild.2"
-        aws_ebs_csi_driver                = "v1.45.0-eksbuild.2"
-        vpc_cni                           = "v1.19.6-eksbuild.7"
+        aws_ebs_csi_driver                = "v1.46.0-eksbuild.1"
+        vpc_cni                           = "v1.20.0-eksbuild.1"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -119,17 +119,17 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
       eks_cluster_version = "1.33"
-      eks_node_version    = "1.41.0-bc3ad241"
+      eks_node_version    = "1.42.0-5ed15786"
       eks_cluster_addon_versions = {
-        coredns                           = "v1.12.1-eksbuild.2"
         kube_proxy                        = "v1.33.0-eksbuild.2"
-        aws_ebs_csi_driver                = "v1.44.0-eksbuild.1"
-        aws_efs_csi_driver                = "v2.1.8-eksbuild.1"
-        aws_guardduty_agent               = "v1.10.0-eksbuild.2"
-        aws_network_flow_monitoring_agent = "v1.0.2-eksbuild.5"
-        eks_pod_identity_agent            = "v1.3.7-eksbuild.2"
+        aws_efs_csi_driver                = "v2.1.9-eksbuild.1"
+        aws_network_flow_monitoring_agent = "v1.0.2-eksbuild.6"
         eks_node_monitoring_agent         = "v1.3.0-eksbuild.2"
-        vpc_cni                           = "v1.19.6-eksbuild.1"
+        coredns                           = "v1.12.2-eksbuild.4"
+        eks_pod_identity_agent            = "v1.3.8-eksbuild.2"
+        aws_guardduty_agent               = "v1.10.0-eksbuild.2"
+        aws_ebs_csi_driver                = "v1.45.0-eksbuild.2"
+        vpc_cni                           = "v1.19.6-eksbuild.7"
       }
 
       /* Data Engineering Airflow */


### PR DESCRIPTION
This PR patches EKS Add Ons as well as EKS Node versions in the `analytical-platform-compute-test` EKS Cluster.

This PR makes use of [this](https://github.com/ministryofjustice/analytical-platform/pull/8158) script and forms part of [this](https://github.com/ministryofjustice/analytical-platform/issues/8049) piece of work.

### :chart_with_upwards_trend: Addon version changes:

| Addon                             | Previous Version         | Updated Version          |
|----------------------------------|---------------------------|---------------------------|
| `coredns`                         | `v1.12.1-eksbuild.2`      | `v1.12.2-eksbuild.4`      |
| `aws_ebs_csi_driver`             | `v1.44.0-eksbuild.1`      | `v1.46.0-eksbuild.1`      |
| `aws_efs_csi_driver`            | `v2.1.8-eksbuild.1`       | `v2.1.9-eksbuild.1`       |
| `aws_network_flow_monitoring_agent` | `v1.0.2-eksbuild.5`   | `v1.0.2-eksbuild.6`       |
| `eks_pod_identity_agent`        | `v1.3.7-eksbuild.2`       | `v1.3.8-eksbuild.2`       |
| `vpc_cni`                         | `v1.19.6-eksbuild.1`      | `v1.20.0-eksbuild.1`      |

EKS Node version: 
`1.41.0-bc3ad241` -> `1.42.0-5ed15786`
