### PR TITLE
dmet-prisons - give data location access to DE SSO roles

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -2,7 +2,7 @@
 locals {
   lf_principals_not_admin = toset(concat(
     [aws_iam_role.dataapi_cross_role.arn],
-    try(data.aws_iam_roles.data_engineering_roles.arns, [])
+    tolist(try(data.aws_iam_roles.data_engineering_roles.arns, toset([])))
   ))
 }
 


### PR DESCRIPTION
The SSO role was previously a Lake Formation (LF) admin. This was removed [here](https://github.com/ministryofjustice/modernisation-platform-environments/commit/cebcef5ed78bfe1058bea711715a933d136b57e6).

The SSO role will need data location access to be able to access LF managed databases.