### PR TITLE
Example - Upgrade to Terraform AWS provider version 6

### DIFF
--- a/terraform/environments/example/environment.tf
+++ b/terraform/environments/example/environment.tf
@@ -1,5 +1,5 @@
 module "environment" {
-  source = "../../modules/environment"
+  source = "../../modules/environment_v6"
 
   providers = {
     aws.modernisation-platform = aws.modernisation-platform

--- a/terraform/environments/example/platform_data.tf
+++ b/terraform/environments/example/platform_data.tf
@@ -43,63 +43,63 @@ data "aws_subnets" "shared-public" {
 data "aws_subnet" "data_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "data_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "data_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "private_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "private_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "private_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "public_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "public_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "public_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}c"
   }
 }
 

--- a/terraform/environments/example/versions.tf
+++ b/terraform/environments/example/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {
@@ -21,5 +21,5 @@ terraform {
       version = "~> 3.0"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.0"
 }

--- a/terraform/modules/environment_v6/README.md
+++ b/terraform/modules/environment_v6/README.md
@@ -1,0 +1,54 @@
+# Environment module
+
+Module for grabbing common resources from a modernisation platform environment
+account. This doesn't create any resources. It does output some common data
+resources and local variables which are often needed, such as:
+
+- vpc and subnet ids
+- business unit kms keys
+- domain names
+- route53 zones (top level and business unit specific)
+
+## Pre-requisites
+
+- An application configuration file accessible via http, for example [nomis.json](https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/nomis.json)
+- Business-unit customer-managed keys in the `core-shared-serviced-production` account's KMS, e.g. `general-hmpps`, `ebs-hmpps`, `rds-hmpps`
+- Modernisation platform provided Route53 zones (top level zones in `core-network-services` account and business unit zones in `core-vpc` account)
+
+## Usage
+
+For example:
+
+```terraform
+module "environment" {
+  source = "../../modules/environment"
+
+  providers = {
+    aws.modernisation-platform = aws.modernisation-platform
+    aws.core-network-services  = aws.core-network-services
+    aws.core-vpc               = aws.core-vpc
+  }
+
+  environment_management = local.environment_management
+  business_unit          = local.business_unit
+  application_name       = local.application_name
+  environment            = local.environment
+  subnet_set             = local.subnet_set
+}
+
+# Access business unit CMK
+module.environment.kms_keys["ebs"].arn
+
+# Access business unit environment VPC id
+module.environment.vpc.id
+
+# Access private subnet ids
+module.environment.subnets["private"].ids
+
+# Access application public and/or internal domain name
+module.environment.domains.public.application_environment
+module.environment.domains.internal.application_environment
+
+# Access business unit specific public route53_zone id
+module.environment.route53_zones[module.environment.domains.public.business_unit_environment].id
+```

--- a/terraform/modules/environment_v6/data.tf
+++ b/terraform/modules/environment_v6/data.tf
@@ -1,0 +1,108 @@
+#------------------------------------------------------------------------------
+# Accounts
+#------------------------------------------------------------------------------
+
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  name = "modernisation_platform_account_id"
+}
+
+#------------------------------------------------------------------------------
+# Environment
+#------------------------------------------------------------------------------
+
+# Get environment specific configuration
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${var.application_name}.json"
+}
+
+#------------------------------------------------------------------------------
+# Network
+#------------------------------------------------------------------------------
+
+data "aws_availability_zones" "this" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_vpc" "this" {
+  tags = {
+    Name = local.vpc_name
+  }
+}
+
+data "aws_subnets" "this" {
+  for_each = toset(local.subnet_names[var.subnet_set])
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+  tags = {
+    Name = "${local.vpc_name}-${var.subnet_set}-${each.key}-${var.region}*"
+  }
+}
+
+data "aws_subnet" "this" {
+  for_each = toset(flatten([
+    for subnet_name in local.subnet_names[var.subnet_set] : [
+      for zone_name in data.aws_availability_zones.this.names : "${subnet_name}-${zone_name}"
+    ]
+  ]))
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+  tags = {
+    Name = "${local.vpc_name}-${var.subnet_set}-${each.key}"
+  }
+}
+
+data "aws_route53_zone" "core_network_services" {
+  for_each = { for key, value in local.route53_zones : key => value if value.account == "core-network-services" }
+
+  provider = aws.core-network-services
+
+  name         = "${each.key}."
+  private_zone = each.value.private_zone
+}
+
+data "aws_route53_zone" "core_vpc" {
+  for_each = { for key, value in local.route53_zones : key => value if value.account == "core-vpc" }
+
+  provider = aws.core-vpc
+
+  name         = "${each.key}."
+  private_zone = each.value.private_zone
+}
+
+#------------------------------------------------------------------------------
+# KMS
+#------------------------------------------------------------------------------
+
+data "aws_kms_key" "this" {
+  for_each = local.kms_keys
+  key_id   = each.value
+}
+
+#------------------------------------------------------------------------------
+# Pager Duty
+#------------------------------------------------------------------------------
+
+# Get the map of pagerduty integration keys from the modernisation platform account
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}
+
+# Data source to get the ARN of an existing SNS topic
+data "aws_sns_topic" "backup_failure_topic" {
+  name = "backup_failure_topic"
+}

--- a/terraform/modules/environment_v6/locals.tf
+++ b/terraform/modules/environment_v6/locals.tf
@@ -1,0 +1,93 @@
+locals {
+  vpc_name     = "${var.business_unit}-${var.environment}"    # e.g. hmpps-development
+  account_name = "${var.application_name}-${var.environment}" # e.g. nomis-development
+
+  possible_account_names = [
+    "${var.application_name}-development",
+    "${var.application_name}-test",
+    "${var.application_name}-preproduction",
+    "${var.application_name}-production",
+  ]
+
+  account_ids = merge(var.environment_management.account_ids, {
+    cortex_account_id = var.environment_management.cortex_account_id
+  })
+
+  account_names = flatten([
+    for name in local.possible_account_names : [
+      contains(keys(var.environment_management.account_ids), name) ? [name] : []
+    ]
+  ])
+
+  devtest_account_names = flatten([
+    for name in local.account_names : [
+      endswith(name, "-development") || endswith(name, "-test") ? [name] : []
+    ]
+  ])
+
+  prodpreprod_account_names = flatten([
+    for name in local.account_names : [
+      endswith(name, "-production") || endswith(name, "-preproduction") ? [name] : []
+    ]
+  ])
+
+  subnet_names = {
+    general = ["data", "private", "public"]
+  }
+
+  domains = {
+    public = {
+      modernisation_platform    = "modernisation-platform.service.justice.gov.uk"
+      business_unit_environment = "${var.business_unit}-${var.environment}.modernisation-platform.service.justice.gov.uk"
+      application_environment   = "${var.application_name}.${var.business_unit}-${var.environment}.modernisation-platform.service.justice.gov.uk"
+      short_name                = "${var.application_name}.service.justice.gov.uk"
+    }
+    internal = {
+      modernisation_platform    = "modernisation-platform.internal"
+      business_unit_environment = "${var.business_unit}-${var.environment}.modernisation-platform.internal"
+      application_environment   = "${var.application_name}.${var.business_unit}-${var.environment}.modernisation-platform.internal"
+    }
+  }
+
+  route53_zones = {
+    (local.domains.public.modernisation_platform) = {
+      account      = "core-network-services"
+      private_zone = false
+    }
+    (local.domains.public.business_unit_environment) = {
+      account      = "core-vpc"
+      private_zone = false
+    }
+    (local.domains.internal.modernisation_platform) = {
+      account      = "core-network-services"
+      private_zone = true
+    }
+    (local.domains.internal.business_unit_environment) = {
+      account      = "core-vpc"
+      private_zone = true
+    }
+  }
+
+  kms_keys = {
+    ebs     = "arn:aws:kms:eu-west-2:${local.account_ids.core-shared-services-production}:alias/ebs-${var.business_unit}"
+    general = "arn:aws:kms:eu-west-2:${local.account_ids.core-shared-services-production}:alias/general-${var.business_unit}"
+    rds     = "arn:aws:kms:eu-west-2:${local.account_ids.core-shared-services-production}:alias/rds-${var.business_unit}"
+    s3      = "alias/aws/s3"
+  }
+
+  environments_file   = jsondecode(data.http.environments_file.response_body)
+  environments_access = { for item in local.environments_file.environments : item.name => item.access }
+
+  # environments_file provides application, business-unit, infrastructure-support and owner tags
+  tags = merge(local.environments_file.tags, {
+    is-production    = var.environment == "production" ? "true" : "false"
+    environment-name = local.account_name
+    source-code      = "https://github.com/ministryofjustice/modernisation-platform-environments"
+  })
+
+  subnet_name_availability_zone = [
+    for subnet_name in local.subnet_names[var.subnet_set] : [
+      for zone_name in data.aws_availability_zones.this.names : "${subnet_name}-${zone_name}"
+    ]
+  ]
+}

--- a/terraform/modules/environment_v6/outputs.tf
+++ b/terraform/modules/environment_v6/outputs.tf
@@ -1,0 +1,148 @@
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "business_unit" {
+  description = "name of business unit which is also used as part of the VPC name, e.g. hmpps"
+  value       = var.business_unit
+}
+
+output "account_name" {
+  description = "name of the application account / terraform workspace, e.g. nomis-test"
+  value       = local.account_name
+}
+
+output "account_names" {
+  description = "list of all accounts for the given application, e.g. ['nomis-development', 'nomis-test', 'nomis-preproduction', 'nomis-production']"
+  value       = local.account_names
+}
+
+output "devtest_account_names" {
+  description = "list of all devtest accounts for the given application, e.g. ['nomis-development', 'nomis-test']"
+  value       = local.devtest_account_names
+}
+
+output "prodpreprod_account_names" {
+  description = "list of all prod and preprod accounts for the given application, e.g. ['nomis-preproduction', 'nomis-production']"
+  value       = local.prodpreprod_account_names
+}
+
+output "modernisation_platform_account_id" {
+  description = "id of the modernisation platform account retrieved from local ssm parameter"
+  value       = data.aws_ssm_parameter.modernisation_platform_account_id.value
+}
+
+# account ids are not secret, but are marked as sensitive as they
+# are read from a SecretsManager secret. This can cause problems
+# with terraform (for_each loops) so marking as nonsensitive
+output "account_id" {
+  description = "id of the application account"
+  value       = nonsensitive(local.account_ids[local.account_name])
+}
+
+output "application_name" {
+  description = "name of application, e.g. nomis, oasys etc.."
+  value       = var.application_name
+}
+
+output "environment" {
+  description = "name of environment, e.g. development, test, preproduction, production"
+  value       = var.environment
+}
+
+output "subnet_set" {
+  description = "modernisation platform subnet set, e.g. general"
+  value       = var.subnet_set
+}
+
+output "account_ids" {
+  description = "account id map where the key is the account name and the value is the account id"
+  value       = nonsensitive(local.account_ids)
+}
+
+output "cross_account_secret_account_ids" {
+  description = "account id lookup for cross-account secrets"
+  value = {
+    delius     = try(local.account_ids["delius-core-${var.environment}"], "delius-core-${var.environment}-not-found")
+    delius_mis = try(local.account_ids["delius-mis-${var.environment}"], "delius-mis-${var.environment}-not-found")
+    hmpps_oem  = local.account_ids["hmpps-oem-${var.environment}"]
+    hmpps_domain = (contains(["development", "test"], var.environment) ?
+      local.account_ids["hmpps-domain-services-test"] :
+      local.account_ids["hmpps-domain-services-production"]
+    )
+  }
+}
+
+output "account_root_arns" {
+  description = "account arn map where the key is the account name and the value is the account id"
+  value       = nonsensitive({ for name, id in local.account_ids : name => "arn:aws:iam::${id}:root" })
+}
+
+output "access" {
+  description = "map of access elements found in the environments file json, e.g. nomis.json.  Map keys include github_slug, level, nuke"
+  value       = local.environments_access[var.environment]
+}
+
+output "tags" {
+  description = "map of default tags populated from environments file (application, business-unit, infrastructure-support, owner) and input variables (environment-name, source-code and is-production)"
+  value       = local.tags
+}
+
+output "availability_zones" {
+  description = "availability zones for this account, see aws_availability_zones data object"
+  value       = data.aws_availability_zones.this
+}
+
+output "vpc_name" {
+  description = "name of vpc, e.g. hmpps-development"
+  value       = local.vpc_name
+}
+
+output "vpc" {
+  description = "shared aws_vpc resource"
+  value       = data.aws_vpc.this
+}
+
+output "subnets" {
+  description = "map of aws_subnets resources where the key is the subnet name, e.g. data, private, public"
+  value       = data.aws_subnets.this
+}
+
+output "subnet" {
+  description = "map of individual aws_subnet resources.  first map key is subnet name, second is zone name, e.g. subnet['private']['eu-west-2a']"
+  value = {
+    for subnet_name in local.subnet_names[var.subnet_set] : subnet_name => {
+      for zone_name in data.aws_availability_zones.this.names : zone_name => data.aws_subnet.this["${subnet_name}-${zone_name}"]
+    }
+  }
+}
+
+output "domains" {
+  description = "a map of public and internal domains, e.g. top-level modernisation platform, business unit specific, and application specific"
+  value       = local.domains
+}
+
+output "route53_zones" {
+  description = "a map of aws_route53_zone data objects where the key is the domain name.  The data objects have extra provider field so you know which account they are in"
+  value = merge(
+    { for key, value in data.aws_route53_zone.core_network_services : key => merge(value, { provider = "core-network-services" }) },
+    { for key, value in data.aws_route53_zone.core_vpc : key => merge(value, { provider = "core-vpc" })
+  })
+}
+
+output "kms_keys" {
+  description = "a map of business unit customer-managed keys where the map key is the prefix name, e.g. general, ebs, rds"
+  value       = data.aws_kms_key.this
+}
+
+output "pagerduty_integration_keys" {
+  description = "pagerduty integration keys managed by modernisation platform"
+  value       = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+  sensitive   = true
+}
+
+output "backup_failure_topic" {
+  description = "existing backup failure topic managed by modernisation platform"
+  value       = data.aws_sns_topic.backup_failure_topic
+}

--- a/terraform/modules/environment_v6/variables.tf
+++ b/terraform/modules/environment_v6/variables.tf
@@ -1,0 +1,31 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+# tflint-ignore: terraform_typed_variables
+variable "environment_management" {
+  description = "The json decoded environment_management secret from modernisation-platform account"
+}
+
+variable "business_unit" {
+  description = "name of business unit which is also used as part of the VPC name, e.g. hmpps"
+  type        = string
+}
+
+variable "application_name" {
+  description = "name of application, e.g. nomis, oasys etc.."
+  type        = string
+}
+
+variable "environment" {
+  description = "name of environment, e.g. development, test, preproduction, production"
+  type        = string
+}
+
+variable "subnet_set" {
+  description = "modernisation platform subnet set, e.g. general"
+  type        = string
+  default     = "general"
+}

--- a/terraform/modules/environment_v6/versions.tf
+++ b/terraform/modules/environment_v6/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      version               = "~> 6.0"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.core-vpc, aws.core-network-services, aws.modernisation-platform]
+    }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
**📌 Summary**
This PR introduces a new version of the environment module (`environment_v6`) to support the upgrade to **Terraform AWS Provider v6** in the `Example` environment. This change is isolated to avoid impacting other environments still using provider v5.

**✅ Changes**
- Duplicated `modules/environment` to `modules/environment_v6`
- Refactored `environment_v6` for compatibility with `AWS Provider v6`:
    -Updated deprecated resource arguments and data sources
    - Verified against `AWS Provider v6` upgrade guide
- Updated `environment.tf` in `Example` to use the new module
- Ran `terraform plan` — no changes detected, confirming compatibility

**🧪 Testing**
- ✅ terraform `validate` passed
- ✅ terraform `plan` completed with no changes