### PR TITLE
[CC-4517] Add GuardDuty Slack alerting to MAAT account

### DIFF
--- a/terraform/environments/maat/s3-lambda-delivery.tf
+++ b/terraform/environments/maat/s3-lambda-delivery.tf
@@ -5,16 +5,60 @@
 module "s3-bucket-shared" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f"
 
-  bucket_name        = "${local.application_name}-${local.environment}-shared"
-  versioning_enabled = true
+  bucket_name         = "${local.application_name}-${local.environment}-shared"
+  versioning_enabled  = true
   replication_enabled = false
   replication_region  = "eu-west-2"
+  sse_algorithm       = "AES256"
+  custom_kms_key      = ""
+  bucket_policy       = [aws_s3_bucket_policy.shared_bucket_policy.policy]
 
   providers = {
     aws.bucket-replication = aws
   }
 
-  tags = local.tags
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      abort_incomplete_multipart_upload_days = 7
+    }
+  ]
+
+  tags = merge(local.tags,
+    { Name = "${local.application_name}-${local.environment}-shared" }
+  )
+}
+
+resource "aws_s3_bucket_policy" "shared_bucket_policy" {
+  bucket = module.s3-bucket-shared.bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "EnforceTLSv12orHigher",
+        Effect = "Deny",
+        Principal = {
+          AWS = "*"
+        },
+        Action   = "s3:*",
+        Resource = ["${module.s3-bucket-shared.bucket.arn}/*", "${module.s3-bucket-shared.bucket.arn}"],
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
+          }
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_s3_object" "folder" {


### PR DESCRIPTION
## Summary

- Mirrors the GuardDuty → Slack alerting pattern already in place for CCMS accounts
- EventBridge rule captures `GuardDuty Finding` events and publishes to an encrypted SNS topic
- SNS subscription triggers a Lambda that forwards findings to `laa-alerts-guardduty-nonprod` (non-prod) or `laa-alerts-guardduty-prod` (production) via a Slack webhook stored in Secrets Manager
- Lambda uses the same `cloudwatch_alarm_slack_integration` code and `pycurl`-based layer as CCMS (copied directly from ccms-ebs)
- Dedicated shared S3 bucket (`maat-<env>-shared`) created using `modernisation-platform-terraform-s3-bucket` module with AES256 encryption, lifecycle rule and TLS 1.2 bucket policy following the `ccms-pui` pattern
- GuardDuty S3 Malware Protection Plan enabled for the shared bucket using `GuardDutyS3MalwareProtectionRole`

## Pre-apply steps required

1. Run `terraform apply -target=module.s3-bucket-shared` to create the shared bucket first
2. Upload `layerV1.zip` to the new shared bucket at key `lambda_delivery/cloudwatch_sns_layer/layerV1.zip`
3. Populate the `maat-<env>-guardduty-slack` secret with real webhook URLs for `slack_channel_webhook_guardduty`

## Test plan

- [x] Terraform plan shows expected resources with no errors for MAAT development
- [x] Shared S3 bucket created (`maat-development-shared`)
- [x] `layerV1.zip` uploaded to the shared bucket prior to apply
- [x] Terraform applied successfully in development
- [x] Slack webhook secrets populated in development
- [x] GuardDuty malware protection plan added for shared S3 bucket
- [ ] Trigger a test GuardDuty finding and confirm message appears in `laa-alerts-guardduty-nonprod`
- [ ] Terraform plan and apply for preproduction
- [ ] Upload `layerV1.zip` to `maat-preproduction-shared` bucket
- [ ] Terraform plan and apply for production
- [ ] Upload `layerV1.zip` to `maat-production-shared` bucket
- [ ] Repeat validation in production after prod apply