### PR TITLE
[CC-4478] Add OEM agent SG rules to CCMS EBS Apps tier

### DIFF
--- a/terraform/environments/ccms-ebs/application_variables.json
+++ b/terraform/environments/ccms-ebs/application_variables.json
@@ -128,7 +128,14 @@
       "ec2_oracle_instance_threads_ssogen": 1,
       "instance_role_ssogen": "ssogen",
       "red_button_lambda_boom": false,
-      "red_button_lambda_debug": true
+      "red_button_lambda_debug": true,
+      "oem": {
+        "agent_port": "3872",
+        "oms_port": "4903",
+        "oms_host": "laa-oem-app.laa-development.modernisation-platform.service.justice.gov.uk",
+        "oms_platform_cidr": "10.26.60.231/32",
+        "oem_db_platform_cidr": "10.26.60.169/32"
+      }
     },
     "test": {
       "short_env": "tst",
@@ -252,7 +259,14 @@
       "ec2_oracle_instance_threads_ssogen": 1,
       "instance_role_ssogen": "ssogen",
       "red_button_lambda_boom": false,
-      "red_button_lambda_debug": true
+      "red_button_lambda_debug": true,
+      "oem": {
+        "agent_port": "3872",
+        "oms_port": "4903",
+        "oms_host": "laa-oem-app.laa-test.modernisation-platform.service.justice.gov.uk",
+        "oms_platform_cidr": "10.26.100.179/32",
+        "oem_db_platform_cidr": "10.26.100.249/32"
+      }
     },
     "preproduction": {
       "short_env": "prep",
@@ -379,7 +393,14 @@
       "ec2_oracle_instance_threads_ssogen": 1,
       "instance_role_ssogen": "ssogen",
       "red_button_lambda_boom": false,
-      "red_button_lambda_debug": true
+      "red_button_lambda_debug": true,
+      "oem": {
+        "agent_port": "3872",
+        "oms_port": "4903",
+        "oms_host": "laa-oem-app.laa-preproduction.modernisation-platform.service.justice.gov.uk",
+        "oms_platform_cidr": "10.27.76.154/32",
+        "oem_db_platform_cidr": "10.27.76.135/32"
+      }
     },
     "production": {
       "short_env": "prod",
@@ -508,7 +529,14 @@
       "ec2_oracle_instance_threads_ssogen": 1,
       "instance_role_ssogen": "ssogen",
       "red_button_lambda_boom": false,
-      "red_button_lambda_debug": true
+      "red_button_lambda_debug": true,
+      "oem": {
+        "agent_port": "3872",
+        "oms_port": "4903",
+        "oms_host": "laa-oem-app.laa-production.modernisation-platform.service.justice.gov.uk",
+        "oms_platform_cidr": "10.27.68.228/32",
+        "oem_db_platform_cidr": "10.27.68.193/32"
+      }
     }
   },
   "webgate_ebs": {

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
@@ -190,6 +190,29 @@ resource "aws_security_group_rule" "ingress_traffic_ebsapps_4443" {
   local.application_data.accounts[local.environment].lz_aws_workspace_prod_subnet_env]
 }
 
+### OEM Agent Port (OMS -> EBS Apps)
+
+resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_agent_3872" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "ingress"
+  description       = "OEM OMS to EBS Apps agent port"
+  protocol          = "TCP"
+  from_port         = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+  to_port           = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
+
+### OEM OMS Upload Port (OMS -> EBS Apps)
+
+resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_oms_4903" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "ingress"
+  description       = "OEM OMS to EBS Apps OMS upload port"
+  protocol          = "TCP"
+  from_port         = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
+  to_port           = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
 
 # EGRESS Rules
 
@@ -359,5 +382,41 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_4443" {
   from_port         = 4443
   to_port           = 4444
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+### OEM Agent Port (EBS Apps -> OMS)
+
+resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_agent_3872" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "egress"
+  description       = "EBS Apps to OEM OMS agent port"
+  protocol          = "TCP"
+  from_port         = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+  to_port           = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
+
+### OEM OMS Upload Port (EBS Apps -> OMS)
+
+resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_oms_4903" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "egress"
+  description       = "EBS Apps to OEM OMS upload port"
+  protocol          = "TCP"
+  from_port         = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
+  to_port           = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
+
+### OEM DB Oracle Listener (EBS Apps -> OEM DB)
+
+resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_db_1521" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "egress"
+  description       = "EBS Apps to OEM DB Oracle listener"
+  protocol          = "TCP"
+  from_port         = 1521
+  to_port           = 1521
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oem_db_platform_cidr]
 }
 

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
@@ -214,6 +214,18 @@ resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_oms_4903" {
   cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
 }
 
+### OEM Agent HTTPS Port (OMS -> EBS Apps)
+
+resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_https_7803" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "ingress"
+  description       = "OEM OMS to EBS Apps agent HTTPS port"
+  protocol          = "TCP"
+  from_port         = 7803
+  to_port           = 7803
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
+
 # EGRESS Rules
 
 ### HTTP
@@ -405,6 +417,18 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_oms_4903" {
   protocol          = "TCP"
   from_port         = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
   to_port           = tonumber(local.application_data.accounts[local.environment].oem.oms_port)
+  cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
+}
+
+### OEM Agent HTTPS Port (EBS Apps -> OMS)
+
+resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_https_7803" {
+  security_group_id = aws_security_group.ec2_sg_ebsapps.id
+  type              = "egress"
+  description       = "EBS Apps to OEM OMS agent HTTPS port"
+  protocol          = "TCP"
+  from_port         = 7803
+  to_port           = 7803
   cidr_blocks       = [local.application_data.accounts[local.environment].oem.oms_platform_cidr]
 }
 

--- a/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
+++ b/terraform/environments/ccms-ebs/ccms-ec2-oracle_ebs_apps-sg.tf
@@ -193,6 +193,7 @@ resource "aws_security_group_rule" "ingress_traffic_ebsapps_4443" {
 ### OEM Agent Port (OMS -> EBS Apps)
 
 resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_agent_3872" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "ingress"
   description       = "OEM OMS to EBS Apps agent port"
@@ -205,6 +206,7 @@ resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_agent_3872" {
 ### OEM OMS Upload Port (OMS -> EBS Apps)
 
 resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_oms_4903" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "ingress"
   description       = "OEM OMS to EBS Apps OMS upload port"
@@ -217,6 +219,7 @@ resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_oms_4903" {
 ### OEM Agent HTTPS Port (OMS -> EBS Apps)
 
 resource "aws_security_group_rule" "ingress_traffic_ebsapps_oem_https_7803" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "ingress"
   description       = "OEM OMS to EBS Apps agent HTTPS port"
@@ -399,6 +402,7 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_4443" {
 ### OEM Agent Port (EBS Apps -> OMS)
 
 resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_agent_3872" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "egress"
   description       = "EBS Apps to OEM OMS agent port"
@@ -411,6 +415,7 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_agent_3872" {
 ### OEM OMS Upload Port (EBS Apps -> OMS)
 
 resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_oms_4903" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "egress"
   description       = "EBS Apps to OEM OMS upload port"
@@ -423,6 +428,7 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_oms_4903" {
 ### OEM Agent HTTPS Port (EBS Apps -> OMS)
 
 resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_https_7803" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "egress"
   description       = "EBS Apps to OEM OMS agent HTTPS port"
@@ -435,6 +441,7 @@ resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_https_7803" {
 ### OEM DB Oracle Listener (EBS Apps -> OEM DB)
 
 resource "aws_security_group_rule" "egress_traffic_ebsapps_oem_db_1521" {
+  count             = local.environment == "development" ? 1 : 0
   security_group_id = aws_security_group.ec2_sg_ebsapps.id
   type              = "egress"
   description       = "EBS Apps to OEM DB Oracle listener"

--- a/terraform/environments/ccms-ebs/versions.tf
+++ b/terraform/environments/ccms-ebs/versions.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0.0"
     }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.1.0"


### PR DESCRIPTION
## Summary

- Add `oem` config to `ccms-ebs/application_variables.json` for all environments with per-environment OMS and OEM DB server CIDRs
- Add ingress SG rules on EBS Apps SG for ports 3872 (agent) and 4903 (OMS upload) from OEM OMS server
- Add egress SG rules on EBS Apps SG for ports 3872 and 4903 to OEM OMS, and port 1521 to OEM DB server

## Background

OEM agent installation is planned on CCMS Dev Apps tier (ccms-ebs-app1 `10.26.56.162` and ccms-ebs-app2 `10.26.57.25`). The following ports are required for OEM agent installation and configuration:

| Port | Direction | Source/Destination | Purpose |
|------|-----------|-------------------|---------|
| 3872 | Ingress + Egress | OEM OMS (`laa-oem-app`) | OEM agent port (bidirectional) |
| 4903 | Ingress + Egress | OEM OMS (`laa-oem-app`) | OMS upload port (bidirectional) |
| 1521 | Egress | OEM DB (`laa-oem-db`) | Oracle listener |

## OEM Server CIDRs per environment

| Environment | OEM OMS | OEM DB |
|-------------|---------|--------|
| Development | 10.26.60.231/32 | 10.26.60.169/32 |
| Test | 10.26.100.179/32 | 10.26.100.249/32 |
| Pre-production | 10.27.76.154/32 | 10.27.76.135/32 |
| Production | 10.27.68.228/32 | 10.27.68.193/32 |

## Test plan

- [ ] Verify Terraform plan shows expected SG rule additions for EBS Apps SG
- [ ] After apply, confirm OEM agent can be installed on ccms-ebs-app1 and ccms-ebs-app2 in dev
- [ ] Verify no regressions on existing Apps tier connectivity