### PR TITLE
Define role for Rekognition access within esupervision

### DIFF
--- a/terraform/environments/hmpps-esupervision/application_variables.json
+++ b/terraform/environments/hmpps-esupervision/application_variables.json
@@ -1,7 +1,8 @@
 {
   "accounts": {
     "development": {
-      "example_var": "dev-data"
+      "example_var": "dev-data",
+      "developer_role_suffix": "912d55d6a0a637c8"
     },
     "test": {
       "example_var": "test-data"

--- a/terraform/environments/hmpps-esupervision/application_variables.json
+++ b/terraform/environments/hmpps-esupervision/application_variables.json
@@ -2,7 +2,11 @@
   "accounts": {
     "development": {
       "example_var": "dev-data",
-      "developer_role_suffix": "912d55d6a0a637c8"
+      "developer_role_suffix": "912d55d6a0a637c8",
+      "service_account_roles": {
+        "CloudPlatformDev": "arn:aws:iam::754256621582:role/cloud-platform-irsa-32bf67b5a4984757-live",
+        "CloudPlatformTest": "arn:aws:iam::754256621582:role/cloud-platform-irsa-27ea034e8f3be2ca-live"
+      }
     },
     "test": {
       "example_var": "test-data"

--- a/terraform/environments/hmpps-esupervision/application_variables.json
+++ b/terraform/environments/hmpps-esupervision/application_variables.json
@@ -15,7 +15,11 @@
       "example_var": "preproduction-data"
     },
     "production": {
-      "example_var": "production-data"
+      "example_var": "production-data",
+      "service_account_roles": {
+        "CloudPlatformPreprod": "arn:aws:iam::754256621582:role/cloud-platform-irsa-7007cde073dea812-live",
+        "CloudPlatformProd": "arn:aws:iam::754256621582:role/cloud-platform-irsa-3d0b407608fa4fc8-live"
+      }
     }
   }
 }

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -68,3 +68,30 @@ resource "aws_secretsmanager_secret_version" "rekognition_user_access_key_value"
     aws_secret_access_key = aws_iam_access_key.rekognition_user_access_key.secret
   })
 }
+
+data "aws_iam_policy_document" "assume_rekognition_role_policy" {
+  statement {
+    sid = "AllowDevAssume"
+    effect = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-developer_${local.developer_role_suffix}"]
+      type = "AWS"
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "rekognition_role" {
+  name = "rekognition-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_rekognition_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "rekognition_s3" {
+  role = aws_iam_role.rekognition_role.name
+  policy_arn = aws_iam_policy.rekognition_s3_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "rekognition_rekognition" {
+  role = aws_iam_role.rekognition_role.name
+  policy_arn = data.aws_iam_policy.rekognition_read.arn
+}

--- a/terraform/environments/hmpps-esupervision/iam.tf
+++ b/terraform/environments/hmpps-esupervision/iam.tf
@@ -70,14 +70,19 @@ resource "aws_secretsmanager_secret_version" "rekognition_user_access_key_value"
 }
 
 data "aws_iam_policy_document" "assume_rekognition_role_policy" {
-  statement {
-    sid = "AllowDevAssume"
-    effect = "Allow"
-    principals {
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-developer_${local.developer_role_suffix}"]
-      type = "AWS"
+  dynamic "statement" {
+    for_each = local.allowed_assume_role_principals
+    iterator = principal
+
+    content {
+      sid = "Allow${principal.key}Assume"
+      effect = "Allow"
+      principals {
+        identifiers = [principal.value]
+        type = "AWS"
+      }
+      actions = ["sts:AssumeRole"]
     }
-    actions = ["sts:AssumeRole"]
   }
 }
 

--- a/terraform/environments/hmpps-esupervision/locals.tf
+++ b/terraform/environments/hmpps-esupervision/locals.tf
@@ -1,5 +1,11 @@
 locals {
   rekog_s3_bucket_name = "${terraform.workspace}-rekognition-uploads"
 
-  developer_role_suffix = local.application_data.accounts[local.environment].developer_role_suffix
+  developer_role_suffix = lookup(local.application_data.accounts[local.environment], "developer_role_suffix", null)
+  developer_role_principals = local.developer_role_suffix == null
+    ? {} :
+    {"Developer": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-developer_${local.developer_role_suffix}"}
+
+  service_account_principals = lookup(local.application_data.accounts[local.environment], "service_account_roles", {})
+  allowed_assume_role_principals = merge(local.developer_role_principals, local.service_account_principals)
 }

--- a/terraform/environments/hmpps-esupervision/locals.tf
+++ b/terraform/environments/hmpps-esupervision/locals.tf
@@ -1,3 +1,5 @@
 locals {
   rekog_s3_bucket_name = "${terraform.workspace}-rekognition-uploads"
+
+  developer_role_suffix = local.application_data.accounts[local.environment].developer_role_suffix
 }

--- a/terraform/environments/hmpps-esupervision/locals.tf
+++ b/terraform/environments/hmpps-esupervision/locals.tf
@@ -2,9 +2,12 @@ locals {
   rekog_s3_bucket_name = "${terraform.workspace}-rekognition-uploads"
 
   developer_role_suffix = lookup(local.application_data.accounts[local.environment], "developer_role_suffix", null)
-  developer_role_principals = local.developer_role_suffix == null
-    ? {} :
-    {"Developer": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-developer_${local.developer_role_suffix}"}
+  developer_role_principals = (local.developer_role_suffix == null ?
+    {} :
+    {
+      "Developer" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_modernisation-platform-developer_${local.developer_role_suffix}"
+    }
+  )
 
   service_account_principals = lookup(local.application_data.accounts[local.environment], "service_account_roles", {})
   allowed_assume_role_principals = merge(local.developer_role_principals, local.service_account_principals)

--- a/terraform/environments/hmpps-esupervision/s3.tf
+++ b/terraform/environments/hmpps-esupervision/s3.tf
@@ -51,6 +51,24 @@ data "aws_iam_policy_document" "rekognition_kms_key_policy" {
     ]
     resources = ["*"]
   }
+
+  # Allow access to rekognition role
+  statement {
+    sid    = "RekognitionRoleKeyUser"
+    effect = "Allow"
+    principals {
+      identifiers = [aws_iam_role.rekognition_role.arn]
+      type        = "AWS"
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_kms_key_policy" "rekognition_encryption_key_policy" {


### PR DESCRIPTION
Define a role which gives access to the resources required for Rekognition calls in the e-supervision application. Attach the Rekogntion read and custom S3 policy.

Allow the modernisation platform 'developer' role within the account to assume this role to be used for local development.