### PR TITLE
implement s3 bucket module

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -357,4 +357,29 @@ locals {
     storage_capacity     = 100
     throughtput_capacity = 16
   }
+
+  # S3 buckets configuration for dev environment
+  s3_buckets_dev = {
+    "mis-data" = {
+      acl                = "private"
+      versioning_enabled = true
+      sse_algorithm      = "aws:kms"
+      iam_policies = {
+        "mis-data-read-write" = [
+          {
+            effect = "Allow"
+            actions = [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:ListBucket",
+              "s3:DeleteObject"
+            ]
+          }
+        ]
+      }
+      tags = {
+        Purpose = "MIS data storage"
+      }
+    }
+  }
 }

--- a/terraform/environments/delius-mis/locals_preproduction.tf
+++ b/terraform/environments/delius-mis/locals_preproduction.tf
@@ -347,4 +347,28 @@ locals {
     storage_capacity     = 200
     throughtput_capacity = 16
   }
+
+  # S3 buckets configuration for preprod environment
+  s3_buckets_preprod = {
+    # Example bucket configuration - customize as needed
+    # "mis-data" = {
+    #   acl                 = "private"
+    #   versioning_enabled  = true
+    #   sse_algorithm       = "aws:kms"
+    #   iam_policies = {
+    #     "mis-data-access" = [
+    #       {
+    #         effect = "Allow"
+    #         actions = [
+    #           "s3:GetObject",
+    #           "s3:PutObject"
+    #         ]
+    #       }
+    #     ]
+    #   }
+    #   tags = {
+    #     Purpose = "MIS data storage"
+    #   }
+    # }
+  }
 }

--- a/terraform/environments/delius-mis/locals_stage.tf
+++ b/terraform/environments/delius-mis/locals_stage.tf
@@ -393,4 +393,28 @@ locals {
     storage_capacity     = 200
     throughtput_capacity = 16
   }
+
+  # S3 buckets configuration for stage environment
+  s3_buckets_stage = {
+    # Example bucket configuration - customize as needed
+    # "mis-data" = {
+    #   acl                 = "private"
+    #   versioning_enabled  = true
+    #   sse_algorithm       = "aws:kms"
+    #   iam_policies = {
+    #     "mis-data-access" = [
+    #       {
+    #         effect = "Allow"
+    #         actions = [
+    #           "s3:GetObject",
+    #           "s3:PutObject"
+    #         ]
+    #       }
+    #     ]
+    #   }
+    #   tags = {
+    #     Purpose = "MIS data storage"
+    #   }
+    # }
+  }
 }

--- a/terraform/environments/delius-mis/main_development.tf
+++ b/terraform/environments/delius-mis/main_development.tf
@@ -39,6 +39,8 @@ module "environment_dev" {
 
   fsx_config = local.fsx_config_dev
 
+  s3_buckets = local.s3_buckets_dev
+
   domain_join_ports = local.domain_join_ports
 
   pagerduty_integration_key = local.pagerduty_integration_key

--- a/terraform/environments/delius-mis/main_preproduction.tf
+++ b/terraform/environments/delius-mis/main_preproduction.tf
@@ -37,6 +37,8 @@ module "environment_stage" {
 
   fsx_config = local.fsx_config_stage
 
+  s3_buckets = local.s3_buckets_stage
+
   domain_join_ports = local.domain_join_ports
 
   pagerduty_integration_key = local.pagerduty_integration_key
@@ -79,6 +81,8 @@ module "environment_preproduction" {
   mis_db_config = local.mis_db_config_preprod
 
   fsx_config = local.fsx_config_preprod
+
+  s3_buckets = local.s3_buckets_preprod
 
   domain_join_ports = local.domain_join_ports
 

--- a/terraform/environments/delius-mis/modules/mis_environment/outputs.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/outputs.tf
@@ -1,1 +1,10 @@
+# S3 Bucket outputs
+output "s3_buckets" {
+  description = "Map of S3 buckets created"
+  value       = module.s3_bucket
+}
 
+output "s3_bucket_iam_policies" {
+  description = "Map of IAM policies created for S3 bucket access"
+  value       = aws_iam_policy.s3_bucket_access
+}

--- a/terraform/environments/delius-mis/modules/mis_environment/s3_bucket.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/s3_bucket.tf
@@ -1,0 +1,74 @@
+locals {
+
+  # get list of policy names
+  s3_buckets_iam_policy_names = distinct(flatten([
+    for s3_key, s3_value in var.s3_buckets : keys(s3_value.iam_policies)
+  ]))
+
+  # form s3 bucket statements per policy
+  s3_buckets_iam_policies = {
+    for policy_name in local.s3_buckets_iam_policy_names : policy_name => {
+      description = "Allows access to S3 bucket"
+      path        = "/"
+      statements = flatten([
+        for s3_key, s3_value in var.s3_buckets : [
+          for policy_key, policy_value in s3_value.iam_policies : [
+            for statement in policy_value : merge(statement, {
+              resources = [
+                module.s3_bucket[s3_key].bucket.arn,
+                "${module.s3_bucket[s3_key].bucket.arn}/*"
+              ]
+            })
+          ] if policy_key == policy_name
+        ]
+      ])
+    }
+  }
+}
+
+module "s3_bucket" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash; skip as this is MoJ Repo
+
+  for_each = var.s3_buckets
+
+  source = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.2"
+
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  bucket_prefix              = each.key
+  acl                        = each.value.acl
+  ownership_controls         = each.value.ownership_controls
+  versioning_enabled         = each.value.versioning_enabled
+  replication_enabled        = each.value.replication_enabled
+  replication_region         = coalesce(each.value.replication_region, var.account_info.region)
+  bucket_policy              = each.value.bucket_policy
+  bucket_policy_v2           = each.value.bucket_policy_v2
+  custom_kms_key             = each.value.custom_kms_key
+  custom_replication_kms_key = each.value.custom_replication_kms_key
+  lifecycle_rule             = each.value.lifecycle_rule
+  log_bucket                 = each.value.log_bucket
+  log_prefix                 = each.value.log_prefix
+  replication_role_arn       = each.value.replication_role_arn
+  force_destroy              = each.value.force_destroy
+  sse_algorithm              = each.value.sse_algorithm
+
+  tags = merge(local.tags, each.value.tags)
+}
+
+# Create IAM policies for S3 bucket access
+resource "aws_iam_policy" "s3_bucket_access" {
+  for_each = local.s3_buckets_iam_policies
+
+  name        = "${var.env_name}-${each.key}"
+  description = each.value.description
+  path        = each.value.path
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = each.value.statements
+  })
+
+  tags = var.tags
+}

--- a/terraform/environments/delius-mis/modules/mis_environment/variables.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/variables.tf
@@ -96,3 +96,53 @@ variable "domain_join_ports" {
   description = "Ports required for domain join"
   type        = any
 }
+
+variable "s3_buckets" {
+  description = "map of s3 buckets to create where the map key is the bucket prefix.  See s3_bucket module for more variable details.  Use iam_policies to automatically create a iam policies for the bucket where the key is the name of the policy"
+  type = map(object({
+    acl                 = optional(string, "private")
+    ownership_controls  = optional(string, "BucketOwnerPreferred")
+    versioning_enabled  = optional(bool, true)
+    replication_enabled = optional(bool, false)
+    replication_region  = optional(string)
+    bucket_policy       = optional(list(string), ["{}"])
+    bucket_policy_v2 = optional(list(object({
+      sid     = optional(string, null)
+      effect  = string
+      actions = list(string)
+      principals = optional(object({
+        type        = string
+        identifiers = list(string)
+      }))
+      conditions = optional(list(object({
+        test     = string
+        variable = string
+        values   = list(string)
+      })), [])
+    })), [])
+    custom_kms_key             = optional(string)
+    custom_replication_kms_key = optional(string)
+    lifecycle_rule             = any # see module baseline_presets.s3 for examples
+    log_bucket                 = optional(string)
+    log_prefix                 = optional(string, "")
+    replication_role_arn       = optional(string, "")
+    force_destroy              = optional(bool, false)
+    sse_algorithm              = optional(string, "aws:kms")
+    iam_policies = optional(map(list(object({
+      sid     = optional(string, null)
+      effect  = string
+      actions = list(string)
+      principals = optional(object({
+        type        = string
+        identifiers = list(string)
+      }))
+      conditions = optional(list(object({
+        test     = string
+        variable = string
+        values   = list(string)
+      })), [])
+    }))), {})
+    tags = optional(map(string), {})
+  }))
+  default = {}
+}

--- a/terraform/environments/delius-mis/s3_examples.tf.example
+++ b/terraform/environments/delius-mis/s3_examples.tf.example
@@ -1,0 +1,123 @@
+# Example S3 Bucket Configuration for delius-mis
+# This shows how to configure S3 buckets using the retrofitted module
+
+## Example 1: Simple bucket for data storage
+s3_buckets_example = {
+  "mis-data-storage" = {
+    acl                 = "private"
+    versioning_enabled  = true
+    sse_algorithm       = "aws:kms"
+    
+    # IAM policies automatically created for this bucket
+    iam_policies = {
+      "mis-data-read-write" = [
+        {
+          effect = "Allow"
+          actions = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:ListBucket"
+          ]
+        }
+      ]
+      "mis-data-read-only" = [
+        {
+          effect = "Allow"
+          actions = [
+            "s3:GetObject",
+            "s3:ListBucket"
+          ]
+        }
+      ]
+    }
+    
+    lifecycle_rule = [
+      {
+        id      = "transition_and_expiration"
+        enabled = true
+        
+        transition = [
+          {
+            days          = 30
+            storage_class = "STANDARD_IA"
+          },
+          {
+            days          = 90
+            storage_class = "GLACIER"
+          }
+        ]
+        
+        expiration = {
+          days = 365
+        }
+      }
+    ]
+    
+    tags = {
+      Purpose     = "MIS data storage"
+      Environment = "development"
+    }
+  }
+}
+
+## Example 2: Bucket with replication
+s3_buckets_with_replication = {
+  "mis-backup-storage" = {
+    acl                 = "private"
+    versioning_enabled  = true
+    replication_enabled = true
+    replication_region  = "eu-west-1"  # Different from primary region
+    sse_algorithm       = "aws:kms"
+    
+    iam_policies = {
+      "backup-access" = [
+        {
+          effect = "Allow"
+          actions = [
+            "s3:GetObject",
+            "s3:PutObject"
+          ]
+        }
+      ]
+    }
+    
+    tags = {
+      Purpose = "MIS backup storage"
+      Backup  = "true"
+    }
+  }
+}
+
+## Example 3: Bucket with custom bucket policy
+s3_buckets_with_policy = {
+  "mis-shared-data" = {
+    acl                 = "private"
+    versioning_enabled  = true
+    
+    bucket_policy_v2 = [
+      {
+        sid    = "AllowCrossAccountAccess"
+        effect = "Allow"
+        actions = [
+          "s3:GetObject"
+        ]
+        principals = {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::123456789012:root"]  # Replace with actual account ID
+        }
+        conditions = [
+          {
+            test     = "StringEquals"
+            variable = "s3:prefix"
+            values   = ["shared/*"]
+          }
+        ]
+      }
+    ]
+    
+    tags = {
+      Purpose = "Shared data access"
+    }
+  }
+}


### PR DESCRIPTION
- add s3 module to delius-mis/environment module
- allow s3 buckets in delius-mis environement
- goal is ultimately to specify a kms key that can be used to copy the legacy delius-mis reports into the mis-data bucket in each dev/stage/preprod environment