### PR TITLE
Swapped lot numbers

### DIFF
--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -15,7 +15,7 @@ DATABASE = os.environ["DATABASE"]
 S3_OUTPUT_PATH = os.environ["S3_OUTPUT_PATH"].rstrip("/")
 S3_ATHENA_RESULTS_PATH = os.environ["S3_ATHENA_RESULTS_PATH"].rstrip("/")
 
-LOTS = ["LOT1", "LOT2", "LOT3", "LOT4", "LOT5"]
+LOTS = ["1", "2", "3", "4", "5"]
 
 TABLES = [
     "property_cafm__acm_action_plan_record",


### PR DESCRIPTION
This pull request updates the way LOT identifiers are handled in the `lambda.py` file for the property CAFM data migration Lambda module. The main change is to represent LOTs as numeric strings instead of the previous "LOT" prefixed format, which likely improves compatibility or consistency with other components.

**Data handling improvements:**

* Changed the `LOTS` list from `["LOT1", "LOT2", "LOT3", "LOT4", "LOT5"]` to `["1", "2", "3", "4", "5"]` in `lambda.py` to standardize LOT identifiers as numeric strings.