### PR TITLE
fix: empty policy issue fixed

### DIFF
--- a/terraform/environments/ccms-ebs/member-data.tf
+++ b/terraform/environments/ccms-ebs/member-data.tf
@@ -177,11 +177,11 @@ data "aws_iam_policy_document" "s3_topic_policy" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values = concat([
+      values = concat(compact([
         try(data.aws_s3_bucket.sftp_client1_bucket[0].arn, ""),
         module.s3-bucket-logging.bucket.arn,
         module.s3-bucket-dbbackup.bucket.arn,
-        ],
+        ]),
         [
           for name, b in aws_s3_bucket.buckets :
           b.arn if name == "laa-ccms-inbound-${local.environment}-mp"


### PR DESCRIPTION
empty string causing slack notification to not work, tested in test environment with ssogen rebased branch. 