### PR TITLE
amended reusable terraform workflow to accept environment override

### DIFF
--- a/.github/workflows/analytical-platform-compute.yml
+++ b/.github/workflows/analytical-platform-compute.yml
@@ -53,6 +53,7 @@
         # Pass along the "application" and "environment" from the matrix
         application: "${{ github.workflow }}"
         environment: "${{ matrix.target }}"
+        account_environment_override: "${{ matrix.target == 'internal-development' && 'development' || '' }}"  # If the target environment is internal-development, use development for AWS account lookup, otherwise use the target environment
         action: "${{ matrix.action }}"
         component: "${{ matrix.component }}"      # If your strategy workflow also outputs "matrix.component"
       secrets:

--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -12,6 +12,11 @@
             type: string
             required: true
             description: "Name of the environment, e.g. development"
+          account_environment_override:
+            type: string
+            required: false
+            description: "Optional account environment override for AWS account lookup"
+            default: ""
           action:
             type: string
             required: false
@@ -49,7 +54,7 @@
             required: true
 
     env:
-      ACCOUNT_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
+      ACCOUNT_NAME: "${{ inputs.application }}-${{ inputs.account_environment_override != '' && inputs.account_environment_override || inputs.environment }}"
       WORKSPACE_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
       SKIP_PLAN_EVALUATOR: '["cloud-platform-development", "data-platform-development", "data-platform-test", "data-platform-preproduction", "data-platform-production"]'
     concurrency:

--- a/terraform/environments/analytical-platform-compute/airflow/data.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/data.tf
@@ -9,7 +9,7 @@ data "dns_a_record_set" "mwaa_webserver_vpc_endpoint" {
 # APC VPC
 data "aws_vpc" "apc_vpc" {
   tags = {
-    "Name" = "${var.networking[0].application}-${local.environment}"
+    "Name" = "${var.networking[0].application}-${local.mapped_environment}"
   }
 }
 
@@ -19,7 +19,7 @@ data "aws_subnets" "apc_public_subnets" {
     values = [data.aws_vpc.apc_vpc.id]
   }
   tags = {
-    Name = "${var.networking[0].application}-${local.environment}-public*"
+    Name = "${var.networking[0].application}-${local.mapped_environment}-public*"
   }
 }
 
@@ -29,7 +29,7 @@ data "aws_subnet" "apc_private_subnet_a" {
     values = [data.aws_vpc.apc_vpc.id]
   }
   tags = {
-    Name = "${var.networking[0].application}-${local.environment}-private-${data.aws_region.current.region}a"
+    Name = "${var.networking[0].application}-${local.mapped_environment}-private-${data.aws_region.current.region}a"
   }
 }
 
@@ -39,7 +39,7 @@ data "aws_subnet" "apc_private_subnet_b" {
     values = [data.aws_vpc.apc_vpc.id]
   }
   tags = {
-    Name = "${var.networking[0].application}-${local.environment}-private-${data.aws_region.current.region}b"
+    Name = "${var.networking[0].application}-${local.mapped_environment}-private-${data.aws_region.current.region}b"
   }
 }
 

--- a/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
@@ -1,5 +1,18 @@
 locals {
   environment_configurations = {
+    internal-development = {
+      /* Route53 */
+      route53_zone = "compute.development.analytical-platform.service.justice.gov.uk"
+
+      /* MWAA */
+      airflow_version                 = "2.10.3"
+      airflow_environment_class       = "mw1.large"
+      airflow_webserver_instance_name = "Internal_Development"
+      airflow_max_workers             = 10
+      airflow_min_workers             = 2
+      airflow_schedulers              = 2
+      airflow_celery_worker_autoscale = "7,1"
+    }
     development = {
       /* Route53 */
       route53_zone = "compute.development.analytical-platform.service.justice.gov.uk"

--- a/terraform/environments/analytical-platform-compute/airflow/locals.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/locals.tf
@@ -1,5 +1,8 @@
 locals {
-  eks_cluster_name = "${local.application_name}-${local.environment}"
+  /* internal-development needs to use development network resources and EKS, so here we map it to the development environment */
+  mapped_environment = local.environment == "internal-development" ? "development" : local.environment
+
+  eks_cluster_name = "${local.application_name}-${local.mapped_environment}"
 
   /* Environment Configuration */
   environment_configuration = local.environment_configurations[local.environment]

--- a/terraform/environments/analytical-platform-compute/airflow/platform_locals.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/platform_locals.tf
@@ -10,10 +10,11 @@ locals {
 
   # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
   # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
-  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
-  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
-  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
-  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+  is-production           = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction        = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test                 = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+  is-internal-development = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-internal-development"
 
   # Merge tags from the environment json file with additional ones
   tags = merge(

--- a/terraform/environments/analytical-platform-compute/airflow/src/airflow/local-settings/internal-development/airflow_local_settings.py
+++ b/terraform/environments/analytical-platform-compute/airflow/src/airflow/local-settings/internal-development/airflow_local_settings.py
@@ -1,0 +1,9 @@
+from airflow.www.utils import UIAlert
+
+DASHBOARD_UIALERTS = [
+    UIAlert(
+        'Analytical Platform Airflow Service',
+        category="info",
+        html=True,
+    )
+]


### PR DESCRIPTION
We need to spin up a new mwaa instance in the analytical-platform-compute-dev AWS account. The instance needs to use the Development networking resources and the Development EKS. 
We want to do this using a new workspace: analytical-platform-compute-internal-development, and use Terraform conditional expressions for minimal code changes.

The issue we have is with the workspace/account mapping in the reusable terraform workflow, which uses the logic of workspace = account. 
To get around this we would like to introduce and `account_environment_override` argument to the reusable terraform workflow. 
The updates to the reusable Terraform workflow maintain its environment-agnostic design and ensure the change is not specific to AP
                                                                                                                                               