### PR TITLE
Double volume size on large EC2 instance

### DIFF
--- a/terraform/environments/electronic-monitoring-data/bastion_linux.tf
+++ b/terraform/environments/electronic-monitoring-data/bastion_linux.tf
@@ -196,7 +196,7 @@ module "zip_bastion" {
   subnet_set    = local.subnet_set
   environment   = local.environment
   region        = "eu-west-2"
-  volume_size   = 500
+  volume_size   = 1000
   # tags
   tags_common = local.tags
   tags_prefix = terraform.workspace


### PR DESCRIPTION
[ELM-4040](https://dsdmoj.atlassian.net/browse/ELM-4040)

Doubled volume size again to help with decompression task of larger emsys_mvp zip

Emsys ZIP has gone from 370GB to 473GB in size and the current 500GB storage attached to EC2 will not support this.

Recommend to keep it at increased size until all decompression tasks are completed



[ELM-4040]: https://dsdmoj.atlassian.net/browse/ELM-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ