### PR TITLE
Simplify `format-code` workflow

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,21 +7,8 @@ on:
 
 permissions: read-all
 
-concurrency:
-  group: '${{ github.ref }}-${{ github.workflow }}'
-  cancel-in-progress: true
-
 jobs:
-  fetch-secrets:
-    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@ac5b118d8d519a521d3a526b564f49fa294dce2c # v3.4.1
-    secrets:
-      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
-      PASSPHRASE: ${{ secrets.PASSPHRASE }}
-    permissions:
-      id-token: write
-      contents: read
   format-code:
-    needs: fetch-secrets
     permissions:
       contents: write
       pull-requests: write
@@ -32,18 +19,11 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-
-      - name: Decrypt Secrets
-        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@ac5b118d8d519a521d3a526b564f49fa294dce2c # v3.4.1
-        with:
-          terraform_github_token: ${{ needs.fetch-secrets.outputs.terraform_github_token }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-
       - name: Prepare Git options
         run: bash ./scripts/git-setup.sh
 
       - name: Run Format Code Action
-        uses: ministryofjustice/modernisation-platform-github-actions/format-code@ac5b118d8d519a521d3a526b564f49fa294dce2c # v3.4.1
+        uses: ministryofjustice/modernisation-platform-github-actions/format-code@7f78ec79dd45ec7db8966ecb619c85712d4e68d7 # v3.4.2
         with:
           APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
           APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
@@ -56,7 +36,7 @@ jobs:
           REPORT_OUTPUT_FOLDER: none
 
       - name: Run Signed Commit Action
-        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@ac5b118d8d519a521d3a526b564f49fa294dce2c # v3.4.1
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@7f78ec79dd45ec7db8966ecb619c85712d4e68d7 # v3.4.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_title: "GitHub Actions Code Formatter workflow"


### PR DESCRIPTION
Remove need for MP secrets and bump GitHub Actions version 