### PR TITLE
drop rds module to add later

### DIFF
--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -1,20 +1,24 @@
-module "rds_export" {
-  source = "github.com/ministryofjustice/terraform-rds-export?ref=230537b0367f7a55d27ee91c219f13a263ba615e"
+# module "rds_export" {
+#   source = "github.com/ministryofjustice/terraform-rds-export?ref=230537b0367f7a55d27ee91c219f13a263ba615e"
 
-  # Replace the kms_key_arn, name, vpc_id and (database_subnet_ids in a list)
-  kms_key_arn         = aws_kms_key.sns_kms.arn
-  name                = "cafm"
-  vpc_id              = module.vpc.vpc_id
-  database_subnet_ids = module.vpc.private_subnets
+#   # Replace the kms_key_arn, name, vpc_id and (database_subnet_ids in a list)
+#   kms_key_arn         = aws_kms_key.sns_kms.arn
+#   name                = "cafm"
+#   vpc_id              = module.vpc.vpc_id
+#   database_subnet_ids = module.vpc.private_subnets
 
-  tags = {
-    business-unit = "Property"
-    application   = local.application_name
-    is-production = "false"
-    owner         = "shanmugapriya.basker@justice.gov.uk"
-  }
+#   tags = {
+#     business-unit = "Property"
+#     application   = local.application_name
+#     is-production = "false"
+#     owner         = "shanmugapriya.basker@justice.gov.uk"
+#   }
+# }
+
+resource "aws_secretsmanager_secret" "db_master_user_secret" {
+  # checkov:skip=CKV2_AWS_57: Skipping because automatic rotation not needed.
+  name       = "cafm-database-master-user-secret-test1"
 }
-
 
 module "endpoints" {
   # Commit has for v5.21.0

--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -18,6 +18,7 @@
 resource "aws_secretsmanager_secret" "db_master_user_secret" {
   # checkov:skip=CKV2_AWS_57: Skipping because automatic rotation not needed.
   name       = "cafm-database-master-user-secret-test1"
+  kms_key_id  = aws_kms_key.sns_kms.arn
 }
 
 module "endpoints" {


### PR DESCRIPTION
The latest release of the RDS Terraform module introduces significant functionality improvements. It now:

- Builds the SQL Server instance
- Restores the .bak file
- Transforms table data into Parquet format
- Stores the transformed data in S3
- Drops the database upon successful completion via the Step Function

However, in the currently deployed environment, the SQL Server was provisioned separately, outside the Step Function workflow. As a result, it does not align with the updated module flow, where provisioning and teardown are integrated into the state machine.

To align with the new functionality, I plan to:

- Destroy all resources previously created via the existing RDS module
- Re-deploy the updated RDS module to ensure that all resources—including the SQL Server—are managed entirely within the Step Function lifecycle

This will ensure that the system operates consistently with the intended design and supports full automation of the data restore and transform process.