### PR TITLE
TM-1540: add windows diskspace per disk dashboard widget

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_cloudwatch_dashboards.tf
@@ -17,7 +17,9 @@ locals {
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
-        # CloudWatch agent not running, monitored by Glenn Bot instead
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
       ]
     }
 
@@ -69,7 +71,9 @@ locals {
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
-        # CloudWatch agent not running, monitored by Glenn Bot instead
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
       ]
     }
 

--- a/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
@@ -31,8 +31,8 @@ locals {
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_collectd_service_status_os.service-status-error-os-layer,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_collectd_service_status_app.service-status-error-app-layer,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_windows.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
-        null,
       ]
     }
 

--- a/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/nomis/locals_cloudwatch_dashboards.tf
@@ -31,8 +31,8 @@ locals {
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_collectd_service_status_os.service-status-error-os-layer,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_collectd_service_status_app.service-status-error-app-layer,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
-        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_autoscaling_group_cwagent_windows.free-disk-space-low,
         module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+        null,
       ]
     }
 

--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -58,6 +58,7 @@ locals {
           module.baseline_presets.cloudwatch_dashboard_widget_groups.lb,
           local.cloudwatch_dashboard_widget_groups.db,
           local.cloudwatch_dashboard_widget_groups.syscon,
+          local.cloudwatch_dashboard_widget_groups.asg,
           module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
         ]
       }

--- a/terraform/environments/oasys-national-reporting/locals.tf
+++ b/terraform/environments/oasys-national-reporting/locals.tf
@@ -25,7 +25,7 @@ locals {
         "ec2",
         "ec2_linux",
         "ec2_instance_linux",
-        "ec2_windows",
+        "ec2_instance_only_windows",
         "ssm_command",
       ]
       cloudwatch_metric_alarms_default_actions   = ["pagerduty"]

--- a/terraform/environments/planetfm/locals.tf
+++ b/terraform/environments/planetfm/locals.tf
@@ -20,12 +20,6 @@ locals {
 
   baseline_presets_all_environments = {
     options = {
-      cloudwatch_dashboard_default_widget_groups = [
-        "network_lb",
-        "ec2",
-        "ec2_windows",
-        "ssm_command",
-      ]
       cloudwatch_metric_alarms_default_actions   = ["pagerduty"]
       cloudwatch_metric_oam_links_ssm_parameters = ["hmpps-oem-${local.environment}"]
       cloudwatch_metric_oam_links                = ["hmpps-oem-${local.environment}"]

--- a/terraform/environments/planetfm/locals_cloudwatch_dashboards.tf
+++ b/terraform/environments/planetfm/locals_cloudwatch_dashboards.tf
@@ -1,0 +1,76 @@
+locals {
+
+  cloudwatch_dashboard_widget_groups = {
+    app = {
+      header_markdown = "## EC2 App Tier"
+      width           = 8
+      height          = 8
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "app" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+      ]
+    }
+
+    db = {
+      header_markdown = "## EC2 SQL Database"
+      width           = 8
+      height          = 8
+      add_ebs_widgets = {
+        iops       = true
+        throughput = true
+      }
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "database" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+      ]
+    }
+
+    web = {
+      header_markdown = "## EC2 Web Tier"
+      width           = 8
+      height          = 8
+      search_filter = {
+        ec2_tag = [
+          { tag_name = "component", tag_value = "web" },
+        ]
+      }
+      widgets = [
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+      ]
+    }
+
+  }
+}
+

--- a/terraform/environments/planetfm/locals_preproduction.tf
+++ b/terraform/environments/planetfm/locals_preproduction.tf
@@ -13,6 +13,20 @@ locals {
   # please keep resources in alphabetical order
   baseline_preproduction = {
 
+    cloudwatch_dashboards = {
+      "CloudWatch-Default" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
+          local.cloudwatch_dashboard_widget_groups.db,
+          local.cloudwatch_dashboard_widget_groups.app,
+          local.cloudwatch_dashboard_widget_groups.web,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
+        ]
+      }
+    }
+
     ec2_instances = {
 
       # app servers

--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -13,6 +13,82 @@ locals {
   # please keep resources in alphabetical order
   baseline_production = {
 
+    cloudwatch_dashboards = {
+      "CloudWatch-Default" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.network_lb,
+          local.cloudwatch_dashboard_widget_groups.db,
+          local.cloudwatch_dashboard_widget_groups.app,
+          local.cloudwatch_dashboard_widget_groups.web,
+          module.baseline_presets.cloudwatch_dashboard_widget_groups.ssm_command,
+        ]
+      }
+
+      "pd-cafm-db-a" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          {
+            width         = 8
+            height        = 8
+            search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-cafm-db-a" }] }
+            widgets = [
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+              null,
+            ]
+          },
+          {
+            header_markdown = "## EBS PERFORMANCE"
+            width           = 8
+            height          = 8
+            add_ebs_widgets = { iops = true, throughput = true }
+            search_filter   = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-cafm-db-a" }] }
+            widgets         = []
+          }
+        ]
+      }
+
+      "pd-cafm-db-b" = {
+        periodOverride = "auto"
+        start          = "-PT6H"
+        widget_groups = [
+          {
+            width         = 8
+            height        = 8
+            search_filter = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-cafm-db-b" }] }
+            widgets = [
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.cpu-utilization-high,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-in-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.network-out-bandwidth,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.instance-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.system-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2.attached-ebs-status-check-failed,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+              module.baseline_presets.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+              null,
+            ]
+          },
+          {
+            header_markdown = "## EBS PERFORMANCE"
+            width           = 8
+            height          = 8
+            add_ebs_widgets = { iops = true, throughput = true }
+            search_filter   = { ec2_tag = [{ tag_name = "Name", tag_value = "pd-cafm-db-b" }] }
+            widgets         = []
+          }
+        ]
+      }
+    }
+
     ec2_instances = {
       # app servers
       pd-cafm-a-10-b = merge(local.ec2_instances.app, {

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -1095,6 +1095,16 @@ locals {
         null
       ]
     }
+    ec2_instance_only_windows = {
+      header_markdown = "## EC2 all Windows standalone instances"
+      width           = 8
+      height          = 8
+      widgets = [
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_instance_cwagent_windows.free-disk-space-low,
+        local.cloudwatch_dashboard_widgets.ec2_cwagent_windows.high-memory-usage,
+      ]
+    }
     ec2_linux = {
       header_markdown = "## EC2 all Linux instances"
       width           = 8

--- a/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
+++ b/terraform/modules/baseline_presets/cloudwatch_dashboards.tf
@@ -161,6 +161,46 @@ locals {
         }
       }
     }
+    ec2_instance_cwagent_windows = {
+      free-disk-space-low = {
+        type            = "metric"
+        alarm_threshold = local.cloudwatch_metric_alarms.ec2_cwagent_windows.free-disk-space-low.threshold
+        expression      = "SORT(SEARCH('{CWAgent,InstanceId,instance,objectname} MetricName=\"DISK_FREE\"','Minimum'),MIN,ASC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "EC2 Instance Windows free-disk-space-low"
+          stat    = "Minimum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "disk free %"
+            }
+          }
+        }
+      }
+    }
+    ec2_autoscaling_group_cwagent_windows = {
+      free-disk-space-low = {
+        type            = "metric"
+        alarm_threshold = local.cloudwatch_metric_alarms.ec2_cwagent_windows.free-disk-space-low.threshold
+        expression      = "SORT(SEARCH('{CWAgent,AutoScalingGroupName,InstanceId,instance,objectname} MetricName=\"DISK_FREE\"','Minimum'),MIN,ASC)"
+        properties = {
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "EC2 Autoscaling Group Windows free-disk-space-low"
+          stat    = "Minimum"
+          yAxis = {
+            left = {
+              showUnits = false,
+              label     = "disk used %"
+            }
+          }
+        }
+      }
+    }
 
     ec2_cwagent_linux = {
       free-disk-space-low = {
@@ -247,7 +287,7 @@ locals {
           view    = "timeSeries"
           stacked = false
           region  = "eu-west-2"
-          title   = "EC2 Autoscaling Group free-disk-space-low"
+          title   = "EC2 Autoscaling Group Linux free-disk-space-low"
           stat    = "Maximum"
           yAxis = {
             left = {


### PR DESCRIPTION
Improve windows EC2 dashboards:
- add disk space per drive and memory widgets to CSR
- add missing windows monitoring to nomis-development
- add disk space per drive widget to ONR
- align planetfm dashboard with CSR, separate DB, app, web tier sections plus DB specific dashboard in prod