### PR TITLE
chore(analytical-platform-ingestion): update Terraform modules

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
+++ b/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
@@ -2,7 +2,7 @@ module "datasync_instance" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "6.0.1"
+  version = "6.2.0"
 
   name = "${local.application_name}-${local.environment}-datasync"
   # ami                    = data.aws_ssm_parameter.datasync_ami.value

--- a/terraform/environments/analytical-platform-ingestion/observability.tf
+++ b/terraform/environments/analytical-platform-ingestion/observability.tf
@@ -11,7 +11,7 @@ module "observability_platform_tenant" {
 }
 
 module "analytical_platform_observability" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=81b051e4ab8c19442a091599ad9ed21e9a610661" # 3.0.0
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=4.2.0"
 
   enable_aws_xray_read_only_access = true
 

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -2,7 +2,7 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/route53/aws//modules/resolver-endpoints"
-  version = "5.0.0"
+  version = "6.4.0"
 
   name      = "connected-vpc-outbound"
   vpc_id    = module.connected_vpc.vpc_id

--- a/terraform/environments/analytical-platform-ingestion/vpc.tf
+++ b/terraform/environments/analytical-platform-ingestion/vpc.tf
@@ -2,7 +2,7 @@ module "connected_vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.0.1"
+  version = "6.6.0"
 
   name            = "${local.application_name}-${local.environment}-connected"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -26,7 +26,7 @@ module "isolated_vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.0.1"
+  version = "6.6.0"
 
   name            = "${local.application_name}-${local.environment}-isolated"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
## Changes

- Update terraform-aws-modules/vpc/aws from 6.0.1 to 6.6.0
- Update terraform-aws-modules/route53/aws from 5.0.0 to 6.4.0
- Update terraform-aws-modules/ec2-instance/aws from 6.0.1 to 6.2.0
- Update terraform-aws-analytical-platform-observability from 3.0.0 to 4.2.0

All modules updated to their latest stable versions.