### PR TITLE
TM: tweak threshold for github action monitoring alarm

### DIFF
--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -144,7 +144,7 @@ locals {
     ["dso-infra-azure-fixngo", "terragrunt-NOMSProduction1", "dso-pipelines-pagerduty", {}],
     ["dso-infra-azure-fixngo", "stale", "dso-pipelines-pagerduty", {}],
     ["dso-modernisation-platform-automation", "ssm_command_monitoring", "dso-pipelines-pagerduty", { threshold = "10" }], # pipeline sometimes fails due to API errors hence only alarm if it continually fails
-    ["dso-modernisation-platform-automation", "github_workflow_monitoring", "dso-pipelines-pagerduty", {}],
+    ["dso-modernisation-platform-automation", "github_workflow_monitoring", "dso-pipelines-pagerduty", { threshold = "10" }],
     ["dso-modernisation-platform-automation", "planetfm_gfsl_data_extract", "dso-pipelines-pagerduty", {}],
     ["dso-modernisation-platform-automation", "nomis_environment_start", "nomis-pagerduty", {}],
     ["dso-modernisation-platform-automation", "certificate_renewal", "dso-pipelines-pagerduty", {}],


### PR DESCRIPTION
Increase threshold so we don't alarm unless the pipeline is continually failing. We get the odd failure due to API timeouts which we can ignore.