### PR TITLE
PR 2- adding relevant logs for landing

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-landing.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-landing.tf
@@ -1,0 +1,415 @@
+# ------------------------------------------------------------------------------
+# Landing operations dashboard
+#
+# This dashboard shows the health of process_landing_bucket_files for both
+# FMS and MDSS. It focuses on the shared landing stage before files reach the
+# raw-formatted bucket and downstream loaders.
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_dashboard" "landing_ops" {
+  dashboard_name = "landing-ops-${local.environment_shorthand}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      # --------------------------
+      # Landing DLQ backlog
+      # --------------------------
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 6
+
+        properties = {
+          title  = "SQS DLQs: landing bucket processing"
+          region = "eu-west-2"
+          stat   = "Sum"
+          period = 60
+
+          metrics = [
+            [
+              "AWS/SQS",
+              "ApproximateNumberOfMessagesVisible",
+              "QueueName",
+              local.live_feed_dlq_names.process_landing_bucket_files_fms_general
+            ],
+            [
+              ".",
+              "ApproximateNumberOfMessagesVisible",
+              ".",
+              local.live_feed_dlq_names.process_landing_bucket_files_fms_ho
+            ],
+            [
+              ".",
+              "ApproximateNumberOfMessagesVisible",
+              ".",
+              local.live_feed_dlq_names.process_landing_bucket_files_fms_specials
+            ],
+            [
+              ".",
+              "ApproximateNumberOfMessagesVisible",
+              ".",
+              local.live_feed_dlq_names.process_landing_bucket_files_mdss_general
+            ],
+            [
+              ".",
+              "ApproximateNumberOfMessagesVisible",
+              ".",
+              local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho
+            ],
+            [
+              ".",
+              "ApproximateNumberOfMessagesVisible",
+              ".",
+              local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials
+            ]
+          ]
+        }
+      },
+
+      # --------------------------
+      # Landing outcomes
+      # --------------------------
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 24
+        height = 6
+
+        properties = {
+          title  = "Landing outcomes: OK / retry / final failure"
+          region = "eu-west-2"
+          stat   = "Sum"
+          period = 300
+
+          metrics = [
+            [
+              "EMDS/Landing",
+              "LandingFileOkCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingFileFailCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingFileOkCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingFileFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingFileOkCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingFileFailCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingFileOkCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingFileFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingFileOkCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingFileFailCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingFileOkCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingFileRetryCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingFileFailCountMdssSpecials"
+            ]
+          ]
+        }
+      },
+
+      # --------------------------
+      # Landing final failure breakdown
+      # --------------------------
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 24
+        height = 6
+
+        properties = {
+          title  = "Landing final failures by error class"
+          region = "eu-west-2"
+          stat   = "Sum"
+          period = 300
+
+          metrics = [
+            [
+              "EMDS/Landing",
+              "LandingRetryableTransientFailCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountFmsGeneral"
+            ],
+            [
+              ".",
+              "LandingRetryableTransientFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingRetryableTransientFailCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountFmsSpecials"
+            ],
+            [
+              ".",
+              "LandingRetryableTransientFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingRetryableTransientFailCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountMdssHo"
+            ],
+            [
+              ".",
+              "LandingRetryableTransientFailCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingNonRetryableDataFailCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingNonRetryableConfigFailCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingUnknownFailCountMdssSpecials"
+            ]
+          ]
+        }
+      },
+
+      # --------------------------
+      # Final failures log table
+      # --------------------------
+      {
+        type   = "log"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 8
+
+        properties = {
+          title  = "Final failures: landing processing"
+          region = "eu-west-2"
+          view   = "table"
+
+          query = <<-EOT
+            SOURCE '/aws/lambda/process_landing_bucket_files_fms_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_specials'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_specials'
+            | filter ispresent(message.event)
+            | filter message.event = "LANDING_FILE_FAIL"
+            | fields
+                @timestamp,
+                message.feed,
+                message.order_type,
+                message.table,
+                message.delivery_date,
+                message.source_s3path,
+                message.destination_s3path,
+                message.error_type,
+                message.retry_policy,
+                message.manual_intervention_required,
+                message.reason
+            | sort @timestamp desc
+            | limit 200
+          EOT
+        }
+      },
+
+      # --------------------------
+      # Retry attempts log table
+      # --------------------------
+      {
+        type   = "log"
+        x      = 0
+        y      = 26
+        width  = 24
+        height = 8
+
+        properties = {
+          title  = "Retry attempts: landing processing"
+          region = "eu-west-2"
+          view   = "table"
+
+          query = <<-EOT
+            SOURCE '/aws/lambda/process_landing_bucket_files_fms_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_specials'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_specials'
+            | filter ispresent(message.event)
+            | filter message.event = "LANDING_FILE_RETRY"
+            | fields
+                @timestamp,
+                message.feed,
+                message.order_type,
+                message.table,
+                message.delivery_date,
+                message.source_s3path,
+                message.attempt,
+                message.max_receive_count,
+                message.error_type,
+                message.retry_policy,
+                message.reason
+            | sort @timestamp desc
+            | limit 200
+          EOT
+        }
+      },
+
+      # --------------------------
+      # Outcome summary by feed/order/table
+      # --------------------------
+      {
+        type   = "log"
+        x      = 0
+        y      = 34
+        width  = 24
+        height = 8
+
+        properties = {
+          title  = "Landing outcome summary by feed/order/table"
+          region = "eu-west-2"
+          view   = "table"
+
+          query = <<-EOT
+            SOURCE '/aws/lambda/process_landing_bucket_files_fms_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_specials'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_specials'
+            | filter ispresent(message.event)
+            | filter message.event in [
+                "LANDING_FILE_OK",
+                "LANDING_FILE_RETRY",
+                "LANDING_FILE_FAIL"
+              ]
+            | stats
+                count_distinct(
+                  if(message.event = "LANDING_FILE_OK",
+                  message.source_s3path, null)
+                ) as ok_files,
+                count_distinct(
+                  if(message.event = "LANDING_FILE_RETRY",
+                  message.source_s3path, null)
+                ) as retried_files,
+                count_distinct(
+                  if(message.event = "LANDING_FILE_FAIL",
+                  message.source_s3path, null)
+                ) as failed_files,
+                max(message.attempt) as max_attempt_seen
+              by message.feed, message.order_type, message.table
+            | sort failed_files desc, retried_files desc, ok_files desc
+            | limit 100
+          EOT
+        }
+      }
+    ]
+  })
+}

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-landing.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-landing.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
         properties = {
           title  = "SQS DLQs: landing bucket processing"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
 
           metrics = [
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
         height = 6
 
         properties = {
-          title  = "Landing outcomes: OK / retry / final failure"
+          title  = "Landing outcomes: OK / retry / manual / final failure"
           region = "eu-west-2"
           stat   = "Sum"
           period = 300
@@ -95,6 +95,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingFileManualRequiredCountFmsGeneral"
+            ],
+            [
+              ".",
               "LandingFileFailCountFmsGeneral"
             ],
             [
@@ -104,6 +108,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             [
               ".",
               "LandingFileRetryCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingFileManualRequiredCountFmsHo"
             ],
             [
               ".",
@@ -119,6 +127,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingFileManualRequiredCountFmsSpecials"
+            ],
+            [
+              ".",
               "LandingFileFailCountFmsSpecials"
             ],
             [
@@ -128,6 +140,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             [
               ".",
               "LandingFileRetryCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingFileManualRequiredCountMdssGeneral"
             ],
             [
               ".",
@@ -143,6 +159,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingFileManualRequiredCountMdssHo"
+            ],
+            [
+              ".",
               "LandingFileFailCountMdssHo"
             ],
             [
@@ -152,6 +172,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             [
               ".",
               "LandingFileRetryCountMdssSpecials"
+            ],
+            [
+              ".",
+              "LandingFileManualRequiredCountMdssSpecials"
             ],
             [
               ".",
@@ -192,6 +216,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingMissingSourceFailCountFmsGeneral"
+            ],
+            [
+              ".",
               "LandingUnknownFailCountFmsGeneral"
             ],
             [
@@ -205,6 +233,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             [
               ".",
               "LandingNonRetryableConfigFailCountFmsHo"
+            ],
+            [
+              ".",
+              "LandingMissingSourceFailCountFmsHo"
             ],
             [
               ".",
@@ -224,6 +256,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingMissingSourceFailCountFmsSpecials"
+            ],
+            [
+              ".",
               "LandingUnknownFailCountFmsSpecials"
             ],
             [
@@ -237,6 +273,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             [
               ".",
               "LandingNonRetryableConfigFailCountMdssGeneral"
+            ],
+            [
+              ".",
+              "LandingMissingSourceFailCountMdssGeneral"
             ],
             [
               ".",
@@ -256,6 +296,10 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingMissingSourceFailCountMdssHo"
+            ],
+            [
+              ".",
               "LandingUnknownFailCountMdssHo"
             ],
             [
@@ -272,9 +316,55 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             ],
             [
               ".",
+              "LandingMissingSourceFailCountMdssSpecials"
+            ],
+            [
+              ".",
               "LandingUnknownFailCountMdssSpecials"
             ]
           ]
+        }
+      },
+
+      # --------------------------
+      # Manual intervention table
+      # --------------------------
+      {
+        type   = "log"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 8
+
+        properties = {
+          title  = "Manual intervention required: landing processing"
+          region = "eu-west-2"
+          view   = "table"
+
+          query = <<-EOT
+            SOURCE '/aws/lambda/process_landing_bucket_files_fms_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_fms_specials'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_general'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_ho'
+            | SOURCE '/aws/lambda/process_landing_bucket_files_mdss_specials'
+            | filter ispresent(message.event)
+            | filter message.event = "LANDING_FILE_MANUAL_REQUIRED"
+            | fields
+                @timestamp,
+                message.feed,
+                message.order_type,
+                message.table,
+                message.delivery_date,
+                message.source_s3path,
+                message.destination_s3path,
+                message.error_type,
+                message.retry_policy,
+                message.will_sqs_retry,
+                message.reason
+            | sort @timestamp desc
+            | limit 200
+          EOT
         }
       },
 
@@ -284,7 +374,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
       {
         type   = "log"
         x      = 0
-        y      = 18
+        y      = 26
         width  = 24
         height = 8
 
@@ -326,7 +416,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
       {
         type   = "log"
         x      = 0
-        y      = 26
+        y      = 34
         width  = 24
         height = 8
 
@@ -368,7 +458,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
       {
         type   = "log"
         x      = 0
-        y      = 34
+        y      = 42
         width  = 24
         height = 8
 
@@ -388,6 +478,7 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
             | filter message.event in [
                 "LANDING_FILE_OK",
                 "LANDING_FILE_RETRY",
+                "LANDING_FILE_MANUAL_REQUIRED",
                 "LANDING_FILE_FAIL"
               ]
             | stats
@@ -400,12 +491,19 @@ resource "aws_cloudwatch_dashboard" "landing_ops" {
                   message.source_s3path, null)
                 ) as retried_files,
                 count_distinct(
+                  if(message.event = "LANDING_FILE_MANUAL_REQUIRED",
+                  message.source_s3path, null)
+                ) as manual_required_files,
+                count_distinct(
                   if(message.event = "LANDING_FILE_FAIL",
                   message.source_s3path, null)
                 ) as failed_files,
                 max(message.attempt) as max_attempt_seen
               by message.feed, message.order_type, message.table
-            | sort failed_files desc, retried_files desc, ok_files desc
+            | sort failed_files desc,
+                manual_required_files desc,
+                retried_files desc,
+                ok_files desc
             | limit 100
           EOT
         }

--- a/terraform/environments/electronic-monitoring-data/dlq-locals.tf
+++ b/terraform/environments/electronic-monitoring-data/dlq-locals.tf
@@ -12,4 +12,113 @@ locals {
     process_fms_metadata   = "-process_fms_metadata-dlq"
     push_data_export_to_p1 = "-push_data_export_to_p1-dlq"
   }
+
+  landing_dlq_redriver_config = {
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_general_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "general"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_general,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_general
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_general"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_ho_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "ho"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_ho,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_ho
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_ho"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_specials_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "specials"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_specials,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_specials
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_specials"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_general_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "general"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_general,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_general
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_general"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_ho_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "ho"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_ho"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_specials_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "specials"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_specials"
+    }
+  }
+
+  landing_dlq_redriver_queue_names = distinct(flatten([
+    for _, cfg in local.landing_dlq_redriver_config : [
+      cfg.source_queue_name,
+      cfg.dlq_queue_name,
+    ]
+  ]))
+
+  landing_dlq_redriver_queue_arns = [
+    for queue_name in local.landing_dlq_redriver_queue_names :
+    format(
+      "arn:aws:sqs:%s:%s:%s",
+      data.aws_region.current.region,
+      data.aws_caller_identity.current.account_id,
+      queue_name,
+    )
+  ]
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -2131,3 +2131,107 @@ resource "aws_lakeformation_permissions" "lambda_p1_table_access" {
     wildcard      = true
   }
 }
+
+#-----------------------------------------------------------------------------------
+# Landing DLQ redriver IAM Role
+#-----------------------------------------------------------------------------------
+
+resource "aws_iam_role" "landing_dlq_redriver" {
+  name               = "landing_dlq_redriver_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "landing_dlq_redriver_policy_document" {
+  statement {
+    sid    = "AllowQueueLookup"
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueUrl",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowLandingDlqRedrive"
+    effect = "Allow"
+
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+    ]
+
+    resources = local.landing_dlq_redriver_queue_arns
+  }
+
+  statement {
+    sid    = "AllowLandingFailureLogLookup"
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogStreams",
+      "logs:FilterLogEvents",
+      "logs:GetLogEvents",
+      "logs:GetQueryResults",
+      "logs:StartQuery",
+      "logs:StopQuery",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowAlarmThreadStateRead"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.alarm_thread_state_bucket}/${local.alarm_thread_state_prefix}/${local.environment_shorthand}/*"
+    ]
+  }
+
+  statement {
+    sid    = "AllowPublishToAlertsTopic"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.emds_alerts.arn,
+    ]
+  }
+
+  statement {
+    sid    = "AllowUseOfAlertsKmsKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKey*",
+    ]
+
+    resources = [
+      aws_kms_key.emds_alerts.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "landing_dlq_redriver" {
+  name   = "landing_dlq_redriver_lambda_policy"
+  policy = data.aws_iam_policy_document.landing_dlq_redriver_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "landing_dlq_redriver_attach" {
+  role       = aws_iam_role.landing_dlq_redriver.name
+  policy_arn = aws_iam_policy.landing_dlq_redriver.arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -832,6 +832,54 @@ module "staging_db_janitor" {
     STATE_PREFIX          = local.alarm_thread_state_prefix
   }
 }
+
+# ------------------------------------------------------------------------------
+# Lambda: landing_dlq_redriver
+# ------------------------------------------------------------------------------
+
+module "landing_dlq_redriver" {
+  source                         = "./modules/lambdas"
+  is_image                       = true
+  function_name                  = "landing_dlq_redriver"
+  role_name                      = aws_iam_role.landing_dlq_redriver.name
+  role_arn                       = aws_iam_role.landing_dlq_redriver.arn
+  handler                        = "landing_dlq_redriver.handler"
+  memory_size                    = 512
+  timeout                        = 300
+  reserved_concurrent_executions = 1
+
+  core_shared_services_id = local.environment_management.account_ids[
+    "core-shared-services-production"
+  ]
+
+  production_dev = local.is-production ? "prod" : (
+    local.is-preproduction ? "preprod" : (
+      local.is-test ? "test" : "dev"
+    )
+  )
+
+  security_group_ids = [aws_security_group.lambda_generic.id]
+  subnet_ids         = data.aws_subnets.shared-private.ids
+
+  environment_variables = {
+    POWERTOOLS_LOG_LEVEL = "INFO"
+
+    SNS_TOPIC_ARN = aws_sns_topic.emds_alerts.arn
+    ENVIRONMENT   = local.environment_shorthand
+    STATE_BUCKET  = local.alarm_thread_state_bucket
+    STATE_PREFIX  = local.alarm_thread_state_prefix
+
+    LANDING_DLQ_CONFIG = jsonencode(local.landing_dlq_redriver_config)
+
+    MAX_MESSAGES_PER_RUN                   = "50"
+    MAX_BATCHES_PER_EXECUTION              = "20"
+    DLQ_RECEIVE_VISIBILITY_TIMEOUT_SECONDS = "30"
+    LEGACY_UNKNOWN_RETRY_POLICY            = "retry_once"
+    AUTO_RETRY_MAX_ATTEMPTS                = "2"
+    RETRY_ONCE_MAX_ATTEMPTS                = "1"
+  }
+}
+
 # ------------------------------------------------------------------------------
 # Step Functions: landing DLQ redriver workflow
 # ------------------------------------------------------------------------------

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -832,3 +832,176 @@ module "staging_db_janitor" {
     STATE_PREFIX          = local.alarm_thread_state_prefix
   }
 }
+# ------------------------------------------------------------------------------
+# Step Functions: landing DLQ redriver workflow
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "landing_dlq_redriver_sfn_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["states.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "landing_dlq_redriver_state_machine" {
+  name               = "landing_dlq_redriver_state_machine_role"
+  assume_role_policy = data.aws_iam_policy_document.landing_dlq_redriver_sfn_assume.json
+}
+
+resource "aws_iam_role_policy" "landing_dlq_redriver_state_machine_invoke" {
+  name = "landing_dlq_redriver_state_machine_invoke_policy"
+  role = aws_iam_role.landing_dlq_redriver_state_machine.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowInvokeLandingDlqRedriverLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction",
+        ]
+        Resource = [
+          module.landing_dlq_redriver.lambda_function_arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_sfn_state_machine" "landing_dlq_redriver" {
+  name     = "landing_dlq_redriver"
+  role_arn = aws_iam_role.landing_dlq_redriver_state_machine.arn
+
+  definition = jsonencode({
+    Comment = "Redrives landing DLQ messages after CloudWatch DLQ alarms."
+    StartAt = "WaitForThreadState"
+    States = {
+      WaitForThreadState = {
+        Type    = "Wait"
+        Seconds = 10
+        Next    = "RedriverBatch"
+      }
+
+      RedriverBatch = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          FunctionName = module.landing_dlq_redriver.lambda_function_arn
+          "Payload.$" = "$"
+        }
+        OutputPath = "$.Payload"
+        Retry = [
+          {
+            ErrorEquals = [
+              "Lambda.ServiceException",
+              "Lambda.AWSLambdaException",
+              "Lambda.SdkClientException",
+              "Lambda.TooManyRequestsException",
+            ]
+            IntervalSeconds = 2
+            BackoffRate     = 2
+            MaxAttempts     = 3
+          }
+        ]
+        Next = "CheckStatus"
+      }
+
+      CheckStatus = {
+        Type = "Choice"
+        Choices = [
+          {
+            Variable     = "$.status"
+            StringEquals = "continuing"
+            Next         = "WaitBeforeNextBatch"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "ok"
+            Next         = "Complete"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "halted"
+            Next         = "Complete"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "ignored"
+            Next         = "Complete"
+          }
+        ]
+        Default = "UnexpectedResult"
+      }
+
+      WaitBeforeNextBatch = {
+        Type    = "Wait"
+        Seconds = 30
+        Next    = "RedriverBatch"
+      }
+
+      Complete = {
+        Type = "Succeed"
+      }
+
+      UnexpectedResult = {
+        Type  = "Fail"
+        Error = "UnexpectedLandingRedriverResult"
+        Cause = "The landing redriver returned an unexpected status."
+      }
+    }
+  })
+}
+
+# ------------------------------------------------------------------------------
+# EventBridge: alarm state changes -> landing DLQ redriver workflow
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "landing_dlq_redriver_eventbridge_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "landing_dlq_redriver_eventbridge" {
+  name               = "landing_dlq_redriver_eventbridge_role"
+  assume_role_policy = data.aws_iam_policy_document.landing_dlq_redriver_eventbridge_assume.json
+}
+
+resource "aws_iam_role_policy" "landing_dlq_redriver_eventbridge_start" {
+  name = "landing_dlq_redriver_eventbridge_start_policy"
+  role = aws_iam_role.landing_dlq_redriver_eventbridge.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowStartLandingDlqRedriverWorkflow"
+        Effect = "Allow"
+        Action = [
+          "states:StartExecution",
+        ]
+        Resource = [
+          aws_sfn_state_machine.landing_dlq_redriver.arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "landing_dlq_redriver" {
+  rule     = aws_cloudwatch_event_rule.alarm_state_change_threader.name
+  arn      = aws_sfn_state_machine.landing_dlq_redriver.arn
+  role_arn = aws_iam_role.landing_dlq_redriver_eventbridge.arn
+}

--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-landing.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-landing.tf
@@ -85,6 +85,20 @@ resource "aws_cloudwatch_log_metric_filter" "landing_file_ok" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "landing_file_manual_required" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-file-manual-required-${each.key}"
+  log_group_name = each.value.log_group_name
+  pattern        = "{ $.message.event = \"LANDING_FILE_MANUAL_REQUIRED\" }"
+
+  metric_transformation {
+    name      = "LandingFileManualRequiredCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
 resource "aws_cloudwatch_log_metric_filter" "landing_retryable_transient_fail" {
   for_each = local.landing_processor_log_groups
 
@@ -140,6 +154,21 @@ resource "aws_cloudwatch_log_metric_filter" "landing_unknown_fail" {
 
   metric_transformation {
     name      = "LandingUnknownFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_missing_source_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-missing-source-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+
+  pattern = "{ ($.message.event = \"LANDING_FILE_FAIL\") && ($.message.error_type = \"already_processed_or_missing_source\") }"
+
+  metric_transformation {
+    name      = "LandingMissingSourceFailCount${each.value.metric_suffix}"
     namespace = "EMDS/Landing"
     value     = "1"
   }

--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-landing.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-landing.tf
@@ -1,0 +1,146 @@
+# ------------------------------------------------------------------------------
+# Landing bucket processing log metric filters
+#
+# These filters convert structured LANDING_FILE_* logs emitted by
+# process_landing_bucket_files into CloudWatch metrics.
+#
+# The landing processor is upstream of both live feed loaders:
+# - FMS files must pass landing processing before format_json_fms_data/load_fms
+# - MDSS files must pass landing processing before copy_mdss_data/load_mdss
+# ------------------------------------------------------------------------------
+
+locals {
+  landing_processor_log_groups = {
+    fms_general = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_general"
+      metric_suffix  = "FmsGeneral"
+    }
+
+    fms_ho = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_ho"
+      metric_suffix  = "FmsHo"
+    }
+
+    fms_specials = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_specials"
+      metric_suffix  = "FmsSpecials"
+    }
+
+    mdss_general = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_general"
+      metric_suffix  = "MdssGeneral"
+    }
+
+    mdss_ho = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_ho"
+      metric_suffix  = "MdssHo"
+    }
+
+    mdss_specials = {
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_specials"
+      metric_suffix  = "MdssSpecials"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_file_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-file-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+  pattern        = "{ $.message.event = \"LANDING_FILE_FAIL\" }"
+
+  metric_transformation {
+    name      = "LandingFileFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_file_retry" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-file-retry-${each.key}"
+  log_group_name = each.value.log_group_name
+  pattern        = "{ $.message.event = \"LANDING_FILE_RETRY\" }"
+
+  metric_transformation {
+    name      = "LandingFileRetryCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_file_ok" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-file-ok-${each.key}"
+  log_group_name = each.value.log_group_name
+  pattern        = "{ $.message.event = \"LANDING_FILE_OK\" }"
+
+  metric_transformation {
+    name      = "LandingFileOkCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_retryable_transient_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-retryable-transient-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+
+  pattern = "{ ($.message.event = \"LANDING_FILE_FAIL\") && ($.message.error_type = \"retryable_transient\") }"
+
+  metric_transformation {
+    name      = "LandingRetryableTransientFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_non_retryable_data_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-non-retryable-data-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+
+  pattern = "{ ($.message.event = \"LANDING_FILE_FAIL\") && ($.message.error_type = \"non_retryable_data\") }"
+
+  metric_transformation {
+    name      = "LandingNonRetryableDataFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_non_retryable_config_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-non-retryable-config-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+
+  pattern = "{ ($.message.event = \"LANDING_FILE_FAIL\") && ($.message.error_type = \"non_retryable_config\") }"
+
+  metric_transformation {
+    name      = "LandingNonRetryableConfigFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "landing_unknown_fail" {
+  for_each = local.landing_processor_log_groups
+
+  name           = "landing-unknown-fail-${each.key}"
+  log_group_name = each.value.log_group_name
+
+  pattern = "{ ($.message.event = \"LANDING_FILE_FAIL\") && ($.message.error_type = \"unknown\") }"
+
+  metric_transformation {
+    name      = "LandingUnknownFailCount${each.value.metric_suffix}"
+    namespace = "EMDS/Landing"
+    value     = "1"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/sns.tf
+++ b/terraform/environments/electronic-monitoring-data/sns.tf
@@ -96,6 +96,18 @@ data "aws_iam_policy_document" "emds_alerts_kms" {
       identifiers = [aws_iam_role.staging_db_janitor.arn]
     }
   }
+
+  statement {
+    sid       = "AllowLandingDlqRedriverUseOfKey"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.landing_dlq_redriver.arn]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "emds_alerts_topic_policy" {
@@ -164,6 +176,22 @@ data "aws_iam_policy_document" "emds_alerts_topic_policy" {
     principals {
       type        = "AWS"
       identifiers = [aws_iam_role.staging_db_janitor.arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowLandingDlqRedriverLambdaToPublish"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [aws_sns_topic.emds_alerts.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.landing_dlq_redriver.arn]
     }
   }
 


### PR DESCRIPTION
This is a phased deployment for this ticket
https://github.com/moj-analytical-services/data-and-analytics-engineering-portfolios/issues/1762


PR 1 - https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/820

PR 2 adds operational visibility for the shared landing stage lambda used by both FMS and MDSS.

After PR 1, the Lambda emits structured logs:

```
LANDING_FILE_START
LANDING_FILE_OK
LANDING_FILE_RETRY
LANDING_FILE_FAIL
```

PR 2 turns those logs into:

- CloudWatch metrics
- CloudWatch dashboard widgets
- CloudWatch Logs Insights tables

This lets us see landing-stage failures before they become downstream reconciliation mismatches.
