### PR TITLE
Dave/tm 1638 fixing patchmanager lambda logs

### DIFF
--- a/terraform/environments/hmpps-domain-services/patch-manager.tf
+++ b/terraform/environments/hmpps-domain-services/patch-manager.tf
@@ -1,7 +1,7 @@
 module "patch_manager" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=4eca903f9b6f8b761add546c48768237877559d6" # v5.0.0 + my branch
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=230b4533d98221100c34a6d881e35776d1958dd9" # v5.0.0 + my branch
   providers = {
     aws.bucket-replication = aws
   }

--- a/terraform/environments/hmpps-domain-services/patch-manager.tf
+++ b/terraform/environments/hmpps-domain-services/patch-manager.tf
@@ -1,7 +1,7 @@
 module "patch_manager" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=cc10bed02c7a55915b6f5c5cd0914e1f5053b73f" # v5.0.0 + my branch
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=fc3933c23da63e914830cc43cec6ad16b2561722" # v5.0.0 + my branch
   providers = {
     aws.bucket-replication = aws
   }

--- a/terraform/environments/hmpps-domain-services/patch-manager.tf
+++ b/terraform/environments/hmpps-domain-services/patch-manager.tf
@@ -1,7 +1,7 @@
 module "patch_manager" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=d72e354b3c544304eef0bfed9660d553031cf5c8" # v5.0.0 + my branch
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=4eca903f9b6f8b761add546c48768237877559d6" # v5.0.0 + my branch
   providers = {
     aws.bucket-replication = aws
   }

--- a/terraform/environments/hmpps-domain-services/patch-manager.tf
+++ b/terraform/environments/hmpps-domain-services/patch-manager.tf
@@ -1,6 +1,7 @@
 module "patch_manager" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
+  # source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=cc10bed02c7a55915b6f5c5cd0914e1f5053b73f" # v5.0.0 + my branch
   providers = {
     aws.bucket-replication = aws
   }
@@ -18,7 +19,6 @@ module "patch_manager" {
   maintenance_window_cutoff   = local.baseline_environment_specific.patch_manager.maintenance_window_cutoff
   maintenance_window_duration = local.baseline_environment_specific.patch_manager.maintenance_window_duration
   patch_classifications       = local.baseline_environment_specific.patch_manager.patch_classifications
+  simple_patching             = true # Optional, Use AWS-RunPatchBaseline directly, instead of AWS-PatchInstanceWithRollback which is a wrapper that adds orchestration and prolific lambda logs.
   tags                        = merge(local.tags, { name = "ssm-patching-module" }, )
 }
-
-

--- a/terraform/environments/hmpps-domain-services/patch-manager.tf
+++ b/terraform/environments/hmpps-domain-services/patch-manager.tf
@@ -1,7 +1,7 @@
 module "patch_manager" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions; this is an internal module so commit hashes are not needed
   # source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=3659b4c4d37d5d71bca0ae9f2760cf3541e8d291" # v4.0.1
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=fc3933c23da63e914830cc43cec6ad16b2561722" # v5.0.0 + my branch
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ssm-patching.git?ref=d72e354b3c544304eef0bfed9660d553031cf5c8" # v5.0.0 + my branch
   providers = {
     aws.bucket-replication = aws
   }

--- a/terraform/environments/hmpps-domain-services/versions.tf
+++ b/terraform/environments/hmpps-domain-services/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.4"
       source  = "hashicorp/http"
     }
     archive = {

--- a/terraform/environments/hmpps-domain-services/versions.tf
+++ b/terraform/environments/hmpps-domain-services/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = ">= 5.100"
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
Adding new parameter to switch out AWS owned patch job to a simple task to avoid all the lambda cloudwatch log groups created by the heavy orchestration.

Use a new branch copy of the module.

Had to loose pin the provider version as MP are moving to v6.0 of the AWS provider and have updated the module.