### PR TITLE
add live feed loader stage metrics

### DIFF
--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-fms.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-fms.tf
@@ -1,0 +1,35 @@
+resource "aws_cloudwatch_log_metric_filter" "fms_file_ok" {
+  name           = "fms-file-ok"
+  log_group_name = module.load_fms_lambda.cloudwatch_log_group.name
+  pattern        = "{ $.message.event = \"FMS_FILE_OK\" }"
+
+  metric_transformation {
+    name      = "FmsFileOkCount"
+    namespace = "EMDS/FMS"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "fms_file_fail" {
+  name           = "fms-file-fail"
+  log_group_name = module.load_fms_lambda.cloudwatch_log_group.name
+  pattern        = "{ $.message.event = \"FMS_FILE_FAIL\" }"
+
+  metric_transformation {
+    name      = "FmsFileFailCount"
+    namespace = "EMDS/FMS"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "fms_file_rejected_validation" {
+  name           = "fms-file-rejected-validation"
+  log_group_name = module.load_fms_lambda.cloudwatch_log_group.name
+  pattern        = "{ $.message.event = \"FMS_FILE_REJECTED_VALIDATION\" }"
+
+  metric_transformation {
+    name      = "FmsFileRejectedValidationCount"
+    namespace = "EMDS/FMS"
+    value     = "1"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-mdss.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-mdss.tf
@@ -1,3 +1,15 @@
+resource "aws_cloudwatch_log_metric_filter" "mdss_file_ok" {
+  name           = "mdss-file-ok"
+  log_group_name = module.load_mdss_lambda.cloudwatch_log_group.name
+  pattern        = "{ $.message.event = \"MDSS_FILE_OK\" }"
+
+  metric_transformation {
+    name      = "MdssFileOkCount"
+    namespace = "EMDS/MDSS"
+    value     = "1"
+  }
+}
+
 resource "aws_cloudwatch_log_metric_filter" "mdss_file_fail" {
   name           = "mdss-file-fail"
   log_group_name = module.load_mdss_lambda.cloudwatch_log_group.name


### PR DESCRIPTION
Adds missing loader metrics for live-feed stage count checks needed for the daily digest lambda

## Changes

- Emits  `FMS_FILE_OK`, `FMS_FILE_FAIL`, and `FMS_FILE_REJECTED_VALIDATION` events from `load_fms`.
- Adds FMS CloudWatch log metric filters under `EMDS/FMS`.
- Adds `MdssFileOkCount` for first-try MDSS loads.

## Outcome

Daily handover stage counts can be populated from cheap CloudWatch metrics instead of ad hoc reconciliation.