### PR TITLE
Update DNS target IPs for Route 53 resolver

### DIFF
--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -104,11 +104,11 @@ resource "aws_route53_resolver_rule" "fwd" {
   resolver_endpoint_id = aws_route53_resolver_endpoint.equip-domain.id
 
   target_ip {
-    ip = module.win2016_multiple["COR-A-DC03"].private_ip[0]
+    ip = module.win2022_STD_multiple["COR-A-DC03"].private_ip[0]
   }
 
   target_ip {
-    ip = module.win2016_multiple["COR-A-DC04"].private_ip[0]
+    ip = module.win2022_STD_multiple["COR-A-DC04"].private_ip[0]
   }
 }
 

--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -104,11 +104,11 @@ resource "aws_route53_resolver_rule" "fwd" {
   resolver_endpoint_id = aws_route53_resolver_endpoint.equip-domain.id
 
   target_ip {
-    ip = module.win2022_STD_multiple["COR-A-DC03"].private_ip[0]
+    ip = module.win2022_STD_Datacenter["COR-A-DC03"].private_ip[0]
   }
 
   target_ip {
-    ip = module.win2022_STD_multiple["COR-A-DC04"].private_ip[0]
+    ip = module.win2022_STD_Datacenter["COR-A-DC04"].private_ip[0]
   }
 }
 

--- a/terraform/environments/equip/dns.tf
+++ b/terraform/environments/equip/dns.tf
@@ -104,11 +104,11 @@ resource "aws_route53_resolver_rule" "fwd" {
   resolver_endpoint_id = aws_route53_resolver_endpoint.equip-domain.id
 
   target_ip {
-    ip = module.win2016_multiple["COR-A-DC01"].private_ip[0]
+    ip = module.win2016_multiple["COR-A-DC03"].private_ip[0]
   }
 
   target_ip {
-    ip = module.win2016_multiple["COR-A-DC02"].private_ip[0]
+    ip = module.win2016_multiple["COR-A-DC04"].private_ip[0]
   }
 }
 


### PR DESCRIPTION
I believe this is a leftover issue when migrating form the old DC's to the new ones as we have just seen an issue in Dev where DC01 had 0bytes of disk space and it broke DC03/04 as DNS was failing. Space has been cleared on 01 and 03/04 are functioning again but i believe the long term goal is to remove DC01/02 as they are decommissioned, This has been confirmed with netdom query fsmo on DC03 showing DC03 holds all the roles. Happy to have a wider discussion