### PR TITLE
TM-1440: planetfm: upgrade preprod app 11-a part 3

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -42,9 +42,9 @@ locals {
           availability_zone = "eu-west-2a"
         })
         ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 }                                       # root volume
-          "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
-          "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
+          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
+          "xvdf" = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true


### PR DESCRIPTION
Still not working - removing the 2022 mount.