### PR TITLE
ELM-4696

### DIFF
--- a/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/ap_airflow_iam.tf
@@ -596,6 +596,25 @@ module "load_g4s_atrium_unstructured" {
   source_data_bucket = module.s3-json-directory-structure-bucket.bucket
   new_airflow        = true
 }
+
+module "load_g4s_x_drive" {
+  count  = local.is-production || local.is-development ? 1 : 0
+  source = "./modules/ap_airflow_load_data_iam_role"
+
+  data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
+  de_role_arn             = try(one(data.aws_iam_roles.mod_plat_roles.arns))
+
+  name               = "g4s-x-drive"
+  environment        = local.environment
+  database_name      = "g4s-x-drive"
+  secret_code        = jsondecode(data.aws_secretsmanager_secret_version.airflow_secret.secret_string)["oidc_cluster_identifier"]
+  oidc_arn           = aws_iam_openid_connect_provider.analytical_platform_compute.arn
+  athena_dump_bucket = module.s3-athena-bucket.bucket
+  cadt_bucket        = module.s3-create-a-derived-table-bucket.bucket
+  source_data_bucket = module.s3-json-directory-structure-bucket.bucket
+  new_airflow        = true
+}
+
 module "load_integrity_database" {
   count  = local.is-production ? 1 : 0
   source = "./modules/ap_airflow_load_data_iam_role"


### PR DESCRIPTION
## [ELM-4696](https://dsdmoj.atlassian.net/browse/ELM-4696)
Step 3 - loading the JSONL data with DLT.

- [x] add configuration for x-drive catalogue

[ELM-4696]: https://dsdmoj.atlassian.net/browse/ELM-4696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Links to: https://github.com/moj-analytical-services/airflow-load-em-data/pull/695