### PR TITLE
RST-5550: nginx migration for cloudfront redirects

### DIFF
--- a/terraform/environments/tribunals/cloudfront.tf
+++ b/terraform/environments/tribunals/cloudfront.tf
@@ -15,10 +15,13 @@ resource "aws_cloudfront_distribution" "tribunals_distribution" {
   }
 
   aliases = local.is-production ? [
-    "*.decisions.tribunals.gov.uk",
-    "*.venues.tribunals.gov.uk",
-    "*.reports.tribunals.gov.uk"
-  ] : ["*.${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+  "*.decisions.tribunals.gov.uk",
+  "*.venues.tribunals.gov.uk",
+  "*.reports.tribunals.gov.uk",
+  "siac.tribunal.gov.uk"
+] : ["*.${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+
+
   origin {
     domain_name = aws_lb.tribunals_lb.dns_name
     origin_id   = "tribunalsOrigin"
@@ -53,6 +56,14 @@ resource "aws_cloudfront_distribution" "tribunals_distribution" {
     min_ttl                = 0
     max_ttl                = 31536000
     smooth_streaming       = false
+
+    dynamic "function_association" {
+      for_each = local.is-development ? [] : [1]
+      content {
+        event_type   = "viewer-request"
+        function_arn = aws_cloudfront_function.redirect_function[0].arn
+      }
+    }
   }
 
   enabled         = true
@@ -86,7 +97,7 @@ resource "aws_acm_certificate" "cloudfront" {
   provider                  = aws.us-east-1
   domain_name               = local.is-production ? "*.decisions.tribunals.gov.uk" : "modernisation-platform.service.justice.gov.uk"
   validation_method         = "DNS"
-  subject_alternative_names = local.is-production ? ["*.venues.tribunals.gov.uk", "*.reports.tribunals.gov.uk"] : ["*.${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
+  subject_alternative_names = local.is-production ? ["*.venues.tribunals.gov.uk", "*.reports.tribunals.gov.uk", "siac.tribunals.gov.uk"] : ["*.${var.networking[0].application}.${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk"]
   tags = {
     Environment = local.environment
   }
@@ -271,4 +282,39 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
       override   = true
     }
   }
+}
+
+resource "aws_cloudfront_function" "redirect_function" {
+  count = local.is-development ? 0 : 1
+  name    = "tribunals_redirect_function"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  code    = <<EOF
+  function handler(event) {
+    var request = event.request;
+    var host    = request.headers.host.value;
+    var uri     = request.uri;
+    // Redirect rules for siac.tribunals.gov.uk
+    if (host === "siac.tribunals.gov.uk") {
+      if (uri.toLowerCase() === "/outcomes2007onwards.htm") {
+        return {
+          statusCode: 301,
+          statusDescription: "Moved Permanently",
+          headers: {
+            "location": { "value": "https://siac.decisions.tribunals.gov.uk" }
+          }
+        };
+      }
+      return {
+        statusCode: 301,
+        statusDescription: "Moved Permanently",
+        headers: {
+          "location": { "value": "https://www.gov.uk/guidance/appeal-to-the-special-immigration-appeals-commission" }
+        }
+      };
+    }
+    // Default: Pass through to origin
+    return request;
+  }
+  EOF
 }

--- a/terraform/environments/tribunals/dns-delegate-route53.tf
+++ b/terraform/environments/tribunals/dns-delegate-route53.tf
@@ -40,7 +40,10 @@ locals {
     "charity",
     "consumercreditappeals",
     "estateagentappeals",
-    "fhsaa",
+    "fhsaa"
+  ]
+
+  nginx_records_to_cloudfront = [
     "siac"
   ]
 
@@ -54,6 +57,20 @@ locals {
   ]
 
   production_zone_id = data.aws_route53_zone.production_zone.zone_id
+}
+
+resource "aws_route53_record" "nginx_instances_to_cloudfront" {
+  count    = local.is-production ? length(local.nginx_records_to_cloudfront) : 0
+  provider = aws.core-network-services
+  zone_id  = local.production_zone_id
+  name     = local.nginx_records_to_cloudfront[count.index]
+  type     = "CNAME"
+
+  alias {
+    name                   = aws_cloudfront_distribution.tribunals_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.tribunals_distribution.hosted_zone_id
+    evaluate_target_health = true
+  }
 }
 
 # 'A' records for sftp services currently routed to the existing EC2 Tribunals instance in DSD account via static ip address


### PR DESCRIPTION
This reverts commit 5765160e7a7021b1370aea8b3f97184bdad77107.

Additional changes added to handle http redirect to https