### PR TITLE
TM-2048: csr: tweak db instance-access tag

### DIFF
--- a/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
+++ b/terraform/environments/corporate-staff-rostering/locals_ec2_instances.tf
@@ -79,7 +79,8 @@ locals {
         key_name                     = "ec2-user"
         metadata_options_http_tokens = "optional" # the Oracle installer cannot accommodate a token
         tags = {
-          backup-plan = "daily-and-weekly"
+          backup-plan            = "daily-and-weekly"
+          instance-access-policy = "limited"
         }
         vpc_security_group_ids = ["database", "oem-agent", "ec2-linux"]
       }
@@ -104,12 +105,11 @@ locals {
         ]
       }
       tags = {
-        ami                    = "base_ol_8_5"
-        backup                 = "false" # disable mod platform backup since we use our own policies
-        instance-access-policy = "limited"
-        os-type                = "Linux"
-        component              = "data"
-        server-type            = "csr-db"
+        ami         = "base_ol_8_5"
+        backup      = "false" # disable mod platform backup since we use our own policies
+        os-type     = "Linux"
+        component   = "data"
+        server-type = "csr-db"
       }
     }
 


### PR DESCRIPTION
Running into provider bug, moving instance-access-policy tag so it is only applied on the instance resource