### PR TITLE
Adding container platform label to nodes to enable module updates

### DIFF
--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -40,6 +40,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -68,6 +69,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -104,6 +106,7 @@ locals {
         labels = {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+          "container-platform.justice.gov.uk/monitoring-ng" = "true"
           Cluster                                       = local.environment
         }
       }
@@ -139,6 +142,7 @@ locals {
         labels = {
           Terraform                                 = "true"
           "cloud-platform.justice.gov.uk/system-ng" = "true"
+          "container-platform.justice.gov.uk/system-ng" = "true"
           Cluster                                   = local.environment
         }
       }
@@ -182,6 +186,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -218,6 +223,7 @@ locals {
         labels = {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+          "container-platform.justice.gov.uk/monitoring-ng" = "true"
           Cluster                                       = local.environment
         }
       }
@@ -253,6 +259,7 @@ locals {
         labels = {
           Terraform                                 = "true"
           "cloud-platform.justice.gov.uk/system-ng" = "true"
+          "container-platform.justice.gov.uk/system-ng" = "true"
           Cluster                                   = local.environment
         }
       }
@@ -296,6 +303,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -332,6 +340,7 @@ locals {
         labels = {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+          "container-platform.justice.gov.uk/monitoring-ng" = "true"
           Cluster                                       = local.environment
         }
       }
@@ -367,6 +376,7 @@ locals {
         labels = {
           Terraform                                 = "true"
           "cloud-platform.justice.gov.uk/system-ng" = "true"
+          "container-platform.justice.gov.uk/system-ng" = "true"
           Cluster                                   = local.environment
         }
       }
@@ -410,6 +420,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -446,6 +457,7 @@ locals {
         labels = {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+          "container-platform.justice.gov.uk/monitoring-ng" = "true"
           Cluster                                       = local.environment
         }
       }
@@ -481,6 +493,7 @@ locals {
         labels = {
           Terraform                                 = "true"
           "cloud-platform.justice.gov.uk/system-ng" = "true"
+          "container-platform.justice.gov.uk/system-ng" = "true"
           Cluster                                   = local.environment
         }
       }
@@ -524,6 +537,7 @@ locals {
         labels = {
           Terraform                                  = "true"
           "cloud-platform.justice.gov.uk/default-ng" = "true"
+          "container-platform.justice.gov.uk/default-ng" = "true"
           Cluster                                    = local.environment
         }
       }
@@ -560,6 +574,7 @@ locals {
         labels = {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+          "container-platform.justice.gov.uk/monitoring-ng" = "true"
           Cluster                                       = local.environment
         }
       }
@@ -595,6 +610,7 @@ locals {
         labels = {
           Terraform                                 = "true"
           "cloud-platform.justice.gov.uk/system-ng" = "true"
+          "container-platform.justice.gov.uk/system-ng" = "true"
           Cluster                                   = local.environment
         }
       }


### PR DESCRIPTION
Adding `cloud-platform.justice.gov.uk` labels to nodes to allow new cp modules to select nodes. 