### PR TITLE
Fix SQL version and increase disk size

### DIFF
--- a/terraform/environments/equip/main.tf
+++ b/terraform/environments/equip/main.tf
@@ -877,7 +877,7 @@ data "aws_ami" "windows_2022_std_SQL22_ami" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["Windows_Server-2022-English-Full-SQL_2017_Standard*"]
+    values = ["Windows_Server-2022-English-Full-SQL_2022_Standard*"]
   }
   filter {
     name   = "virtualization-type"
@@ -906,7 +906,7 @@ locals {
         {
           device_name = "/dev/sdf"
           volume_type = "gp3"
-          volume_size = 300
+          volume_size = 500
           encrypted   = true
           kms_key_id  = aws_kms_key.this.arn
           tags = merge(local.tags,


### PR DESCRIPTION
This PR updates the AMI to the correct SQL version of 2022 and also increases the second disk to 500GB as per the request from the user.