### PR TITLE
Fix SQS backlog stats in CloudWatch dashboards

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS: FMS events waiting for load_fms"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS DLQ: FMS events that failed load_fms"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [
@@ -67,7 +67,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS: format_fms_json queue backlog"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS DLQ: format_fms_json failures"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [
@@ -296,7 +296,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS DLQs: FMS landing bucket processing"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [
@@ -333,7 +333,7 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
         properties = {
           title  = "SQS DLQs: FMS support path"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             [

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-mdss.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-mdss.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_dashboard" "mdss_ops" {
         properties = {
           title  = "SQS: S3 events waiting for load_mdss"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             ["AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", module.load_mdss_event_queue.sqs_queue.name],
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_dashboard" "mdss_ops" {
         properties = {
           title  = "SQS DLQ: S3 events that failed load_mdss"
           region = "eu-west-2"
-          stat   = "Sum"
+          stat   = "Maximum"
           period = 60
           metrics = [
             ["AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", module.load_mdss_event_queue.sqs_dlq.name]


### PR DESCRIPTION
## Description

Updates SQS backlog widgets in the MDSS and FMS CloudWatch dashboards to use `Maximum` instead of `Sum`.

## Changes

- Changed MDSS load queue and DLQ widgets to `Maximum`.
- Changed FMS load queue, format queue, landing DLQ, and support-path DLQ widgets to `Maximum`.
- Kept count/event metrics as `Sum`.

## Outcome

Queue depth widgets now better represent backlog size over time.