### PR TITLE
feat: add s3 perms for cortex deps

### DIFF
--- a/terraform/environments/ccms-edrms/application_variables.json
+++ b/terraform/environments/ccms-edrms/application_variables.json
@@ -27,7 +27,8 @@
       "target_min_capacity": "1",
       "target_max_capacity": "3",
       "logging_level_root": "info",
-      "db_log_retention_days": "7"
+      "db_log_retention_days": "7",
+      "cortex_deps_bucket_name": "ccms-shared"
     },
     "test": {
       "app_name": "ccms-edrms",

--- a/terraform/environments/ccms-edrms/application_variables.json
+++ b/terraform/environments/ccms-edrms/application_variables.json
@@ -27,8 +27,7 @@
       "target_min_capacity": "1",
       "target_max_capacity": "3",
       "logging_level_root": "info",
-      "db_log_retention_days": "7",
-      "cortex_deps_bucket_name": "ccms-shared"
+      "db_log_retention_days": "7"
     },
     "test": {
       "app_name": "ccms-edrms",
@@ -115,7 +114,8 @@
       "target_min_capacity": "1",
       "target_max_capacity": "3",
       "logging_level_root": "info",
-      "db_log_retention_days": "0"
+      "db_log_retention_days": "0",
+      "cortex_deps_bucket_name": "ccms-shared"
     }
   }
 }

--- a/terraform/environments/ccms-edrms/ec2.tf
+++ b/terraform/environments/ccms-edrms/ec2.tf
@@ -1,7 +1,8 @@
 data "template_file" "launch-template" {
   template = file("${path.module}/templates/user-data.sh")
   vars = {
-    cluster_name = "${local.application_name}-cluster"
+    cluster_name       = "${local.application_name}-cluster"
+    deploy_environment = local.environment
   }
 }
 

--- a/terraform/environments/ccms-edrms/iam.tf
+++ b/terraform/environments/ccms-edrms/iam.tf
@@ -163,3 +163,34 @@ resource "aws_iam_role_policy_attachment" "attach_ec2_policy" {
   role       = aws_iam_role.ec2_instance_role.name
   policy_arn = aws_iam_policy.ec2_instance_policy.arn
 }
+
+resource "aws_iam_policy" "s3_policy_cortex_deps" {
+  count       = local.is-production ? 1 : 0
+  name        = "${local.application_data.accounts[local.environment].app_name}-s3-policy-cortex-deps"
+  description = "${local.application_data.accounts[local.environment].app_name} s3-policy-cortex-deps"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${local.application_data.accounts[local.environment].cortex_deps_bucket_name}/*",
+                "arn:aws:s3:::${local.application_data.accounts[local.environment].cortex_deps_bucket_name}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "s3_policy_cortex_deps" {
+  count      = local.is-production ? 1 : 0
+  role       = aws_iam_role.ec2_instance_role.name
+  policy_arn = aws_iam_policy.s3_policy_cortex_deps[0].arn
+}

--- a/terraform/environments/ccms-edrms/iam.tf
+++ b/terraform/environments/ccms-edrms/iam.tf
@@ -165,7 +165,7 @@ resource "aws_iam_role_policy_attachment" "attach_ec2_policy" {
 }
 
 resource "aws_iam_policy" "s3_policy_cortex_deps" {
-  count       = local.is-development ? 1 : 0
+  count       = local.is-production ? 1 : 0
   name        = "${local.application_data.accounts[local.environment].app_name}-s3-policy-cortex-deps"
   description = "${local.application_data.accounts[local.environment].app_name} s3-policy-cortex-deps"
 
@@ -190,7 +190,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "s3_policy_cortex_deps" {
-  count      = local.is-development ? 1 : 0
+  count      = local.is-production ? 1 : 0
   role       = aws_iam_role.ec2_instance_role.name
   policy_arn = aws_iam_policy.s3_policy_cortex_deps[0].arn
 }

--- a/terraform/environments/ccms-edrms/iam.tf
+++ b/terraform/environments/ccms-edrms/iam.tf
@@ -165,7 +165,7 @@ resource "aws_iam_role_policy_attachment" "attach_ec2_policy" {
 }
 
 resource "aws_iam_policy" "s3_policy_cortex_deps" {
-  count       = local.is-production ? 1 : 0
+  count       = local.is-development ? 1 : 0
   name        = "${local.application_data.accounts[local.environment].app_name}-s3-policy-cortex-deps"
   description = "${local.application_data.accounts[local.environment].app_name} s3-policy-cortex-deps"
 
@@ -190,7 +190,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "s3_policy_cortex_deps" {
-  count      = local.is-production ? 1 : 0
+  count      = local.is-development ? 1 : 0
   role       = aws_iam_role.ec2_instance_role.name
   policy_arn = aws_iam_policy.s3_policy_cortex_deps[0].arn
 }

--- a/terraform/environments/ccms-edrms/tds_database.tf
+++ b/terraform/environments/ccms-edrms/tds_database.tf
@@ -21,7 +21,7 @@ resource "aws_db_instance" "tds_db" {
   auto_minor_version_upgrade          = true
   storage_type                        = "gp2"
   engine                              = "oracle-se2"
-  engine_version                      = "19.0.0.0.ru-2025-01.rur-2025-01.r1"
+  engine_version                      = "19.0.0.0.ru-2025-04.rur-2025-04.r1"
   instance_class                      = local.application_data.accounts[local.environment].tds_db_instance_type
   multi_az                            = local.application_data.accounts[local.environment].tds_db_deploy_to_multi_azs
   db_name                             = "EDRMSTDS"

--- a/terraform/environments/ccms-edrms/templates/user-data.sh
+++ b/terraform/environments/ccms-edrms/templates/user-data.sh
@@ -3,6 +3,8 @@ echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
 
 start ecs
 
+yum install -y awscli
+
 deploy_cortex() {
   CORTEX_DIR=/tmp/CortexAgent
   CORTEX_VERSION=linux_8_8_0_133595_rpm
@@ -17,7 +19,7 @@ deploy_cortex() {
   #--Installs
   yum install -y selinux-policy-devel
   rpm -Uvh $CORTEX_DIR/$CORTEX_VERSION/cortex-*.rpm
-  systemctl status traps_pmd
+    
   echo "Cortex Install Routine Complete. Installation Is NOT GUARANTEED -- Check Logs For Success"
 }
 

--- a/terraform/environments/ccms-edrms/templates/user-data.sh
+++ b/terraform/environments/ccms-edrms/templates/user-data.sh
@@ -19,10 +19,10 @@ deploy_cortex() {
   #--Installs
   yum install -y selinux-policy-devel
   rpm -Uvh $CORTEX_DIR/$CORTEX_VERSION/cortex-*.rpm
-    
+  systemctl status traps_pmd
   echo "Cortex Install Routine Complete. Installation Is NOT GUARANTEED -- Check Logs For Success"
 }
 
-if [[ "${deploy_environment}" = "development" ]]; then
+if [[ "${deploy_environment}" = "production" ]]; then
   deploy_cortex
 fi

--- a/terraform/environments/ccms-edrms/templates/user-data.sh
+++ b/terraform/environments/ccms-edrms/templates/user-data.sh
@@ -2,3 +2,25 @@
 echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
 
 start ecs
+
+deploy_cortex() {
+  CORTEX_DIR=/tmp/CortexAgent
+  CORTEX_VERSION=linux_8_8_0_133595_rpm
+
+  #--Prep
+  mkdir -p $CORTEX_DIR/linux_8_8_0_133595_rpm
+  mkdir /etc/panw
+  aws s3 sync s3://ccms-shared/CortexAgent/ $CORTEX_DIR #--ccms-shared is in the EBS dev account 767123802783. Bucket is shared at the ORG LEVEL.
+  tar zxf $CORTEX_DIR/$CORTEX_VERSION.tar.gz -C $CORTEX_DIR/$CORTEX_VERSION
+  cp $CORTEX_DIR/$CORTEX_VERSION/cortex.conf /etc/panw/cortex.conf
+
+  #--Installs
+  yum install -y selinux-policy-devel
+  rpm -Uvh $CORTEX_DIR/$CORTEX_VERSION/cortex-*.rpm
+  systemctl status traps_pmd
+  echo "Cortex Install Routine Complete. Installation Is NOT GUARANTEED -- Check Logs For Success"
+}
+
+if [[ "${deploy_environment}" = "development" ]]; then
+  deploy_cortex
+fi


### PR DESCRIPTION
Adds (prod only):
  - S3 policy allowing S3 access to `ccms-shared` bucket
  - Modifies launch template to allow cortex agent (XDR) installation for SOC integration (tested in dev)

Will also apply to prod outstanding changes (prod only):
  - Cloudwatch alarm for RDS storage threshold breach
  - Cloudwatch alarm for RDS CPU threshold breach