### PR TITLE
Add volume and attachment for juniper mgmt server

### DIFF
--- a/terraform/environments/youth-justice-networking/ec2.tf
+++ b/terraform/environments/youth-justice-networking/ec2.tf
@@ -394,6 +394,21 @@ resource "aws_instance" "juniper_management" {
   })
 }
 
+resource "aws_ebs_volume" "data_volume" {
+  availability_zone = aws_instance.juniper_management.availability_zone
+  size              = 80
+  type              = "gp3"
+  encrypted         = true
+  tags              = local.tags
+}
+
+resource "aws_volume_attachment" "data_attach" {
+  device_name  = "/dev/sdf"
+  volume_id    = aws_ebs_volume.data_volume.id
+  instance_id  = aws_instance.juniper_management.id
+  force_detach = true
+}
+
 # Add data sources for AMIs
 data "aws_ami" "amazon_linux_2" {
   most_recent = true


### PR DESCRIPTION
## Issue
https://mojdt.slack.com/archives/C01A7QK5VM1/p1758557415451239

## What's changed?
Adding a new volume to the juniper mgmt server. Adding as a seperate resource and attaching that so as not to trigger a rebuild of the server.