### PR TITLE
Migrate `format-code` to use reusable workflow from modernisation-platform-github-actions

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,28 +1,25 @@
----
 name: 'Format Code: ensure code formatting guidelines are met'
 
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
   schedule:
     - cron: 45 4 * * 1
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: '${{ github.ref }}-${{ github.workflow }}'
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: MegaLinter
+  format-code:
     permissions:
       contents: write
-      pull-requests: write
+      security-events: write  # needed for SARIF upload
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
@@ -30,59 +27,22 @@ jobs:
       - name: Prepare Git options
         run: bash ./scripts/git-setup.sh
 
-      - name: Create new branch
-        run: |
-          date=$(date +%Y_%m_%d)
-          branch_name="date_$date"
-          git checkout -b $branch_name
-
-      - name: Run linter
-        id: ml
-        # You can override MegaLinter flavor used to have faster performances
-        # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/terraform@e08c2b05e3dbc40af4c23f41172ef1e068a7d651 #v8.8.0
-        env:
-          # All available variables are described in documentation
-          # https://megalinter.io/configuration/#shared-variables
-          # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+      - name: Run Format Code Action
+        uses: ministryofjustice/modernisation-platform-github-actions/format-code@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee # v3.4.0
+        with:
           APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
           APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
           APPLY_FIXES_MODE: pull_request # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
           DISABLE_ERRORS: true
           EMAIL_REPORTER: false
           ENABLE_LINTERS: JSON_PRETTIER,YAML_PRETTIER,TERRAFORM_TERRAFORM_FMT,MARKDOWN_MARKDOWNLINT
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           VALIDATE_ALL_CODEBASE: true
           YAML_PRETTIER_FILTER_REGEX_EXCLUDE: (.github/*)
           REPORT_OUTPUT_FOLDER: none
 
-      - name: Check for changes
-        run: |
-          git add .
-          git commit -m "Updates from GitHub Actions Format Code workflow"
-          branch_name=$(git branch --show-current)
-          changes=$(git diff origin/main...$branch_name --name-only)
-          if [ -z "$changes" ]; then
-            echo "No changes detected."
-            exit 1
-          else
-            echo "Changes detected."
-            exit 0
-          fi
-
-      - name: Push changes
-        run: |
-          git config --global push.autoSetupRemote true
-          git push
-
-      - name: Create pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          pr_title="GitHub Actions Code Formatter workflow"
-          pr_body="This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."
-          branch_name=$(git branch --show-current)
-          pr_head="${{ github.repository_owner }}:${branch_name}"
-          pr_base="main"
-          gh pr create --title "$pr_title" --body "$pr_body" --head "$pr_head" --base "$pr_base" --label "code quality"
-      
+      - name: Run Signed Commit Action
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@c25ccb3c17e1ac869ceafc5430a4caf7e39be2ee # v3.4.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "GitHub Actions Code Formatter workflow"
+          pr_body: "This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ out/
 
 terraform/modules/**/*.zip
 terraform/environments/youth-justice-app-framework/modules/quicksight/assets/run_time
+
+megalinter-reports


### PR DESCRIPTION
This PR adds the new [format-code](https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code) GitHub Action workflow to standardise code formatting across this repository.

- ✅ Introduces a reusable workflow to run MegaLinter and optionally apply automatic fixes.
- 🔐 Uses the latest pinned SHA versions of the `format-code` and `signed-commit` actions for security and reproducibility.
- ✍️ Automatically commits any formatting changes via a signed commit, where applicable.

This aligns the repo with the Modernisation Platform’s shared formatting and linting standards.

tested on run: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/16567865228/job/46852206279