### PR TITLE
Update OIDC role to github-actions-apply

### DIFF
--- a/.github/workflows/terraform-state-management.yml
+++ b/.github/workflows/terraform-state-management.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-apply"
           role-session-name: githubactionsrolesession
           aws-region: "eu-west-2"
 


### PR DESCRIPTION
The plan role does not have permissions to put objects into S3, which is causing the import operation to fail. Updating to github-actions-apply should resolve the issue.

https://mojdt.slack.com/archives/C01A7QK5VM1/p1775839716723299