### PR TITLE
Changed ptp_lot to lot_number

### DIFF
--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -82,7 +82,7 @@ def get_query_result_csv(query_execution_id):
     return response["Body"].read().decode("utf-8")
 
 
-def split_csv_by_lot(csv_text, ptp_lot_index):
+def split_csv_by_lot(csv_text, lot_number_index):
     """Split CSV text into per-lot CSV strings."""
     reader = csv.reader(io.StringIO(csv_text))
     header = next(reader)
@@ -90,7 +90,7 @@ def split_csv_by_lot(csv_text, ptp_lot_index):
     lot_rows = {lot: [] for lot in LOTS}
 
     for row in reader:
-        lot_value = row[ptp_lot_index]
+        lot_value = row[lot_number_index]
 
         if lot_value in lot_rows:
             lot_rows[lot_value].append(row)
@@ -114,7 +114,7 @@ def run_table_export(table):
     sql = f"""
         SELECT *
         FROM {table}
-        WHERE ptp_lot IN ({lot_list})
+        WHERE lot_number IN ({lot_list})
     """
 
     logger.info(f"Running query for table={table}")
@@ -136,13 +136,13 @@ def run_table_export(table):
     # Read Athena's CSV result
     csv_text = get_query_result_csv(query_execution_id)
 
-    # Find ptp_lot column index from header
+    # Find lot_number column index from header
     header = csv_text.split("\n", 1)[0]
     columns = next(csv.reader(io.StringIO(header)))
-    ptp_lot_index = columns.index("ptp_lot")
+    lot_number_index = columns.index("lot_number")
 
     # Split by lot and upload
-    lot_csvs = split_csv_by_lot(csv_text, ptp_lot_index)
+    lot_csvs = split_csv_by_lot(csv_text, lot_number_index)
     output_bucket, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
 
     for lot, csv_data in lot_csvs.items():


### PR DESCRIPTION
This pull request updates the codebase to standardize on the column name `lot_number` instead of `ptp_lot` throughout the Lambda function responsible for exporting and splitting CSV data by lot. The changes ensure consistency in column naming and reduce the risk of errors due to mismatched column references.

**Column name standardization:**

* Changed all references of the column name from `ptp_lot` to `lot_number` in the SQL query construction within the `run_table_export` function.
* Updated the logic for extracting the lot column index from the CSV header to use `lot_number` instead of `ptp_lot`.
* Modified the `split_csv_by_lot` function and its call sites to use `lot_number_index` instead of `ptp_lot_index`, ensuring the correct column is used for splitting. [[1]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL85-R93) [[2]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL139-R145)