### PR TITLE
TM: tweak threshold for SSM command monitoring alarm

### DIFF
--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -143,7 +143,7 @@ locals {
     ["dso-infra-azure-fixngo", "terragrunt-NOMSDevTestEnvironments", "dso-pipelines-pagerduty", {}],
     ["dso-infra-azure-fixngo", "terragrunt-NOMSProduction1", "dso-pipelines-pagerduty", {}],
     ["dso-infra-azure-fixngo", "stale", "dso-pipelines-pagerduty", {}],
-    ["dso-modernisation-platform-automation", "ssm_command_monitoring", "dso-pipelines-pagerduty", { threshold = "2" }],
+    ["dso-modernisation-platform-automation", "ssm_command_monitoring", "dso-pipelines-pagerduty", { threshold = "10" }], # pipeline sometimes fails due to API errors hence only alarm if it continually fails
     ["dso-modernisation-platform-automation", "github_workflow_monitoring", "dso-pipelines-pagerduty", {}],
     ["dso-modernisation-platform-automation", "planetfm_gfsl_data_extract", "dso-pipelines-pagerduty", {}],
     ["dso-modernisation-platform-automation", "nomis_environment_start", "nomis-pagerduty", {}],


### PR DESCRIPTION
Increase threshold again as we had 2 failures in 1 week triggering the alarm. Since the pipeline runs every 30 mins we can put the limit much higher.