### PR TITLE
TM-1512: planetfm: re-enable prod app alerts

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -123,7 +123,6 @@ locals {
           local.ec2_instances.app.cloudwatch_metric_alarms,
           module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
         )
-        cloudwatch_metric_alarms = {}
         config = merge(local.ec2_instances.app.config, {
           ami_name          = "pd-cafm-a-2022-image-20250806T1436"
           availability_zone = "eu-west-2b"
@@ -148,7 +147,6 @@ locals {
           local.ec2_instances.app.cloudwatch_metric_alarms,
           module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
         )
-        cloudwatch_metric_alarms = {}
         config = merge(local.ec2_instances.app.config, {
           ami_name          = "pd-cafm-a-2022-image-20250806T1436"
           availability_zone = "eu-west-2a"


### PR DESCRIPTION
Re-enable alarms on prod app win2022 servers (11,14,15)
Disable alarms on dormant win2012 servers (12,13)