### PR TITLE
TM-1239: ncr: monitoring and redundancy improvements

### DIFF
--- a/terraform/environments/nomis-combined-reporting/locals_lbs.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_lbs.tf
@@ -21,12 +21,12 @@ locals {
           health_check = {
             enabled             = true
             healthy_threshold   = 3
-            interval            = 30
+            interval            = 5
             matcher             = "200-399"
             path                = "/keepalive.htm"
             port                = 7777
-            timeout             = 5
-            unhealthy_threshold = 5
+            timeout             = 4
+            unhealthy_threshold = 2
           }
           stickiness = {
             enabled = true
@@ -70,12 +70,12 @@ locals {
           health_check = {
             enabled             = true
             healthy_threshold   = 3
-            interval            = 30
+            interval            = 5
             matcher             = "200-399"
             path                = "/keepalive.htm"
             port                = 7010
-            timeout             = 5
-            unhealthy_threshold = 5
+            timeout             = 4
+            unhealthy_threshold = 2
           }
           stickiness = {
             enabled = true
@@ -88,12 +88,12 @@ locals {
           health_check = {
             enabled             = true
             healthy_threshold   = 3
-            interval            = 30
+            interval            = 5
             matcher             = "200-399"
             path                = "/keepalive.htm"
             port                = 7777
-            timeout             = 5
-            unhealthy_threshold = 5
+            timeout             = 4
+            unhealthy_threshold = 2
           }
           stickiness = {
             enabled = true

--- a/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_preproduction.tf
@@ -309,7 +309,7 @@ locals {
         }
         listeners = merge(local.lbs.private.listeners, {
           http-7777 = merge(local.lbs.private.listeners.http-7777, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [] # don't enable as environments are powered up/down frequently
             rules = {
               web = {
                 priority = 200
@@ -364,7 +364,7 @@ locals {
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [] # don't enable as environments are powered up/down frequently
             rules = {
               webadmin = {
                 priority = 100

--- a/terraform/environments/nomis-combined-reporting/locals_production.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_production.tf
@@ -341,7 +341,9 @@ locals {
         }
         listeners = merge(local.lbs.private.listeners, {
           http-7777 = merge(local.lbs.private.listeners.http-7777, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [
+              "private-pd-http-7777"
+            ]
             rules = {
               web = {
                 priority = 200
@@ -399,7 +401,10 @@ locals {
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [
+              "pd-http-7010",
+              "pd-http-7777",
+            ]
             rules = {
               webadmin = {
                 priority = 100

--- a/terraform/environments/nomis-combined-reporting/locals_test.tf
+++ b/terraform/environments/nomis-combined-reporting/locals_test.tf
@@ -220,7 +220,7 @@ locals {
         }
         listeners = merge(local.lbs.private.listeners, {
           http-7777 = merge(local.lbs.private.listeners.http-7777, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [] # don't enable as environments are powered up/down frequently
             rules = {
               web = {
                 priority = 200
@@ -270,7 +270,7 @@ locals {
         }
         listeners = merge(local.lbs.public.listeners, {
           https = merge(local.lbs.public.listeners.https, {
-            alarm_target_group_names = []
+            alarm_target_group_names = [] # don't enable as environments are powered up/down frequently
             rules = {
               web = {
                 priority = 200


### PR DESCRIPTION
Following operational testing, tweak nomis reporting load balancer health check thresholds so unhealthy hosts detected much quicker. Also enable alerting in prod for unhealthy hosts.