### PR TITLE
feat: active cdn, dns and certs for ebs transfer family

### DIFF
--- a/terraform/environments/ccms-ebs/application_variables.json
+++ b/terraform/environments/ccms-ebs/application_variables.json
@@ -107,10 +107,7 @@
       "certificate_expiry_days": 45,
       "certificate_monitor_email": "ccms-ebs-nonprod-moni-aaaajv4v2trhfezlzkd5sevpsm@moj.org.slack.com",
       "payment_load_monitor_email": "ccms-ebs-nonprod-moni-aaaajv4v2trhfezlzkd5sevpsm@moj.org.slack.com",
-      "alerts_subscription_email": "ccms-ebs-nonprod-moni-aaaajv4v2trhfezlzkd5sevpsm@moj.org.slack.com",
-      "cash_office_idp_arn": "arn:aws:sso:::instance/ssoins-7535d9af4f41fb26",
-      "cash_office_upload_hostname": "ccms-file-uploads",
-      "cash_web_app_url": "webapp-01efa045f0de46e9b.transfer-webapp.eu-west-2.on.aws"
+      "alerts_subscription_email": "ccms-ebs-nonprod-moni-aaaajv4v2trhfezlzkd5sevpsm@moj.org.slack.com"
     },
     "test": {
       "short_env": "tst",
@@ -434,7 +431,7 @@
       "alerts_subscription_email": "ccms-ebs-prod-monitor-aaaajvsud6ikkogrh4dyt53whq@moj.org.slack.com",
       "cash_office_idp_arn": "arn:aws:sso:::instance/ssoins-7535d9af4f41fb26",
       "cash_office_upload_hostname": "ccms-file-uploads",
-      "cash_web_app_url": "webapp-01efa045f0de46e9b.transfer-webapp.eu-west-2.on.aws"
+      "cash_web_app_url": "webapp-15b7379e05fb4e428.transfer-webapp.eu-west-2.on.aws"
     }
   },
   "webgate_ebs": {


### PR DESCRIPTION
Creates for cash office transfer family solution:
- Cloudfront distro
- ACM cert (and validation)
- DNS record (R53)