### PR TITLE
feat: resize `analytical-platform-ingestion` Datasync instance to `m6i.xlarge`

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
+++ b/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
@@ -7,7 +7,7 @@ module "datasync_instance" {
   name = "${local.application_name}-${local.environment}-datasync"
   # ami                    = data.aws_ssm_parameter.datasync_ami.value
   ami                    = "ami-037ee8c0ba1cbd1f6" # TODO: Remove hardcoded AMI
-  instance_type          = "m5.2xlarge"
+  instance_type          = "m6i.xlarge"
   subnet_id              = element(module.connected_vpc.private_subnets, 0)
   vpc_security_group_ids = [module.datasync_instance_security_group.security_group_id]
   create_security_group  = false


### PR DESCRIPTION
## Summary

This PR resizes the DataSync EC2 instance in `analytical-platform-ingestion` from `m5.2xlarge` to `m6i.xlarge` for cost optimisation.

## Cost Savings

| Change | Monthly Savings | Annual Savings |
|--------|-----------------|----------------|
| Per environment (dev or prod) | $151/month | $1,812/year |
| **Both environments (dev + prod)** | **$302/month** | **$3,624/year** |

## Changes

- Updated `instance_type` from `m5.2xlarge` to `m6i.xlarge` in [ec2-instances.tf](terraform/environments/analytical-platform-ingestion/ec2-instances.tf)

## Why m6i.xlarge instead of r6g.xlarge?

⚠️ **Architecture Compatibility**: AWS DataSync agent AMIs are **x86_64 only**. The `r6g` instance family uses ARM64 (Graviton2) architecture, which is incompatible with the DataSync agent AMI.

| Instance Type | Architecture | Compatibility | Pricing |
|---------------|--------------|---------------|---------|
| [m5.2xlarge](https://instances.vantage.sh/aws/ec2/m5.2xlarge?currency=USD&region=eu-west-2&duration=annually) (current) | x86_64 | ✅ Compatible | ~$280/month |
| [**m6i.xlarge**](https://instances.vantage.sh/aws/ec2/m6i.xlarge?currency=USD&region=eu-west-2&duration=annually) (proposed) | x86_64 | ✅ Compatible | ~$140/month |
| [r6g.xlarge](https://instances.vantage.sh/aws/ec2/r6g.xlarge?currency=USD&region=eu-west-2&duration=annually) | ARM64 | ❌ Not compatible with DataSync AMI | - |

The `m6i` instance family:
- Uses Intel Ice Lake processors (x86_64)
- Provides up to 15% better compute performance than m5
- Maintains full compatibility with the existing DataSync agent AMI