### PR TITLE
feat(integration-hub): add idempotency to managed file transfer

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/dynamo-db.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/dynamo-db.tf
@@ -1,0 +1,24 @@
+module "dynamodb_idempotency" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "integration-hub-s3-idempotency"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attributes = [
+    {
+      name = "id"
+      type = "S"
+    }
+  ]
+
+  table_class        = "STANDARD"
+  ttl_attribute_name = "expiration"
+  ttl_enabled        = true
+  timeouts = {
+    "create" : "60m",
+    "delete" : "60m",
+    "update" : "60m"
+  }
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
@@ -32,7 +32,7 @@ module "eventbridge_guard_duty_malware_protection_for_s3" {
           }
           input_template = <<-EOF
 					{
-					  "source_bucket": "${module.s3_bucket["processing"].s3_bucket_id}",
+            "source_bucket_name": "${module.s3_bucket["processing"].s3_bucket_id}",
 					  "destination_bucket_key": "${each.value.destination_bucket_key}",
 					  "delete_source": ${jsonencode(each.value.delete_source)},
 					  "object_key": "<object_key>",

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -17,7 +17,8 @@ module "lambda_unscanned_to_processing" {
   }
 
   environment_variables = {
-    DESTINATION_BUCKET = module.s3_bucket["processing"].s3_bucket_id
+    DESTINATION_BUCKET_NAME = module.s3_bucket["processing"].s3_bucket_id
+    IDEMPOTENCY_TABLE       = module.dynamodb_idempotency.dynamodb_table_id
   }
 
   attach_policy_statements = true
@@ -59,6 +60,18 @@ module "lambda_unscanned_to_processing" {
         module.kms_s3_bucket["processing"].key_arn,
       ]
     }
+    idempotency_table_access = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+      ]
+      resources = [
+        module.dynamodb_idempotency.dynamodb_table_arn,
+      ]
+    }
   }
 
   attach_policies    = true
@@ -91,13 +104,14 @@ module "lambda_processing_to_post_scan" {
   }
 
   environment_variables = {
-    BUCKETS_BY_KEY = jsonencode({
+    BUCKET_NAMES_BY_KEY = jsonencode({
       processing    = module.s3_bucket["processing"].s3_bucket_id
       clean         = module.s3_bucket["clean"].s3_bucket_id
       quarantine    = module.s3_bucket["quarantine"].s3_bucket_id
       investigation = module.s3_bucket["investigation"].s3_bucket_id
     })
     DEFAULT_SOURCE_BUCKET_KEY = local.iam_configuration.malware_scanning_processing_bucket_key
+    IDEMPOTENCY_TABLE         = module.dynamodb_idempotency.dynamodb_table_id
   }
 
   attach_policy_statements = true
@@ -143,6 +157,18 @@ module "lambda_processing_to_post_scan" {
         module.kms_s3_bucket["investigation"].key_arn,
         module.kms_s3_bucket["processing"].key_arn,
         module.kms_s3_bucket["quarantine"].key_arn,
+      ]
+    }
+    idempotency_table_access = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+      ]
+      resources = [
+        module.dynamodb_idempotency.dynamodb_table_arn,
       ]
     }
   }

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -3,10 +3,23 @@ import os
 from urllib.parse import unquote_plus
 
 import boto3
+from aws_lambda_powertools.utilities.idempotency import (
+    DynamoDBPersistenceLayer,
+    IdempotencyConfig,
+    idempotent_function,
+)
 
 s3 = boto3.client("s3")
-BUCKETS_BY_KEY = json.loads(os.environ["BUCKETS_BY_KEY"])
+BUCKET_NAMES_BY_KEY = json.loads(os.environ["BUCKET_NAMES_BY_KEY"])
 DEFAULT_SOURCE_BUCKET_KEY = os.environ["DEFAULT_SOURCE_BUCKET_KEY"]
+IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
+
+persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
+# Use the resolved source and destination buckets so transport-level duplicates
+# are treated as the same post-scan file move.
+idempotency_config = IdempotencyConfig(
+    event_key_jmespath='["operation", "source_bucket_name", "source_key", "source_version_id", "destination_bucket_name", "delete_source"]'
+)
 
 
 def iter_events(event):
@@ -37,45 +50,78 @@ def as_bool(value):
     return str(value).lower() == "true"
 
 
-def lambda_handler(event, context):
-    for payload in iter_events(event):
-        source_bucket_key = payload.get("source_bucket_key", DEFAULT_SOURCE_BUCKET_KEY)
-        destination_bucket_key = payload.get("destination_bucket_key")
+def normalise_payload(payload):
+    source_bucket_key = payload.get("source_bucket_key", DEFAULT_SOURCE_BUCKET_KEY)
+    destination_bucket_key = payload.get("destination_bucket_key")
 
-        if destination_bucket_key is None and "destination_bucket" not in payload:
-            raise KeyError("destination_bucket_key")
+    if destination_bucket_key is None and "destination_bucket_name" not in payload and "destination_bucket" not in payload:
+        raise KeyError("destination_bucket_key")
 
-        source_bucket = payload.get("source_bucket", BUCKETS_BY_KEY[source_bucket_key])
-        destination_bucket = payload.get(
-            "destination_bucket",
-            BUCKETS_BY_KEY[destination_bucket_key],
-        )
+    source_bucket_name = payload.get(
+        "source_bucket_name",
+        payload.get("source_bucket", BUCKET_NAMES_BY_KEY[source_bucket_key]),
+    )
+    destination_bucket_name = payload.get(
+        "destination_bucket_name",
+        payload.get("destination_bucket", BUCKET_NAMES_BY_KEY[destination_bucket_key]),
+    )
+    source_key, version_id = get_object_details(payload)
 
-        source_key, version_id = get_object_details(payload)
+    return {
+        "operation": "processing-to-post-scan",
+        "source_bucket_name": source_bucket_name,
+        "source_key": source_key,
+        "source_version_id": version_id,
+        "destination_bucket_name": destination_bucket_name,
+        "delete_source": as_bool(payload.get("delete_source", False)),
+    }
 
-        copy_source = {
-            "Bucket": source_bucket,
-            "Key": source_key,
+
+@idempotent_function(
+    data_keyword_argument="operation",
+    persistence_store=persistence_layer,
+    config=idempotency_config,
+    key_prefix="managed-file-transfer/processing-to-post-scan",
+)
+def process_record(*, operation):
+    copy_source = {
+        "Bucket": operation["source_bucket_name"],
+        "Key": operation["source_key"],
+    }
+
+    if operation["source_version_id"]:
+        copy_source["VersionId"] = operation["source_version_id"]
+
+    s3.copy_object(
+        Bucket=operation["destination_bucket_name"],
+        Key=operation["source_key"],
+        CopySource=copy_source,
+        MetadataDirective="COPY",
+        TaggingDirective="COPY",
+    )
+
+    if operation["delete_source"]:
+        delete_kwargs = {
+            "Bucket": operation["source_bucket_name"],
+            "Key": operation["source_key"],
         }
 
-        if version_id:
-            copy_source["VersionId"] = version_id
+        if operation["source_version_id"]:
+            delete_kwargs["VersionId"] = operation["source_version_id"]
 
-        s3.copy_object(
-            Bucket=destination_bucket,
-            Key=source_key,
-            CopySource=copy_source,
-            MetadataDirective="COPY",
-            TaggingDirective="COPY",
-        )
+        s3.delete_object(**delete_kwargs)
 
-        if as_bool(payload.get("delete_source", False)):
-            delete_kwargs = {
-                "Bucket": source_bucket,
-                "Key": source_key,
-            }
+    return {
+        "delete_source": operation["delete_source"],
+        "destination_bucket_name": operation["destination_bucket_name"],
+        "source_bucket_name": operation["source_bucket_name"],
+        "source_key": operation["source_key"],
+        "source_version_id": operation["source_version_id"],
+    }
 
-            if version_id:
-                delete_kwargs["VersionId"] = version_id
 
-            s3.delete_object(**delete_kwargs)
+def lambda_handler(event, context):
+    idempotency_config.register_lambda_context(context)
+
+    for payload in iter_events(event):
+        process_record(operation=normalise_payload(payload))

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -18,7 +18,7 @@ persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use the resolved source and destination buckets so transport-level duplicates
 # are treated as the same post-scan file move.
 idempotency_config = IdempotencyConfig(
-    event_key_jmespath='["operation", "source_bucket_name", "source_key", "source_version_id", "destination_bucket_name", "delete_source"]'
+    event_key_jmespath="[source_bucket_name, source_key, source_version_id, destination_bucket_name, delete_source]"
 )
 
 

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/requirements.txt
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/requirements.txt
@@ -1,0 +1,1 @@
+aws-lambda-powertools==3.29.0

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -3,9 +3,22 @@ import os
 from urllib.parse import unquote_plus
 
 import boto3
+from aws_lambda_powertools.utilities.idempotency import (
+    DynamoDBPersistenceLayer,
+    IdempotencyConfig,
+    idempotent_function,
+)
 
 s3 = boto3.client("s3")
-DESTINATION_BUCKET = os.environ["DESTINATION_BUCKET"]
+DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
+IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
+
+persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
+# Use object identity rather than transport metadata so duplicate SQS deliveries
+# collapse onto the same logical move operation.
+idempotency_config = IdempotencyConfig(
+    event_key_jmespath='["operation", "source_bucket_name", "source_key", "source_version_id", "destination_bucket_name"]'
+)
 
 
 def iter_s3_records(event):
@@ -20,23 +33,51 @@ def iter_s3_records(event):
             yield s3_record
 
 
+def normalise_record(record):
+    object_details = record["s3"]["object"]
+
+    return {
+        "operation": "unscanned-to-processing",
+        "source_bucket_name": record["s3"]["bucket"]["name"],
+        "source_key": unquote_plus(object_details["key"]),
+        "source_version_id": object_details.get("versionId"),
+        "destination_bucket_name": DESTINATION_BUCKET_NAME,
+    }
+
+
+@idempotent_function(
+    data_keyword_argument="operation",
+    persistence_store=persistence_layer,
+    config=idempotency_config,
+    key_prefix="managed-file-transfer/unscanned-to-processing",
+)
+def process_record(*, operation):
+    copy_source = {
+        "Bucket": operation["source_bucket_name"],
+        "Key": operation["source_key"],
+    }
+
+    if operation["source_version_id"]:
+        copy_source["VersionId"] = operation["source_version_id"]
+
+    s3.copy_object(
+        Bucket=operation["destination_bucket_name"],
+        Key=operation["source_key"],
+        CopySource=copy_source,
+        MetadataDirective="COPY",
+        TaggingDirective="COPY",
+    )
+
+    return {
+        "destination_bucket_name": operation["destination_bucket_name"],
+        "source_bucket_name": operation["source_bucket_name"],
+        "source_key": operation["source_key"],
+        "source_version_id": operation["source_version_id"],
+    }
+
+
 def lambda_handler(event, context):
+    idempotency_config.register_lambda_context(context)
+
     for record in iter_s3_records(event):
-        source_bucket = record["s3"]["bucket"]["name"]
-        source_key = unquote_plus(record["s3"]["object"]["key"])
-
-        copy_source = {
-            "Bucket": source_bucket,
-            "Key": source_key,
-        }
-
-        if "versionId" in record["s3"]["object"]:
-            copy_source["VersionId"] = record["s3"]["object"]["versionId"]
-
-        s3.copy_object(
-            Bucket=DESTINATION_BUCKET,
-            Key=source_key,
-            CopySource=copy_source,
-            MetadataDirective="COPY",
-            TaggingDirective="COPY",
-        )
+        process_record(operation=normalise_record(record))

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/requirements.txt
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/requirements.txt
@@ -1,0 +1,1 @@
+aws-lambda-powertools==3.29.0

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -22,6 +22,10 @@ module "s3_bucket" {
   restrict_public_buckets = true
 
   lifecycle_rule = each.value.lifecycle_rule
+  versioning = {
+    status     = true
+    mfa_delete = false
+  }
 }
 
 module "s3_bucket_notification" {


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What
- add a DynamoDB-backed idempotency table for managed file transfer 🧱
- wire both Lambda functions to the table and grant the required DynamoDB access 🔐
- use AWS Lambda Powertools idempotency in both handlers to make duplicate event delivery safe 🔁
- tidy the bucket-related naming so bucket names and bucket keys are easier to follow 🪣
- enable the supporting S3 versioning needed for the move flow ♻️

## Why
This tightens the reliability of the event-driven file transfer path so repeated S3, SQS, or EventBridge deliveries do not cause accidental duplicate mutations.

## Checks
- `terraform validate` ✅
- `python -m py_compile` for both Lambda handlers ✅

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>