### PR TITLE
Updated access to underlying tables

### DIFF
--- a/terraform/environments/property-cafm-data-migration/lakeformation.tf
+++ b/terraform/environments/property-cafm-data-migration/lakeformation.tf
@@ -40,6 +40,45 @@ resource "aws_lakeformation_permissions" "staging-export-tables" {
   }
 }
 
+# The property views chain through planetfm staging tables - grant LF access to that database too
+resource "aws_lakeformation_permissions" "staging-export-planetfm-database" {
+  principal   = module.lambda-staging-export.role_arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = "planetfm"
+  }
+}
+
+resource "aws_lakeformation_permissions" "staging-export-planetfm-tables" {
+  principal   = module.lambda-staging-export.role_arn
+  permissions = ["SELECT", "DESCRIBE"]
+
+  table {
+    database_name = "planetfm"
+    wildcard      = true
+  }
+}
+
+resource "aws_lakeformation_permissions" "staging-export-concept-database" {
+  principal   = module.lambda-staging-export.role_arn
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = "concept"
+  }
+}
+
+resource "aws_lakeformation_permissions" "staging-export-concept-tables" {
+  principal   = module.lambda-staging-export.role_arn
+  permissions = ["SELECT", "DESCRIBE"]
+
+  table {
+    database_name = "concept"
+    wildcard      = true
+  }
+}
+
 module "query_results" {
   source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399"
   bucket_prefix = "property-query-results-${local.environment}-"

--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -105,7 +105,7 @@ module "lambda-staging-export" {
 
   function_name                = "cafm-staging-export"
   description                  = "Exports Athena view data as CSV into the CAFM staging S3 bucket"
-  database_name                = "property"
+  source_database              = "property"
   s3_output_path               = "s3://${module.aws_s3_staging.bucket.id}"
   s3_output_bucket_arn         = module.aws_s3_staging.bucket.arn
   s3_athena_results_bucket_arn = module.query_results.bucket.arn
@@ -115,6 +115,9 @@ module "lambda-staging-export" {
     module.datalake.bucket.arn,
     "${module.datalake.bucket.arn}/*"
   ]
+
+  # All Glue databases the role needs access to: the source database and any databases its views resolve through
+  additional_database_names = ["property", "planetfm", "concept"]
 
   kms_key_arn = aws_kms_key.shared_kms_key.arn
   tags        = local.tags

--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/main.tf
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/main.tf
@@ -2,6 +2,20 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+locals {
+  glue_resources = concat(
+    ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"],
+    flatten([
+      for db in var.additional_database_names : [
+        "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${db}",
+        "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${db}_*",
+        "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*",
+        "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}_*/*",
+      ]
+    ])
+  )
+}
+
 resource "aws_iam_role" "lambda" {
   name = "${var.function_name}-role"
 
@@ -47,13 +61,7 @@ resource "aws_iam_role_policy" "lambda" {
           "glue:GetDatabases",
           "glue:GetPartitions"
         ]
-        Resource = [
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${var.database_name}",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${var.database_name}_*",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.database_name}/*",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.database_name}_*/*"
-        ]
+        Resource = local.glue_resources
       },
       {
         Sid    = "S3OutputBucketLevelAccess"
@@ -160,7 +168,7 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      DATABASE               = var.database_name
+      DATABASE               = var.source_database
       S3_OUTPUT_PATH         = var.s3_output_path
       S3_ATHENA_RESULTS_PATH = var.s3_athena_results_path
     }

--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/variables.tf
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/variables.tf
@@ -34,14 +34,20 @@ variable "s3_source_bucket_arns" {
   type        = list(string)
 }
 
-variable "database_name" {
-  description = "Glue catalogue database containing the Athena view"
+variable "source_database" {
+  description = "Glue catalogue database the Lambda queries (used as the DATABASE env var)"
   type        = string
 }
 
 variable "kms_key_arn" {
   description = "ARN of the KMS key used for S3 encryption"
   type        = string
+}
+
+variable "additional_database_names" {
+  description = "Glue database names the Lambda role needs IAM and Lake Formation access to (includes the source database and any databases its views resolve through)"
+  type        = list(string)
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
This pull request expands the permissions and configuration of the Lambda function responsible for exporting Athena view data, to support querying across multiple Glue databases (not just the primary `property` database). The changes ensure that the Lambda has the necessary IAM and Lake Formation permissions to access the `planetfm` and `concept` databases and their tables, in addition to `property`. Some variable names have also been updated for clarity.

**Permissions and Access Expansion:**

* Added new `aws_lakeformation_permissions` resources to grant the Lambda role `DESCRIBE` and `SELECT` access to the `planetfm` and `concept` databases and all their tables, ensuring the Lambda can resolve views that chain through these databases.
* Updated the Lambda module to accept a list of additional database names (`additional_database_names`) for which IAM and Lake Formation permissions are required. [[1]](diffhunk://#diff-50215ac3bf9d0107eff1fb11a8bf190c264c8a33133fc9a801274e7375fbac9dR119-R121) [[2]](diffhunk://#diff-43fbbfca3008798f554bb9ea1c05dab521d7724221f65823a687a8d4718cc90dR47-R52)

**IAM Policy Refactoring:**

* Refactored the IAM policy to dynamically construct the list of Glue resources based on all relevant database names, rather than only the primary database. This is done using a new `local.glue_resources` variable. [[1]](diffhunk://#diff-2ef3d7f248dcca6c813dc03a638c59c99da167ee1ffdf090b93a20fcd8732d50R5-R18) [[2]](diffhunk://#diff-2ef3d7f248dcca6c813dc03a638c59c99da167ee1ffdf090b93a20fcd8732d50L50-R64)

**Variable and Environment Updates:**

* Renamed the `database_name` variable to `source_database` for clarity, and updated its usage throughout the module and Lambda environment variables. [[1]](diffhunk://#diff-50215ac3bf9d0107eff1fb11a8bf190c264c8a33133fc9a801274e7375fbac9dL108-R108) [[2]](diffhunk://#diff-2ef3d7f248dcca6c813dc03a638c59c99da167ee1ffdf090b93a20fcd8732d50L163-R171) [[3]](diffhunk://#diff-43fbbfca3008798f554bb9ea1c05dab521d7724221f65823a687a8d4718cc90dL37-R38)