### PR TITLE
Upgrading the eks helm charts

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -115,24 +115,24 @@ locals {
 
       helm_chart_version = {
         aws_cloudwatch_metrics = "0.0.11"
-        aws_for_fluent_bit     = "0.1.35"
+        aws_for_fluent_bit     = "0.2.0"
         cert_manager           = "v1.19.2"
-        cluster_autoscaler     = "9.54.1"
+        cluster_autoscaler     = "9.56.0"
         external_dns           = "1.20.0"
-        external_secrets       = "1.2.1"
+        external_secrets       = "2.2.0"
         ingress_nginx          = "4.15.0"
-        karpenter              = "1.8.5"
+        karpenter              = "1.10.0"
         keda                   = "2.18.3"
-        kube_prometheus_stack  = "81.1.0"
+        kube_prometheus_stack  = "82.16.0"
         kyverno                = "3.6.2"
-        velero                 = "11.3.2"
+        velero                 = "12.0.0"
       }
 
       /* Velero */
-      velero_aws_plugin_version = "v1.13.2"
+      velero_aws_plugin_version = "v1.14.0"
 
       /* Kube Prometheus Stack */
-      prometheus_operator_crd_version = "v0.88.0"
+      prometheus_operator_crd_version = "v0.89.0"
 
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-prod-execution-role"


### PR DESCRIPTION
MR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9517) ticket.

Upgrade Helm charts and related components for the analytical-platform-compute prod.

**Version changes**

- aws-for-fluent-bit: 0.1.35 → 0.2.0
- cluster-autoscaler: 9.54.1 → 9.56.0
- external-secrets: 1.2.1 → 2.2.0
- karpenter: 1.8.5 → 1.10.0
- kube-prometheus-stack: 81.1.0 → 82.16.0
- velero (Helm chart): 11.3.2 → 12.0.0
- velero AWS plugin: v1.13.2 → v1.14.0
- prometheus-operator CRDs: v0.88.0 → v0.89.0