### PR TITLE
TM-1540: planetfm: increase ebs throughput on couple of DB drives

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -257,11 +257,11 @@ locals {
           "/dev/sdb"  = { type = "gp3", size = 500 }
           "/dev/sdc"  = { type = "gp3", size = 50 }
           "/dev/sdd"  = { type = "gp3", size = 224 }
-          "/dev/sde"  = { type = "gp3", size = 500 }
+          "/dev/sde"  = { type = "gp3", size = 500, throughput = 175 }
           "/dev/sdf"  = { type = "gp3", size = 100 }
-          "/dev/sdg"  = { type = "gp3", size = 170 } # S: drive
-          "/dev/sdh"  = { type = "gp3", size = 150 } # T: drive
-          "/dev/sdi"  = { type = "gp3", size = 250 } # U: drive
+          "/dev/sdg"  = { type = "gp3", size = 170 }                   # S: drive
+          "/dev/sdh"  = { type = "gp3", size = 150 }                   # T: drive
+          "/dev/sdi"  = { type = "gp3", size = 250, throughput = 175 } # U: drive
         }
         instance = merge(local.ec2_instances.db.instance, {
           disable_api_termination = true


### PR DESCRIPTION
After looking at new dashboards, I can see a couple of drives are flat out, boosting their throughput