### PR TITLE
:copilot: chore(terraform): update module versions in `analytical-platform-common`

### DIFF
--- a/terraform/environments/analytical-platform-common/dynamodb-tables.tf
+++ b/terraform/environments/analytical-platform-common/dynamodb-tables.tf
@@ -3,7 +3,7 @@ module "analytical_platform_airflow_auto_approval_dynamodb_table" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/dynamodb-table/aws"
-  version = "4.4.0"
+  version = "5.5.0"
 
   name         = "analytical-platform-airflow-auto-approval"
   billing_mode = "PAY_PER_REQUEST"

--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -72,7 +72,7 @@ module "ecr_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name_prefix = "ecr-access"
 
@@ -115,7 +115,7 @@ module "analytical_platform_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name_prefix = "analytical-platform-terraform"
 
@@ -176,7 +176,7 @@ module "analytical_platform_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name_prefix = "analytical-platform-github-actions"
 
@@ -212,7 +212,7 @@ module "data_engineering_datalake_access_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name_prefix = "data-engineering-datalake-access-github-actions"
 
@@ -255,7 +255,7 @@ module "data_engineering_datalake_access_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name_prefix = "data-engineering-datalake-access-terraform"
 

--- a/terraform/environments/analytical-platform-common/iam-roles.tf
+++ b/terraform/environments/analytical-platform-common/iam-roles.tf
@@ -3,7 +3,7 @@ module "ecr_access_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name = "ecr-access"
 
@@ -24,7 +24,7 @@ module "analytical_platform_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name = "analytical-platform-github-actions"
 
@@ -42,7 +42,7 @@ module "analytical_platform_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.59.0"
+  version = "5.60.0"
 
   create_role = true
 
@@ -61,7 +61,7 @@ module "data_engineering_datalake_access_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.59.0"
+  version = "5.60.0"
 
   name = "data-engineering-datalake-access-github-actions"
 
@@ -79,7 +79,7 @@ module "data_engineering_datalake_access_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.59.0"
+  version = "5.60.0"
 
   create_role = true
 

--- a/terraform/environments/analytical-platform-common/kms-keys.tf
+++ b/terraform/environments/analytical-platform-common/kms-keys.tf
@@ -3,7 +3,7 @@ module "ecr_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["ecr/default"]
   description           = "ECR default KMS key"
@@ -19,7 +19,7 @@ module "terraform_s3_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["s3/terraform"]
   description           = "S3 Terraform KMS key"
@@ -35,7 +35,7 @@ module "secrets_manager_common_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["secretsmanager/common"]
   description           = "Secrets Manager Common KMS key"

--- a/terraform/environments/analytical-platform-common/observability.tf
+++ b/terraform/environments/analytical-platform-common/observability.tf
@@ -11,7 +11,7 @@ module "observability_platform_tenant" {
 }
 
 module "analytical_platform_observability" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=81b051e4ab8c19442a091599ad9ed21e9a610661" # 3.0.0
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=4b9c9013bff6035e8e3b77a00d124e62bbb4de56" # 4.2.0
 
   enable_aws_xray_read_only_access = true
 

--- a/terraform/environments/analytical-platform-common/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-common/s3-buckets.tf
@@ -3,7 +3,7 @@ module "terraform_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.2.0"
+  version = "5.10.0"
 
   bucket = "mojap-common-${local.environment}-tfstate"
 

--- a/terraform/environments/analytical-platform-common/secrets.tf
+++ b/terraform/environments/analytical-platform-common/secrets.tf
@@ -3,7 +3,7 @@ module "analytical_platform_compute_cluster_data_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.0.1"
+  version = "2.1.0"
 
   name       = "analytical-platform-compute/cluster-data"
   kms_key_id = module.secrets_manager_common_kms.key_arn
@@ -21,7 +21,7 @@ module "airflow_github_app_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.0.1"
+  version = "2.1.0"
 
   name        = "github/airflow-github-app"
   description = "https://github.com/ministryofjustice/analytical-platform-airflow"


### PR DESCRIPTION
## Terraform Module Updates

| Module | Old Version | New Version | Notes |
| ------ | ----------- | ----------- | ----- |
| [terraform-aws-modules/dynamodb-table/aws](https://registry.terraform.io/modules/terraform-aws-modules/dynamodb-table/aws) | [4.4.0](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/releases/tag/v4.4.0) | [5.5.0](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/releases/tag/v5.5.0) | ℹ️ Major version bump (see below) |
| [terraform-aws-modules/iam/aws](https://registry.terraform.io/modules/terraform-aws-modules/iam/aws) | [5.59.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.59.0) | [5.60.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.60.0) | ⚠️ v6.x skipped - breaking changes |
| [terraform-aws-modules/s3-bucket/aws](https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws) | [5.2.0](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/releases/tag/v5.2.0) | [5.10.0](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/releases/tag/v5.10.0) | |
| [terraform-aws-modules/secrets-manager/aws](https://registry.terraform.io/modules/terraform-aws-modules/secrets-manager/aws) | [2.0.1](https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/releases/tag/v2.0.1) | [2.1.0](https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/releases/tag/v2.1.0) | |
| [terraform-aws-modules/kms/aws](https://registry.terraform.io/modules/terraform-aws-modules/kms/aws) | [4.0.0](https://github.com/terraform-aws-modules/terraform-aws-kms/releases/tag/v4.0.0) | [4.2.0](https://github.com/terraform-aws-modules/terraform-aws-kms/releases/tag/v4.2.0) | |
| [ministryofjustice/observability-platform-tenant/aws](https://registry.terraform.io/modules/ministryofjustice/observability-platform-tenant/aws) | [2.0.0](https://github.com/ministryofjustice/modernisation-platform-terraform-observability-platform-tenant/releases/tag/v2.0.0) | 2.0.0 | Already latest |
| [ministryofjustice/terraform-aws-analytical-platform-observability](https://github.com/ministryofjustice/terraform-aws-analytical-platform-observability) | [3.0.0](https://github.com/ministryofjustice/terraform-aws-analytical-platform-observability/releases/tag/3.0.0) | [4.2.0](https://github.com/ministryofjustice/terraform-aws-analytical-platform-observability/releases/tag/4.2.0) | ℹ️ Major version bump (see below) |

### Skipped Updates

- **terraform-aws-modules/iam/aws v6.x**: Breaking changes include submodule restructuring - `iam-assumable-role` renamed to `iam-role`, `iam-github-oidc-role` merged into `iam-role`, `iam-assumable-roles` removed. Updated to latest 5.x (5.60.0) instead.

### Breaking Changes Avoided

- **terraform-aws-modules/iam/aws v6.x**:
  - Submodules have been renamed/merged: `iam-assumable-role` → `iam-role`, `iam-github-oidc-role` → merged into `iam-role`
  - Several submodules removed entirely: `iam-assumable-roles`, `iam-assumable-roles-with-saml`, `iam-eks-role`
  - Variable restructuring and trust policy changes
  - Upgrade guide: https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/docs/UPGRADE-6.0.md
  - Migration would require renaming all module sources and updating variable structures

### Major Version Bumps Applied

- **terraform-aws-modules/dynamodb-table/aws v5.x**: Only breaking change is AWS provider v6.3 minimum requirement (already satisfied by this environment which uses `~> 6.0`)
- **ministryofjustice/terraform-aws-analytical-platform-observability v4.x**: Only breaking change is AWS provider v6.0 minimum requirement (already satisfied by this environment)