### PR TITLE
TM-1239: ncr: add cloudwatch alarms

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
@@ -1,7 +1,20 @@
 locals {
 
   cloudwatch_metric_alarms = {
-    bip_app = merge(
+    bip_app_nonprod = merge(
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os, {
+        filesystems-check-error = module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_filesystems_check.filesystems-check-error
+        # don't include the filesystems-check-metric-not-updated as server maybe powered down over weekend
+      }
+    )
+    bip_web_nonprod = merge(
+      module.baseline_presets.cloudwatch_metric_alarms.ec2,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
+    )
+    bip_app_prod = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
@@ -9,7 +22,7 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_filesystems_check,
     )
-    bip_web = merge(
+    bip_web_prod = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,

--- a/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_cloudwatch_metric_alarms.tf
@@ -6,14 +6,15 @@ locals {
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
-      # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app, # add in once there are custom services monitored
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_filesystems_check,
     )
     bip_web = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_cwagent_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_linux,
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_os,
-      # module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app, # add in once there are custom services monitored
+      module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_service_status_app,
     )
     db = merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2,

--- a/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
@@ -3,7 +3,7 @@ locals {
   ec2_instances = {
 
     bip_app = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_nonprod
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-bip"
@@ -52,7 +52,7 @@ locals {
     }
 
     bip_cms = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_nonprod
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-bip"
@@ -101,7 +101,7 @@ locals {
     }
 
     bip_webadmin = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_nonprod
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-web"
@@ -150,7 +150,7 @@ locals {
     }
 
     bip_web = {
-      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_nonprod
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-web"

--- a/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_ec2_instances.tf
@@ -3,6 +3,7 @@ locals {
   ec2_instances = {
 
     bip_app = {
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-bip"
@@ -51,6 +52,7 @@ locals {
     }
 
     bip_cms = {
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-bip"
@@ -99,6 +101,7 @@ locals {
     }
 
     bip_webadmin = {
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-web"
@@ -147,6 +150,7 @@ locals {
     }
 
     bip_web = {
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web
       config = {
         ami_name                  = "base_rhel_8_5_2023-07*" # RHEL 8.8
         iam_resource_names_prefix = "ec2-web"
@@ -194,6 +198,7 @@ locals {
     }
 
     db = {
+      cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.db
       config = {
         ami_name                  = "hmpps_ol_8_5_oracledb_19c_release_2023-08-08T13-49-56.195Z"
         ami_owner                 = "self"

--- a/terraform/environments/nomis-combined-reporting/locals_production.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_production.tf
@@ -35,6 +35,7 @@ locals {
     ec2_instances = {
 
       pd-ncr-app-1 = merge(local.ec2_instances.bip_app, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_app.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_app.config.instance_profile_policies, [
@@ -47,6 +48,7 @@ locals {
         })
       })
       pd-ncr-app-2 = merge(local.ec2_instances.bip_app, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_app.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.bip_app.config.instance_profile_policies, [
@@ -59,6 +61,7 @@ locals {
         })
       })
       pd-ncr-app-3 = merge(local.ec2_instances.bip_app, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_app.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_app.config.instance_profile_policies, [
@@ -71,6 +74,7 @@ locals {
         })
       })
       pd-ncr-app-4 = merge(local.ec2_instances.bip_app, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_app.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.bip_app.config.instance_profile_policies, [
@@ -128,6 +132,7 @@ locals {
       })
 
       pd-ncr-cms-1 = merge(local.ec2_instances.bip_cms, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_cms.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_cms.config.instance_profile_policies, [
@@ -140,6 +145,7 @@ locals {
       })
 
       pd-ncr-cms-2 = merge(local.ec2_instances.bip_cms, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_app_prod
         config = merge(local.ec2_instances.bip_cms.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.bip_cms.config.instance_profile_policies, [
@@ -152,6 +158,7 @@ locals {
       })
 
       pd-ncr-webadmin-1 = merge(local.ec2_instances.bip_webadmin, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_prod
         config = merge(local.ec2_instances.bip_webadmin.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_webadmin.config.instance_profile_policies, [
@@ -164,6 +171,7 @@ locals {
       })
 
       pd-ncr-web-1 = merge(local.ec2_instances.bip_web, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_prod
         config = merge(local.ec2_instances.bip_web.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_web.config.instance_profile_policies, [
@@ -176,6 +184,7 @@ locals {
       })
 
       pd-ncr-web-2 = merge(local.ec2_instances.bip_web, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_prod
         config = merge(local.ec2_instances.bip_web.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.bip_web.config.instance_profile_policies, [
@@ -188,6 +197,7 @@ locals {
       })
 
       pd-ncr-web-3 = merge(local.ec2_instances.bip_web, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_prod
         config = merge(local.ec2_instances.bip_web.config, {
           availability_zone = "eu-west-2a"
           instance_profile_policies = concat(local.ec2_instances.bip_web.config.instance_profile_policies, [
@@ -200,6 +210,7 @@ locals {
       })
 
       pd-ncr-web-4 = merge(local.ec2_instances.bip_web, {
+        cloudwatch_metric_alarms = local.cloudwatch_metric_alarms.bip_web_prod
         config = merge(local.ec2_instances.bip_web.config, {
           availability_zone = "eu-west-2b"
           instance_profile_policies = concat(local.ec2_instances.bip_web.config.instance_profile_policies, [


### PR DESCRIPTION
Add alerting for nomis-combined-reporting in advance of prod cutover
Non-prod alerts cater for the environment being shutdown over weekend.