### PR TITLE
☁️ Cloud Platform Network Monitoring

### DIFF
--- a/terraform/environments/analytical-platform-compute/cloudwatch-network-monitor.tf
+++ b/terraform/environments/analytical-platform-compute/cloudwatch-network-monitor.tf
@@ -1,3 +1,4 @@
+# HMCTS SDP
 module "hmcts_sdp_network_monitoring" {
   for_each = local.environment_configuration.hmcts_sdp_endpoints
 
@@ -10,12 +11,46 @@ module "hmcts_sdp_network_monitoring" {
   tags             = local.tags
 }
 
+# HMCTS SDP OneCrown
 module "hmcts_sdp_onecrown_network_monitoring" {
   for_each = local.environment_configuration.hmcts_sdp_onecrown_endpoints
 
   source = "./modules/network-monitoring"
 
   monitor_name     = "hmcts-sdp-onecrown-${each.key}"
+  destination      = each.value.destination
+  destination_port = each.value.destination_port
+  source_arns      = local.private_subnet_arns
+
+  tags = local.tags
+}
+
+# Cloud Platform
+data "dns_a_record_set" "cloud_platform_internal" {
+  for_each = local.environment_configuration.cloud_platform_endpoints
+
+  host = each.value.destination
+}
+
+locals {
+  cloud_platform_endpoints_flattened = merge([
+    for environment, configuration in local.environment_configuration.cloud_platform_endpoints : {
+      for idx, addr in data.dns_a_record_set.cloud_platform_internal[environment].addrs :
+      "${environment}-${idx}" => {
+        environment      = environment
+        destination      = addr
+        destination_port = configuration.destination_port
+      }
+    }
+  ]...)
+}
+
+module "cloud_platform_internal_network_monitoring" {
+  for_each = local.cloud_platform_endpoints_flattened
+
+  source = "./modules/network-monitoring"
+
+  monitor_name     = "cloud-platform-internal-${each.value.environment}-${replace(each.value.destination, ".", "-")}"
   destination      = each.value.destination
   destination_port = each.value.destination_port
   source_arns      = local.private_subnet_arns

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -6,6 +6,7 @@ locals {
       managed_prometheus_kms_access_iam_policy_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-compute-development"]}:policy/managed-prometheus-kms-access20240521093109516600000001"
 
       /* Network Monitoring */
+      cloud_platform_endpoints     = {}
       hmcts_sdp_endpoints          = {}
       hmcts_sdp_onecrown_endpoints = {}
     }
@@ -15,6 +16,17 @@ locals {
       managed_prometheus_kms_access_iam_policy_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-compute-test"]}:policy/managed-prometheus-kms-access20240521093123650600000001"
 
       /* Network Monitoring */
+      cloud_platform_endpoints = {
+        non-prod = {
+          destination      = "ingress.internal-non-prod.cloud-platform.service.justice.gov.uk"
+          destination_port = "443"
+        }
+        prod = {
+          destination      = "ingress.internal.cloud-platform.service.justice.gov.uk"
+          destination_port = "443"
+        }
+      }
+
       hmcts_sdp_endpoints = {
         mipersistentithc-blob = {
           destination      = "10.168.4.13"

--- a/terraform/environments/analytical-platform-compute/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/environment-configuration.tf
@@ -83,6 +83,17 @@ locals {
       managed_prometheus_kms_access_iam_policy_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-compute-production"]}:policy/managed-prometheus-kms-access20240522102621280000000012"
 
       /* Network Monitoring */
+      cloud_platform_endpoints = {
+        non-prod = {
+          destination      = "ingress.internal-non-prod.cloud-platform.service.justice.gov.uk"
+          destination_port = "443"
+        }
+        prod = {
+          destination      = "ingress.internal.cloud-platform.service.justice.gov.uk"
+          destination_port = "443"
+        }
+      }
+
       hmcts_sdp_endpoints = {
         mipersistentithc-blob = {
           destination      = "10.168.4.13"


### PR DESCRIPTION
## Proposed Changes

- Adds a CloudWatch Network Monitor for Cloud Platform's internal ingress

## Notes

The connectivity isn't working, but I think that is out of scope for this

```
analyticalplatform@network-debug:~$ curl --verbose https://ingress.internal-non-prod.cloud-platform.service.justice.gov.uk/
* Host ingress.internal-non-prod.cloud-platform.service.justice.gov.uk:443 was resolved.
* IPv6: (none)
* IPv4: 172.20.143.89, 172.20.95.25, 172.20.103.178
*   Trying 172.20.143.89:443...
*
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>