### PR TITLE
Update dashboard-service Helm chart version to 0.2.9

### DIFF
--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.2.7"
+  version    = "0.2.9"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.2.6"
+  version    = "0.2.8"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.2.8"
+  version    = "0.2.7"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [


### PR DESCRIPTION
Had to create a 0.2.9 to resolve errors writing to temp files in 0.2.8