### PR TITLE
Add null provider to Terraform configuration

### DIFF
--- a/terraform/environments/cooker/versions.tf
+++ b/terraform/environments/cooker/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
   required_version = "~> 1.10"
 }


### PR DESCRIPTION
Include the null provider in the Terraform configuration to fix [error](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/18258490711/job/51983172533#step:7:54)