### PR TITLE
TM-1546: enable remaining oracle listener xsiam integration

### DIFF
--- a/terraform/environments/nomis/locals_production.tf
+++ b/terraform/environments/nomis/locals_production.tf
@@ -8,7 +8,8 @@ locals {
 
   baseline_presets_production = {
     options = {
-      enable_xsiam_s3_integration = true
+      enable_xsiam_cloudwatch_integration = true
+      enable_xsiam_s3_integration         = true
       route53_resolver_rules = {
         outbound-data-and-private-subnets = ["azure-fixngo-domain", "infra-int-domain"]
       }

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -2,7 +2,8 @@ locals {
 
   baseline_presets_preproduction = {
     options = {
-      enable_xsiam_s3_integration = true
+      enable_xsiam_cloudwatch_integration = true
+      enable_xsiam_s3_integration         = true
       sns_topics = {
         pagerduty_integrations = {
           pagerduty = "oasys-preproduction"

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -4,8 +4,9 @@ locals {
 
   baseline_presets_production = {
     options = {
-      db_backup_lifecycle_rule    = "rman_backup_one_month"
-      enable_xsiam_s3_integration = true
+      db_backup_lifecycle_rule            = "rman_backup_one_month"
+      enable_xsiam_cloudwatch_integration = true
+      enable_xsiam_s3_integration         = true
 
       sns_topics = {
         pagerduty_integrations = {


### PR DESCRIPTION
Turn on oracle listener xsiam integration for nomis prod and oasys preprod/prod. Already implemented and tested in nomis preprod.