### PR TITLE
PRISONS_DE: add curated_prisons_history to list of AP share DBs

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -655,6 +655,10 @@
             {
               "glue_database": "curated_prisons_history_preprod_dbt",
               "glue_tables": ["*"]
+            },
+            {
+              "glue_database": "curated_prisons_history",
+              "glue_tables": ["*"]
             }
           ]
         }


### PR DESCRIPTION
This will allow us (MOJ AP DE) to share this database withi teh AP instead of the one with the long suffix (preprod_dbt)