### PR TITLE
TM-2054: planetfm: add additional acm option

### DIFF
--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -37,7 +37,6 @@ locals {
         certificate_transparency_logging_preference = false # this should have been set to true
         cloudwatch_metric_alarms                    = module.baseline_presets.cloudwatch_metric_alarms.acm
         domain_name                                 = "*.preproduction.hmpps-domain.service.justice.gov.uk"
-        certificate_transparency_logging_preference = false # this should have been set to true
         export                                      = true
         subject_alternate_names = [
           "*.pp.planetfm.service.justice.gov.uk",

--- a/terraform/environments/hmpps-domain-services/locals_preproduction.tf
+++ b/terraform/environments/hmpps-domain-services/locals_preproduction.tf
@@ -34,9 +34,11 @@ locals {
       }
 
       remote_desktop_and_planetfm_wildcard_cert_v3 = {
-        cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.acm
-        domain_name              = "*.preproduction.hmpps-domain.service.justice.gov.uk"
-        export                   = true
+        certificate_transparency_logging_preference = false # this should have been set to true
+        cloudwatch_metric_alarms                    = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name                                 = "*.preproduction.hmpps-domain.service.justice.gov.uk"
+        certificate_transparency_logging_preference = false # this should have been set to true
+        export                                      = true
         subject_alternate_names = [
           "*.pp.planetfm.service.justice.gov.uk",
         ]
@@ -44,6 +46,19 @@ locals {
           description = "wildcard cert for hmpps remote desktop services"
         }
       }
+
+      # TM-2057: Oct 2026, use below to replace above 2 certs
+      # remote_desktop_and_planetfm_wildcard_cert_v4 = {
+      #   cloudwatch_metric_alarms = module.baseline_presets.cloudwatch_metric_alarms.acm
+      #   domain_name              = "*.preproduction.hmpps-domain.service.justice.gov.uk"
+      #   export                   = true
+      #   subject_alternate_names = [
+      #     "*.pp.planetfm.service.justice.gov.uk",
+      #   ]
+      #   tags = {
+      #     description = "wildcard cert for hmpps remote desktop services"
+      #   }
+      # }
     }
 
     cloudwatch_dashboards = {

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -54,7 +54,7 @@ locals {
       }
 
       # TM-2057: Oct 2026, use below to replace above 2 certs
-      # remote_desktop_wildcard_and_planetfm_cert_v3 = {
+      # remote_desktop_wildcard_and_planetfm_cert_v4 = {
       #   cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
       #   domain_name                         = "*.hmpps-domain.service.justice.gov.uk"
       #   export                              = true

--- a/terraform/environments/hmpps-domain-services/locals_production.tf
+++ b/terraform/environments/hmpps-domain-services/locals_production.tf
@@ -38,10 +38,11 @@ locals {
       }
 
       remote_desktop_wildcard_and_planetfm_cert_v3 = {
-        cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
-        domain_name                         = "*.hmpps-domain.service.justice.gov.uk"
-        export                              = true
-        external_validation_records_created = true
+        certificate_transparency_logging_preference = false # this should have been set to true
+        cloudwatch_metric_alarms                    = module.baseline_presets.cloudwatch_metric_alarms.acm
+        domain_name                                 = "*.hmpps-domain.service.justice.gov.uk"
+        export                                      = true
+        external_validation_records_created         = true
         subject_alternate_names = [
           "*.planetfm.service.justice.gov.uk",
           "cafmtx.az.justice.gov.uk",
@@ -51,6 +52,22 @@ locals {
           description = "wildcard cert for hmpps remote desktop services"
         }
       }
+
+      # TM-2057: Oct 2026, use below to replace above 2 certs
+      # remote_desktop_wildcard_and_planetfm_cert_v3 = {
+      #   cloudwatch_metric_alarms            = module.baseline_presets.cloudwatch_metric_alarms.acm
+      #   domain_name                         = "*.hmpps-domain.service.justice.gov.uk"
+      #   export                              = true
+      #   external_validation_records_created = true
+      #   subject_alternate_names = [
+      #     "*.planetfm.service.justice.gov.uk",
+      #     "cafmtx.az.justice.gov.uk",
+      #     "hmpps-az-gw1.justice.gov.uk",
+      #   ]
+      #   tags = {
+      #     description = "wildcard cert for hmpps remote desktop services"
+      #   }
+      # }
     }
 
     cloudwatch_dashboards = {

--- a/terraform/modules/acm_certificate/main.tf
+++ b/terraform/modules/acm_certificate/main.tf
@@ -1,7 +1,7 @@
 locals {
-  acm_cert_options = var.export == true ? {
-    certificate_transparency_logging_preference = "DISABLED"
-    export                                      = "ENABLED"
+  acm_cert_options = var.export != null || var.certificate_transparency_logging_preference != null ? {
+    certificate_transparency_logging_preference = var.certificate_transparency_logging_preference == false ? "DISABLED" : "ENABLED"
+    export                                      = var.export == true ? "ENABLED" : "DISABLED"
   } : null
 }
 

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -8,9 +8,15 @@ variable "domain_name" {
   description = "Domain name for which the certificate should be issued"
 }
 
+variable "certificate_transparency_logging_preference" {
+  type        = bool
+  description = "Set to false to disable the certificate transparency log. See https://docs.aws.amazon.com/acm/latest/userguide/acm-concepts.html#concept-transparency for more details"
+  default     = null
+}
+
 variable "export" {
   type        = bool
-  description = "Set to true to allow certificate can be exported. Note issuing an exportable certificate is subject to additional charges"
+  description = "Set to true to allow export of certificate private key. Note issuing an exportable certificate is subject to additional charges"
   default     = null
 }
 

--- a/terraform/modules/baseline/acm_certificate.tf
+++ b/terraform/modules/baseline/acm_certificate.tf
@@ -8,13 +8,14 @@ module "acm_certificate" {
     aws.core-network-services = aws.core-network-services
   }
 
-  name                                = each.key
-  domain_name                         = each.value.domain_name
-  export                              = each.value.export
-  subject_alternate_names             = each.value.subject_alternate_names
-  route53_zones                       = local.route53_zones
-  validation                          = each.value.validation
-  external_validation_records_created = each.value.external_validation_records_created
+  name                                        = each.key
+  domain_name                                 = each.value.domain_name
+  certificate_transparency_logging_preference = each.value.certificate_transparency_logging_preference
+  export                                      = each.value.export
+  subject_alternate_names                     = each.value.subject_alternate_names
+  route53_zones                               = local.route53_zones
+  validation                                  = each.value.validation
+  external_validation_records_created         = each.value.external_validation_records_created
 
   cloudwatch_metric_alarms = {
     for key, value in each.value.cloudwatch_metric_alarms : key => merge(value, {

--- a/terraform/modules/baseline/variables.tf
+++ b/terraform/modules/baseline/variables.tf
@@ -1,9 +1,10 @@
 variable "acm_certificates" {
   description = "map of acm certificates to create where the map key is the tags.Name.  See acm_certificate module for more variable details"
   type = map(object({
-    domain_name             = string
-    export                  = optional(bool)
-    subject_alternate_names = optional(list(string), [])
+    domain_name                                 = string
+    certificate_transparency_logging_preference = optional(bool)
+    export                                      = optional(bool)
+    subject_alternate_names                     = optional(list(string), [])
     validation = optional(map(object({
       account   = optional(string, "self")
       zone_name = string


### PR DESCRIPTION
Add certificate_transparency_logging_preference option to ACM module.

For HMPPS Domain Services next cert renewal, both export and certificate_transparency_logging_preference need to be enabled so we can drop back down to one cert. Prepare the code for this as well.