### PR TITLE
feat(integration-hub): add managed file transfer AWS Transfer PoC

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -4,6 +4,8 @@
       "iam_configuration": {
         "guardduty_role_name": "integration-hub-development-guardduty-s3-plan",
         "guardduty_policy_name": "integration-hub-development-guardduty-s3-plan",
+        "transfer_role_name": "integration-hub-development-transfer",
+        "transfer_policy_name": "integration-hub-development-transfer-policy",
         "malware_scanning_processing_bucket_key": "processing",
         "malware_scanning_object_prefix": ["incoming/"],
         "kms_key_arn_list": [

--- a/terraform/environments/integration-hub/managed-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/kms.tf
@@ -5,12 +5,85 @@ module "kms_s3_bucket" {
   source  = "terraform-aws-modules/kms/aws"
   version = "4.2.0"
 
-  description         = "Key for cryptographic functions on ${trimsuffix(each.value.bucket_prefix, "-")} S3 bucket"
-  multi_region        = false
-  is_enabled          = true
-  key_usage           = "ENCRYPT_DECRYPT"
-  enable_key_rotation = true
+  description           = "Key for cryptographic functions on ${trimsuffix(each.value.bucket_prefix, "-")} S3 bucket"
+  deletion_window_in_days = 30
+  enable_default_policy = true
+  enable_key_rotation   = true
+  key_usage             = "ENCRYPT_DECRYPT"
+  is_enabled            = true
+  aliases               = ["integration-hub/s3/${trimsuffix(each.value.bucket_prefix, "-")}"]
 
   # Allow the root account as administrator
   key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+}
+
+module "kms_secrets" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 4.1.0"
+
+  description             = "KMS CMK for Secrets Manager encryption"
+  deletion_window_in_days = 30
+  enable_default_policy   = true
+  enable_key_rotation     = true
+  key_usage               = "ENCRYPT_DECRYPT"
+  is_enabled              = true
+  aliases                 = ["integration-hub/secrets"]
+
+  # Allow the root account as administrator
+  key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+
+  # Explicitly allow only necessary roles to use the key
+  key_users = [
+    for role_name in toset([
+      var.collaborator_access,
+      "MemberInfrastructureAccess",
+    ]) :
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role_name}"
+  ]
+
+  # Allow Secrets Manager to use the key
+  key_statements = [
+    {
+      sid = "AllowSecretsManagerService"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["secretsmanager.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "AllowCIRoles"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            for role_name in toset([
+              var.collaborator_access,
+              "MemberInfrastructureAccess",
+            ]) :
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role_name}"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -1,0 +1,44 @@
+module "secrets_transfer_user_ssh_keys" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.0.0"
+
+  name                    = "transfer-user-ssh-keys"
+  description             = "Transfer user SSH keys"
+  recovery_window_in_days = 7
+  kms_key_id              = module.kms_secrets.key_id
+  create_policy           = true
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  policy_statements = {
+    read = {
+      sid = "AllowCIRolesToRead"
+      principals = [{
+        type = "AWS"
+        identifiers = [
+          for role_name in toset([
+            var.collaborator_access,
+            "MemberInfrastructureAccess",
+          ]) :
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role_name}"
+        ]
+      }]
+      actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      resources = ["*"]
+    }
+  }
+  # This value is manually maintained in AWS and ignored after creation.
+  # {
+  #   "random-pet-name": {
+  #     "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample transfer-user"
+  #   }
+  # }
+  secret_string = jsonencode({
+
+  })
+}
+
+data "aws_secretsmanager_secret_version" "secrets_transfer_user_ssh_keys" {
+  secret_id = module.secrets_transfer_user_ssh_keys.secret_id
+
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
@@ -179,7 +179,7 @@ resource "aws_transfer_user" "transfer_user" {
 
   home_directory_mappings {
     entry  = "/"
-    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/$${transfer:UserName}"
+    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/incoming/$${transfer:UserName}"
   }
 
   tags = local.tags

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
@@ -1,0 +1,197 @@
+resource "aws_cloudwatch_log_group" "transfer" {
+  name_prefix = "transfer_test_"
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "transfer_user_access" {
+  statement {
+    sid    = "AllowListingOfUserFolder"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+    resources = [module.s3_bucket["unscanned"].s3_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        random_pet.transfer_user.id,
+        "${random_pet.transfer_user.id}/*",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "HomeDirObjectAccess"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+    resources = ["${module.s3_bucket["unscanned"].s3_bucket_arn}/${random_pet.transfer_user.id}/*"]
+  }
+
+  statement {
+    sid    = "HomeDirKmsAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+    ]
+    resources = [module.kms_s3_bucket["unscanned"].key_arn]
+  }
+}
+
+data "aws_iam_policy_document" "transfer_user_session" {
+  statement {
+    sid    = "AllowListingOfUserFolder"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [module.s3_bucket["unscanned"].s3_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "$${transfer:UserName}",
+        "$${transfer:UserName}/*",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "HomeDirObjectAccess"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+    resources = ["arn:aws:s3:::${module.s3_bucket["unscanned"].s3_bucket_id}/$${transfer:UserName}/*"]
+  }
+}
+
+module "transfer_logging_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  use_name_prefix = false
+  name            = local.iam_configuration.transfer_role_name
+
+  trust_policy_permissions = {
+    AllowTransferService = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+    }
+  }
+
+  policies = {
+    transfer_logging_access = "arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"
+  }
+
+  tags = local.tags
+}
+
+module "transfer_user_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.0"
+
+  name        = local.iam_configuration.transfer_policy_name
+  description = "AWS Transfer user access policy"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.transfer_user_access.json
+
+  tags = local.tags
+}
+
+module "transfer_user_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  use_name_prefix = false
+  name            = "${local.iam_configuration.transfer_role_name}-user"
+
+  trust_policy_permissions = {
+    AllowTransferService = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+    }
+  }
+
+  policies = {
+    transfer_user_access = module.transfer_user_policy.arn
+  }
+
+  tags = local.tags
+}
+
+resource "aws_transfer_server" "transfer" {
+  domain                 = "S3"
+  endpoint_type          = "PUBLIC"
+  identity_provider_type = "SERVICE_MANAGED"
+  logging_role           = module.transfer_logging_role.arn
+  protocols              = ["SFTP"]
+  security_policy_name   = "TransferSecurityPolicy-2025-03"
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.transfer.arn}:*"
+  ]
+
+  tags = local.tags
+}
+
+resource "aws_transfer_user" "transfer_user" {
+  server_id = aws_transfer_server.transfer.id
+  user_name = random_pet.transfer_user.id
+  role      = module.transfer_user_role.arn
+  policy    = data.aws_iam_policy_document.transfer_user_session.json
+
+  home_directory_type = "LOGICAL"
+
+  home_directory_mappings {
+    entry  = "/"
+    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/$${transfer:UserName}"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_transfer_ssh_key" "transfer_user" {
+  body      = trimspace(jsondecode(data.aws_secretsmanager_secret_version.secrets_transfer_user_ssh_keys.secret_string)[random_pet.transfer_user.id].key)
+  server_id = aws_transfer_server.transfer.id
+  user_name = random_pet.transfer_user.id
+}
+
+resource "random_pet" "transfer_user" {
+  length    = 3
+  separator = "-"
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

This change introduces an AWS Transfer proof of concept for Integration Hub managed file transfer.

The aim of the PoC is to provide a testbed for an enterprise managed file transfer solution using an event-driven approach, while allowing account administrators to prove the approach is sound and build familiarity with the underlying AWS services.

## What Changed

- add AWS Transfer resources for a single service-managed SFTP user
- add IAM role and policy configuration for AWS Transfer logging and user access
- add Secrets Manager storage for the Transfer user's SSH public key
- add a dedicated KMS key for Secrets Manager encryption and update KMS configuration for the PoC
- add environment configuration values for Transfer IAM resource naming
- update the Transfer user home directory pathing to align uploads with the intended unscanned bucket flow

## Current PoC Scope

This branch is intentionally limited to a narrow proof of concept:

- single user only
- public AWS Transfer endpoint accepted for now
- SSH public key populated manually and stored in Secrets Manager
- focus is on proving the front-end AWS Transfer integration and event-driven file handling approach

Out of scope for this PoC:

- broader partner onboarding and multi-user design
- RBAC or SSO integration, including later Entra ID work
- downstream retrieval from the `clean` bucket by an application or individual
- further hardening beyond what is needed to prove the approach

## Testing

The following validation has been completed:

- `terraform validate` run locally
- end-to-end manual testing of the downstream S3-based flow using clean, dirty, and password-protected file types

Limitations of current testing:

- file submission was tested through direct S3 upload rather than through AWS Transfer/SFTP itself

## Follow-up Notes

Reviewers should treat this as the first step that introduces AWS Transfer on the front end for Integration Hub managed file transfer.

Further work is expected around:

- exercising the ingress path through AWS Transfer/SFTP directly
- future RBAC/SSO work
- assessing the path from PoC to a more production-ready operating model

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>