### PR TITLE
TM-2048: csr: allow db instance access

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -104,11 +104,12 @@ locals {
         ]
       }
       tags = {
-        ami         = "base_ol_8_5"
-        backup      = "false" # disable mod platform backup since we use our own policies
-        os-type     = "Linux"
-        component   = "data"
-        server-type = "csr-db"
+        ami                    = "base_ol_8_5"
+        backup                 = "false" # disable mod platform backup since we use our own policies
+        instance-access-policy = "limited"
+        os-type                = "Linux"
+        component              = "data"
+        server-type            = "csr-db"
       }
     }
 


### PR DESCRIPTION
Allow SSM port forwarding access to CSR DBs for those with instance-access role. Requested by Peter Phillips