### PR TITLE
Revert unnecessary role name change

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-roles.tf
@@ -173,7 +173,7 @@ module "laa_data_analysis_replication_iam_role" {
 
   create = true
 
-  name            = "laa-analysis-${local.environment}-repl"
+  name            = "laa-data-analysis-${local.environment}-replication"
   use_name_prefix = false
 
   trust_policy_permissions = {


### PR DESCRIPTION
The name change applied in this [PR](https://github.com/ministryofjustice/modernisation-platform-environments/pull/15390/changes#diff-fc615c5609227b9f14191f00904e48cbb31417974bfb2e1ee6e37e6cef52143fL112) in February was unnecessary (the name does not hit the 64 char limit) and changing it breaks downstream references. Reverting to fix.