### PR TITLE
Bump ECR tag

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -122,7 +122,7 @@ module "virus_scan_file" {
   function_name           = "scan"
   is_image                = true
   ecr_repo_name           = "analytical-platform-ingestion-scan"
-  function_tag            = "0.2.0-rc2"
+  function_tag            = "0.2.0-rc3"
   role_name               = aws_iam_role.virus_scan_file.name
   role_arn                = aws_iam_role.virus_scan_file.arn
   ephemeral_storage_size  = 10240


### PR DESCRIPTION
Integration test:
copy files into raw bucket:
<img width="2359" height="243" alt="Screenshot 2025-09-23 at 14 40 52" src="https://github.com/user-attachments/assets/6d23353f-96f3-43cc-aa80-cb4f156cc4bf" />

check lambda works and succeeds (despite having pre-scanned tags):
<img width="1414" height="592" alt="Screenshot 2025-09-23 at 14 39 38" src="https://github.com/user-attachments/assets/ee20aa57-1498-4713-8ed0-c5dcc5242233" />