### PR TITLE
ABC

### DIFF
--- a/terraform/environments/analytical-platform-common/kms-keys.tf
+++ b/terraform/environments/analytical-platform-common/kms-keys.tf
@@ -35,7 +35,7 @@ module "secrets_manager_common_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
 
   aliases               = ["secretsmanager/common"]
   description           = "Secrets Manager Common KMS key"


### PR DESCRIPTION
## Summary

Updates the `secrets_manager_common_kms` module in the analytical-platform-common environment from version 4.1.0 to 4.2.0.

## Changes

- Updated `terraform-aws-modules/kms/aws` module version from `4.1.0` to `4.2.0` for the `secrets_manager_common_kms` resource
- This aligns the module version with the other KMS modules (`ecr_kms` and `terraform_s3_kms`) in the same file

## Reason

Keeping modules up to date ensures we have the latest bug fixes, security patches, and features.