### PR TITLE
Coat GitHub tfstate

### DIFF
--- a/terraform/environments/coat/kms.tf
+++ b/terraform/environments/coat/kms.tf
@@ -2,6 +2,7 @@
 module "coat_github_repos_s3_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  count = local.is-production ? 1 : 0
 
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.1"

--- a/terraform/environments/coat/kms.tf
+++ b/terraform/environments/coat/kms.tf
@@ -1,0 +1,16 @@
+# COAT GitHub repositories KMS for Terraform state bucket
+module "coat_github_repos_s3_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["s3/coat-github-repos"]
+  description           = "S3 COAT github repos terraform KMS key"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+
+  tags = local.tags
+}

--- a/terraform/environments/coat/s3.tf
+++ b/terraform/environments/coat/s3.tf
@@ -288,3 +288,28 @@ resource "aws_s3_object" "pod_waste_reports" {
   key    = "pod_waste_reports/"
   acl    = "private"
 }
+
+
+# COAT GitHub repositories Terraform state bucket
+module "coat_github_repos_tfstate_bucket" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.3.0"
+
+  bucket = "coat-github-repos-tfstate"
+
+  force_destroy = true
+
+  attach_deny_insecure_transport_policy = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.coat_github_repos_s3_kms.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+

--- a/terraform/environments/coat/s3.tf
+++ b/terraform/environments/coat/s3.tf
@@ -293,6 +293,7 @@ resource "aws_s3_object" "pod_waste_reports" {
 # COAT GitHub repositories Terraform state bucket
 module "coat_github_repos_tfstate_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  count = local.is-production ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.3.0"
@@ -306,7 +307,7 @@ module "coat_github_repos_tfstate_bucket" {
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.coat_github_repos_s3_kms.key_arn
+        kms_master_key_id = module.coat_github_repos_s3_kms[0].key_arn
         sse_algorithm     = "aws:kms"
       }
     }


### PR DESCRIPTION
Manage COAT GitHub Team and Repos via IAC. [#191](https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/191)
Creating **`coat-github-repos-tfstate`** S3 bucket and KMS key to store the state in COAT Production account only.
