### PR TITLE
Refactor transfer-user module for an SG per user

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
@@ -73,14 +73,34 @@ resource "aws_transfer_ssh_key" "this" {
   body      = var.ssh_key
 }
 
-resource "aws_security_group_rule" "this" {
+# Create an aws_security_group per user as part of this module
+resource "aws_security_group" "this" {
+  description = "Security Group for Transfer Server User ${var.name}"
+  name        = "transfer-server-${var.name}"
+  vpc_id      = var.isolated_vpc_id
+  # tags        = local.tags # Not picking this up
+}
+
+# resource "aws_security_group_rule" "this" {
+#   description       = var.name
+#   type              = "ingress"
+#   from_port         = 2222
+#   to_port           = 2222
+#   protocol          = "tcp"
+#   cidr_blocks       = var.cidr_blocks
+#   security_group_id = var.transfer_server_security_group
+# }
+
+# Replace aws_security_group_rule with recommended resource
+resource "aws_vpc_security_group_ingress_rule" "this" {
   description       = var.name
-  type              = "ingress"
   from_port         = 2222
+  ip_protocol       = "tcp"
   to_port           = 2222
-  protocol          = "tcp"
-  cidr_blocks       = var.cidr_blocks
-  security_group_id = var.transfer_server_security_group
+  security_group_id = aws_security_group.this.id
+  # security_group_id = var.transfer_server_security_group
+  for_each          = var.cidr_blocks
+  cidr_ipv4         = each.value
 }
 
 resource "aws_secretsmanager_secret" "this" {

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/variables.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/variables.tf
@@ -6,17 +6,27 @@ variable "ssh_key" {
   type = string
 }
 
+# variable "cidr_blocks" {
+#   type = list(string)
+# }
+
+# cidr_blocks as set; deduplicates at user level
 variable "cidr_blocks" {
-  type = list(string)
+  type = set(string)
 }
 
 variable "transfer_server" {
   type = string
 }
 
-variable "transfer_server_security_group" {
+variable "isolated_vpc_id" {
   type = string
 }
+
+# original
+# variable "transfer_server_security_group" {
+#   type = string
+# }
 
 variable "landing_bucket" {
   type = string

--- a/terraform/environments/analytical-platform-ingestion/transfer-user.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-user.tf
@@ -7,11 +7,12 @@ module "sftp_users" {
   ssh_key     = each.value.ssh_key
   cidr_blocks = each.value.cidr_blocks
 
-  transfer_server                = aws_transfer_server.this.id
-  transfer_server_security_group = aws_security_group.transfer_server.id
-  landing_bucket                 = module.landing_bucket.s3_bucket_id
-  landing_bucket_kms_key         = module.s3_landing_kms.key_arn
-  supplier_data_kms_key          = module.supplier_data_kms.key_arn
+  transfer_server = aws_transfer_server.this.id
+  # transfer_server_security_group = aws_security_group.transfer_server.id # Now created in module
+  isolated_vpc_id        = module.isolated_vpc.vpc_id
+  landing_bucket         = module.landing_bucket.s3_bucket_id
+  landing_bucket_kms_key = module.s3_landing_kms.key_arn
+  supplier_data_kms_key  = module.supplier_data_kms.key_arn
 }
 
 module "sftp_users_with_egress" {


### PR DESCRIPTION
This refactor solves the issue of the duplicate security group rule error, which occurs when two different users want to connect from the same IP address, within the current shared security group. Creating a security group per user also ensures a user can only connect via the CIDR blocks associated with their security group (rather than any allowed CIDR block in the shared SG).

♻️ Refactor `transfer-family/user` module to create a security group per user, and then add those ingress rules to the user's security group
✨ Updates to use `aws_vpc_security_group_ingress_rule` over `aws_security_group_rule` as per [recommendation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)

Not done yet
Made similar change to module `transfer-family/user-with-egress`
Removed creation of shared transfer family security group