### PR TITLE
github added for coat

### DIFF
--- a/terraform/environments/coat/github/repositories/data.tf
+++ b/terraform/environments/coat/github/repositories/data.tf
@@ -1,0 +1,3 @@
+data "github_team" "cloud_optimisation_and_accountability" {
+  slug = "cloud-optimisation-and-accountability"
+}

--- a/terraform/environments/coat/github/repositories/main.tf
+++ b/terraform/environments/coat/github/repositories/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+    acl     = "private"
+    bucket  = "coat-github-repos-tfstate"
+    encrypt = true
+    key     = "terraform/github-repos/terraform.tfstate"
+    region  = "eu-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.31.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+  required_version = "~> 1.6"
+}
+

--- a/terraform/environments/coat/github/repositories/ministryofjustice/cloud-optimisation-and-accountability.tf
+++ b/terraform/environments/coat/github/repositories/ministryofjustice/cloud-optimisation-and-accountability.tf
@@ -1,0 +1,16 @@
+module "cloud-optimisation-and-accountability" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.2.1"
+
+  poc = false
+
+  name        = "cloud-optimisation-and-accountability"
+  description = "A GitHub repository for the Cloud Optimisation and Accountability Team"
+  topics      = ["cloud-optimisation-and-accountability"]
+
+  homepage_url = "https://cloud-optimisation-and-accountability.justice.gov.uk/"
+
+  team_access = {
+    admin = [var.cloud_optimisation_and_accountability_team_id]
+  }
+}

--- a/terraform/environments/coat/github/repositories/ministryofjustice/coat-cur-data-pipeline.tf
+++ b/terraform/environments/coat/github/repositories/ministryofjustice/coat-cur-data-pipeline.tf
@@ -1,0 +1,21 @@
+module "coat-cur-data-pipeline" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.2.1"
+
+  poc = false
+
+  name        = "coat-cur-data-pipeline"
+  description = "A GitHub repository for the Cloud Optimisation and Accountability Team Cost and Usage Report Data Pipeline "
+  topics      = ["cloud-optimisation-and-accountability"]
+
+  homepage_url = "https://cloud-optimisation-and-accountability.justice.gov.uk/"
+
+  team_access = {
+    admin = [var.cloud_optimisation_and_accountability_team_id]
+  }
+
+  template = {
+    "owner" : "ministryofjustice",
+    "repository" : "analytical-platform-airflow-python-template"
+  }
+}

--- a/terraform/environments/coat/github/repositories/ministryofjustice/variables.tf
+++ b/terraform/environments/coat/github/repositories/ministryofjustice/variables.tf
@@ -1,0 +1,4 @@
+variable "cloud_optimisation_and_accountability_team_id" {
+  description = "cloud-optimisation-and-accountability team id"
+  type        = string
+}

--- a/terraform/environments/coat/github/repositories/ministryofjustice/versions.tf
+++ b/terraform/environments/coat/github/repositories/ministryofjustice/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 1.6"
+}

--- a/terraform/environments/coat/github/repositories/orgs.tf
+++ b/terraform/environments/coat/github/repositories/orgs.tf
@@ -1,0 +1,6 @@
+module "ministryofjustice" {
+  source = "./ministryofjustice"
+
+  cloud_optimisation_and_accountability_team_id = data.github_team.cloud_optimisation_and_accountability.id
+}
+

--- a/terraform/environments/coat/github/repositories/variables.tf
+++ b/terraform/environments/coat/github/repositories/variables.tf
@@ -1,0 +1,11 @@
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+variable "github_owner" {
+  type        = string
+  description = "Default organisation for the GitHub provider configuration"
+  default     = "ministryofjustice"
+}


### PR DESCRIPTION
Manage COAT GitHub Team and Repos via IAC. [#191](https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/191)

Added **github folder** inside **coat folder** added repos

- cloud-optimisation-and-accountability 
- coat-cur-data-pipeline 