### PR TITLE
Fix State Remove job

### DIFF
--- a/.github/workflows/terraform-state-management.yml
+++ b/.github/workflows/terraform-state-management.yml
@@ -131,7 +131,7 @@ jobs:
               SUMMARY+="- **Lock ID:** ${{ github.event.inputs.lock_id }}\n"
           else
               # Convert comma-separated values to newlines for display
-              ADDRESSES_DISPLAY=$(echo "${{ github.event.inputs.resource_addresses }}" | tr ',' '\n')
+              ADDRESSES_DISPLAY=$(echo '${{ github.event.inputs.resource_addresses }}' | tr ',' '\n')
               
               echo "**Resource Addresses:**" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
@@ -139,7 +139,7 @@ jobs:
               echo '```' >> $GITHUB_STEP_SUMMARY
               
               # Format for output to next job (keep as comma-separated)
-              SUMMARY+="- **Resources:** ${{ github.event.inputs.resource_addresses }}\n"
+              SUMMARY+='- **Resources:** ${{ github.event.inputs.resource_addresses }}\n'
               
               if [[ "${{ github.event.inputs.operation }}" == "import" ]]; then
                 # Convert comma-separated values to newlines for display
@@ -221,7 +221,7 @@ jobs:
         run: |
           mkdir -p temp
           # Convert comma-separated values to newlines
-          echo "${{ github.event.inputs.resource_addresses }}" | tr ',' '\n' > temp/resource_addresses.txt
+          echo '${{ github.event.inputs.resource_addresses }}' | tr ',' '\n' > temp/resource_addresses.txt
 
       - name: Write Resource IDs to File
         if: github.event.inputs.operation == 'import'

--- a/scripts/terraform-remove.sh
+++ b/scripts/terraform-remove.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 # Script for removing resources from Terraform state
 # Usage: scripts/terraform-remove.sh <terraform_dir> <addresses_file>
@@ -23,7 +24,6 @@ while IFS= read -r ADDRESS; do
   if [ -z "$ADDRESS" ]; then
     continue
   fi
-  
   echo "Removing from state: $ADDRESS"
   terraform -chdir="$TERRAFORM_DIR" state rm "$ADDRESS" | ./scripts/redact-output.sh
 done < "$ADDRESSES_FILE"

--- a/terraform/environments/sprinkler/application_variables.json
+++ b/terraform/environments/sprinkler/application_variables.json
@@ -5,7 +5,7 @@
       "region": "eu-west-2",
       "ecs_type": "FARGATE",
       "rds_storage": 5,
-      "rds_postgresql_version": "12.15",
+      "rds_postgresql_version": "12.22",
       "rds_instance_class": "db.t3.micro"
     },
     "production": {
@@ -13,7 +13,7 @@
       "region": "eu-west-2",
       "ecs_type": "FARGATE",
       "rds_storage": 5,
-      "rds_postgresql_version": "12.15",
+      "rds_postgresql_version": "12.22",
       "rds_instance_class": "db.t3.micro"
     }
   }


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/11214

## What's Changed?
1. I've set `set -o pipefail` to the `terraform-remove.sh` script to ensure it fails when any commands fail. The TF remove command was piped to the redact script (which succeeded) causing it to fail silently.

1. I've added single quotes around the commands which write the resource addresses into a text file for processing so that any resource addresses containing double quotes are preserved. This is common when `for_each` is used and you get indexes like `module.bastion_linux.aws_s3_object.user_public_keys["davidelliott"]`

1. I've updated the postgres db versions to match updates that have been automatically applied in the environment.

## Testing

Successful run deleting a resource containing double quotes.. https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/17092906862

A failure when the script fails... https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/17073923437