### PR TITLE
Added date to export files

### DIFF
--- a/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
+++ b/terraform/environments/property-cafm-data-migration/modules/lambda_staging_export/lambda.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import boto3
@@ -114,7 +115,9 @@ def _run_export(sql, out_key, log_label):
 
     # Read Athena's CSV result from S3
     bucket, prefix = parse_s3_uri(S3_ATHENA_RESULTS_PATH)
-    key = f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
+    key = (
+        f"{prefix}/{query_execution_id}.csv" if prefix else f"{query_execution_id}.csv"
+    )
     response = s3.get_object(Bucket=bucket, Key=key)
     csv_data = response["Body"].read()
 
@@ -152,7 +155,13 @@ def run_lot_export(table, lot):
 
     lot_dir = LOT_DIR_MAP[lot]
     _, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
-    out_key = f"{output_prefix}/{lot_dir}/{table}.csv" if output_prefix else f"{lot_dir}/{table}.csv"
+    export_date = datetime.now(timezone.utc).strftime("%Y%m%d")
+    
+    out_key = (
+        f"{output_prefix}/{lot_dir}/{table}_{export_date}.csv"
+        if output_prefix
+        else f"{lot_dir}/{table}_{export_date}.csv"
+    )
 
     logger.info(f"Running query for table={table} lot={lot}")
     _run_export(sql, out_key, f"{lot_dir}/{table}")
@@ -171,7 +180,12 @@ def run_wsm_export(table):
     sql = f"SELECT * FROM {table} WHERE lot_number IN ({lot_list})"
 
     _, output_prefix = parse_s3_uri(S3_OUTPUT_PATH)
-    out_key = f"{output_prefix}/WSM/{table}.csv" if output_prefix else f"WSM/{table}.csv"
+    export_date = datetime.now(timezone.utc).strftime("%Y%m%d")
+    out_key = (
+        f"{output_prefix}/WSM/{table}_{export_date}.csv"
+        if output_prefix
+        else f"WSM/{table}_{export_date}.csv"
+    )
 
     logger.info(f"Running WSM query for table={table}")
     _run_export(sql, out_key, f"WSM/{table}")


### PR DESCRIPTION
This pull request updates the export logic in the `lambda_staging_export` Lambda function to include the current UTC date in the filenames of exported CSVs. This change helps distinguish exports by date and prevents overwriting previous files. Additionally, the pull request introduces a minor code style improvement for better readability.

**Export filename enhancements:**

* Updated both `run_lot_export` and `run_wsm_export` functions to append the current UTC date (formatted as `YYYYMMDD`) to the exported CSV filenames, ensuring each export is uniquely identified by date. [[1]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL155-R164) [[2]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL174-R188)
* Added `from datetime import datetime, timezone` to support date formatting in export filenames.

**Code readability improvements:**

* Reformatted the construction of S3 keys for Athena CSV results and export outputs to use multi-line expressions, improving code clarity. [[1]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL117-R120) [[2]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL155-R164) [[3]](diffhunk://#diff-b0414d9b207dce806fef365bf2c61c1acd041389f58ef3ed8146607ba46ccd1cL174-R188)