### PR TITLE
EM: MDSS to 6 retries

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
+++ b/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
@@ -195,6 +195,7 @@ module "load_mdss_event_queue" {
   lambda_function_name = module.load_mdss_lambda[0].lambda_function_name
   bucket_prefix        = local.bucket_prefix
   maximum_concurrency  = 100
+  max_retries          = 6
 }
 
 module "load_fms_event_queue" {

--- a/terraform/environments/electronic-monitoring-data/modules/sqs_s3_lambda_trigger/main.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/sqs_s3_lambda_trigger/main.tf
@@ -13,7 +13,7 @@ resource "aws_sqs_queue" "s3_event_queue" {
   visibility_timeout_seconds = (15 * 60) + 1 # lambda execution time plus 1
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.s3_event_dlq.arn
-    maxReceiveCount     = 2
+    maxReceiveCount     = var.max_retries - 1
   })
   sqs_managed_sse_enabled = true
 }

--- a/terraform/environments/electronic-monitoring-data/modules/sqs_s3_lambda_trigger/variables.tf
+++ b/terraform/environments/electronic-monitoring-data/modules/sqs_s3_lambda_trigger/variables.tf
@@ -23,3 +23,9 @@ variable "maximum_concurrency" {
   default     = 10
   nullable    = true
 }
+
+variable "max_retries" {
+  description = "max number of retries before failure"
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
Up the number of retries in MDSS to 6 retries, by increasing mdss sqs queue max number of messages to 5.

This will increase the time to an hour and half from 45 mins. So we won't see true failures until 90 mins after.