### PR TITLE
Remove `oasys-national-reporting-development` references 

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_secretsmanager.tf
+++ b/terraform/environments/hmpps-domain-services/locals_secretsmanager.tf
@@ -13,7 +13,6 @@ locals {
       "arn:aws:iam::${module.environment.account_ids.nomis-development}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.nomis-test}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.nomis-data-hub-test}:role/EC2HmppsDomainSecretsRole",
-      "arn:aws:iam::${module.environment.account_ids.oasys-national-reporting-development}:role/EC2HmppsDomainSecretsRole",
       "arn:aws:iam::${module.environment.account_ids.oasys-national-reporting-test}:role/EC2HmppsDomainSecretsRole",
     ]
     preproduction = []

--- a/terraform/environments/hmpps-oem/locals_development.tf
+++ b/terraform/environments/hmpps-oem/locals_development.tf
@@ -166,7 +166,6 @@ locals {
           "nomis-development",
           "nomis-data-hub-development",
           "oasys-development",
-          "oasys-national-reporting-development",
           "planetfm-development",
         ]
       }

--- a/terraform/environments/nomis/scripts/all-secrets.sh
+++ b/terraform/environments/nomis/scripts/all-secrets.sh
@@ -29,7 +29,6 @@ profiles="corporate-staff-rostering-development
  oasys-test
  oasys-preproduction
  oasys-production
- oasys-national-reporting-development
  oasys-national-reporting-test
  oasys-national-reporting-preproduction
  oasys-national-reporting-production

--- a/terraform/environments/nomis/scripts/all-ssm.sh
+++ b/terraform/environments/nomis/scripts/all-ssm.sh
@@ -29,7 +29,6 @@ profiles="corporate-staff-rostering-development
  oasys-test
  oasys-preproduction
  oasys-production
- oasys-national-reporting-development
  oasys-national-reporting-test
  oasys-national-reporting-preproduction
  oasys-national-reporting-production

--- a/terraform/environments/nomis/scripts/all-tfstate.sh
+++ b/terraform/environments/nomis/scripts/all-tfstate.sh
@@ -29,7 +29,6 @@ profiles="corporate-staff-rostering-development
  oasys-test
  oasys-preproduction
  oasys-production
- oasys-national-reporting-development
  oasys-national-reporting-test
  oasys-national-reporting-preproduction
  oasys-national-reporting-production


### PR DESCRIPTION
Following the removal of the `oasys-national-reporting-development` environment (issue: [11083](https://github.com/ministryofjustice/modernisation-platform/issues/11083)), this PR removes any remaining references to the environment.