### PR TITLE
Update role-to-assume for Terraform state management workflow

### DIFF
--- a/.github/workflows/terraform-state-management.yml
+++ b/.github/workflows/terraform-state-management.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
           role-session-name: githubactionsrolesession
           aws-region: "eu-west-2"
 


### PR DESCRIPTION
## Issue

Raised in ask channel https://mojdt.slack.com/archives/C01A7QK5VM1/p1775743477813599

The state management workflow is broken as the `github-actions` role has been decomissioned.

## Changes

Updated workflow to use the new `github-actions-plan` role.

This worked when tested on branch here: https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/24195349185/job/70624183931#step:7:3

