### PR TITLE
TM-1440: planetfm: preprod app-11 upgrade part5

### DIFF
--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -42,7 +42,7 @@ locals {
           availability_zone = "eu-west-2a"
         })
         ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 }                                       # root volume
+          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -43,8 +43,6 @@ locals {
         })
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 }                                       # root volume
-          "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
-          "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
@@ -56,35 +54,6 @@ locals {
           instance-scheduling = "skip-scheduling"
           pre-migration       = "PPFAW011"
         })
-      })
-
-      # upgrade test instance - do not use
-      # rename and join the domain FIRST
-      # Mount drive
-      # Upgrade OS - Server DataCenter 2019
-      # Join domain as pp-cafm-a-19-a
-      # Remove drive
-      # Check E: drive also gone
-      # Reboot
-      pp-cafm-a-20-a = merge(local.ec2_instances.app, {
-        config = merge(local.ec2_instances.app.config, {
-          ami_name          = "pp-cafm-a-11-a-unjoined"
-          availability_zone = "eu-west-2a"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-          # "xvdd"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media (created outside of code)
-        }
-        instance = merge(local.ec2_instances.app.instance, {
-          disable_api_termination = false
-          instance_type           = "t3.large"
-        })
-        tags = merge(local.ec2_instances.app.tags, {
-          ami                 = "pp-cafm-a-11-a-unjoined"
-          description         = "RDS session host and app server upgrade test"
-          instance-scheduling = "skip-scheduling"
-        })
-        cloudwatch_metric_alarms = null
       })
 
       # database servers

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -52,6 +52,8 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
           "/dev/sdb"  = { type = "gp3", size = 200 }
+          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
@@ -77,6 +79,8 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
           "/dev/sdb"  = { type = "gp3", size = 200 }
+          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true
@@ -102,6 +106,8 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
           "/dev/sdb"  = { type = "gp3", size = 28 }
+          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true


### PR DESCRIPTION
app-11 now on 2022. Tidy up:
- Remove install drives
- Remove temporary app-20 EC2
- Copy install volume config (commented out) for when we do prod