### PR TITLE
CC-4518: Add GuardDuty Slack alerting to MOJFIN account

### DIFF
--- a/terraform/environments/mojfin/guardduty.tf
+++ b/terraform/environments/mojfin/guardduty.tf
@@ -1,0 +1,284 @@
+# ---------------------------------------------
+# GuardDuty Findings → Slack Alerting
+# ---------------------------------------------
+
+resource "aws_kms_key" "cloudwatch_sns_alerts_key" {
+  description             = "KMS Key for CloudWatch SNS Alerts Encryption"
+  deletion_window_in_days = 30
+
+  tags = merge(local.tags,
+    { Name = lower(format("%s-%s-cloudwatch-sns-alerts-kms-key", local.application_name, local.environment)) }
+  )
+}
+
+resource "aws_kms_alias" "cloudwatch_sns_alerts_key" {
+  name          = "alias/${local.application_name}-${local.environment}-cloudwatch-sns-alerts-key"
+  target_key_id = aws_kms_key.cloudwatch_sns_alerts_key.id
+}
+
+resource "aws_kms_key_policy" "cloudwatch_sns_alerts_key" {
+  key_id = aws_kms_key.cloudwatch_sns_alerts_key.id
+  policy = data.aws_iam_policy_document.cloudwatch_sns_encryption.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_sns_encryption" {
+  version = "2012-10-17"
+  statement {
+    sid    = "AllowCloudWatchSNSUseOfTheKey"
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "cloudwatch.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowAccountAdmins"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_sns_topic" "guardduty_alerts" {
+  name = "${local.application_name}-guardduty-alerts"
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 20,
+      "maxDelayTarget": 20,
+      "numRetries": 3,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 0,
+      "numMinDelayRetries": 0,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": false,
+    "defaultRequestPolicy": {
+      "headerContentType": "text/plain; charset=UTF-8"
+    }
+  }
+}
+EOF
+  kms_master_key_id = aws_kms_key.cloudwatch_sns_alerts_key.id
+  tags = merge(local.tags,
+    { Name = "${local.application_name}-guardduty-alerts" }
+  )
+}
+
+data "aws_iam_policy_document" "guardduty_alerting_sns" {
+  version = "2012-10-17"
+  statement {
+    sid    = "EventsAllowPublishSnsTopic"
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+    ]
+    resources = [
+      aws_sns_topic.guardduty_alerts.arn
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "guardduty_default" {
+  arn    = aws_sns_topic.guardduty_alerts.arn
+  policy = data.aws_iam_policy_document.guardduty_alerting_sns.json
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty" {
+  name = "${local.application_name}-guardduty-findings"
+  event_pattern = jsonencode({
+    "source" : ["aws.guardduty"],
+    "detail-type" : ["GuardDuty Finding"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_to_sns" {
+  rule = aws_cloudwatch_event_rule.guardduty.name
+  arn  = aws_sns_topic.guardduty_alerts.arn
+}
+
+resource "aws_secretsmanager_secret" "guardduty_slack_secret" {
+  name                    = "${local.application_name}-${local.environment}-guardduty-slack"
+  description             = "Slack webhook URLs for GuardDuty alerts (laa-alerts-guardduty-nonprod or laa-alerts-guardduty-prod)"
+  recovery_window_in_days = local.is-production ? 30 : 0
+
+  tags = merge(local.tags, {
+    Name = "${local.application_name}-${local.environment}-guardduty-slack"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "guardduty_slack_secret" {
+  secret_id = aws_secretsmanager_secret.guardduty_slack_secret.id
+  secret_string = jsonencode({
+    "slack_channel_webhook"           = ""
+    "slack_channel_webhook_guardduty" = ""
+    "slack_channel_webhook_s3"        = ""
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_iam_role" "lambda_guardduty_sns_role" {
+  name = "${local.application_name}-${local.environment}-lambda-guardduty-sns-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+  tags = merge(local.tags, {
+    Name = "${local.application_name}-${local.environment}-lambda-guardduty-sns-role"
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_guardduty_sns_policy" {
+  name = "${local.application_name}-${local.environment}-lambda-guardduty-sns-policy"
+  role = aws_iam_role.lambda_guardduty_sns_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+        Resource = [aws_secretsmanager_secret.guardduty_slack_secret.arn]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.guardduty_slack_notify.function_name}:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:GenerateDataKey*",
+          "kms:Decrypt"
+        ]
+        Resource = [aws_kms_key.cloudwatch_sns_alerts_key.arn]
+      }
+    ]
+  })
+}
+
+# Lambda Layer loaded from the mojfin shared S3 bucket
+# Note: the zip file must be manually uploaded to the bucket at the path below
+# See: https://dsdmoj.atlassian.net/wiki/spaces/LDD/pages/5975606239/Build+Layered+Function+for+Lambda
+resource "aws_lambda_layer_version" "guardduty_sns_layer" {
+  layer_name               = "${local.application_name}-${local.environment}-guardduty-sns-layer"
+  s3_key                   = "lambda_delivery/cloudwatch_sns_layer/layerV1.zip"
+  s3_bucket                = module.s3-bucket-shared.bucket.id
+  compatible_runtimes      = ["python3.13"]
+  compatible_architectures = ["x86_64"]
+  description              = "Lambda Layer for ${local.application_name} GuardDuty SNS Alerts Integration"
+}
+
+data "archive_file" "guardduty_lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/cloudwatch_alarm_slack_integration"
+  output_path = "${path.module}/lambda/cloudwatch_alarm_slack_integration.zip"
+}
+
+resource "aws_lambda_function" "guardduty_slack_notify" {
+  filename         = data.archive_file.guardduty_lambda_zip.output_path
+  source_code_hash = base64sha256(join("", local.lambda_source_hashes))
+  function_name    = "${local.application_name}-${local.environment}-guardduty-slack-notify"
+  role             = aws_iam_role.lambda_guardduty_sns_role.arn
+  handler          = "lambda_function.lambda_handler"
+  layers           = [aws_lambda_layer_version.guardduty_sns_layer.arn]
+  runtime          = "python3.13"
+  timeout          = 30
+  publish          = true
+
+  environment {
+    variables = {
+      SECRET_NAME = aws_secretsmanager_secret.guardduty_slack_secret.name
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  tags = merge(local.tags, {
+    Name = "${local.application_name}-${local.environment}-guardduty-slack-notify"
+  })
+}
+
+resource "aws_lambda_permission" "allow_sns_invoke_guardduty" {
+  statement_id  = "AllowExecutionFromGuardDutySNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.guardduty_slack_notify.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.guardduty_alerts.arn
+}
+
+resource "aws_sns_topic_subscription" "guardduty_lambda" {
+  topic_arn = aws_sns_topic.guardduty_alerts.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.guardduty_slack_notify.arn
+}
+
+# ---------------------------------------------
+# GuardDuty Malware Protection - S3 bucket scan
+# ---------------------------------------------
+
+data "aws_iam_role" "guardduty_s3_scan" {
+  name = "GuardDutyS3MalwareProtectionRole"
+}
+
+resource "aws_guardduty_malware_protection_plan" "s3_shared" {
+  role = data.aws_iam_role.guardduty_s3_scan.arn
+
+  protected_resource {
+    s3_bucket {
+      bucket_name = module.s3-bucket-shared.bucket.id
+    }
+  }
+
+  actions {
+    tagging {
+      status = "ENABLED"
+    }
+  }
+
+  tags = merge(local.tags,
+    { Name = lower(format("s3-%s-%s-guardduty-mpp", local.application_name, local.environment)) }
+  )
+
+  depends_on = [module.s3-bucket-shared]
+}

--- a/terraform/environments/mojfin/lambda/cloudwatch_alarm_slack_integration/lambda_function.py
+++ b/terraform/environments/mojfin/lambda/cloudwatch_alarm_slack_integration/lambda_function.py
@@ -1,0 +1,667 @@
+"""
+AWS Lambda function to pull CloudWatch Alarm from SNS Topic and
+publish into Slack. This will also publish GuardDuty findings, EventBridge events and S3 events into Slack.
+"""
+
+import json
+import os
+import logging
+import io
+import tracemalloc
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Union, cast
+from datetime import datetime
+import boto3
+import pycurl
+from botocore.exceptions import ClientError
+from mypy_boto3_secretsmanager import SecretsManagerClient
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+@dataclass
+class Config:
+    """Configuration settings for the Lambda function."""
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Create configuration from environment variables."""
+        return cls()
+
+
+class ConfigValidator:
+    """Validator class for configuration validation."""
+
+    @staticmethod
+    def validate_mandatory_fields(config_dict: Dict[str, Any], field_name: str) -> None:
+        """Validate that all mandatory fields are present and non-empty."""
+        mandatory_fields = {
+            "slack_channel_webhook": config_dict.get("slack_channel_webhook"),
+            "slack_channel_webhook_guardduty": config_dict.get("slack_channel_webhook_guardduty"),
+            "slack_channel_webhook_s3": config_dict.get("slack_channel_webhook_s3"),
+        }
+        missing_fields = [name for name, value in mandatory_fields.items() if not value]
+        if missing_fields:
+            raise ValueError(
+                f"Missing required {field_name} fields: {', '.join(missing_fields)}"
+            )
+
+    @staticmethod
+    def get_mandatory_secret(secrets_data: Dict, key: str) -> str:
+        """Extract and validate a mandatory field from secrets."""
+        value = secrets_data.get(key)
+        if not value or not isinstance(value, str):
+            raise ValueError(
+                f"{key} must be a non-empty string in secrets, got: {value}"
+            )
+        return value
+
+    @staticmethod
+    def get_optional_secret(secrets_data: Dict, key: str) -> Optional[str]:
+        """Extract and validate an optional field from secrets."""
+        value = secrets_data.get(key)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(
+                f"{key} must be a string in secrets, got: {type(value).__name__}"
+            )
+        return value if value else None
+
+    @staticmethod
+    def get_mandatory_env(env_data: Dict, key: str) -> str:
+        """Extract and validate a mandatory field from environment."""
+        value = env_data.get(key)
+        if not value:
+            raise ValueError(f"{key} environment variable is required")
+        return value
+
+
+@dataclass
+class ValidateConfig:
+    """Configuration with validation."""
+
+    slack_channel_webhook: str
+    slack_channel_webhook_guardduty: str
+    slack_channel_webhook_s3: str
+
+    def __post_init__(self):
+        """Validate configuration after initialization."""
+        config_dict = {
+            "slack_channel_webhook": self.slack_channel_webhook,
+            "slack_channel_webhook_guardduty": self.slack_channel_webhook_guardduty,
+            "slack_channel_webhook_s3": self.slack_channel_webhook_s3,
+        }
+
+        ConfigValidator.validate_mandatory_fields(config_dict, "configuration")
+        logger.info("Configuration validated")
+
+
+class SecretsManager:
+    """Manager for retrieving configuration from AWS Secrets Manager."""
+
+    def __init__(self):
+        self.client = cast(SecretsManagerClient, boto3.client("secretsmanager"))
+        logger.info("Initialized Secrets Manager client")
+
+    def get_credentials(self, secret_name: str) -> Dict[str, Union[str, int, bool]]:
+        """Retrieve and parse credentials from Secrets Manager."""
+        try:
+            logger.info(f"Retrieving secret: {secret_name}")
+            response = self.client.get_secret_value(SecretId=secret_name)
+
+            # Parse the secret string
+            secret_data = json.loads(response["SecretString"])
+            logger.info(
+                f"Successfully retrieved credentials with {len(secret_data)} keys"
+            )
+
+            return secret_data
+
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_msg = f"Failed to retrieve secret {secret_name}: {error_code}"
+            logger.error(error_msg)
+            raise Exception(error_msg)
+        except json.JSONDecodeError as e:
+            error_msg = f"Failed to parse secret JSON: {e}"
+            logger.error(error_msg)
+            raise Exception(error_msg)
+
+
+def parse_config_from_env_and_secrets(
+    env_data: Dict[str, Optional[str]], secrets_data: Dict[str, Union[str, int, bool]]
+) -> ValidateConfig:
+    """
+    Parse configuration from both environment variables and secrets data.
+
+    This function combines non-sensitive configuration from environment variables
+    with sensitive credentials from AWS Secrets Manager.
+    """
+
+    config = ValidateConfig(
+        slack_channel_webhook=ConfigValidator.get_mandatory_secret(
+            secrets_data, "slack_channel_webhook"
+        ),
+        slack_channel_webhook_guardduty=ConfigValidator.get_mandatory_secret(
+            secrets_data, "slack_channel_webhook_guardduty"
+        ),
+        slack_channel_webhook_s3=ConfigValidator.get_mandatory_secret(
+            secrets_data, "slack_channel_webhook_s3"
+        ),
+    )
+
+    return config
+
+
+class NotificationService:
+    """Service for sending notifications to Slack."""
+
+    def __init__(self, webhook_url: str, function_name: str = "CloudWatch SNS Alarm to Lambda"):
+        if not webhook_url:
+            raise ValueError("Slack webhook URL is required for notifications")
+
+        self.webhook_url = webhook_url
+        self.function_name = function_name
+        logger.info("Slack notifications configured")
+
+    def send_notification(
+        self, title: str, alarmdetails: dict, timestamp: str, type: str, is_error: bool = False
+    ) -> bool:
+        """Send a notification to Slack using the webhook."""
+        curl = pycurl.Curl()
+        logger.info("alarmdetailsinside:\n" + json.dumps(alarmdetails, indent=2))
+
+        # ---------------- GuardDuty ----------------
+        if type == "GuardDuty":
+            severity = alarmdetails.get('detail', {}).get('severity', 'Unknown Severity')
+            if isinstance(severity, (int, float)):
+                if severity < 4.0:
+                    emoji = ":large_blue_circle:"
+                    strseverity = "Low"
+                elif severity < 7.0:
+                    emoji = ":large_orange_circle:"
+                    strseverity = "Medium"
+                elif severity < 9.0:
+                    emoji = ":small_red_triangle:"
+                    strseverity = "High"
+                else:
+                    emoji = ":broken_heart:"
+                    strseverity = "Critical"
+            else:
+                emoji = ":grey_question:"
+                strseverity = "Unknown"
+
+            finding_type = alarmdetails.get('detail', {}).get('type', 'Unknown Finding')
+            region = alarmdetails.get('detail', {}).get('region', 'Unknown Region')
+            account_id = alarmdetails.get('detail', {}).get('accountId', 'Unknown Account')
+            header = f"{emoji} | GuardDuty Finding | {region} | Account: {account_id}"
+            title = alarmdetails.get('detail', {}).get('description', 'No Title Provided')
+            threatcount = alarmdetails.get('detail', {}).get('service', {}).get('count', 'N/A')
+            firstseennofmt = alarmdetails.get('detail', {}).get('service', {}).get('eventFirstSeen', 'N/A')
+            lastseennofmt = alarmdetails.get('detail', {}).get('service', {}).get('eventLastSeen', 'N/A')
+
+            firstseen = firstseennofmt
+            lastseen = lastseennofmt
+            try:
+                if firstseennofmt != 'N/A':
+                    dt_first = datetime.strptime(firstseennofmt, "%Y-%m-%dT%H:%M:%S.%fZ")
+                    firstseen = dt_first.strftime("%a, %d %b %Y %H:%M:%S UTC")
+            except Exception:
+                pass
+
+            try:
+                if lastseennofmt != 'N/A':
+                    dt_last = datetime.strptime(lastseennofmt, "%Y-%m-%dT%H:%M:%S.%fZ")
+                    lastseen = dt_last.strftime("%a, %d %b %Y %H:%M:%S UTC")
+            except Exception:
+                pass
+
+            payload = {
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": f"{header}"
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Finding Type* - {finding_type}"
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Details*"
+                    }
+                },
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "text": f"{title}"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*FirstSeen:* {firstseen}"
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*LastSeen:* {lastseen}"
+                        }
+                    ]
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Severity:* {strseverity}"
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Threat Count:* {threatcount}"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # ---------------- CloudWatch Alarm ----------------
+        elif type == "CloudWatch Alarm":
+            alarm_name = alarmdetails.get('AlarmName', 'Unknown Alarm')
+            region = alarmdetails.get('Region', '')
+            alarm_state = alarmdetails.get('NewStateValue', '')
+            reason = alarmdetails.get('NewStateReason', '')
+            namespace = alarmdetails.get('Trigger', {}).get('Namespace', '')
+            metric_name = alarmdetails.get('Trigger', {}).get('MetricName', '')
+            dimensions = alarmdetails.get('Trigger', {}).get('Dimensions', [])
+            alarmdescription = alarmdetails.get('AlarmDescription', 'Alarm Description')
+
+            dim_text = '\n'.join([f"{d['name']} = {d['value']}" for d in dimensions])
+            emoji = ":broken_heart:" if is_error else ":white_check_mark:"
+            color = "danger" if is_error else "good"
+            title = f"{emoji} | {title} | {alarm_name} | {region}"
+
+            payload = {
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {"type": "plain_text", "text": f"{alarm_state} - {alarm_name}"}
+                    },
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*{title}*"}
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*Reason:* {reason}"}
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Namespace:* {namespace}"
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Metric:* {metric_name}"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Timestamp:* {timestamp}"
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Alarm Description:* {alarmdescription}"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*Resource Details:*\n {dim_text}"}
+                    }
+                ]
+            }
+
+        elif type == "S3 Event":
+            if "Records" not in alarmdetails or not alarmdetails["Records"]:
+                s3_info = alarmdetails.get("detail", {})
+                bucket_name = s3_info.get("bucket", {}).get("name", "Unknown Bucket")
+                object_key = s3_info.get("object", {}).get("key", "Unknown Key")
+                object_size = s3_info.get("object", {}).get("size", "Unknown Size")
+                if "rejected" in object_key.lower():
+                    emoji = ":broken_heart:"
+                else:             
+                    emoji = ":white_check_mark:"
+                header = f"{emoji} *S3 Object Uploaded on bucket {bucket_name}.*"
+                payload = {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": header}
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": (
+                                    "*Details*\n"
+                                    f" • *Object:* `s3://{bucket_name}/{object_key}`\n"
+                                    f" • *Size (bytes):* {object_size} bytes\n"
+                                    f" • *Timestamp:* {timestamp}"
+                                )
+                            }
+                        }
+                    ]
+                }
+            if "Records" in alarmdetails and alarmdetails["Records"]:
+                records = alarmdetails.get("Records", [])
+                record = records[0] if records else {}
+
+
+                s3_info = record.get("s3", {})
+                bucket = s3_info.get("bucket", {})
+                obj = s3_info.get("object", {})
+
+                bucket_name = bucket.get("name", "Unknown Bucket")
+                object_key = obj.get("key", "Unknown Key")
+                object_size = obj.get("size", "Unknown Size")
+
+                user_identity = record.get("userIdentity", {})
+                principal_id = user_identity.get("principalId", "Unknown Principal")
+                if "rejected" in object_key.lower():
+                    emoji = ":broken_heart:"
+                else:             
+                    emoji = ":white_check_mark:"
+
+                header = f"{emoji} *S3 Object Uploaded on bucket {bucket_name}.*"
+
+                payload = {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": header}
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": (
+                                    "*Details*\n"
+                                    f" • *Object:* `s3://{bucket_name}/{object_key}`\n"
+                                    f" • *Size (bytes):* {object_size} bytes\n"
+                                    f" • *Principal:* {principal_id}\n"
+                                    f" • *Timestamp:* {timestamp}"
+                                )
+                            }
+                        }
+                    ]
+                }
+
+        # ---------------- Fallback ----------------
+        else:
+            payload = {
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*{title}*"}
+                    },
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"```{json.dumps(alarmdetails, indent=2)}```"}
+                    }
+                ]
+            }
+
+        try:
+            # Convert payload to JSON
+            json_payload = json.dumps(payload)
+            logger.info(f"Prepared Slack payload: {json_payload}")
+            # Configure curl for HTTP POST with JSON
+            curl.setopt(pycurl.URL, self.webhook_url)
+            curl.setopt(pycurl.POST, 1)
+            curl.setopt(pycurl.POSTFIELDS, json_payload)
+            curl.setopt(pycurl.HTTPHEADER, ["Content-Type: application/json"])
+            curl.setopt(pycurl.TIMEOUT, 10)
+
+            # Buffer for response (though Slack webhook responses are minimal)
+            response_buffer = io.BytesIO()
+            curl.setopt(pycurl.WRITEDATA, response_buffer)
+
+            # Send the notification
+            curl.perform()
+
+            # Check HTTP status code
+            http_code = curl.getinfo(pycurl.RESPONSE_CODE)
+            if http_code >= 400:
+                raise Exception(f"HTTP error {http_code}")
+
+            logger.info(f"Slack notification sent successfully: {title}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to send Slack notification: {e}")
+            return False
+        finally:
+            curl.close()
+
+
+def lambda_handler(event, context):
+    """
+    Main Lambda handler function. 
+    
+    This function gets triggered by SNS Topic subscriptions to CloudWatch Alarms,
+    GuardDuty findings, eventbridge and S3 events.
+    """
+
+    tracemalloc.start()
+
+    notification_service = None
+    formatted = datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S UTC")
+    type = "Unknown"
+    is_error = True
+
+    env_config = {
+        # Mandatory environment variables (currently none)
+    }
+
+    # Get secret name from environment or event
+    secret_name = os.environ.get("SECRET_NAME", event.get("secret_name"))
+    if not secret_name:
+        raise ValueError("SECRET_NAME not found in environment or event")
+    if not isinstance(secret_name, str):
+        raise ValueError(
+            f"SECRET_NAME must be a string, got: {type(secret_name).__name__}"
+        )
+
+    logger.info("Retrieving credentials from AWS Secrets Manager")
+    secrets_manager = SecretsManager()
+    secrets_data = secrets_manager.get_credentials(secret_name)
+
+    # Validate that required credentials are present
+    required_secrets = [
+        "slack_channel_webhook",
+        "slack_channel_webhook_guardduty",
+        "slack_channel_webhook_s3",
+    ]
+    missing_secrets = [key for key in required_secrets if key not in secrets_data]
+    if missing_secrets:
+        raise ValueError(f"Missing required secrets: {', '.join(missing_secrets)}")
+
+    # Parse combined configuration
+    logger.info("Parsing configuration from environment and secrets")
+    config = parse_config_from_env_and_secrets(env_config, secrets_data)
+
+    sns_message = event['Records'][0]['Sns']
+    message_str = sns_message.get('Message', '{}')
+    
+    # Check for SNS control message types and ignore them
+    sns_type = sns_message.get('Type', '')
+    if sns_type in ("SubscriptionConfirmation", "UnsubscribeConfirmation"):
+        logger.info(f"Ignoring SNS control message Type={sns_type}")
+        return
+
+    try:
+        alarm_details = json.loads(message_str)
+        logger.info("alarm_details:" + json.dumps(alarm_details, indent=2))
+
+        # Detect source:
+        # - GuardDuty / CloudWatch / EventBridge-style -> 'source'
+        # - S3 via SNS -> Records[0].eventSource == 'aws:s3'
+        source = alarm_details.get('source')
+        if not source and "Records" in alarm_details:
+            first_record = alarm_details["Records"][0]
+            event_source = first_record.get("eventSource")
+            if event_source == "aws:s3":
+                source = "aws.s3"
+
+        # helper to detect CloudWatch Alarm payloads (SNS -> CloudWatch Alarms often have no 'source')
+        def looks_like_cloudwatch_alarm(d: dict) -> bool:  
+            if not isinstance(d, dict):                     
+                return False                                
+            required = ("AlarmName", "NewStateValue")   
+            return all(k in d for k in required)
+
+        if not source:
+        #     # Default to CloudWatch if nothing else matches
+        #     # source = "aws.cloudwatch"
+            if looks_like_cloudwatch_alarm(alarm_details):
+                source = "aws.cloudwatch"                    
+            else:
+                logger.warning(
+                    "Source not detected and payload does not look like a CloudWatch Alarm; skipping notification."
+                )
+                return
+        
+        logger.info("source:" + str(source))
+
+        # ---------------- GuardDuty ----------------
+        if source == "aws.guardduty":
+            logger.info("GuardDuty finding detected in SNS message")
+            logger.info("Starting Notification to Slack for GuardDuty Alarm via SNS Topic")
+
+            timestamp_str = alarm_details.get('time')
+            if timestamp_str:
+                dt = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%SZ")
+                formatted = dt.strftime("%a, %d %b %Y %H:%M:%S UTC")
+
+            channelconfig = config.slack_channel_webhook_guardduty
+            alarmnotifiction = "GuardDuty Finding Notification"
+            type = "GuardDuty"
+            is_error = True  # usually "bad" findings
+
+        # ---------------- S3 Event ----------------
+        elif source == "aws.s3":
+            logger.info("S3 event detected in SNS message")
+            logger.info("Starting Notification to Slack for S3 Event via SNS Topic")
+            if "Records" not in alarm_details or not alarm_details["Records"]:
+                timestamp_str = alarm_details.get('time')
+            if "Records" in alarm_details and alarm_details["Records"]:
+                # S3 time is in the record
+                first_record = alarm_details["Records"][0]
+                timestamp_str = first_record.get("eventTime")
+            if timestamp_str:
+                # Example: 2026-01-12T16:10:07.364Z
+                try:
+                    dt = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+                except ValueError:
+                    dt = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%SZ")
+                formatted = dt.strftime("%d %b %Y %H:%M:%S UTC")
+
+            channelconfig = config.slack_channel_webhook_s3
+            alarmnotifiction = "S3 Object Event Notification"
+            type = "S3 Event"
+            is_error = False   # S3 put is informational
+
+        # ---------------- CloudWatch Alarm (default) ----------------
+        else:
+            logger.info("CloudWatch Alarm detected in SNS message")
+            logger.info("Starting Notification to Slack for CloudWatch Alarm via SNS Topic")
+
+            timestamp_str = sns_message.get('Timestamp')
+            if timestamp_str:
+                dt = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+                formatted = dt.strftime("%a, %d %b %Y %H:%M:%S UTC")
+
+            channelconfig = config.slack_channel_webhook
+            alarmnotifiction = "CloudWatch Alarm Notification"
+            type = "CloudWatch Alarm"
+
+            new_state = alarm_details.get('NewStateValue', '')
+            if new_state == "OK":
+                is_error = False
+
+        # Initialize services
+        notification_service = NotificationService(
+            channelconfig, context.function_name
+        )
+
+        notification_service.send_notification(
+            alarmnotifiction,
+            alarm_details,
+            formatted,
+            type,
+            is_error
+        )
+
+        # Prepare response
+        response = {
+            "statusCode": 200,
+            "body": {
+                "message": "Successfully completed publishing notifications"
+            },
+        }
+
+        logger.info(f"Lambda execution completed successfully: {response}")
+        return response
+
+    except Exception as e:
+        error_msg = f"Lambda execution failed:\n{str(e)}"
+        logger.error(error_msg, exc_info=True)
+
+        # Send error notification if notification service is available
+        if notification_service is not None:
+            try:
+                notification_service.send_notification(
+                    "Lambda Execution Failed", {"error": error_msg}, formatted, type, is_error=True
+                )
+            except Exception as notification_error:
+                logger.error(f"Failed to send error notification: {notification_error}")
+
+        # Return error response
+        return {"statusCode": 500, "body": {"error": error_msg}}
+    finally:
+        current, peak = tracemalloc.get_traced_memory()
+        logger.info(
+            f"Current memory usage: {current / 1024 / 1024:.2f} MB; Peak: {peak / 1024 / 1024:.2f} MB"
+        )
+        tracemalloc.stop()
+

--- a/terraform/environments/mojfin/lambda/cloudwatch_alarm_slack_integration/requirements.txt
+++ b/terraform/environments/mojfin/lambda/cloudwatch_alarm_slack_integration/requirements.txt
@@ -1,0 +1,9 @@
+boto3==1.41.2
+botocore==1.41.2
+jmespath==1.0.1
+mypy-boto3-secretsmanager==1.41.0
+pycurl==7.45.7
+python-dateutil==2.9.0.post0
+s3transfer==0.15.0
+six==1.17.0
+urllib3==2.5.0

--- a/terraform/environments/mojfin/member_locals.tf
+++ b/terraform/environments/mojfin/member_locals.tf
@@ -90,4 +90,11 @@ locals {
   }
 
   prod_domain_name = "laa-finance-data.service.justice.gov.uk"
+
+  lambda_folder_name = ["lambda_delivery", "cloudwatch_sns_layer"]
+
+  lambda_source_hashes = [
+    for f in fileset("./lambda/cloudwatch_alarm_slack_integration", "**") :
+    sha256(file("${path.module}/lambda/cloudwatch_alarm_slack_integration/${f}"))
+  ]
 }

--- a/terraform/environments/mojfin/s3-lambda-delivery.tf
+++ b/terraform/environments/mojfin/s3-lambda-delivery.tf
@@ -1,0 +1,28 @@
+# Shared S3 bucket for Lambda layer delivery
+# Note: upload lambda_delivery/cloudwatch_sns_layer/layerV1.zip manually before first apply
+# See: https://dsdmoj.atlassian.net/wiki/spaces/LDD/pages/5975606239/Build+Layered+Function+for+Lambda
+
+module "s3-bucket-shared" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
+
+  bucket_name         = "${local.application_name}-${local.environment}-shared"
+  versioning_enabled  = true
+  replication_enabled = false
+  replication_region  = "eu-west-2"
+
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  tags = local.tags
+}
+
+resource "aws_s3_object" "folder" {
+  bucket = module.s3-bucket-shared.bucket.id
+  for_each = {
+    for index, name in local.lambda_folder_name :
+    name => index == 0 ? "${name}/" : "lambda_delivery/${name}/"
+  }
+
+  key = each.value
+}


### PR DESCRIPTION
## Summary

- Mirrors the GuardDuty → Slack alerting pattern already in place for CCMS, MAAT and MAATDB accounts
- EventBridge rule captures `GuardDuty Finding` events and publishes to an encrypted SNS topic
- SNS subscription triggers a Lambda that forwards findings to `laa-alerts-guardduty-nonprod` (non-prod) or `laa-alerts-guardduty-prod` (production) via a Slack webhook stored in Secrets Manager
- Lambda uses the same `cloudwatch_alarm_slack_integration` code and `pycurl`-based layer as CCMS (copied directly from ccms-ebs)
- Dedicated shared S3 bucket (`mojfin-<env>-shared`) created using `modernisation-platform-terraform-s3-bucket` module (ref `474f27a3`) for Lambda layer delivery
- GuardDuty S3 Malware Protection Plan enabled for the shared bucket using `GuardDutyS3MalwareProtectionRole`

## Pre-apply steps required

1. Run `terraform apply -target=module.s3-bucket-shared` to create the shared bucket first
2. Upload `layerV1.zip` to the new shared bucket at key `lambda_delivery/cloudwatch_sns_layer/layerV1.zip`
3. Populate the `mojfin-<env>-guardduty-slack` secret with real webhook URLs for `slack_channel_webhook_guardduty`

## Test plan

- [ ] Terraform plan shows expected resources with no errors for MOJFIN development
- [ ] Shared S3 bucket created (`mojfin-development-shared`)
- [ ] `layerV1.zip` uploaded to the shared bucket prior to apply
- [ ] Terraform applied successfully in development
- [ ] Slack webhook secrets populated in development
- [ ] Trigger a test GuardDuty finding and confirm message appears in `laa-alerts-guardduty-nonprod`
- [ ] Terraform plan and apply for preproduction
- [ ] Upload `layerV1.zip` to `mojfin-preproduction-shared` bucket
- [ ] Terraform plan and apply for production
- [ ] Upload `layerV1.zip` to `mojfin-production-shared` bucket
- [ ] Repeat validation in production after prod apply