### PR TITLE
CDI-323 set AMI for restore

### DIFF
--- a/terraform/environments/cica-tariff/tariff_ec2_app_poc.tf
+++ b/terraform/environments/cica-tariff/tariff_ec2_app_poc.tf
@@ -2,7 +2,8 @@
 resource "aws_instance" "tariff_app_dev_poc_clone" {
   count = local.environment == "development" ? 1 : 0
   # ami   = "ami-079bedd5037ad8609"
-  ami = "ami-044bcc0b671b75b6e" # CDI-319: restore from backup
+  # ami = "ami-044bcc0b671b75b6e" # CDI-319: restore from backup
+  ami = "ami-0b1782be4891b79a6" # CDI-323: restore from backup
   #Ignore changes to most recent ami from data filter, as this would destroy existing instance.
   lifecycle {
     ignore_changes = [user_data] # ami removed to allow restore


### PR DESCRIPTION
This pull request updates the Amazon Machine Image (AMI) used for the `tariff_app_dev_poc_clone` EC2 instance in the development environment. The change is intended to restore from a new backup as part of CDI-323, replacing the previous backup image.

Infrastructure update:

* Updated the `ami` value in `terraform/environments/cica-tariff/tariff_ec2_app_poc.tf` to use `ami-0b1782be4891b79a6` for restoring from a new backup (CDI-323), and commented out the previous AMI used for CDI-319.