### PR TITLE
Dynamic environment name selection based on component input

### DIFF
--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -279,7 +279,7 @@
         needs: [plan, fetch-secrets]
         if: inputs.action == 'plan_apply' && needs.plan.outputs.plan_exitcode == '2'
         runs-on: ubuntu-latest
-        environment: "${{ inputs.application }}-${{ inputs.environment }}"
+        environment: ${{ inputs.component != 'root' && format('{0}-{1}-{2}', inputs.application, inputs.environment, inputs.component) || format('{0}-{1}', inputs.application, inputs.environment) }}
         steps:
           - name: Checkout Repository
             uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4


### PR DESCRIPTION
This PR updates the workflow to dynamically determine the GitHub Actions environment name based on whether a `component` input is provided.
- If `component` is not `root`, the environment will be set to: `<application>-<environment>-<component>`
- If `component` is `root`, it defaults to: `<application>-<environment>`

Previously, the `environment` field was always set to `<application>-<environment>`, which did not support the new component-level environments. This ensures the correct GitHub environment context is used when applying Terraform changes, aligning with the recently introduced per-component environments.
[#issue](https://github.com/ministryofjustice/modernisation-platform/issues/9879)