### PR TITLE
feat: add Headlamp with Karpenter plugin to compute cluster

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -34,6 +34,7 @@ locals {
         kube_prometheus_stack  = "81.1.0"
         kyverno                = "3.6.2"
         velero                 = "11.3.2"
+        headlamp               = "0.40.0"
       }
 
       /* Data Engineering Airflow */
@@ -74,6 +75,7 @@ locals {
         kube_prometheus_stack  = "81.1.0"
         kyverno                = "3.6.2"
         velero                 = "11.3.2"
+        headlamp               = "0.40.0"
       }
 
       /* Data Engineering Airflow */
@@ -114,6 +116,7 @@ locals {
         kube_prometheus_stack  = "81.1.0"
         kyverno                = "3.6.2"
         velero                 = "11.3.2"
+        headlamp               = "0.40.0"
       }
 
       /* Data Engineering Airflow */

--- a/terraform/environments/analytical-platform-compute/cluster/helm-charts-system.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/helm-charts-system.tf
@@ -341,3 +341,22 @@ resource "helm_release" "velero" {
     )
   ]
 }
+
+/* Headlamp */
+resource "helm_release" "headlamp" {
+  /* https://artifacthub.io/packages/helm/headlamp/headlamp */
+  name       = "headlamp"
+  repository = "https://kubernetes-sigs.github.io/headlamp/"
+  chart      = "headlamp"
+  version    = local.environment_configuration.helm_chart_version.headlamp
+  namespace  = kubernetes_namespace.headlamp.metadata[0].name
+  values = [
+    templatefile(
+      "${path.module}/src/helm/values/headlamp/values.yml.tftpl",
+      {
+        headlamp_hostname = "headlamp.${local.environment_configuration.route53_zone}"
+      }
+    )
+  ]
+  depends_on = [helm_release.ingress_nginx]
+}

--- a/terraform/environments/analytical-platform-compute/cluster/kubernetes-namespaces.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/kubernetes-namespaces.tf
@@ -57,3 +57,9 @@ resource "kubernetes_namespace" "velero" {
     name = "velero"
   }
 }
+
+resource "kubernetes_namespace" "headlamp" {
+  metadata {
+    name = "headlamp"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/cluster/src/helm/values/headlamp/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/cluster/src/helm/values/headlamp/values.yml.tftpl
@@ -1,0 +1,30 @@
+---
+config:
+  inCluster: true
+  pluginsDir: "/headlamp/plugins"
+
+clusterRoleBinding:
+  create: true
+  clusterRoleName: cluster-admin
+
+pluginsManager:
+  enabled: true
+  configContent: |
+    plugins:
+      - name: "@headlamp-k8s/karpenter"
+        source: https://github.com/headlamp-k8s/plugins/releases/download/karpenter-0.2.0/headlamp-k8s-karpenter-0.2.0.tar.gz
+
+ingress:
+  enabled: true
+  ingressClassName: "default"
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production-http01
+  hosts:
+    - host: ${headlamp_hostname}
+      paths:
+        - path: /
+          type: ImplementationSpecific
+  tls:
+    - secretName: headlamp-tls
+      hosts:
+        - ${headlamp_hostname}


### PR DESCRIPTION
## What

Deploy [Headlamp](https://headlamp.dev/) Kubernetes dashboard with the [Karpenter plugin](https://github.com/headlamp-k8s/plugins/tree/main/karpenter) to the analytical-platform-compute cluster.

## Why

Improve visibility of spot instances and Karpenter autoscaling decisions in the compute cluster.

Relates to: ministryofjustice/data-platform#283

## Changes

| File | Change |
|------|--------|
| `kubernetes-namespaces.tf` | Add `headlamp` namespace |
| `environment-configuration.tf` | Add `headlamp = \"0.40.0\"` chart version to all environments |
| `helm-charts-system.tf` | Add `helm_release.headlamp` resource |
| `src/helm/values/headlamp/values.yml.tftpl` | New values template with ingress, Karpenter plugin via pluginsManager sidecar |

## How it works

- Headlamp is deployed via its official Helm chart (`https://kubernetes-sigs.github.io/headlamp/`)
- The Karpenter plugin (v0.2.0) is installed via the built-in `pluginsManager` sidecar
- Ingress is configured at `headlamp.<route53_zone>` with TLS via cert-manager
- Uses a `cluster-admin` ClusterRoleBinding (can be scoped down later)
- No OIDC authentication configured initially

## Follow-up considerations

- [ ] Scope down RBAC from `cluster-admin` to a read-only ClusterRole
- [ ] Add OIDC authentication ~(Auth0 integration like dashboard-service)~
- [ ] ~Consider adding the [OpenCost plugin](https://github.com/headlamp-k8s/plugins/tree/main/opencost) for cost visibility"~ 