### PR TITLE
DPR2-2722 increased reports external table retention in prod by 1 day

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -902,7 +902,7 @@
           ]
         }
       ],
-      "redshift_table_expiry_days": 1,
+      "redshift_table_expiry_days": 2,
       "enable_s3_data_migrate_lambda": false,
       "create_postgres_load_generator_job": false,
       "enable_probation_discovery_node": false,


### PR DESCRIPTION
The retention time for retrieving the Redshift execution status is 24 hours. 
If the external tables get deleted after the 24 hour window there is no need to make an extra JDBC call in the /status endpoint to check if the table is there.