### PR TITLE
deploy full size instance mis-db-config-stage

### DIFF
--- a/terraform/environments/delius-core/modules/components/oracle_db_instance/cloudwatch.tf
+++ b/terraform/environments/delius-core/modules/components/oracle_db_instance/cloudwatch.tf
@@ -4,6 +4,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_alarm" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = local.alarm_name
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
@@ -21,11 +22,13 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_alarm" {
 }
 
 resource "aws_cloudwatch_log_group" "ec2_status_check_log_group" {
+  count             = var.enable_cloudwatch_alarms ? 1 : 0
   name              = "/metrics/${var.env_name}/${local.alarm_name}"
   retention_in_days = 0 # Retain indefinitely
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_status_check_failed_event" {
+  count       = var.enable_cloudwatch_alarms ? 1 : 0
   name        = local.alarm_name
   description = "Rule to capture EC2 instance status check failures"
   event_pattern = jsonencode({
@@ -41,7 +44,8 @@ resource "aws_cloudwatch_event_rule" "ec2_status_check_failed_event" {
 }
 
 resource "aws_cloudwatch_event_target" "ec2_status_check_failed_target" {
-  rule      = aws_cloudwatch_event_rule.ec2_status_check_failed_event.name
-  arn       = aws_cloudwatch_log_group.ec2_status_check_log_group.arn
+  count     = var.enable_cloudwatch_alarms ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.ec2_status_check_failed_event[0].name
+  arn       = aws_cloudwatch_log_group.ec2_status_check_log_group[0].arn
   target_id = local.alarm_name
 }

--- a/terraform/environments/delius-core/modules/components/oracle_db_instance/instance.tf
+++ b/terraform/environments/delius-core/modules/components/oracle_db_instance/instance.tf
@@ -69,7 +69,7 @@ module "instance" {
     var.enable_platform_backups != null ? { "backup" = var.enable_platform_backups ? "true" : "false" } : {}
   )
 
-  cloudwatch_metric_alarms = merge(
+  cloudwatch_metric_alarms = var.enable_cloudwatch_alarms ? merge(
     local.cloudwatch_metric_alarms.ec2
-  )
+  ) : {}
 }

--- a/terraform/environments/delius-core/modules/components/oracle_db_instance/variables.tf
+++ b/terraform/environments/delius-core/modules/components/oracle_db_instance/variables.tf
@@ -183,3 +183,9 @@ variable "inline_ebs" {
   description = "Whether to create EBS volumes inline with the instance"
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Enable or disable CloudWatch metric alarms for the instance"
+  type        = bool
+  default     = true
+}
+

--- a/terraform/environments/delius-mis/locals_stage.tf
+++ b/terraform/environments/delius-mis/locals_stage.tf
@@ -385,6 +385,8 @@ locals {
       ansible_repo_basedir = "ansible"
       ansible_args         = "oracle_19c_install"
     }
+
+    enable_cloudwatch_alarms = false
   }
 
   fsx_config_stage = {

--- a/terraform/environments/delius-mis/modules/mis_environment/databases.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/databases.tf
@@ -80,6 +80,8 @@ module "oracle_db_dsd" {
 
   deploy_oracle_stats = false
 
+  enable_cloudwatch_alarms = try(var.dsd_db_config.enable_cloudwatch_alarms, true)
+
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 
   providers = {
@@ -132,6 +134,8 @@ module "oracle_db_boe" {
   instance_profile_policies = local.boe_instance_policies
 
   deploy_oracle_stats = false
+
+  enable_cloudwatch_alarms = try(var.boe_db_config.enable_cloudwatch_alarms, true)
 
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 
@@ -186,6 +190,8 @@ module "oracle_db_mis" {
   instance_profile_policies = local.mis_instance_policies
 
   deploy_oracle_stats = false
+
+  enable_cloudwatch_alarms = try(var.mis_db_config.enable_cloudwatch_alarms, true)
 
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 


### PR DESCRIPTION
- deploy mis-db-stage instance 
  - will be manually turned off until db's can work on it (it's quite large)
- add var.enable_cloudwatch_alarms to module so that we can turn this off without all the alarms firing

Once the db's are in place will be used as the installer target for dfi IPS/DataServices installation

IMPORTANT: Will be turned off when not in use