### PR TITLE
updated new airflow parameter

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -233,6 +233,8 @@ module "load_emsys_tpims_database" {
   athena_dump_bucket   = module.s3-athena-bucket.bucket
   cadt_bucket          = module.s3-create-a-derived-table-bucket.bucket
   max_session_duration = 12 * 60 * 60
+
+  new_airflow          = true
 }
 
 module "load_fep_database" {


### PR DESCRIPTION
var.environment is "production" |||| ([load_emsys_tpims_database](https://github.com/ministryofjustice/modernisation-platform-environments/blob/7935e51b48038108b8bbdf6e674da2c827251f9c/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf#L219-L236) )

so local.env_suffixes[var.environment] = "" |||| ([locals.env_suffixes code](https://github.com/ministryofjustice/modernisation-platform-environments/blob/7935e51b48038108b8bbdf6e674da2c827251f9c/terraform/environments/electronic-monitoring-data/modules/ap_airflow_iam_role/main.tf#L9))

local.role_name_suffix comes from [role_name_suffix](https://github.com/ministryofjustice/modernisation-platform-environments/blob/7935e51b48038108b8bbdf6e674da2c827251f9c/terraform/environments/electronic-monitoring-data/modules/ap_airflow_iam_role/main.tf#L14C1-L14C121) , which is not preproduction, so takes the value of var.role_name_suffix

I'm not 100% sure but I think is coming from the [ap_airflow_load_data_iam_role main.tf](https://github.com/ministryofjustice/modernisation-platform-environments/blob/7935e51b48038108b8bbdf6e674da2c827251f9c/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/main.tf#L17)

because [var.full_reload isn't defined it's defaulting to false](https://github.com/ministryofjustice/modernisation-platform-environments/blob/7935e51b48038108b8bbdf6e674da2c827251f9c/terraform/environments/electronic-monitoring-data/modules/ap_airflow_load_data_iam_role/variables.tf#L72-L77) , so the suffix becomes: "load-${var.name}${local.env_suffixes[var.environment]}"

var.name = "emsys-tpims" from the ap_airflow_iam.tf file, and the suffixes are the same, still ""

That makes:
mwaa = `mwaa:electronic-monitoring-data-store""-"load-emsys-tpims"`

This will need to be the naming convention in the [New airflow repo](https://github.com/ministryofjustice/analytical-platform-airflow/tree/main/environments/production/electronic-monitoring-data-store)