### PR TITLE
Update Helm charts actions-runner to latest runners version 2.327.1-1

### DIFF
--- a/terraform/environments/analytical-platform-compute/actions-runner/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/helm-charts-actions-runners.tf
@@ -6,7 +6,7 @@ resource "helm_release" "actions_runner_mojas_airflow" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -32,7 +32,7 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-airflow-create-a-pipeline"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -81,7 +81,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -109,7 +109,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -133,7 +133,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a_n
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-cadt-sandbox-a-non-spot"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -161,7 +161,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -185,7 +185,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -209,7 +209,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_test" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-test"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -233,7 +233,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_dev" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-dpr-dev"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -257,7 +257,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-test"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -281,7 +281,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_pp" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds-pp"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -305,7 +305,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-mojas-create-a-derived-table-emds"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [
@@ -331,7 +331,7 @@ resource "helm_release" "actions_runner_moj_data_catalogue" {
   /* https://github.com/ministryofjustice/analytical-platform-actions-runner */
   name       = "actions-runner-moj-data-catalogue"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "2.326.0-1"
+  version    = "2.327.1-1"
   chart      = "actions-runner"
   namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
   values = [


### PR DESCRIPTION
This PR is required as part of the maintenance  [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/34?pane=issue&itemId=117914402&issue=ministryofjustice%7Canalytical-platform%7C8048) , this [PR](https://github.com/ministryofjustice/analytical-platform-actions-runner/pull/217)  and updates the `actions-runner` chart to `2.327.1-1`