### PR TITLE
TM-1491: planetfm: temporarily remove 13 and 14 app servers

### DIFF
--- a/terraform/environments/planetfm/locals_production.tf
+++ b/terraform/environments/planetfm/locals_production.tf
@@ -140,59 +140,59 @@ locals {
         })
       })
 
-      pd-cafm-a-12-b = merge(local.ec2_instances.app, {
-        #cloudwatch_metric_alarms = merge(
-        #  local.ec2_instances.app.cloudwatch_metric_alarms,
-        #  module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
-        #)
-        config = merge(local.ec2_instances.app.config, {
-          ami_name          = "pd-cafm-a-12-b"
-          availability_zone = "eu-west-2b"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-          "/dev/sdb"  = { type = "gp3", size = 200 }
-          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
-          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
-        }
-        instance = merge(local.ec2_instances.app.instance, {
-          disable_api_termination = true
-          instance_type           = "t3.xlarge"
-        })
-        tags = merge(local.ec2_instances.app.tags, {
-          ami              = "pd-cafm-a-12-b"
-          description      = "RDS session host and app Server"
-          pre-migration    = "PDFAW0012"
-          update-ssm-agent = "patchgroup2"
-        })
-      })
+      # pd-cafm-a-12-b = merge(local.ec2_instances.app, {
+      #   #cloudwatch_metric_alarms = merge(
+      #   #  local.ec2_instances.app.cloudwatch_metric_alarms,
+      #   #  module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
+      #   #)
+      #   config = merge(local.ec2_instances.app.config, {
+      #     ami_name      #     = "pd-cafm-a-12-b"
+      #     availability_zone = "eu-west-2b"
+      #   })
+      #   ebs_volumes = {
+      #     "/dev/sda1" = { type = "gp3", size = 128 } # root volume
+      #     "/dev/sdb"  = { type = "gp3", size = 200 }
+      #     # "xvde"      # = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+      #     # "xvdf"      # = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
+      #   }
+      #   instance = merge(local.ec2_instances.app.instance, {
+      #     disable_api_termination = true
+      #     instance_type      #      = "t3.xlarge"
+      #   })
+      #   tags = merge(local.ec2_instances.app.tags, {
+      #     ami      #       #   = "pd-cafm-a-12-b"
+      #     description      # = "RDS session host and app Server"
+      #     pre-migration    = "PDFAW0012"
+      #     update-ssm-agent = "patchgroup2"
+      #   })
+      # })
 
-      pd-cafm-a-13-a = merge(local.ec2_instances.app, {
-        #cloudwatch_metric_alarms = merge(
-        #  local.ec2_instances.app.cloudwatch_metric_alarms,
-        #  module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
-        #)
-        config = merge(local.ec2_instances.app.config, {
-          ami_name          = "pd-cafm-a-13-a"
-          availability_zone = "eu-west-2a"
-        })
-        ebs_volumes = {
-          "/dev/sda1" = { type = "gp3", size = 128 } # root volume
-          "/dev/sdb"  = { type = "gp3", size = 28 }
-          # "xvde"      = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
-          # "xvdf"      = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
-        }
-        instance = merge(local.ec2_instances.app.instance, {
-          disable_api_termination = true
-          instance_type           = "t3.xlarge"
-        })
-        tags = merge(local.ec2_instances.app.tags, {
-          ami              = "pd-cafm-a-13-a"
-          description      = "RDS session host and App Server"
-          pre-migration    = "PDFAW0013"
-          update-ssm-agent = "patchgroup1"
-        })
-      })
+      # pd-cafm-a-13-a = merge(local.ec2_instances.app, {
+      #   #cloudwatch_metric_alarms = merge(
+      #   #  local.ec2_instances.app.cloudwatch_metric_alarms,
+      #   #  module.baseline_presets.cloudwatch_metric_alarms.ec2_instance_or_cwagent_stopped_windows
+      #   #)
+      #   config = merge(local.ec2_instances.app.config, {
+      #     ami_name      #     = "pd-cafm-a-13-a"
+      #     availability_zone = "eu-west-2a"
+      #   })
+      #   ebs_volumes = {
+      #     "/dev/sda1" = { type = "gp3", size = 128 } # root volume
+      #     "/dev/sdb"  = { type = "gp3", size = 28 }
+      #     # "xvde"      # = { type = "gp3", size = 6, snapshot_id = "snap-040a13a16f7ffb223" } # Windows 2019 English Installation Media
+      #     # "xvdf"      # = { type = "gp3", size = 6, snapshot_id = "snap-04435aa8246764616" } # Windows 2022 English Installation Media
+      #   }
+      #   instance = merge(local.ec2_instances.app.instance, {
+      #     disable_api_termination = true
+      #     instance_type      #      = "t3.xlarge"
+      #   })
+      #   tags = merge(local.ec2_instances.app.tags, {
+      #     ami      #       #   = "pd-cafm-a-13-a"
+      #     description      # = "RDS session host and App Server"
+      #     pre-migration    = "PDFAW0013"
+      #     update-ssm-agent = "patchgroup1"
+      #   })
+      # })
 
       pd-cafm-a-14-b = merge(local.ec2_instances.app, {
         cloudwatch_metric_alarms = merge(


### PR DESCRIPTION
Terminate app 12 and 13 EC2. These are currently not in use + will be rebuilt from a 2022 image.