### PR TITLE
PR 4 - landing redriver role and permissions

### DIFF
--- a/terraform/environments/electronic-monitoring-data/dlq-locals.tf
+++ b/terraform/environments/electronic-monitoring-data/dlq-locals.tf
@@ -12,4 +12,113 @@ locals {
     process_fms_metadata   = "-process_fms_metadata-dlq"
     push_data_export_to_p1 = "-push_data_export_to_p1-dlq"
   }
+
+  landing_dlq_redriver_config = {
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_general_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "general"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_general,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_general
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_general"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_ho_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "ho"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_ho,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_ho
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_ho"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_fms_specials_dlq"
+    ].alarm_name) = {
+      feed              = "fms"
+      order_type        = "specials"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_specials,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_fms_specials
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_fms_specials"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_general_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "general"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_general,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_general
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_general"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_ho_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "ho"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_ho"
+    }
+
+    (aws_cloudwatch_metric_alarm.sqs_dlq_has_messages[
+      "process_landing_bucket_files_mdss_specials_dlq"
+    ].alarm_name) = {
+      feed              = "mdss"
+      order_type        = "specials"
+      source_queue_name = trimsuffix(
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials,
+        "-dlq"
+      )
+      dlq_queue_name = (
+        local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials
+      )
+      log_group_name = "/aws/lambda/process_landing_bucket_files_mdss_specials"
+    }
+  }
+
+  landing_dlq_redriver_queue_names = distinct(flatten([
+    for _, cfg in local.landing_dlq_redriver_config : [
+      cfg.source_queue_name,
+      cfg.dlq_queue_name,
+    ]
+  ]))
+
+  landing_dlq_redriver_queue_arns = [
+    for queue_name in local.landing_dlq_redriver_queue_names :
+    format(
+      "arn:aws:sqs:%s:%s:%s",
+      data.aws_region.current.region,
+      data.aws_caller_identity.current.account_id,
+      queue_name,
+    )
+  ]
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -2131,3 +2131,107 @@ resource "aws_lakeformation_permissions" "lambda_p1_table_access" {
     wildcard      = true
   }
 }
+
+#-----------------------------------------------------------------------------------
+# Landing DLQ redriver IAM Role
+#-----------------------------------------------------------------------------------
+
+resource "aws_iam_role" "landing_dlq_redriver" {
+  name               = "landing_dlq_redriver_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "landing_dlq_redriver_policy_document" {
+  statement {
+    sid    = "AllowQueueLookup"
+    effect = "Allow"
+
+    actions = [
+      "sqs:GetQueueUrl",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowLandingDlqRedrive"
+    effect = "Allow"
+
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+    ]
+
+    resources = local.landing_dlq_redriver_queue_arns
+  }
+
+  statement {
+    sid    = "AllowLandingFailureLogLookup"
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogStreams",
+      "logs:FilterLogEvents",
+      "logs:GetLogEvents",
+      "logs:GetQueryResults",
+      "logs:StartQuery",
+      "logs:StopQuery",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowAlarmThreadStateRead"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.alarm_thread_state_bucket}/${local.alarm_thread_state_prefix}/${local.environment_shorthand}/*"
+    ]
+  }
+
+  statement {
+    sid    = "AllowPublishToAlertsTopic"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.emds_alerts.arn,
+    ]
+  }
+
+  statement {
+    sid    = "AllowUseOfAlertsKmsKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKey*",
+    ]
+
+    resources = [
+      aws_kms_key.emds_alerts.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "landing_dlq_redriver" {
+  name   = "landing_dlq_redriver_lambda_policy"
+  policy = data.aws_iam_policy_document.landing_dlq_redriver_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "landing_dlq_redriver_attach" {
+  role       = aws_iam_role.landing_dlq_redriver.name
+  policy_arn = aws_iam_policy.landing_dlq_redriver.arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -832,3 +832,176 @@ module "staging_db_janitor" {
     STATE_PREFIX          = local.alarm_thread_state_prefix
   }
 }
+# ------------------------------------------------------------------------------
+# Step Functions: landing DLQ redriver workflow
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "landing_dlq_redriver_sfn_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["states.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "landing_dlq_redriver_state_machine" {
+  name               = "landing_dlq_redriver_state_machine_role"
+  assume_role_policy = data.aws_iam_policy_document.landing_dlq_redriver_sfn_assume.json
+}
+
+resource "aws_iam_role_policy" "landing_dlq_redriver_state_machine_invoke" {
+  name = "landing_dlq_redriver_state_machine_invoke_policy"
+  role = aws_iam_role.landing_dlq_redriver_state_machine.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowInvokeLandingDlqRedriverLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction",
+        ]
+        Resource = [
+          module.landing_dlq_redriver.lambda_function_arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_sfn_state_machine" "landing_dlq_redriver" {
+  name     = "landing_dlq_redriver"
+  role_arn = aws_iam_role.landing_dlq_redriver_state_machine.arn
+
+  definition = jsonencode({
+    Comment = "Redrives landing DLQ messages after CloudWatch DLQ alarms."
+    StartAt = "WaitForThreadState"
+    States = {
+      WaitForThreadState = {
+        Type    = "Wait"
+        Seconds = 10
+        Next    = "RedriverBatch"
+      }
+
+      RedriverBatch = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Parameters = {
+          FunctionName = module.landing_dlq_redriver.lambda_function_arn
+          "Payload.$" = "$"
+        }
+        OutputPath = "$.Payload"
+        Retry = [
+          {
+            ErrorEquals = [
+              "Lambda.ServiceException",
+              "Lambda.AWSLambdaException",
+              "Lambda.SdkClientException",
+              "Lambda.TooManyRequestsException",
+            ]
+            IntervalSeconds = 2
+            BackoffRate     = 2
+            MaxAttempts     = 3
+          }
+        ]
+        Next = "CheckStatus"
+      }
+
+      CheckStatus = {
+        Type = "Choice"
+        Choices = [
+          {
+            Variable     = "$.status"
+            StringEquals = "continuing"
+            Next         = "WaitBeforeNextBatch"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "ok"
+            Next         = "Complete"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "halted"
+            Next         = "Complete"
+          },
+          {
+            Variable     = "$.status"
+            StringEquals = "ignored"
+            Next         = "Complete"
+          }
+        ]
+        Default = "UnexpectedResult"
+      }
+
+      WaitBeforeNextBatch = {
+        Type    = "Wait"
+        Seconds = 30
+        Next    = "RedriverBatch"
+      }
+
+      Complete = {
+        Type = "Succeed"
+      }
+
+      UnexpectedResult = {
+        Type  = "Fail"
+        Error = "UnexpectedLandingRedriverResult"
+        Cause = "The landing redriver returned an unexpected status."
+      }
+    }
+  })
+}
+
+# ------------------------------------------------------------------------------
+# EventBridge: alarm state changes -> landing DLQ redriver workflow
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "landing_dlq_redriver_eventbridge_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "landing_dlq_redriver_eventbridge" {
+  name               = "landing_dlq_redriver_eventbridge_role"
+  assume_role_policy = data.aws_iam_policy_document.landing_dlq_redriver_eventbridge_assume.json
+}
+
+resource "aws_iam_role_policy" "landing_dlq_redriver_eventbridge_start" {
+  name = "landing_dlq_redriver_eventbridge_start_policy"
+  role = aws_iam_role.landing_dlq_redriver_eventbridge.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowStartLandingDlqRedriverWorkflow"
+        Effect = "Allow"
+        Action = [
+          "states:StartExecution",
+        ]
+        Resource = [
+          aws_sfn_state_machine.landing_dlq_redriver.arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "landing_dlq_redriver" {
+  rule     = aws_cloudwatch_event_rule.alarm_state_change_threader.name
+  arn      = aws_sfn_state_machine.landing_dlq_redriver.arn
+  role_arn = aws_iam_role.landing_dlq_redriver_eventbridge.arn
+}

--- a/terraform/environments/electronic-monitoring-data/sns.tf
+++ b/terraform/environments/electronic-monitoring-data/sns.tf
@@ -96,6 +96,18 @@ data "aws_iam_policy_document" "emds_alerts_kms" {
       identifiers = [aws_iam_role.staging_db_janitor.arn]
     }
   }
+
+  statement {
+    sid       = "AllowLandingDlqRedriverUseOfKey"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.landing_dlq_redriver.arn]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "emds_alerts_topic_policy" {
@@ -164,6 +176,22 @@ data "aws_iam_policy_document" "emds_alerts_topic_policy" {
     principals {
       type        = "AWS"
       identifiers = [aws_iam_role.staging_db_janitor.arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowLandingDlqRedriverLambdaToPublish"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [aws_sns_topic.emds_alerts.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.landing_dlq_redriver.arn]
     }
   }
 


### PR DESCRIPTION
This is a phased deployment for this ticket

https://github.com/moj-analytical-services/data-and-analytics-engineering-portfolios/issues/1762

PR 1 - https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/820
PR2 - https://github.com/ministryofjustice/modernisation-platform-environments/pull/16380
PR 3 - https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/822

PR4 wires the landing process redeliver lambda into Terraform so the existing CloudWatch alarm lifecycle can trigger it without changing cloudwatch_alarm_threader.