### PR TITLE
remove count, add s3 module, change params

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -353,6 +353,8 @@ locals {
     }
   })
 
+  dfi_report_bucket_config = {}
+
   fsx_config_dev = {
     storage_capacity     = 100
     throughtput_capacity = 16

--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -353,7 +353,9 @@ locals {
     }
   })
 
-  dfi_report_bucket_config = {}
+  dfi_report_bucket_config = {
+    bucket_policy_enabled = true
+  }
 
   fsx_config_dev = {
     storage_capacity     = 100

--- a/terraform/environments/delius-mis/main_development.tf
+++ b/terraform/environments/delius-mis/main_development.tf
@@ -37,7 +37,8 @@ module "environment_dev" {
   boe_db_config = local.boe_db_config_dev
   mis_db_config = local.mis_db_config_dev
 
-  fsx_config = local.fsx_config_dev
+  fsx_config               = local.fsx_config_dev
+  dfi_report_bucket_config = local.dfi_report_bucket_config
 
   domain_join_ports = local.domain_join_ports
 

--- a/terraform/environments/delius-mis/modules/mis_environment/databases.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/databases.tf
@@ -85,10 +85,8 @@ module "oracle_db_dsd" {
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 
   providers = {
-    aws                       = aws
-    aws.bucket-replication    = aws
-    aws.core-vpc              = aws.core-vpc
-    aws.core-network-services = aws.core-network-services
+    aws          = aws
+    aws.core-vpc = aws.core-vpc
   }
 }
 
@@ -140,10 +138,8 @@ module "oracle_db_boe" {
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 
   providers = {
-    aws                       = aws
-    aws.bucket-replication    = aws
-    aws.core-vpc              = aws.core-vpc
-    aws.core-network-services = aws.core-network-services
+    aws          = aws
+    aws.core-vpc = aws.core-vpc
   }
 }
 
@@ -196,10 +192,8 @@ module "oracle_db_mis" {
   sns_topic_arn = aws_sns_topic.delius_mis_alarms.arn
 
   providers = {
-    aws                       = aws
-    aws.bucket-replication    = aws
-    aws.core-vpc              = aws.core-vpc
-    aws.core-network-services = aws.core-network-services
+    aws          = aws
+    aws.core-vpc = aws.core-vpc
   }
 }
 

--- a/terraform/environments/delius-mis/modules/mis_environment/dfi.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/dfi.tf
@@ -27,9 +27,6 @@ data "aws_security_group" "dsd_db" {
 module "dfi_instance" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v3.0.1"
 
-  # allow environment not to have this var set and still work
-  count = var.dfi_config != null ? var.dfi_config.instance_count : 0
-
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
   }

--- a/terraform/environments/delius-mis/modules/mis_environment/dfi.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/dfi.tf
@@ -27,6 +27,9 @@ data "aws_security_group" "dsd_db" {
 module "dfi_instance" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-ec2-instance?ref=v3.0.1"
 
+  # allow environment not to have this var set and still work
+  count = var.dfi_config != null ? var.dfi_config.instance_count : 0
+
   providers = {
     aws.core-vpc = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
   }

--- a/terraform/environments/delius-mis/modules/mis_environment/s3.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/s3.tf
@@ -5,6 +5,7 @@ module "s3-dfi-report-bucket" { #tfsec:ignore:aws-s3-enable-versioning
 
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v9.0.0"
   providers = {
+    aws                    = aws
     aws.bucket-replication = aws
   }
 

--- a/terraform/environments/delius-mis/modules/mis_environment/s3.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/s3.tf
@@ -1,0 +1,78 @@
+# DFI Report bucket for document and file storage
+# checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+module "s3-dfi-report-bucket" { #tfsec:ignore:aws-s3-enable-versioning
+  count = var.dfi_report_bucket_config != null ? 1 : 0
+
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v9.0.0"
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  bucket_prefix      = "delius-mis-${var.env_name}-dfi-report-"
+  versioning_enabled = false
+  bucket_policy      = var.dfi_report_bucket_config.bucket_policy_enabled ? [data.aws_iam_policy_document.dfi_report_bucket_policy[0].json] : []
+  force_destroy      = true
+
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+        }
+      ]
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+        }
+      ]
+
+      noncurrent_version_expiration = {
+        days = 365
+      }
+    }
+  ]
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "dfi_report_bucket_policy" {
+  count = var.dfi_report_bucket_config != null && var.dfi_report_bucket_config.bucket_policy_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "${module.s3-dfi-report-bucket[0].bucket.arn}/*",
+      module.s3-dfi-report-bucket[0].bucket.arn
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgPaths"
+      values   = ["${data.aws_organizations_organization.root_account.id}/*/${var.platform_vars.environment_management.modernisation_platform_organisation_unit_id}/*"]
+    }
+  }
+}

--- a/terraform/environments/delius-mis/modules/mis_environment/s3.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/s3.tf
@@ -3,7 +3,7 @@
 module "s3-dfi-report-bucket" { #tfsec:ignore:aws-s3-enable-versioning
   count = var.dfi_report_bucket_config != null ? 1 : 0
 
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v9.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.2"
   providers = {
     aws                    = aws
     aws.bucket-replication = aws

--- a/terraform/environments/delius-mis/modules/mis_environment/s3.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/s3.tf
@@ -1,3 +1,6 @@
+# Data source for organization information
+data "aws_organizations_organization" "root_account" {}
+
 # DFI Report bucket for document and file storage
 # checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 module "s3-dfi-report-bucket" { #tfsec:ignore:aws-s3-enable-versioning

--- a/terraform/environments/delius-mis/modules/mis_environment/variables.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/variables.tf
@@ -70,7 +70,7 @@ variable "auto_config" {
   default = null #optional
 }
 
-variable "dfi_config" {
+variable "dfi_report_bucket_config" {
   type    = any
   default = null #optional
 }

--- a/terraform/environments/delius-mis/modules/mis_environment/variables.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/variables.tf
@@ -70,6 +70,11 @@ variable "auto_config" {
   default = null #optional
 }
 
+variable "dfi_config" {
+  type    = any
+  default = null #optional
+}
+
 variable "dfi_report_bucket_config" {
   type    = any
   default = null #optional

--- a/terraform/environments/delius-mis/modules/mis_environment/versions.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.0"
+      version               = "~> 5.0, != 5.86.0"
       configuration_aliases = [aws.bucket-replication, aws.core-vpc, aws.core-network-services]
     }
   }


### PR DESCRIPTION
- add s3 bucket to mis-environments module
  - cannot use lates s3 bucket version as this requires aws provider 6.0 which isn't supported in delius env
- set up in locals_development.tf 
  - will likely have to change the 'condition' value for the dfi_report_bucket_policy resource
  - however, let's set it up first and change it later 