### PR TITLE
Updated zip lambda python lib version.

### DIFF
--- a/terraform/environments/maatdb/application_variables.json
+++ b/terraform/environments/maatdb/application_variables.json
@@ -34,6 +34,7 @@
       "build_transfer": false,
       "build_ses": true,
       "build_ec2": true,
+      "build_hub_integration" : true,
       "pagerduty_integration_key_name": "laa_maat_nonprod_alarms",
       "hosted_zone": "modernisation-platform.service.justice.gov.uk",
       "ses_domain": "maatdb.dev.modernisation-platform.service.justice.gov.uk",
@@ -44,7 +45,7 @@
       "ftp_lambda_source_file": "ftpclient_1.2.zip",
       "ftp_lambda_source_file_version": "LKYb32.Rqjizm17IiAsa.YZhOXfumTGj",
       "zip_lambda_source_file": "zip_s3_objects.zip",
-      "zip_lambda_source_file_version": ".wom0wRS4Mwe.11JXs8XIFy4xT8dEXW9",
+      "zip_lambda_source_file_version": "TevkiwEbMJttB_5X7VX03Sas1u6ONJbE",
       "ftp_lambda_eventbridge_cron": "cron(0 * * * ? 2999)",
       "zip_lambda_eventbridge_cron": "cron(45 6 * * ? 2999)"
     },
@@ -81,6 +82,7 @@
       "build_transfer": false,
       "build_ses": true,
       "build_ec2": false,
+      "build_hub_integration": false,
       "pagerduty_integration_key_name": "laa_maat_nonprod_alarms",
       "hosted_zone": "modernisation-platform.service.justice.gov.uk",
       "ses_domain": "maatdb.tst.modernisation-platform.service.justice.gov.uk",
@@ -91,7 +93,7 @@
       "ftp_lambda_source_file": "ftpclient_1.2.zip",
       "ftp_lambda_source_file_version": "LKYb32.Rqjizm17IiAsa.YZhOXfumTGj",
       "zip_lambda_source_file": "zip_s3_objects.zip",
-      "zip_lambda_source_file_version": ".wom0wRS4Mwe.11JXs8XIFy4xT8dEXW9",
+      "zip_lambda_source_file_version": "TevkiwEbMJttB_5X7VX03Sas1u6ONJbE",
       "ftp_lambda_eventbridge_cron": "cron(0 * * * ? 2999)",
       "zip_lambda_eventbridge_cron": "cron(45 6 * * ? 2999)"
     },
@@ -127,6 +129,7 @@
       "build_transfer": false,
       "build_ses": true,
       "build_ec2": false,
+      "build_hub_integration": false,
       "pagerduty_integration_key_name": "laa_maat_nonprod_alarms",
       "hosted_zone": "modernisation-platform.service.justice.gov.uk",
       "ses_domain": "maatdb.uat.modernisation-platform.service.justice.gov.uk",
@@ -137,7 +140,7 @@
       "ftp_lambda_source_file": "ftpclient_1.2.zip",
       "ftp_lambda_source_file_version": "LKYb32.Rqjizm17IiAsa.YZhOXfumTGj",
       "zip_lambda_source_file": "zip_s3_objects.zip",
-      "zip_lambda_source_file_version": ".wom0wRS4Mwe.11JXs8XIFy4xT8dEXW9",
+      "zip_lambda_source_file_version": "TevkiwEbMJttB_5X7VX03Sas1u6ONJbE",
       "ftp_lambda_eventbridge_cron": "cron(0 * * * ? 2999)",
       "zip_lambda_eventbridge_cron": "cron(45 6 * * ? 2999)"
     },
@@ -174,6 +177,7 @@
       "build_transfer": false,
       "build_ses": true,
       "build_ec2": false,
+      "build_hub_integration": false,
       "pagerduty_integration_key_name": "laa_maat_prod_alarm",
       "hosted_zone": "legalservices.gov.uk",
       "ses_domain": "legalservices.gov.uk",
@@ -184,7 +188,7 @@
       "ftp_lambda_source_file": "ftpclient_1.2.zip",
       "ftp_lambda_source_file_version": "LKYb32.Rqjizm17IiAsa.YZhOXfumTGj",
       "zip_lambda_source_file": "zip_s3_objects.zip",
-      "zip_lambda_source_file_version": ".wom0wRS4Mwe.11JXs8XIFy4xT8dEXW9",
+      "zip_lambda_source_file_version": "TevkiwEbMJttB_5X7VX03Sas1u6ONJbE",
       "ftp_lambda_eventbridge_cron": "cron(0 * * * ? *)",
       "zip_lambda_eventbridge_cron": "cron(45 6 * * ? *)"
     }

--- a/terraform/environments/maatdb/locals.tf
+++ b/terraform/environments/maatdb/locals.tf
@@ -6,11 +6,12 @@ locals {
 
   region = "eu-west-2"
 
-  build_s3       = local.application_data.accounts[local.environment].build_s3
-  build_ftp      = local.application_data.accounts[local.environment].build_ftp
-  build_ses      = local.application_data.accounts[local.environment].build_ses
-  build_ec2      = local.application_data.accounts[local.environment].build_ec2
-  build_transfer = local.application_data.accounts[local.environment].build_transfer
+  build_s3              = local.application_data.accounts[local.environment].build_s3
+  build_ftp             = local.application_data.accounts[local.environment].build_ftp
+  build_ses             = local.application_data.accounts[local.environment].build_ses
+  build_ec2             = local.application_data.accounts[local.environment].build_ec2
+  build_transfer        = local.application_data.accounts[local.environment].build_transfer
+  build_hub_integration = local.application_data.accounts[local.environment].build_hub_integration
 
   ftp_layer_bucket          = local.application_data.accounts[local.environment].ftp_layer_bucket
   ftp_layer_folder_location = local.application_data.accounts[local.environment].ftp_layer_folder_location

--- a/terraform/environments/maatdb/modules/rds/rds.tf
+++ b/terraform/environments/maatdb/modules/rds/rds.tf
@@ -280,12 +280,15 @@ resource "aws_security_group" "mlra_ecs_sec_group" {
     security_groups = [var.mlra_ecs_cluster_sec_group_id]
   }
 
-  ingress {
-    description     = "RDS Access from the HUB 2.0 MAAT Lambda"
-    from_port       = 1521
-    to_port         = 1521
-    protocol        = "tcp"
-    security_groups = [var.hub20_sec_group_id]
+  dynamic "ingress" {
+    for_each = length(trimspace(var.hub20_sec_group_id != null ? var.hub20_sec_group_id : "")) > 0 ? [1] : []
+    content {
+      description     = "RDS Access from the HUB 2.0 MAAT Lambda"
+      from_port       = 1521
+      to_port         = 1521
+      protocol        = "tcp"
+      security_groups = [var.hub20_sec_group_id]
+    }
   }
 
   egress {
@@ -372,6 +375,7 @@ resource "aws_iam_role" "rds_s3_access" {
 }
 
 resource "aws_iam_policy" "rds_s3_access_policy" {
+  count = length(trimspace(var.hub20_s3_bucket != null ? var.hub20_s3_bucket : "")) > 0 ? 1 : 0
   name        = "rds-hub20-s3-bucket-policy"
   description = "Allow Oracle RDS instance to read objects from HUB 2.0 S3 bucket"
 
@@ -397,8 +401,9 @@ resource "aws_iam_policy" "rds_s3_access_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "rds_s3_access_policy_attachment" {
+  count = length(trimspace(var.hub20_s3_bucket != null ? var.hub20_s3_bucket : "")) > 0 ? 1 : 0
   role       = aws_iam_role.rds_s3_access.name
-  policy_arn = aws_iam_policy.rds_s3_access_policy.arn
+  policy_arn = aws_iam_policy.rds_s3_access_policy[0].arn
 }
 
 resource "aws_db_instance_role_association" "rds_s3_role_association" {

--- a/terraform/environments/maatdb/rds.tf
+++ b/terraform/environments/maatdb/rds.tf
@@ -42,8 +42,8 @@ module "rds" {
   bastion_security_group_id             = module.bastion_linux.bastion_security_group
   ecs_cluster_sec_group_id              = "${local.environment_management.account_ids["maat-${local.environment}"]}/${local.application_data.accounts[local.environment].ecs_cluster_sec_group_id}"
   mlra_ecs_cluster_sec_group_id         = "${local.environment_management.account_ids["mlra-${local.environment}"]}/${local.application_data.accounts[local.environment].mlra_ecs_cluster_sec_group_id}"
-  hub20_sec_group_id                    = "${local.environment_management.account_ids["laa-enterprise-service-bus-${local.environment}"]}/${local.application_data.accounts[local.environment].hub20_sec_group_id}"
-  hub20_s3_bucket                       = local.application_data.accounts[local.environment].hub20_s3_bucket
+  hub20_sec_group_id                    = local.build_hub_integration ? "${local.environment_management.account_ids["laa-enterprise-service-bus-${local.environment}"]}/${local.application_data.accounts[local.environment].hub20_sec_group_id}" : ""
+  hub20_s3_bucket                       = local.build_hub_integration ? local.application_data.accounts[local.environment].hub20_s3_bucket : ""
   kms_key_arn                           = local.rds_kms_key_arn
 
   tags = local.tags


### PR DESCRIPTION
This PR applies two sets of changes:

1. Applies the updated zip python lambda script to the lambda terraform via the ref to the s3 bucket, folder and file version.

2. Adds a workaround for the hub2 RDS to S3 integration to avoid the terraform for that failing the rest of the build if either the hub2 changes have not been applied to the account & so don't exist, or the hub2 environment is missing - namely preproduction but the maatdb terraform will try and reference it.

Changes have been tested in dev and also deployed to test.