### PR TITLE
TM-2054: hmpps-domain: switch to new exportable preprod cert

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -183,7 +183,7 @@ locals {
               "pp-rdgw-1-http",
               "pp-rds-1-https",
             ]
-            certificate_names_or_arns = ["remote_desktop_and_planetfm_wildcard_cert"]
+            certificate_names_or_arns = ["remote_desktop_and_planetfm_wildcard_cert_v3"]
             rules = {
               pp-rdgw-1-http = {
                 priority = 100


### PR DESCRIPTION
Swap to the new cert. A subsequent PR will zap the old cert.