### PR TITLE
Deduplicate CIDR blocks 

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/security-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/security-groups.tf
@@ -37,7 +37,7 @@ module "transfer_server_security_group" {
   version = "5.3.0"
 
   name        = "${local.application_name}-${local.environment}-transfer-server"
-  description = "To Be Security Group for Transfer Server"
+  description = "Security Group for Transfer Server"
 
   vpc_id = module.isolated_vpc.vpc_id
 


### PR DESCRIPTION
This aims to fix the issue of the duplicate security group rule error by removing the security group rule creation from the transfer-family/user module and deduplicating the list of CIDR blocks  before adding an ingress rule for each.

**Phase 1**
- ✨ Add new SG with ingress rules for each distinct CIDR block (for user and user-with-egress)

Notes
Currently user names are used as the description for the ingress rule and are visible in AWS, but this is not feasible if two users use the same IP address. Concatenating the names is not a solution; if there are many the name gets long and it is disproportionately complex to do for the dubious 'gain'. We can still read which users are linked to which IP addresses in the code.
