### PR TITLE
🪵 S3 access logging

### DIFF
--- a/terraform/environments/data-platform/aws-s3-access-logging.tf
+++ b/terraform/environments/data-platform/aws-s3-access-logging.tf
@@ -1,9 +1,19 @@
-module "s3_access_logs_kms_key" {
-  source = "github.com/terraform-aws-modules/terraform-aws-kms.git?ref=83e5418372a0716f6dae00ef04eaf42110f9f072" # v4.1.0
-
-  aliases                 = ["s3/mojdp-${local.environment}-s3-access-logs"]
-  enable_default_policy   = true
-  deletion_window_in_days = 7
+data "aws_iam_policy_document" "s3_access_logs_bucket_policy" {
+  statement {
+    sid       = "AllowS3ServerAccessLogs"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::mojdp-${local.environment}-s3-access-logs/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
 }
 
 module "s3_access_logs_s3_bucket" {
@@ -11,13 +21,27 @@ module "s3_access_logs_s3_bucket" {
 
   bucket = "mojdp-${local.environment}-s3-access-logs"
 
-  server_side_encryption_configuration = {
-    rule = {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.s3_access_logs_kms_key.key_arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
+  force_destroy = false
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.s3_access_logs_bucket_policy.json
+
+  object_lock_enabled = false
+
+  versioning = {
+    status = "Disabled"
+  }
+}
+
+module "s3_access_logs_testing_s3_bucket" {
+  source = "github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=c375418373496865e2770ad8aabfaf849d4caee5" # v5.7.0
+
+  bucket = "mojdp-${local.environment}-s3-access-logs-testing"
+
+  force_destroy = true
+
+  logging = {
+    target_bucket = module.s3_access_logs_s3_bucket.s3_bucket_id
+    target_prefix = "${module.s3_access_logs_testing_s3_bucket.s3_bucket_id}/"
   }
 }

--- a/terraform/environments/data-platform/aws-s3-access-logging.tf
+++ b/terraform/environments/data-platform/aws-s3-access-logging.tf
@@ -1,9 +1,13 @@
+locals {
+  s3_access_logs_bucket_name = "mojdp-${local.environment}-s3-access-logs"
+}
+
 data "aws_iam_policy_document" "s3_access_logs_bucket_policy" {
   statement {
     sid       = "AllowS3ServerAccessLogs"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::mojdp-${local.environment}-s3-access-logs/*"]
+    resources = ["arn:aws:s3:::${local.s3_access_logs_bucket_name}/*"]
     principals {
       type        = "Service"
       identifiers = ["logging.s3.amazonaws.com"]
@@ -20,7 +24,7 @@ data "aws_iam_policy_document" "s3_access_logs_bucket_policy" {
 module "s3_access_logs_s3_bucket" {
   source = "github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=c375418373496865e2770ad8aabfaf849d4caee5" # v5.7.0
 
-  bucket = "mojdp-${local.environment}-s3-access-logs"
+  bucket = local.s3_access_logs_bucket_name
 
   force_destroy = false
 

--- a/terraform/environments/data-platform/aws-s3-access-logging.tf
+++ b/terraform/environments/data-platform/aws-s3-access-logging.tf
@@ -1,0 +1,23 @@
+module "s3_access_logs_kms_key" {
+  source = "github.com/terraform-aws-modules/terraform-aws-kms.git?ref=83e5418372a0716f6dae00ef04eaf42110f9f072" # v4.1.0
+
+  aliases                 = ["s3/mojdp-${local.environment}-s3-access-logs"]
+  enable_default_policy   = true
+  deletion_window_in_days = 7
+}
+
+module "s3_access_logs_s3_bucket" {
+  source = "github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=c375418373496865e2770ad8aabfaf849d4caee5" # v5.7.0
+
+  bucket = "mojdp-${local.environment}-s3-access-logs"
+
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = true
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.s3_access_logs_kms_key.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}

--- a/terraform/environments/data-platform/aws-s3-access-logging.tf
+++ b/terraform/environments/data-platform/aws-s3-access-logging.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "s3_access_logs_bucket_policy" {
   }
 }
 
+#trivy:ignore:AVD-AWS-0132: S3 Server Access Logging bucket cannot use SSE-KMS (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
 module "s3_access_logs_s3_bucket" {
   source = "github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=c375418373496865e2770ad8aabfaf849d4caee5" # v5.7.0
 
@@ -27,6 +28,14 @@ module "s3_access_logs_s3_bucket" {
   policy        = data.aws_iam_policy_document.s3_access_logs_bucket_policy.json
 
   object_lock_enabled = false
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   versioning = {
     status = "Disabled"

--- a/terraform/environments/data-platform/aws-s3-access-logging.tf
+++ b/terraform/environments/data-platform/aws-s3-access-logging.tf
@@ -32,16 +32,3 @@ module "s3_access_logs_s3_bucket" {
     status = "Disabled"
   }
 }
-
-module "s3_access_logs_testing_s3_bucket" {
-  source = "github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=c375418373496865e2770ad8aabfaf849d4caee5" # v5.7.0
-
-  bucket = "mojdp-${local.environment}-s3-access-logs-testing"
-
-  force_destroy = true
-
-  logging = {
-    target_bucket = module.s3_access_logs_s3_bucket.s3_bucket_id
-    target_prefix = "${module.s3_access_logs_testing_s3_bucket.s3_bucket_id}/"
-  }
-}


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/data-platform/issues/15

## Proposed Changes

- Creates bucket for S3 server access logging

## Notes

This bucket does not use `SSE-KMS` as per the documentation ([source](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html))

>You can use [default bucket encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html) on the destination bucket only if you use server-side encryption with Amazon S3 managed keys (SSE-S3), which uses the 256-bit Advanced Encryption Standard (AES-256). Default server-side encryption with AWS Key Management Service (AWS KMS) keys (SSE-KMS) is not supported.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>