### PR TITLE
Redirect requests to use HTTPS in MLRA CloudFront 

### DIFF
--- a/terraform/environments/mlra/alb.tf
+++ b/terraform/environments/mlra/alb.tf
@@ -87,7 +87,7 @@ module "alb" {
     forwarded_values_headers                   = ["Authorization", "CloudFront-Forwarded-Proto", "CloudFront-Is-Desktop-Viewer", "CloudFront-Is-Mobile-Viewer", "CloudFront-Is-SmartTV-Viewer", "CloudFront-Is-Tablet-Viewer", "CloudFront-Viewer-Country", "Host", "User-Agent"]
     forwarded_values_cookies_forward           = "whitelist"
     forwarded_values_cookies_whitelisted_names = ["AWSALB", "JSESSIONID"]
-    viewer_protocol_policy                     = "https-only"
+    viewer_protocol_policy                     = "redirect-to-https"
   }
   # Other cache behaviors are processed in the order in which they're listed in the CloudFront console or, if you're using the CloudFront API, the order in which they're listed in the DistributionConfig element for the distribution.
   cloudfront_ordered_cache_behavior = {


### PR DESCRIPTION
Incidents and support requests are sometimes raised by caseworkers that they cannot access MLRA, receiving a HTTP 403 response, which is caused when they navigate to the app over HTTP and not HTTPS.

CloudFront is the front door and the first point of infra within AWS when a request is made by a user to MLRA. The `viewer_protocol_policy` of the CloudFront distribution controls how users can access the origin and the value is currently set to `https-only`, which means that requests not receieved over HTTPS will be rejected outright and there is no opportunity to put in a redirect downstream (say at the load balancer) to redirect to HTTPS, as CloudFront will not call further down the stack.

This PR changes the value for the `viewer_protocol_policy` of the default cache behaviour for the distribution from `https-only` to `redirect-to-https`, which will redirect requests received over HTTP to HTTPS that are not handled by the specific cache behaviours (currently in place for assets -  images, stylesheets and JavaScript files). Only the initial request to MLRA sent over HTTP will need to be redirected to HTTPS, hence only the default behaviour needs to be modified; the remaining asset-specific behaviours can all keep their `viewer_protocol_policy` values of `https-only`.

Tested using Edge, initial request made over HTTP, 307 redirect received (as per the docs linked to below) and all subsequent requests made over HTTPS:

<img width="781" height="728" alt="Screenshot 2025-09-26 at 13 53 34" src="https://github.com/user-attachments/assets/32b5e4f2-d151-404a-a2f3-5691f9a9f7c5" />

Further reading:

[CloudFront docs for redirecting HTTP to HTTPS](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html#configure-cloudfront-HTTPS-viewers).

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3679)