### PR TITLE
chore: remove deprecated diagram MCP server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,14 +8,6 @@
     }
   ],
   "servers": {
-    "awslabs.aws-diagram-mcp-server": {
-      "command": "uvx",
-      "args": ["awslabs.aws-diagram-mcp-server@latest"],
-      "env": {
-        "AWS_PROFILE": "${input:aws-profile}",
-        "AWS_REGION": "eu-west-2"
-      }
-    },
     "awslabs.billing-cost-management-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.billing-cost-management-mcp-server@latest"],

--- a/docs/GITHUB_COPILOT_MCP_SERVERS.md
+++ b/docs/GITHUB_COPILOT_MCP_SERVERS.md
@@ -53,7 +53,6 @@ This document covers the set up of MCP servers for use within [GitHub Copilot Ch
 
 | Server                                         | Documentation                                                              |
 | ---------------------------------------------- | -------------------------------------------------------------------------- |
-| `awslabs.aws-diagram-mcp-server`               | <https://awslabs.github.io/mcp/servers/aws-diagram-mcp-server>               |
 | `awslabs.billing-cost-management-mcp-server`   | <https://awslabs.github.io/mcp/servers/billing-cost-management-mcp-server>   |
 | `awslabs.cloudtrail-mcp-server`                | <https://awslabs.github.io/mcp/servers/cloudtrail-mcp-server>                |
 | `awslabs.cloudwatch-mcp-server`                | <https://awslabs.github.io/mcp/servers/cloudwatch-mcp-server>                |


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What
- removes `awslabs.aws-diagram-mcp-server` from the workspace MCP configuration
- removes the deprecated server from the MCP server documentation table

## Why
VS Code now reports the diagram MCP package as unsatisfiable because it has been yanked upstream, so this change stops the repository from advertising a server that cannot start.

You can see the removal PR here: https://github.com/awslabs/mcp/pull/3096 ⚰️

Attempting to run the MCP server results in the following:

```
2026-05-05 11:32:51.676 [info] Starting server awslabs.aws-diagram-mcp-server
2026-05-05 11:32:51.677 [info] Connection state: Starting
2026-05-05 11:32:51.677 [info] Starting server from LocalProcess extension host
2026-05-05 11:32:51.680 [info] Connection state: Starting
2026-05-05 11:32:51.681 [info] Connection state: Running
2026-05-05 11:32:52.751 [warning] [server stderr]   × No solution found when resolving tool dependencies:
2026-05-05 11:32:52.751 [warning] [server stderr]   ╰─▶ Because only the following versions of awslabs-aws-diagram-mcp-server
2026-05-05 11:32:52.751 [warning] [server stderr]       are available:
...
2026-05-05 11:32:52.753 [warning] [server stderr]           awslabs-aws-diagram-mcp-server==1.0.23
2026-05-05 11:32:52.753 [warning] [server stderr]       and awslabs-aws-diagram-mcp-server==0.8.111441 was yanked
2026-05-05 11:32:52.754 [warning] [server stderr]       (reason: deprecated and removed from source), we can conclude that
2026-05-05 11:32:52.754 [warning] [server stderr]       awslabs-aws-diagram-mcp-server<0.8.2025141004 cannot be used.
2026-05-05 11:32:52.754 [warning] [server stderr]       And because awslabs-aws-diagram-mcp-server>=0.8.2025141004 was yanked
2026-05-05 11:32:52.754 [warning] [server stderr]       (reason: Superceeded by diagram agent skill in the deploy-on-aws plugin
2026-05-05 11:32:52.754 [warning] [server stderr]       https://github.com/awslabs/agent-plugins/tree/main/plugins/deploy-on-aws)
2026-05-05 11:32:52.754 [warning] [server stderr]       and you require awslabs-aws-diagram-mcp-server, we can conclude that
2026-05-05 11:32:52.754 [warning] [server stderr]       your requirements are unsatisfiable.
2026-05-05 11:32:52.754 [info] Connection state: Error Process exited with code 1
2026-05-05 11:40:16.150 [info] Stopping server awslabs.aws-diagram-mcp-server
```

## Testing
- not run; documentation and configuration change only

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>