### PR TITLE
fix live feed handover stage counts

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -536,6 +536,9 @@ module "mdss_daily_failure_digest" {
     NAMESPACE      = "EMDS/MDSS"
     LOOKBACK_HOURS = "24"
 
+    LOAD_MDSS_QUEUE_NAME = module.load_mdss_event_queue.sqs_queue.name
+    LOAD_FMS_QUEUE_NAME  = module.load_fms_event_queue.sqs_queue.name
+
     LOAD_MDSS_DLQ_NAME = module.load_mdss_event_queue.sqs_dlq.name
     CLEAN_DLT_DLQ_NAME = aws_sqs_queue.clean_dlt_load_dlq.name
     LOAD_FMS_DLQ_NAME  = module.load_fms_event_queue.sqs_dlq.name
@@ -556,6 +559,11 @@ module "mdss_daily_failure_digest" {
     LOAD_FMS_FUNCTION_NAME             = module.load_fms_lambda.lambda_function_name
     PROCESS_FMS_METADATA_FUNCTION_NAME = module.process_fms_metadata.lambda_function_name
     FORMAT_JSON_FMS_DATA_FUNCTION_NAME = module.format_json_fms_data.lambda_function_name
+
+    LAMBDAS_PRODUCTION_RUN_URL = "https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/actions/workflows/push-to-ecr.yaml"
+    CADT_DAILY_RUN_URL         = "https://github.com/moj-analytical-services/create-a-derived-table/actions/workflows/emds-live-workflow.yml"
+    ROTA_GUIDE_URL             = "https://jubilant-adventure-g65j3om.pages.github.io/hmpps/electronic_monitoring/data_engineering_guides/rota_duties/"
+    EARS_SARS_TALLY_URL        = "https://justiceuk.sharepoint.com/:x:/r/sites/EMExpansionProgrammeteam/_layouts/15/doc2.aspx?sourcedoc=%7B25644699-3837-4A02-9C09-020EF0ECA744%7D&file=Monthly%20Tally%20of%20EARs%20and%20SARs.xlsx&action=default&mobileredirect=true"
   }
 }
 


### PR DESCRIPTION
Update the live feed handover digest so the daily stage count check shows the
main pipeline stages:

- Landing OK
- Raw formatted
- Athena loaded

The previous `Load started` column read `MdssFileStartCount` and
`FmsFileStartCount`, but those metrics are not created by Terraform. This meant
the column could show `0` even when files had reached the raw-formatted stage.

Lambda PR - https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/827