### PR TITLE
TM-1478: planetfm: prepare prod app-11 for 2022 upgrade

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -41,10 +41,11 @@ locals {
       })
 
       pd-cafm-a-11-a = merge(local.ec2_instances.app, {
-        cloudwatch_metric_alarms = merge(
-          local.ec2_instances.app.cloudwatch_metric_alarms,
-          module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
-        )
+        #cloudwatch_metric_alarms = merge(
+        #  local.ec2_instances.app.cloudwatch_metric_alarms,
+        #  module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows,
+        #)
+        cloudwatch_metric_alarms = {}
         config = merge(local.ec2_instances.app.config, {
           ami_name          = "pd-cafm-a-11-a"
           availability_zone = "eu-west-2a"
@@ -52,8 +53,8 @@ locals {
         ebs_volumes = {
           "/dev/sda1" = { type = "gp3", size = 128 } # root volume
           "/dev/sdb"  = { type = "gp3", size = 200 }
-          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
-          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
+          "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+          "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
         }
         instance = merge(local.ec2_instances.app.instance, {
           disable_api_termination = true


### PR DESCRIPTION
Add installation media and remove alarms for app-11 in prep for 2012 -> 2019 -> 2022 upgrade