### PR TITLE
fix failure alerts in non prod for ftp lambda 

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
+++ b/terraform/environments/ccms-ebs/ccms-ftp-lambda.tf
@@ -231,7 +231,7 @@ module "allpay_ftp_lambda_outbound" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -252,7 +252,7 @@ module "allpay_ftp_lambda_inbound" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -273,7 +273,7 @@ module "LAA-ftp-xerox-ccms-outbound" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -293,7 +293,7 @@ module "LAA-ftp-xerox-ccms-outbound-peterborough" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -313,7 +313,7 @@ module "LAA-ftp-eckoh-outbound-ccms" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -334,7 +334,7 @@ module "LAA-ftp-eckoh-inbound-ccms" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -354,7 +354,7 @@ module "LAA-ftp-rossendales-ccms-inbound" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 }
 
@@ -375,6 +375,6 @@ module "LAA-ftp-1stlocate-ccms-inbound" {
   s3_bucket_ftp                = aws_s3_bucket.buckets["laa-ccms-ftp-lambda-${local.environment}-mp"].bucket
   s3_object_ftp_clientlibs     = aws_s3_object.ftp_lambda_layer.key
   s3_object_ftp_client         = aws_s3_object.ftp_client.key
-  ftp_cron                     = "cron(0 10 * * ? *)"
+  #ftp_cron                     = "cron(0 10 * * ? *)"
   enabled_cron_in_environments = local.enable_cron_in_environments
 } 

--- a/terraform/environments/ccms-ebs/modules/ftp-lambda/main.tf
+++ b/terraform/environments/ccms-ebs/modules/ftp-lambda/main.tf
@@ -132,7 +132,7 @@ resource "aws_lambda_function" "ftp_lambda" {
 resource "aws_cloudwatch_event_rule" "ftp_schedule" {
   count               = contains(var.enabled_cron_in_environments, var.env) ? 1 : 0
   name                = "${var.lambda_name}-schedule"
-  schedule_expression = var.ftp_cron
+  schedule_expression = var.env == "production" ? "cron(0 10 * * ? *)" : "cron(0 10 ? * MON-FRI *)"
 }
 ### cw event lambda target
 resource "aws_cloudwatch_event_target" "ftp_target" {


### PR DESCRIPTION
Failure alerts are triggered in slack channel for non prod over the weekend for ftp lambda when the ftp-server is down. Fix is added to changed the schedule to run from MON-FRI for non prod ONLY