### PR TITLE
patch: update litellm gateway version

### DIFF
--- a/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
@@ -3,8 +3,8 @@ locals {
   environment_configurations = {
     development = {
       litellm_versions = {
-        application = "main-v1.82.3-stable.patch.2"
-        chart       = "1.82.3-stable.patch.2"
+        application = "main-v1.83.7-stable"
+        chart       = "1.83.7-stable"
       }
       llm_gateway_hostname = "llm-gateway.development.data-platform.service.justice.gov.uk"
       llm_gateway_ingress_allowlist = [


### PR DESCRIPTION
Updated `litellm` to use `1.83.7-stable` - this PR relates to [this](https://github.com/ministryofjustice/data-platform-security/issues/38) issue. 