### PR TITLE
TM-1440: planetfm: add windows 2022 install volume to preprod

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -71,6 +71,8 @@ locals {
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
+          # "xvdd"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media (created outside of code)
+          "xvde" = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = false


### PR DESCRIPTION
For 2022 upgrade test