### PR TITLE
ACM_230925_6

### DIFF
--- a/terraform/environments/ppud/certificates.tf
+++ b/terraform/environments/ppud/certificates.tf
@@ -59,6 +59,8 @@ resource "aws_route53_record" "preprod_dns_record" {
   zone_id = each.value.zone_id
 }
 
+# Commenting out ACM cert validation to give DNS time to propagate, seeing timeout issues with the validation.
+/*
 resource "aws_acm_certificate_validation" "preprod_certificate_validation" {
   for_each = local.is-preproduction ? aws_acm_certificate.preprod_certificates : {}
   certificate_arn = each.value.arn
@@ -71,6 +73,7 @@ resource "aws_acm_certificate_validation" "preprod_certificate_validation" {
     aws_route53_record.preprod_dns_record
   ]
 }
+*/
 
 ########################
 # Production Environment


### PR DESCRIPTION
Removing ACM Cert Validation to allow DNS to fully propagate. Seeing timeout issues.