### PR TITLE
Add WSM export support

### DIFF
--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -89,26 +89,15 @@ def wait_for_query(query_execution_id):
     raise TimeoutError(f"Query {query_execution_id} did not complete within timeout")
 
 
-def run_lot_export(table, lot):
+def _run_export(sql, out_key, log_label):
     """
-    Export a single lot's rows from an Athena table to S3 as a CSV file.
-
-    Executes a query filtering by lot_number, reads the resulting CSV directly
-    from the Athena results bucket, uploads it to the staging output bucket at
-    {lot}/{table}.csv, then cleans up the Athena result files.
+    Execute an Athena query, upload the CSV result to S3, then clean up.
 
     Args:
-        table: The Athena table name to query.
-        lot:   The lot number to filter on (e.g. '1').
+        sql:       The SQL string to execute.
+        out_key:   The S3 key (within the output bucket) to write the CSV to.
+        log_label: A label used in log messages (e.g. 'LOT1/property_cafm__site_record').
     """
-    sql = f"""
-        SELECT *
-        FROM {table}
-        WHERE lot_number = '{lot}'
-    """
-
-    logger.info(f"Running query for table={table} lot={lot}")
-
     results_bucket, results_prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
 
     response = athena.start_query_execution(
@@ -125,27 +114,15 @@ def run_lot_export(table, lot):
 
     # Read Athena's CSV result from S3
     bucket, prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
-
-    key = (
-        f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
-    )
-    
+    key = f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
     response = s3.get_object(Bucket=bucket, Key=key)
     csv_data = response["Body"].read()
 
     row_count = csv_data.count(b"\n") - 1  # subtract header
 
-    output_bucket, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
-    lot_dir = LOT_DIR_MAP[lot]
-
-    out_key = (
-        f"{output_prefix}/{lot_dir}/{table}.csv"
-        if output_prefix
-        else f"{lot_dir}/{table}.csv"
-    )
-
+    output_bucket, _ = parse_s3_uri(S3_OUTPUT_PATH)
     s3.put_object(Bucket=output_bucket, Key=out_key, Body=csv_data)
-    logger.info(f"Exported {row_count} rows for {lot}/{table}")
+    logger.info(f"Exported {row_count} rows for {log_label}")
 
     # Clean up Athena result files
     for suffix in [f"{query_execution_id}.csv", f"{query_execution_id}.csv.metadata"]:
@@ -155,6 +132,49 @@ def run_lot_export(table, lot):
             s3.delete_object(Bucket=results_bucket, Key=cleanup_key)
         except Exception:
             logger.debug(f"Could not clean up {cleanup_key}")
+
+
+def run_lot_export(table, lot):
+    """
+    Export a single lot's rows from an Athena table to S3 as a CSV file.
+
+    Writes to {LOT_DIR_MAP[lot]}/{table}.csv in the staging output bucket.
+
+    Args:
+        table: The Athena table name to query.
+        lot:   The lot number to filter on (e.g. '1').
+    """
+    sql = f"""
+        SELECT *
+        FROM {table}
+        WHERE lot_number = '{lot}'
+    """
+
+    lot_dir = LOT_DIR_MAP[lot]
+    _, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
+    out_key = f"{output_prefix}/{lot_dir}/{table}.csv" if output_prefix else f"{lot_dir}/{table}.csv"
+
+    logger.info(f"Running query for table={table} lot={lot}")
+    _run_export(sql, out_key, f"{lot_dir}/{table}")
+
+
+def run_wsm_export(table):
+    """
+    Export all rows from an Athena table (across all lots) to S3 as a CSV file under WSM/.
+
+    Writes to WSM/{table}.csv in the staging output bucket.
+
+    Args:
+        table: The Athena table name to query.
+    """
+    lot_list = ",".join(f"'{lot}'" for lot in LOTS)
+    sql = f"SELECT * FROM {table} WHERE lot_number IN ({lot_list})"
+
+    _, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
+    out_key = f"{output_prefix}/WSM/{table}.csv" if output_prefix else f"WSM/{table}.csv"
+
+    logger.info(f"Running WSM query for table={table}")
+    _run_export(sql, out_key, f"WSM/{table}")
 
 
 def run_table_export(table):
@@ -172,6 +192,8 @@ def run_table_export(table):
     """
     for lot in LOTS:
         run_lot_export(table, lot)
+
+    run_wsm_export(table)
 
     return table
 

--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -1,5 +1,3 @@
-import csv
-import io
 import logging
 import os
 import time
@@ -43,13 +41,33 @@ MAX_POLL_ATTEMPTS = 900  # 15 minutes max
 
 
 def parse_s3_uri(uri):
-    """Parse an S3 URI into bucket and prefix."""
+    """
+    Parse an S3 URI (e.g. s3://bucket/prefix) into its bucket name and key prefix.
+
+    Args:
+        uri: An S3 URI string.
+
+    Returns:
+        A tuple of (bucket, prefix) where prefix has no leading slash.
+    """
     parsed = urlparse(uri)
     return parsed.netloc, parsed.path.lstrip("/")
 
 
 def wait_for_query(query_execution_id):
-    """Poll Athena for query completion, raise if it fails or times out."""
+    """
+    Poll Athena until the query reaches a terminal state.
+
+    Args:
+        query_execution_id: The Athena query execution ID to poll.
+
+    Returns:
+        The final GetQueryExecution response when the query succeeds.
+
+    Raises:
+        RuntimeError: If the query fails or is cancelled.
+        TimeoutError: If the query does not complete within MAX_POLL_ATTEMPTS seconds.
+    """
     for _ in range(MAX_POLL_ATTEMPTS):
         response = athena.get_query_execution(QueryExecutionId=query_execution_id)
         state = response["QueryExecution"]["Status"]["State"]
@@ -69,55 +87,25 @@ def wait_for_query(query_execution_id):
     raise TimeoutError(f"Query {query_execution_id} did not complete within timeout")
 
 
-def get_query_result_csv(query_execution_id):
-    """Read the Athena CSV result file directly from S3."""
-    results_path = S3_ATHENA_RESULTS_PATH
-    bucket, prefix = parse_s3_uri(results_path)
+def run_lot_export(table, lot):
+    """
+    Export a single lot's rows from an Athena table to S3 as a CSV file.
 
-    key = (
-        f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
-    )
+    Executes a query filtering by lot_number, reads the resulting CSV directly
+    from the Athena results bucket, uploads it to the staging output bucket at
+    {lot}/{table}.csv, then cleans up the Athena result files.
 
-    response = s3.get_object(Bucket=bucket, Key=key)
-    return response["Body"].read().decode("utf-8")
-
-
-def split_csv_by_lot(csv_text, lot_number_index):
-    """Split CSV text into per-lot CSV strings."""
-    reader = csv.reader(io.StringIO(csv_text))
-    header = next(reader)
-
-    lot_rows = {lot: [] for lot in LOTS}
-
-    for row in reader:
-        lot_value = row[lot_number_index]
-
-        if lot_value in lot_rows:
-            lot_rows[lot_value].append(row)
-
-    result = {}
-
-    for lot, rows in lot_rows.items():
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(header)
-        writer.writerows(rows)
-        result[lot] = buf.getvalue()
-
-    return result
-
-
-def run_table_export(table):
-    """Run one Athena query per table, split result by lot, upload to staging."""
-    lot_list = ",".join(f"'{lot}'" for lot in LOTS)
-
+    Args:
+        table: The Athena table name to query.
+        lot:   The lot number to filter on (e.g. '1').
+    """
     sql = f"""
         SELECT *
         FROM {table}
-        WHERE lot_number IN ({lot_list})
+        WHERE lot_number = '{lot}'
     """
 
-    logger.info(f"Running query for table={table}")
+    logger.info(f"Running query for table={table} lot={lot}")
 
     results_bucket, results_prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
 
@@ -133,29 +121,23 @@ def run_table_export(table):
 
     wait_for_query(query_execution_id)
 
-    # Read Athena's CSV result
-    csv_text = get_query_result_csv(query_execution_id)
+    # Read Athena's CSV result from S3
+    bucket, prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
+    key = f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
+    response = s3.get_object(Bucket=bucket, Key=key)
+    csv_data = response["Body"].read()
 
-    # Find lot_number column index from header
-    header = csv_text.split("\n", 1)[0]
-    columns = next(csv.reader(io.StringIO(header)))
-    lot_number_index = columns.index("lot_number")
+    row_count = csv_data.count(b"\n") - 1  # subtract header
 
-    # Split by lot and upload
-    lot_csvs = split_csv_by_lot(csv_text, lot_number_index)
     output_bucket, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
+    out_key = (
+        f"{output_prefix}/{lot}/{table}.csv"
+        if output_prefix
+        else f"{lot}/{table}.csv"
+    )
 
-    for lot, csv_data in lot_csvs.items():
-        row_count = csv_data.count("\n") - 1  # subtract header
-
-        key = (
-            f"{output_prefix}/{lot}/{table}.csv"
-            if output_prefix
-            else f"{lot}/{table}.csv"
-        )
-
-        s3.put_object(Bucket=output_bucket, Key=key, Body=csv_data.encode("utf-8"))
-        logger.info(f"Exported {row_count} rows for {lot}/{table}")
+    s3.put_object(Bucket=output_bucket, Key=out_key, Body=csv_data)
+    logger.info(f"Exported {row_count} rows for {lot}/{table}")
 
     # Clean up Athena result files
     for suffix in [f"{query_execution_id}.csv", f"{query_execution_id}.csv.metadata"]:
@@ -166,10 +148,41 @@ def run_table_export(table):
         except Exception:
             logger.debug(f"Could not clean up {cleanup_key}")
 
+
+def run_table_export(table):
+    """
+    Export all lots for a single table by running one query per lot.
+
+    Iterates over LOTS sequentially to keep peak memory usage bounded,
+    then returns the table name on completion.
+
+    Args:
+        table: The Athena table name to export.
+
+    Returns:
+        The table name.
+    """
+    for lot in LOTS:
+        run_lot_export(table, lot)
+
     return table
 
 
 def lambda_handler(event, context):
+    """
+    Lambda entry point. Exports all CAFM tables from Athena to the staging S3 bucket.
+
+    Processes up to 5 tables concurrently. Each table's lots are exported
+    sequentially (one Athena query per lot) to limit memory usage.
+    Raises RuntimeError if any table export fails.
+
+    Args:
+        event:   Lambda event payload (unused).
+        context: Lambda context object (unused).
+
+    Returns:
+        A dict with 'status' and 'results' keys listing succeeded/failed tables.
+    """
     results = {"succeeded": [], "failed": []}
 
     with ThreadPoolExecutor(max_workers=5) as executor:
@@ -177,6 +190,7 @@ def lambda_handler(event, context):
 
         for future in as_completed(futures):
             table = futures[future]
+
             try:
                 future.result()
                 results["succeeded"].append(table)

--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -15,6 +15,8 @@ S3_ATHENA_RESULTS_PATH = os.environ["S3_ATHENA_RESULTS_PATH"].rstrip("/")
 
 LOTS = ["1", "2", "3", "4", "5"]
 
+LOT_DIR_MAP = {lot: f"LOT{lot}" for lot in LOTS}
+
 TABLES = [
     "property_cafm__acm_action_plan_record",
     "property_cafm__acm_inspection_record",
@@ -123,17 +125,23 @@ def run_lot_export(table, lot):
 
     # Read Athena's CSV result from S3
     bucket, prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
-    key = f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
+
+    key = (
+        f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
+    )
+    
     response = s3.get_object(Bucket=bucket, Key=key)
     csv_data = response["Body"].read()
 
     row_count = csv_data.count(b"\n") - 1  # subtract header
 
     output_bucket, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
+    lot_dir = LOT_DIR_MAP[lot]
+
     out_key = (
-        f"{output_prefix}/{lot}/{table}.csv"
+        f"{output_prefix}/{lot_dir}/{table}.csv"
         if output_prefix
-        else f"{lot}/{table}.csv"
+        else f"{lot_dir}/{table}.csv"
     )
 
     s3.put_object(Bucket=output_bucket, Key=out_key, Body=csv_data)


### PR DESCRIPTION
This pull request refactors and streamlines the Lambda function responsible for exporting Athena tables to S3, with a focus on per-lot and WSM exports. The main improvements include simplifying the code by removing unnecessary CSV parsing and splitting logic, introducing helper functions for clarity, and improving documentation with detailed docstrings.

**Refactoring and simplification:**

* Removed the use of the `csv` and `io` modules, eliminating the need to manually parse and split CSV results by lot; instead, the export logic now runs one Athena query per lot and one for WSM, directly writing results to S3. [[1]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL1-L2) [[2]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL72-R223)
* Introduced new helper functions: `_run_export` (handles Athena query execution and S3 upload), `run_lot_export` (exports a single lot), and `run_wsm_export` (exports all lots to a WSM directory), improving code modularity and readability.

**Documentation and code clarity:**

* Added or expanded detailed docstrings for all major functions, clarifying their purpose, arguments, and return values. [[1]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL46-R72) [[2]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL72-R223)
* Introduced `LOT_DIR_MAP` for consistent and clear mapping of lot numbers to directory names.

**Concurrency and performance:**

* The Lambda handler now processes up to 5 tables concurrently, but each table's lots are exported sequentially to control memory usage.

These changes make the Lambda export logic more maintainable, efficient, and easier to understand.