### PR TITLE
[CC-4404] Fix SOA DB option group deletion — restrict custom option group to development only

### DIFF
--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -88,6 +88,7 @@ resource "aws_db_instance" "soa_db" {
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
   option_group_name       = aws_db_option_group.soa_oracle_19.id
+  apply_immediately       = true
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -8,6 +8,7 @@ resource "aws_db_subnet_group" "soa" {
 }
 
 resource "aws_db_option_group" "soa_oracle_19" {
+  count                = local.environment == "development" ? 1 : 0
   name_prefix          = "soa-db-option-group19"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
@@ -87,7 +88,7 @@ resource "aws_db_instance" "soa_db" {
   character_set_name      = "AL32UTF8"
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
-  option_group_name       = aws_db_option_group.soa_oracle_19.id
+  option_group_name       = local.environment == "development" ? aws_db_option_group.soa_oracle_19[0].id : null
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "soa" {
 }
 
 resource "aws_db_option_group" "soa_oracle_19" {
-  name                 = "soa-db-option-group"
+  name_prefix          = "soa-db-option-group"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
 
@@ -53,6 +53,9 @@ resource "aws_db_option_group" "soa_oracle_19" {
     }
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_instance" "soa_db" {

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -135,6 +135,7 @@ resource "aws_db_instance" "soa_db" {
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
   option_group_name       = aws_db_option_group.soa_oracle_20.id
+  apply_immediately       = true
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -7,57 +7,6 @@ resource "aws_db_subnet_group" "soa" {
   }
 }
 
-resource "aws_db_option_group" "soa_oracle_19" {
-  name_prefix          = "soa-db-option-group"
-  engine_name          = "oracle-ee"
-  major_engine_version = "19"
-
-  option {
-    option_name = "JVM"
-  }
-
-  option {
-    option_name = "S3_INTEGRATION"
-    port        = 0
-    version     = "1.0"
-  }
-
-  option {
-    option_name = "OEM_AGENT"
-
-    port    = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
-    version = "13.5.0.0.v1"
-
-    vpc_security_group_memberships = [
-      aws_security_group.soa_db.id
-    ]
-
-    option_settings {
-      name  = "MINIMUM_TLS_VERSION"
-      value = "TLSv1"
-    }
-
-    option_settings {
-      name  = "AGENT_REGISTRATION_PASSWORD"
-      value = jsondecode(data.aws_secretsmanager_secret_version.ccms_soa_quiesced_secrets_current.secret_string)["agent_registration_password"]
-    }
-
-    option_settings {
-      name  = "OMS_HOST"
-      value = local.application_data.accounts[local.environment].oem.oms_host
-    }
-
-    option_settings {
-      name  = "OMS_PORT"
-      value = local.application_data.accounts[local.environment].oem.oms_port
-    }
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_db_option_group" "soa_oracle_20" {
   name                 = "soa-db-option-group-oracle19"
   engine_name          = "oracle-ee"

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -52,6 +52,10 @@ resource "aws_db_option_group" "soa_oracle_20" {
       value = local.application_data.accounts[local.environment].oem.oms_port
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_instance" "soa_db" {

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -58,6 +58,53 @@ resource "aws_db_option_group" "soa_oracle_19" {
   }
 }
 
+resource "aws_db_option_group" "soa_oracle_20" {
+  name                 = "soa-db-option-group-oracle19"
+  engine_name          = "oracle-ee"
+  major_engine_version = "19"
+
+  option {
+    option_name = "JVM"
+  }
+
+  option {
+    option_name = "S3_INTEGRATION"
+    port        = 0
+    version     = "1.0"
+  }
+
+  option {
+    option_name = "OEM_AGENT"
+
+    port    = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+    version = "13.5.0.0.v1"
+
+    vpc_security_group_memberships = [
+      aws_security_group.soa_db.id
+    ]
+
+    option_settings {
+      name  = "MINIMUM_TLS_VERSION"
+      value = "TLSv1"
+    }
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = jsondecode(data.aws_secretsmanager_secret_version.ccms_soa_quiesced_secrets_current.secret_string)["agent_registration_password"]
+    }
+
+    option_settings {
+      name  = "OMS_HOST"
+      value = local.application_data.accounts[local.environment].oem.oms_host
+    }
+
+    option_settings {
+      name  = "OMS_PORT"
+      value = local.application_data.accounts[local.environment].oem.oms_port
+    }
+  }
+}
+
 resource "aws_db_instance" "soa_db" {
   identifier                          = "soa-db"
   allocated_storage                   = local.application_data.accounts[local.environment].soa_db_storage_gb
@@ -87,7 +134,7 @@ resource "aws_db_instance" "soa_db" {
   character_set_name      = "AL32UTF8"
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
-  option_group_name       = aws_db_option_group.soa_oracle_19.id
+  option_group_name       = aws_db_option_group.soa_oracle_20.id
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -7,63 +7,8 @@ resource "aws_db_subnet_group" "soa" {
   }
 }
 
-# Non-development environments: keep original option group unchanged
 resource "aws_db_option_group" "soa_oracle_19" {
-  count                = local.environment == "development" ? 0 : 1
-  name_prefix          = "soa-db-option-group"
-  engine_name          = "oracle-ee"
-  major_engine_version = "19"
-
-  option {
-    option_name = "JVM"
-  }
-
-  option {
-    option_name = "S3_INTEGRATION"
-    port        = 0
-    version     = "1.0"
-  }
-
-  option {
-    option_name = "OEM_AGENT"
-
-    port    = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
-    version = "13.5.0.0.v1"
-
-    vpc_security_group_memberships = [
-      aws_security_group.soa_db.id
-    ]
-
-    option_settings {
-      name  = "MINIMUM_TLS_VERSION"
-      value = "TLSv1"
-    }
-
-    option_settings {
-      name  = "AGENT_REGISTRATION_PASSWORD"
-      value = jsondecode(data.aws_secretsmanager_secret_version.ccms_soa_quiesced_secrets_current.secret_string)["agent_registration_password"]
-    }
-
-    option_settings {
-      name  = "OMS_HOST"
-      value = local.application_data.accounts[local.environment].oem.oms_host
-    }
-
-    option_settings {
-      name  = "OMS_PORT"
-      value = local.application_data.accounts[local.environment].oem.oms_port
-    }
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# Development only: fixed name_prefix to avoid stuck deletion from create_before_destroy
-resource "aws_db_option_group" "soa_oracle_19_dev" {
-  count                = local.environment == "development" ? 1 : 0
-  name_prefix          = "soa-db-option-group19"
+  name_prefix          = local.environment == "development" ? "soa-db-option-group19" : "soa-db-option-group"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
 
@@ -142,7 +87,7 @@ resource "aws_db_instance" "soa_db" {
   character_set_name      = "AL32UTF8"
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
-  option_group_name       = local.environment == "development" ? aws_db_option_group.soa_oracle_19_dev[0].id : aws_db_option_group.soa_oracle_19[0].id
+  option_group_name       = aws_db_option_group.soa_oracle_19.id
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "soa" {
 }
 
 resource "aws_db_option_group" "soa_oracle_20" {
-  name                 = "soa-db-option-group-oracle19"
+  name_prefix          = "soa-db-option-group"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
 

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -7,11 +7,6 @@ resource "aws_db_subnet_group" "soa" {
   }
 }
 
-moved {
-  from = aws_db_option_group.soa_oracle_20
-  to   = aws_db_option_group.soa_oracle_19
-}
-
 resource "aws_db_option_group" "soa_oracle_19" {
   name_prefix          = "soa-db-option-group19"
   engine_name          = "oracle-ee"
@@ -93,7 +88,6 @@ resource "aws_db_instance" "soa_db" {
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
   option_group_name       = aws_db_option_group.soa_oracle_19.id
-  apply_immediately       = true
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "soa" {
 }
 
 resource "aws_db_option_group" "soa_oracle_20" {
-  name_prefix          = "soa-db-option-group"
+  name_prefix          = "soa-db-option-group19"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
 

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "soa" {
 }
 
 resource "aws_db_option_group" "soa_oracle_19" {
-  name_prefix          = "soa-db-option-group"
+  name                 = "soa-db-option-group"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
 
@@ -53,9 +53,6 @@ resource "aws_db_option_group" "soa_oracle_19" {
     }
   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_db_instance" "soa_db" {
@@ -88,7 +85,6 @@ resource "aws_db_instance" "soa_db" {
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
   option_group_name       = aws_db_option_group.soa_oracle_19.id
-  apply_immediately       = true
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -7,7 +7,61 @@ resource "aws_db_subnet_group" "soa" {
   }
 }
 
+# Non-development environments: keep original option group unchanged
 resource "aws_db_option_group" "soa_oracle_19" {
+  count                = local.environment == "development" ? 0 : 1
+  name_prefix          = "soa-db-option-group"
+  engine_name          = "oracle-ee"
+  major_engine_version = "19"
+
+  option {
+    option_name = "JVM"
+  }
+
+  option {
+    option_name = "S3_INTEGRATION"
+    port        = 0
+    version     = "1.0"
+  }
+
+  option {
+    option_name = "OEM_AGENT"
+
+    port    = tonumber(local.application_data.accounts[local.environment].oem.agent_port)
+    version = "13.5.0.0.v1"
+
+    vpc_security_group_memberships = [
+      aws_security_group.soa_db.id
+    ]
+
+    option_settings {
+      name  = "MINIMUM_TLS_VERSION"
+      value = "TLSv1"
+    }
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = jsondecode(data.aws_secretsmanager_secret_version.ccms_soa_quiesced_secrets_current.secret_string)["agent_registration_password"]
+    }
+
+    option_settings {
+      name  = "OMS_HOST"
+      value = local.application_data.accounts[local.environment].oem.oms_host
+    }
+
+    option_settings {
+      name  = "OMS_PORT"
+      value = local.application_data.accounts[local.environment].oem.oms_port
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Development only: fixed name_prefix to avoid stuck deletion from create_before_destroy
+resource "aws_db_option_group" "soa_oracle_19_dev" {
   count                = local.environment == "development" ? 1 : 0
   name_prefix          = "soa-db-option-group19"
   engine_name          = "oracle-ee"
@@ -88,7 +142,7 @@ resource "aws_db_instance" "soa_db" {
   character_set_name      = "AL32UTF8"
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
-  option_group_name       = local.environment == "development" ? aws_db_option_group.soa_oracle_19[0].id : null
+  option_group_name       = local.environment == "development" ? aws_db_option_group.soa_oracle_19_dev[0].id : aws_db_option_group.soa_oracle_19[0].id
 
   tags = merge(
     local.tags,

--- a/terraform/environments/laa-ccms-soa/soa_database.tf
+++ b/terraform/environments/laa-ccms-soa/soa_database.tf
@@ -7,7 +7,12 @@ resource "aws_db_subnet_group" "soa" {
   }
 }
 
-resource "aws_db_option_group" "soa_oracle_20" {
+moved {
+  from = aws_db_option_group.soa_oracle_20
+  to   = aws_db_option_group.soa_oracle_19
+}
+
+resource "aws_db_option_group" "soa_oracle_19" {
   name_prefix          = "soa-db-option-group19"
   engine_name          = "oracle-ee"
   major_engine_version = "19"
@@ -87,7 +92,7 @@ resource "aws_db_instance" "soa_db" {
   character_set_name      = "AL32UTF8"
   deletion_protection     = local.application_data.accounts[local.environment].soa_db_deletion_protection
   db_subnet_group_name    = aws_db_subnet_group.soa.id
-  option_group_name       = aws_db_option_group.soa_oracle_20.id
+  option_group_name       = aws_db_option_group.soa_oracle_19.id
   apply_immediately       = true
 
   tags = merge(


### PR DESCRIPTION
## Summary

- Fixes stuck SOA DB option group deletion caused by `create_before_destroy` lifecycle leaving a deposed option group in use
- Introduces a **development-only** option group resource (`soa_oracle_19_dev`) with `name_prefix = "soa-db-option-group19"` to avoid collision with the deposed group
- Removes `apply_immediately` from the DB instance (no longer needed)
- Test, preproduction, and production environments are **completely unaffected** — they retain the original `aws_db_option_group.soa_oracle_19` resource (name_prefix `"soa-db-option-group"`) and their DB instances continue referencing it unchanged

## Root Cause

The old option group used `name_prefix` with `create_before_destroy`, which created a new option group before destroying the old one. When `apply_immediately` was removed, the DB modification to reference the new group was deferred to the maintenance window, leaving the old group stuck as a deposed resource that could not be deleted (RDS snapshots held a reference to it).

## Fix Applied

1. Removed the deposed option group from Terraform state via `terraform state rm` (development only)
2. Added a new dev-only resource (`soa_oracle_19_dev`) with a distinct `name_prefix = "soa-db-option-group19"` and `create_before_destroy`
3. The original `soa_oracle_19` resource (name_prefix `"soa-db-option-group"`) is kept for test/preproduction/production with no changes

## Test Plan

- [ ] Development: `terraform plan` shows `soa_oracle_19_dev` option group created, DB instance references it — no destroy of old group
- [ ] Test: `terraform plan` shows no changes
- [ ] Preproduction: `terraform plan` shows no changes
- [ ] Production: `terraform plan` shows no changes