### PR TITLE
TM-1239: ncr: add admin reporting endpoint monitoring

### DIFF
--- a/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
+++ b/terraform/environments/hmpps-oem/locals_cloudwatch_metric_alarms.tf
@@ -45,6 +45,7 @@ locals {
       # nomis-combined-reporting
       nomis-reporting-pp-azure = ["reporting.pp-nomis.az.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
       nomis-reporting-pp-aws   = ["preproduction.reporting.nomis.service.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
+      nomis-reporting-pp-admin = ["admin.preproduction.reporting.nomis.service.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
 
       # oasys
       oasys-pp = ["pp.oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
@@ -79,6 +80,7 @@ locals {
       # nomis-combined-reporting
       nomis-reporting-azure = ["reporting.nomis.az.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
       nomis-reporting-aws   = ["reporting.nomis.service.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
+      nomis-reporting-admin = ["admin.reporting.nomis.service.justice.gov.uk", true, "nomis-combined-reporting-pagerduty"]
 
       # oasys
       oasys          = ["oasys.service.justice.gov.uk", true, "oasys-pagerduty"]
@@ -100,6 +102,8 @@ locals {
     for key, value in local.endpoint_alarms[local.environment] : "endpoint-down-${key}" => merge(
       module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_cwagent_collectd_endpoint_monitoring["endpoint-down"],
       {
+        evaluation_periods  = local.environment == "production" ? "1" : "3"
+        datapoints_to_alarm = local.environment == "production" ? "1" : "3"
         dimensions = {
           type          = "exitcode"
           type_instance = value[0]


### PR DESCRIPTION
Add monitoring for admin reporting endpoint
In production only, try speeding up the detection of failed endpoints. There's already a retry mechanism in the endpoint detection script.