### PR TITLE
Xhibit portal/terraform provider upgrade

### DIFF
--- a/terraform/environments/xhibit-portal/bastion_linux.tf
+++ b/terraform/environments/xhibit-portal/bastion_linux.tf
@@ -5,7 +5,7 @@ locals {
 
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=29c5908bd41b183808fe0c02d9ae06f0ede2036b" # v6.0.0
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/xhibit-portal/importrole.tf
+++ b/terraform/environments/xhibit-portal/importrole.tf
@@ -1,7 +1,11 @@
 module "vm-import" {
   # checkov:skip=CKV_TF_1: "Ensure Terraform module sources use a commit hash"
   # checkov:skip=CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import?ref=bd592550a2ce393c165693660877e405b0328c0b" # v3.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import?ref=abbfa64bfdb17540733d06864ef399dd5e7ceb22" # v3.1.0
+
+  providers = {
+    aws.bucket-replication = aws # replication_enabled = false, alias required by module
+  }
 
   bucket_prefix    = local.application_data.accounts[local.environment].bucket_prefix
   tags             = local.tags

--- a/terraform/environments/xhibit-portal/importrole.tf
+++ b/terraform/environments/xhibit-portal/importrole.tf
@@ -1,7 +1,7 @@
 module "vm-import" {
   # checkov:skip=CKV_TF_1: "Ensure Terraform module sources use a commit hash"
   # checkov:skip=CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import?ref=v2.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import?ref=bd592550a2ce393c165693660877e405b0328c0b" # v3.0.0
 
   bucket_prefix    = local.application_data.accounts[local.environment].bucket_prefix
   tags             = local.tags

--- a/terraform/environments/xhibit-portal/platform_data.tf
+++ b/terraform/environments/xhibit-portal/platform_data.tf
@@ -43,63 +43,63 @@ data "aws_subnets" "shared-public" {
 data "aws_subnet" "data_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "data_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "data_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "private_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "private_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "private_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "public_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "public_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "public_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}c"
   }
 }
 

--- a/terraform/environments/xhibit-portal/shield.tf
+++ b/terraform/environments/xhibit-portal/shield.tf
@@ -9,7 +9,7 @@ data "aws_shield_protection" "excluded" {
 }
 
 module "shield" {
-  source   = "../../modules/shield_advanced"
+  source   = "../../modules/shield_advanced_v6"
   for_each = local.is-production ? { "build" = true } : {}
   providers = {
     aws.modernisation-platform = aws.modernisation-platform

--- a/terraform/environments/xhibit-portal/versions.tf
+++ b/terraform/environments/xhibit-portal/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/terraform/environments/xhibit-portal/xhibit-waf.tf
+++ b/terraform/environments/xhibit-portal/xhibit-waf.tf
@@ -1,5 +1,5 @@
 module "waf" {
-  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=a96a97c0cc64c14f1ee66b272e31101cce5aee61" # v2.0.0
+  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=9b74c1430f04614f1d81995ac033d4b0b9859baf" # v2.1.0
   enable_ddos_protection   = true
   ddos_rate_limit          = 3000
   block_non_uk_traffic     = true

--- a/terraform/environments/xhibit-portal/xhibit-waf.tf
+++ b/terraform/environments/xhibit-portal/xhibit-waf.tf
@@ -1,5 +1,5 @@
 module "waf" {
-  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=9b74c1430f04614f1d81995ac033d4b0b9859baf" # v2.1.0
+  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=178c6b090cb6ab3b32277795deb2939ea699fd33" # v2.1.0
   enable_ddos_protection   = true
   ddos_rate_limit          = 3000
   block_non_uk_traffic     = true

--- a/terraform/environments/xhibit-portal/xhibit-waf.tf
+++ b/terraform/environments/xhibit-portal/xhibit-waf.tf
@@ -1,5 +1,5 @@
 module "waf" {
-  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=86fa9d802455114baf80628f3c5670dddc732a7f"
+  source                   = "git::https://github.com/ministryofjustice/modernisation-platform-terraform-aws-waf?ref=a96a97c0cc64c14f1ee66b272e31101cce5aee61" # v2.0.0
   enable_ddos_protection   = true
   ddos_rate_limit          = 3000
   block_non_uk_traffic     = true


### PR DESCRIPTION
## What

Upgrades the xhibit-portal environment to the AWS provider v6 and updates dependent modules accordingly.

## Changes

### Provider
- Bumped `hashicorp/aws` constraint from `~> 5.0` to `~> 6.0` in `versions.tf`

### Modules
- `modernisation-platform-terraform-bastion-linux` → v6.0.0
- `modernisation-platform-terraform-aws-vm-import` → v3.1.0  (adds `configuration_aliases` declaration for `aws.bucket-replication`)
- `modernisation-platform-terraform-aws-waf` → v2.1.0 (adds `configuration_aliases` declaration for `aws.modernisation-platform`)
- `shield_advanced` → updated source to `shield_advanced_v6` local module

### Bug fixes
- Replaced deprecated `data.aws_region.current.name` with `data.aws_region.current.region` across all subnet data source tag lookups in `platform_data.tf` (9 occurrences) — `.name` was removed in the AWS provider v6