### PR TITLE
Add Component Input to terraform reusable workflow call

### DIFF
--- a/.github/workflows/ccms-ebs.yml
+++ b/.github/workflows/ccms-ebs.yml
@@ -48,6 +48,7 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
+      component: "${{ matrix.component }}"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
This PR adds support for passing the `component` input parameter to the Terraform reusable workflow from the matrix strategy. This allows targeting specific Terraform components/subfolders dynamically during workflow runs.
