### PR TITLE
tfstate role update

### DIFF
--- a/terraform/environments/coat/data.tf
+++ b/terraform/environments/coat/data.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy_document" {
       test     = "StringLike"
       variable = "${local.oidc_provider}:sub"
       values = [
-        "repo:ministryofjustice/operations-engineering:*"
+        "repo:ministryofjustice/cloud-optimisation-and-accountability:*"
       ]
     }
 


### PR DESCRIPTION
To support work for the tickegt Manage COAT GitHub Team and Repos via IAC. https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/191 create terraform_github_repos_state_role role in Production account only.

Updated reference to **cloud-optimisation-and-accountability** has been corrected in the role.