### PR TITLE
PDHD-162: Probation secret placeholders with optional ability to grant cloud platform access

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -60,7 +60,14 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "scheduled_dataset_lambda_version": "vLatest",
-      "probation_domains": ["prb-sentence-plan", "prb-assessment-view"],
+      "probation_domains": {
+        "pr-sentence-plan": {
+          "share_with_cloud_platform": false
+        },
+        "pr-assessment-view": {
+          "share_with_cloud_platform": true
+        }
+      },
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -180,19 +187,27 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": ["dpr-structured-historical-development"],
+          "data_locations": [
+            "dpr-structured-historical-development"
+          ],
           "resource_shares": [
             {
               "glue_database": "dpr_ap_integration_test_newtag_dev_dbt",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "curated_prisons_history_dev_dbt",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "staged_prisons_history_dev_dbt",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             }
           ]
         }
@@ -292,7 +307,14 @@
       "setup_scheduled_action_iam_role": true,
       "setup_redshift_schedule": true,
       "scheduled_dataset_lambda_version": "vLatest",
-      "probation_domains": ["prb-sentence-plan", "prb-assessment-view"],
+      "probation_domains": {
+        "pr-sentence-plan": {
+          "share_with_cloud_platform": false
+        },
+        "pr-assessment-view": {
+          "share_with_cloud_platform": true
+        }
+      },
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -501,7 +523,14 @@
       "setup_redshift_schedule": true,
       "enable_redshift_health_check": true,
       "scheduled_dataset_lambda_version": "vLatest",
-      "probation_domains": ["prb-sentence-plan", "prb-assessment-view"],
+      "probation_domains": {
+        "pr-sentence-plan": {
+          "share_with_cloud_platform": false
+        },
+        "pr-assessment-view": {
+          "share_with_cloud_platform": true
+        }
+      },
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -619,15 +648,21 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": ["dpr-structured-historical-preproduction"],
+          "data_locations": [
+            "dpr-structured-historical-preproduction"
+          ],
           "resource_shares": [
             {
               "glue_database": "staged_prisons_history_preprod_dbt",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "curated_prisons_history_preprod_dbt",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             }
           ]
         }
@@ -727,7 +762,14 @@
       "setup_scheduled_action_iam_role": false,
       "setup_redshift_schedule": false,
       "scheduled_dataset_lambda_version": "vLatest",
-      "probation_domains": ["prb-sentence-plan", "prb-assessment-view"],
+      "probation_domains": {
+        "pr-sentence-plan": {
+          "share_with_cloud_platform": false
+        },
+        "pr-assessment-view": {
+          "share_with_cloud_platform": true
+        }
+      },
       "dps_domains": [
         "dps-activities",
         "dps-case-notes",
@@ -845,23 +887,33 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": ["dpr-structured-historical-production"],
+          "data_locations": [
+            "dpr-structured-historical-production"
+          ],
           "resource_shares": [
             {
               "glue_database": "staged_prisons_history",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "curated_prisons_history",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "prison_derived",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             },
             {
               "glue_database": "prison_datamarts",
-              "glue_tables": ["*"]
+              "glue_tables": [
+                "*"
+              ]
             }
           ]
         }

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -61,7 +61,7 @@
       "setup_redshift_schedule": true,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-sentence-plan": {
+        "pr-test-domain": {
           "share_with_cloud_platform": false
         },
         "pr-assessment-view": {
@@ -308,7 +308,7 @@
       "setup_redshift_schedule": true,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-sentence-plan": {
+        "pr-test-domain": {
           "share_with_cloud_platform": false
         },
         "pr-assessment-view": {
@@ -524,7 +524,7 @@
       "enable_redshift_health_check": true,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-sentence-plan": {
+        "pr-test-domain": {
           "share_with_cloud_platform": false
         },
         "pr-assessment-view": {
@@ -763,7 +763,7 @@
       "setup_redshift_schedule": false,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-sentence-plan": {
+        "pr-test-domain": {
           "share_with_cloud_platform": false
         },
         "pr-assessment-view": {

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -62,10 +62,12 @@
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
         "pr-test-domain": {
-          "share_with_cloud_platform": false
+          "share_with_cloud_platform": false,
+          "create_glue_connection": true
         },
         "pr-assessment-view": {
-          "share_with_cloud_platform": true
+          "share_with_cloud_platform": true,
+          "create_glue_connection": false
         }
       },
       "dps_domains": [
@@ -309,10 +311,12 @@
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
         "pr-test-domain": {
-          "share_with_cloud_platform": false
+          "share_with_cloud_platform": false,
+          "create_glue_connection": false
         },
         "pr-assessment-view": {
-          "share_with_cloud_platform": true
+          "share_with_cloud_platform": true,
+          "create_glue_connection": false
         }
       },
       "dps_domains": [
@@ -525,10 +529,12 @@
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
         "pr-test-domain": {
-          "share_with_cloud_platform": false
+          "share_with_cloud_platform": false,
+          "create_glue_connection": false
         },
         "pr-assessment-view": {
-          "share_with_cloud_platform": true
+          "share_with_cloud_platform": true,
+          "create_glue_connection": false
         }
       },
       "dps_domains": [
@@ -764,10 +770,12 @@
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
         "pr-test-domain": {
-          "share_with_cloud_platform": false
+          "share_with_cloud_platform": false,
+          "create_glue_connection": false
         },
         "pr-assessment-view": {
-          "share_with_cloud_platform": true
+          "share_with_cloud_platform": true,
+          "create_glue_connection": false
         }
       },
       "dps_domains": [

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -310,10 +310,6 @@
       "setup_redshift_schedule": true,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-test-domain": {
-          "share_with_cloud_platform": false,
-          "create_glue_connection": false
-        },
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": false
@@ -528,10 +524,6 @@
       "enable_redshift_health_check": true,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-test-domain": {
-          "share_with_cloud_platform": false,
-          "create_glue_connection": false
-        },
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": false
@@ -769,10 +761,6 @@
       "setup_redshift_schedule": false,
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
-        "pr-test-domain": {
-          "share_with_cloud_platform": false,
-          "create_glue_connection": false
-        },
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": false

--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -189,27 +189,19 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": [
-            "dpr-structured-historical-development"
-          ],
+          "data_locations": ["dpr-structured-historical-development"],
           "resource_shares": [
             {
               "glue_database": "dpr_ap_integration_test_newtag_dev_dbt",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "curated_prisons_history_dev_dbt",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "staged_prisons_history_dev_dbt",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             }
           ]
         }
@@ -646,21 +638,15 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": [
-            "dpr-structured-historical-preproduction"
-          ],
+          "data_locations": ["dpr-structured-historical-preproduction"],
           "resource_shares": [
             {
               "glue_database": "staged_prisons_history_preprod_dbt",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "curated_prisons_history_preprod_dbt",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             }
           ]
         }
@@ -883,33 +869,23 @@
           "target_account_id": "593291632749",
           "assume_account_name": "analytical-platform-management-production",
           "assume_account_id": "042130406152",
-          "data_locations": [
-            "dpr-structured-historical-production"
-          ],
+          "data_locations": ["dpr-structured-historical-production"],
           "resource_shares": [
             {
               "glue_database": "staged_prisons_history",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "curated_prisons_history",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "prison_derived",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             },
             {
               "glue_database": "prison_datamarts",
-              "glue_tables": [
-                "*"
-              ]
+              "glue_tables": ["*"]
             }
           ]
         }

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -125,17 +125,17 @@ data "aws_secretsmanager_secret_version" "dps" {
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
   for_each = toset(local.probation_domains_list)
-  name     = "external/${local.project}-${each.value}-source-secrets"
+  name     = "external/${local.project}-${each.name}-source-secrets"
 
-  depends_on = [aws_secretsmanager_secret_version.probation]
+  depends_on = [module.probation_source_secret]
 }
 
 data "aws_secretsmanager_secret_version" "probation" {
   for_each = toset(local.probation_domains_list)
 
-  secret_id = data.aws_secretsmanager_secret.probation[each.value].id
+  secret_id = data.aws_secretsmanager_secret.probation[each.name].id
 
-  depends_on = [aws_secretsmanager_secret.probation]
+  depends_on = [module.probation_source_secret]
 }
 
 

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -124,14 +124,14 @@ data "aws_secretsmanager_secret_version" "dps" {
 
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
-  for_each = toset(local.probation_domains_map)
+  for_each = local.probation_domains_map
   name     = "external/${local.project}-${each.key}-source-secrets"
 
   depends_on = [module.probation_source_secret]
 }
 
 data "aws_secretsmanager_secret_version" "probation" {
-  for_each = toset(local.probation_domains_map)
+  for_each = local.probation_domains_map
 
   secret_id = data.aws_secretsmanager_secret.probation[each.key].id
 

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -125,7 +125,7 @@ data "aws_secretsmanager_secret_version" "dps" {
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
   for_each = toset(local.probation_domains_list)
-  name     = "external/${local.project}-${each.name}-source-secrets"
+  name     = "external/${local.project}-${each.key}-source-secrets"
 
   depends_on = [module.probation_source_secret]
 }
@@ -133,7 +133,7 @@ data "aws_secretsmanager_secret" "probation" {
 data "aws_secretsmanager_secret_version" "probation" {
   for_each = toset(local.probation_domains_list)
 
-  secret_id = data.aws_secretsmanager_secret.probation[each.name].id
+  secret_id = data.aws_secretsmanager_secret.probation[each.key].id
 
   depends_on = [module.probation_source_secret]
 }

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -124,14 +124,14 @@ data "aws_secretsmanager_secret_version" "dps" {
 
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
-  for_each = local.probation_domains_map
+  for_each = local.probation_domains
   name     = "external/${local.project}-${each.key}-source-secrets"
 
   depends_on = [module.probation_source_secret]
 }
 
 data "aws_secretsmanager_secret_version" "probation" {
-  for_each = local.probation_domains_map
+  for_each = local.probation_domains
 
   secret_id = data.aws_secretsmanager_secret.probation[each.key].id
 

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -122,18 +122,6 @@ data "aws_secretsmanager_secret_version" "dps" {
   depends_on = [aws_secretsmanager_secret.dps]
 }
 
-# Source Probation Secrets
-data "aws_secretsmanager_secret" "probation" {
-  for_each = { for key, instance in module.probation_source_secret : key => instance.secret_name }
-  name     = each.value
-}
-
-data "aws_secretsmanager_secret_version" "probation" {
-  for_each  = { for key, instance in module.probation_source_secret : key => instance.secret_id }
-  secret_id = each.value
-}
-
-
 # DPR Secret
 data "aws_secretsmanager_secret" "test_db" {
   count = local.is_dev_or_test ? 1 : 0

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -124,14 +124,14 @@ data "aws_secretsmanager_secret_version" "dps" {
 
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
-  for_each = toset(local.probation_domains_list)
+  for_each = toset(local.probation_domains_map)
   name     = "external/${local.project}-${each.key}-source-secrets"
 
   depends_on = [module.probation_source_secret]
 }
 
 data "aws_secretsmanager_secret_version" "probation" {
-  for_each = toset(local.probation_domains_list)
+  for_each = toset(local.probation_domains_map)
 
   secret_id = data.aws_secretsmanager_secret.probation[each.key].id
 

--- a/terraform/environments/digital-prison-reporting/data.tf
+++ b/terraform/environments/digital-prison-reporting/data.tf
@@ -124,18 +124,13 @@ data "aws_secretsmanager_secret_version" "dps" {
 
 # Source Probation Secrets
 data "aws_secretsmanager_secret" "probation" {
-  for_each = local.probation_domains
-  name     = "external/${local.project}-${each.key}-source-secrets"
-
-  depends_on = [module.probation_source_secret]
+  for_each = { for key, instance in module.probation_source_secret : key => instance.secret_name }
+  name     = each.value
 }
 
 data "aws_secretsmanager_secret_version" "probation" {
-  for_each = local.probation_domains
-
-  secret_id = data.aws_secretsmanager_secret.probation[each.key].id
-
-  depends_on = [module.probation_source_secret]
+  for_each  = { for key, instance in module.probation_source_secret : key => instance.secret_id }
+  secret_id = each.value
 }
 
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -105,7 +105,7 @@ resource "aws_glue_connection" "glue_probation_connection" {
   connection_properties = {
     JDBC_CONNECTION_URL    = local.probation_connection_string[each.key]
     JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
-    SECRET_ID              = module.probation_source_secret[each.key].name
+    SECRET_ID              = module.probation_source_secret[each.key].secret_name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,8 +21,14 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
+  probation_source_secrets_requiring_glue_connections = {
+    for key, value in local.probation_domains :
+    key => module.probation_source_secret[key]
+    if value.create_glue_connection
+  }
+
   probation_connection_string = {
-    for key, entity in module.probation_source_secret :
+    for key, entity in local.probation_source_secrets_requiring_glue_connections :
     key => "jdbc:postgresql://${entity.secret_contents_endpoint}:${entity.secret_contents_port}/${entity.secret_contents_db_name}"
   }
 }

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -98,7 +98,7 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? local.probation_domains_map : []
+  for_each        = local.create_glue_connection ? local.probation_domains_map : {}
   name            = "${local.project}-${each.key}-connection"
   connection_type = "JDBC"
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -28,19 +28,19 @@ locals {
   }
 
   probation_endpoint = {
-    for key, _ in local.probation_glue_connections :
+    for key, _ in local.probation_domains :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["endpoint"]
   }
   probation_port = {
-    for key, _ in local.probation_glue_connections :
+    for key, _ in local.probation_domains :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["port"]
   }
   probation_database = {
-    for key, _ in local.probation_glue_connections :
+    for key, _ in local.probation_domains :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for key, _ in local.probation_glue_connections :
+    for key, _ in local.probation_domains :
     key => "jdbc:postgresql://${local.probation_endpoint[key]}:${local.probation_port[key]}/${local.probation_database[key]}"
   }
 }

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -22,20 +22,20 @@ locals {
   }
 
   probation_endpoint = {
-    for item in local.probation_domains_map :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["endpoint"]
+    for key, _ in local.probation_domains_map :
+    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["endpoint"]
   }
   probation_port = {
-    for item in local.probation_domains_map :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["port"]
+    for key, _ in local.probation_domains_map :
+    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["port"]
   }
   probation_database = {
-    for item in local.probation_domains_map :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["db_name"]
+    for key, _ in local.probation_domains_map :
+    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for item in local.probation_domains_map :
-    item => "jdbc:postgresql://${local.probation_endpoint[item.key]}:${local.probation_port[item.key]}/${local.probation_database[item.key]}"
+    for key, _ in local.probation_domains_map :
+    key => "jdbc:postgresql://${local.probation_endpoint[key]}:${local.probation_port[key]}/${local.probation_database[key]}"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,23 +21,21 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
-  probation_domains_names_list = [for item in local.probation_domains_list: item.name]
-
   probation_endpoint = {
-    for item in local.probation_domains_names_list :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["endpoint"]
+    for item in local.probation_domains_list :
+    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["endpoint"]
   }
   probation_port = {
-    for item in local.probation_domains_names_list :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["port"]
+    for item in local.probation_domains_list :
+    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["port"]
   }
   probation_database = {
-    for item in local.probation_domains_names_list :
-    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["db_name"]
+    for item in local.probation_domains_list :
+    item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for item in local.probation_domains_names_list :
-    item => "jdbc:postgresql://${local.probation_endpoint[item]}:${local.probation_port[item]}/${local.probation_database[item]}"
+    for item in local.probation_domains_list :
+    item => "jdbc:postgresql://${local.probation_endpoint[item.key]}:${local.probation_port[item.key]}/${local.probation_database[item.key]}"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -22,19 +22,19 @@ locals {
   }
 
   probation_endpoint = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_map :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["endpoint"]
   }
   probation_port = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_map :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["port"]
   }
   probation_database = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_map :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item.key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_map :
     item => "jdbc:postgresql://${local.probation_endpoint[item.key]}:${local.probation_port[item.key]}/${local.probation_database[item.key]}"
   }
 }
@@ -98,14 +98,14 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? local.probation_domains_list : []
-  name            = "${local.project}-${each.name}-connection"
+  for_each        = local.create_glue_connection ? local.probation_domains_map : []
+  name            = "${local.project}-${each.key}-connection"
   connection_type = "JDBC"
 
   connection_properties = {
-    JDBC_CONNECTION_URL    = local.probation_connection_string[each.name]
+    JDBC_CONNECTION_URL    = local.probation_connection_string[each.key]
     JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
-    SECRET_ID              = module.probation_source_secret[each.name].name
+    SECRET_ID              = module.probation_source_secret[each.key].name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,20 +21,26 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
+  probation_glue_connections = {
+    for key, value in local.probation_domains :
+    key => value
+    if value.create_glue_connection
+  }
+
   probation_endpoint = {
-    for key, _ in local.probation_domains_map :
+    for key, _ in local.probation_glue_connections :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["endpoint"]
   }
   probation_port = {
-    for key, _ in local.probation_domains_map :
+    for key, _ in local.probation_glue_connections :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["port"]
   }
   probation_database = {
-    for key, _ in local.probation_domains_map :
+    for key, _ in local.probation_glue_connections :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for key, _ in local.probation_domains_map :
+    for key, _ in local.probation_glue_connections :
     key => "jdbc:postgresql://${local.probation_endpoint[key]}:${local.probation_port[key]}/${local.probation_database[key]}"
   }
 }
@@ -98,7 +104,7 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? local.probation_domains_map : {}
+  for_each        = local.create_glue_connection ? local.probation_glue_connections : {}
   name            = "${local.project}-${each.key}-connection"
   connection_type = "JDBC"
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,21 +21,9 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
-  probation_endpoint = {
-    for key, _ in module.probation_source_secret :
-    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["endpoint"]
-  }
-  probation_port = {
-    for key, _ in module.probation_source_secret :
-    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["port"]
-  }
-  probation_database = {
-    for key, _ in module.probation_source_secret :
-    key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["db_name"]
-  }
   probation_connection_string = {
-    for key, _ in module.probation_source_secret :
-    key => "jdbc:postgresql://${local.probation_endpoint[key]}:${local.probation_port[key]}/${local.probation_database[key]}"
+    for key, entity in module.probation_source_secret :
+    key => "jdbc:postgresql://${entity.secret_contents_endpoint}:${entity.secret_contents_port}/${entity.secret_contents_db_name}"
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,26 +21,20 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
-  probation_glue_connections = {
-    for key, value in local.probation_domains :
-    key => value
-    if value.create_glue_connection
-  }
-
   probation_endpoint = {
-    for key, _ in local.probation_domains :
+    for key, _ in module.probation_source_secret :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["endpoint"]
   }
   probation_port = {
-    for key, _ in local.probation_domains :
+    for key, _ in module.probation_source_secret :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["port"]
   }
   probation_database = {
-    for key, _ in local.probation_domains :
+    for key, _ in module.probation_source_secret :
     key => jsondecode(data.aws_secretsmanager_secret_version.probation[key].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for key, _ in local.probation_domains :
+    for key, _ in module.probation_source_secret :
     key => "jdbc:postgresql://${local.probation_endpoint[key]}:${local.probation_port[key]}/${local.probation_database[key]}"
   }
 }
@@ -104,7 +98,7 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? local.probation_glue_connections : {}
+  for_each        = local.create_glue_connection ? module.probation_source_secret : {}
   name            = "${local.project}-${each.key}-connection"
   connection_type = "JDBC"
 

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -21,20 +21,22 @@ locals {
     item => "jdbc:postgresql://${local.dps_endpoint[item]}:${local.dps_port[item]}/${local.dps_database[item]}"
   }
 
+  probation_domains_names_list = [for item in local.probation_domains_list: item.name]
+
   probation_endpoint = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_names_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["endpoint"]
   }
   probation_port = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_names_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["port"]
   }
   probation_database = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_names_list :
     item => jsondecode(data.aws_secretsmanager_secret_version.probation[item].secret_string)["db_name"]
   }
   probation_connection_string = {
-    for item in local.probation_domains_list :
+    for item in local.probation_domains_names_list :
     item => "jdbc:postgresql://${local.probation_endpoint[item]}:${local.probation_port[item]}/${local.probation_database[item]}"
   }
 }
@@ -98,14 +100,14 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? toset(local.probation_domains_list) : []
-  name            = "${local.project}-${each.value}-connection"
+  for_each        = local.create_glue_connection ? local.probation_domains_list : []
+  name            = "${local.project}-${each.name}-connection"
   connection_type = "JDBC"
 
   connection_properties = {
-    JDBC_CONNECTION_URL    = local.probation_connection_string[each.value]
+    JDBC_CONNECTION_URL    = local.probation_connection_string[each.name]
     JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver"
-    SECRET_ID              = aws_secretsmanager_secret.probation[each.value].name
+    SECRET_ID              = module.probation_source_secret[each.name].name
   }
 
   physical_connection_requirements {

--- a/terraform/environments/digital-prison-reporting/glue-connections.tf
+++ b/terraform/environments/digital-prison-reporting/glue-connections.tf
@@ -92,7 +92,7 @@ resource "aws_glue_connection" "glue_dps_connection" {
 
 # All Probation connections
 resource "aws_glue_connection" "glue_probation_connection" {
-  for_each        = local.create_glue_connection ? module.probation_source_secret : {}
+  for_each        = local.create_glue_connection ? local.probation_source_secrets_requiring_glue_connections : {}
   name            = "${local.project}-${each.key}-connection"
   connection_type = "JDBC"
 

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -437,7 +437,7 @@ locals {
     heartbeat_endpoint = "0.0.0.0"
   }
 
-  probation_domains_map = local.application_data.accounts[local.environment].probation_domains
+  probation_domains = local.application_data.accounts[local.environment].probation_domains
 
   # Operational DataStore Secrets PlaceHolder
   operational_datastore_secrets_placeholder = {

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -437,7 +437,7 @@ locals {
     heartbeat_endpoint = "0.0.0.0"
   }
 
-  probation_domains_list = local.application_data.accounts[local.environment].probation_domains
+  probation_domains_map = local.application_data.accounts[local.environment].probation_domains
 
   # Operational DataStore Secrets PlaceHolder
   operational_datastore_secrets_placeholder = {

--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -438,15 +438,6 @@ locals {
   }
 
   probation_domains_list = local.application_data.accounts[local.environment].probation_domains
-  probation_secrets_placeholder = {
-    db_name            = "dps"
-    password           = "placeholder"
-    user               = "placeholder"
-    username           = "placeholder"
-    endpoint           = "0.0.0.0"
-    port               = "5432"
-    heartbeat_endpoint = "0.0.0.0"
-  }
 
   # Operational DataStore Secrets PlaceHolder
   operational_datastore_secrets_placeholder = {

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
@@ -1,11 +1,12 @@
 locals {
   secret_payload_placeholder = {
-    db_name  = "placeholder"
-    username = "placeholder"
-    user     = "placeholder"
-    password = "placeholder"
-    host     = "placeholder"
-    port     = "placeholder"
+    db_name            = "placeholder"
+    username           = "placeholder"
+    user               = "placeholder"
+    password           = "placeholder"
+    endpoint           = "0.0.0.0"
+    port               = "5432"
+    heartbeat_endpoint = "0.0.0.0"
   }
 
   cloud_platform_aws_account_arn = "arn:aws:iam::${var.cloud_platform_aws_account_id}:root"
@@ -79,4 +80,5 @@ resource "aws_secretsmanager_secret_version" "this" {
 
 data "aws_secretsmanager_secret_version" "this" {
   secret_id = aws_secretsmanager_secret.this.id
+  version_id = aws_secretsmanager_secret_version.this.id
 }

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
@@ -76,3 +76,7 @@ resource "aws_secretsmanager_secret_version" "this" {
     ignore_changes = [secret_string]
   }
 }
+
+data "aws_secretsmanager_secret_version" "this" {
+  secret_id = aws_secretsmanager_secret.this.id
+}

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
@@ -1,0 +1,78 @@
+locals {
+  secret_payload_placeholder = {
+    db_name  = "placeholder"
+    username = "placeholder"
+    user     = "placeholder"
+    password = "placeholder"
+    host     = "placeholder"
+    port     = "placeholder"
+  }
+
+  cloud_platform_aws_account_arn = "arn:aws:iam::${var.cloud_platform_aws_account_id}:root"
+}
+
+resource "aws_secretsmanager_secret" "this" {
+  #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
+  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
+  name        = "external/${var.project_id}-${var.ingestion_domain_name}-source-secrets"
+  description = "Source secret for ${var.ingestion_domain_name}${var.is_cloud_platform_accessible ? " - accessible from Cloud Platform" : ""}"
+  kms_key_id  = var.is_cloud_platform_accessible ? var.cloud_platform_shared_kms_key_id : null
+
+  tags = merge(
+    var.tags,
+    {
+      dpr-name          = "external/${var.project_id}-${var.ingestion_domain_name}-source-secrets"
+      dpr-resource-type = "Secrets"
+      dpr-domain        = var.ingestion_domain_name
+    }
+  )
+}
+
+# Gives Cloud Platform access to read and update this secret
+# The IAM policy on the CP role will control which specific roles can perform each action
+# See https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/6147506402/Datahub+Cross-Account+Secret+Sharing for notes
+# on the original implementation
+resource "aws_secretsmanager_secret_policy" "this" {
+  for_each = var.is_cloud_platform_accessible ? { create = true } : {}
+
+  secret_arn = aws_secretsmanager_secret.this.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudPlatformAccountToReadSecret"
+        Effect = "Allow"
+        Principal = {
+          AWS = local.cloud_platform_aws_account_arn
+        }
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowCloudPlatformAccountToWriteSecret"
+        Effect = "Allow"
+        Principal = {
+          AWS = local.cloud_platform_aws_account_arn
+        }
+        Action = [
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = jsonencode(local.secret_payload_placeholder)
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
@@ -80,5 +80,4 @@ resource "aws_secretsmanager_secret_version" "this" {
 
 data "aws_secretsmanager_secret_version" "this" {
   secret_id = aws_secretsmanager_secret.this.id
-  version_id = aws_secretsmanager_secret_version.this.id
 }

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -13,3 +13,21 @@ output "secret_name" {
 output "secret_version_id" {
   value = aws_secretsmanager_secret_version.this.version_id
 }
+
+output "secret_contents_endpoint" {
+  description = "The endpoint extracted from the secret string"
+  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["endpoint"]
+  sensitive   = true
+}
+
+output "secret_contents_port" {
+  description = "The port extracted from the secret string"
+  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["port"]
+  sensitive   = true
+}
+
+output "secret_contents_db_name" {
+  description = "The db_name extracted from the secret string"
+  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["db_name"]
+  sensitive   = true
+}

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -2,7 +2,7 @@ output "secret_arn" {
   value = aws_secretsmanager_secret.this.arn
 }
 
-output "secret_name" {
+  output "secret_name" {
   value = aws_secretsmanager_secret.this.name
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -1,0 +1,11 @@
+output "secret_arn" {
+  value = aws_secretsmanager_secret.this.arn
+}
+
+output "secret_name" {
+  value = aws_secretsmanager_secret.this.name
+}
+
+output "secret_version_id" {
+  value = aws_secretsmanager_secret_version.this.version_id
+}

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -16,18 +16,18 @@ output "secret_version_id" {
 
 output "secret_contents_endpoint" {
   description = "The endpoint extracted from the secret string"
-  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["endpoint"]
+  value       = jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["endpoint"]
   sensitive   = true
 }
 
 output "secret_contents_port" {
   description = "The port extracted from the secret string"
-  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["port"]
+  value       = jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["port"]
   sensitive   = true
 }
 
 output "secret_contents_db_name" {
   description = "The db_name extracted from the secret string"
-  value       = jsondecode(aws_secretsmanager_secret_version.this.secret_string)["db_name"]
+  value       = jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["db_name"]
   sensitive   = true
 }

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -1,17 +1,21 @@
 output "secret_arn" {
-  value = aws_secretsmanager_secret.this.arn
+  value       = aws_secretsmanager_secret.this.arn
+  description = "The ARN of the secret"
 }
 
 output "secret_id" {
-  value = aws_secretsmanager_secret.this.id
+  value       = aws_secretsmanager_secret.this.id
+  description = "The ID of the secret"
 }
 
 output "secret_name" {
-  value = aws_secretsmanager_secret.this.name
+  value       = aws_secretsmanager_secret.this.name
+  description = "The name of the secret"
 }
 
 output "secret_version_id" {
-  value = aws_secretsmanager_secret_version.this.version_id
+  value       = aws_secretsmanager_secret_version.this.version_id
+  description = "The ID of the secret version"
 }
 
 output "secret_contents_endpoint" {

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/outputs.tf
@@ -2,7 +2,11 @@ output "secret_arn" {
   value = aws_secretsmanager_secret.this.arn
 }
 
-  output "secret_name" {
+output "secret_id" {
+  value = aws_secretsmanager_secret.this.id
+}
+
+output "secret_name" {
   value = aws_secretsmanager_secret.this.name
 }
 

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/variables.tf
@@ -1,0 +1,31 @@
+variable "ingestion_domain_name" {
+  description = "Name of the ingestion domain, e.g. prb-some-service for Probation services, dps-some-service for DPS services"
+  type        = string
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project Short ID that will be used in naming resources"
+}
+
+variable "cloud_platform_shared_kms_key_id" {
+  description = "This KMS key ID or ARN is used to encrypt the secret if cloud platform should have access to this secret."
+  type        = string
+}
+
+variable "cloud_platform_aws_account_id" {
+  description = "AWS account ID of the cloud platform"
+  type        = string
+}
+
+variable "is_cloud_platform_accessible" {
+  description = "Whether the Cloud Platform AWS account should be granted access to the secret or not"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "(Optional) Key-value map of resource tags."
+}

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/versions.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 5.0, != 5.86.0"
+      source  = "hashicorp/aws"
+    }
+
+  }
+  required_version = "~> 1.10"
+}

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -480,7 +480,7 @@ data "aws_iam_policy_document" "redshift_federated_query" {
     actions = [
       "secretsmanager:GetSecretValue"
     ]
-    resources = [for s in data.aws_secretsmanager_secret.probation : s.arn]
+    resources = [for s in module.probation_source_secret : s.secret_arn]
   }
 }
 

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -234,7 +234,7 @@ resource "aws_secretsmanager_secret_version" "dps" {
 
 # Probation Source Secrets
 module "probation_source_secret" {
-  for_each                         = local.probation_domains_list
+  for_each                         = local.probation_domains_map
 
   source                           = "./modules/data_source_secret"
 

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -233,34 +233,17 @@ resource "aws_secretsmanager_secret_version" "dps" {
 }
 
 # Probation Source Secrets
-resource "aws_secretsmanager_secret" "probation" {
-  #checkov:skip=CKV2_AWS_57: “Ignore - Ensure Secrets Manager secrets should have automatic rotation enabled"
-  #checkov:skip=CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
+module "probation_source_secret" {
+  for_each                         = local.probation_domains_list
 
-  for_each = toset(local.probation_domains_list)
-  name     = "external/${local.project}-${each.value}-source-secrets"
+  source                           = "./modules/data_source_secret"
 
-  tags = merge(
-    local.all_tags,
-    {
-      dpr-name          = "external/${local.project}-${each.value}-source-secrets"
-      dpr-resource-type = "Secrets"
-      dpr-source        = "Probation"
-      dpr-domain        = each.value
-      dpr-jira          = "PDHD-1111"
-    }
-  )
-}
-
-resource "aws_secretsmanager_secret_version" "probation" {
-  for_each = toset(local.probation_domains_list)
-
-  secret_id     = aws_secretsmanager_secret.probation[each.key].id
-  secret_string = jsonencode(local.probation_secrets_placeholder)
-
-  lifecycle {
-    ignore_changes = [secret_string, ]
-  }
+  cloud_platform_aws_account_id    = "754256621582"
+  cloud_platform_shared_kms_key_id = aws_kms_key.crossaccount_secret.arn
+  project_id                       = local.project
+  ingestion_domain_name            = each.name
+  is_cloud_platform_accessible     = each.value.share_with_cloud_platform
+  tags                             = local.all_tags
 }
 
 # Redshift Access Secrets

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -241,7 +241,7 @@ module "probation_source_secret" {
   cloud_platform_aws_account_id    = "754256621582"
   cloud_platform_shared_kms_key_id = aws_kms_key.crossaccount_secret.arn
   project_id                       = local.project
-  ingestion_domain_name            = each.name
+  ingestion_domain_name            = each.key
   is_cloud_platform_accessible     = each.value.share_with_cloud_platform
   tags                             = local.all_tags
 }

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -234,7 +234,7 @@ resource "aws_secretsmanager_secret_version" "dps" {
 
 # Probation Source Secrets
 module "probation_source_secret" {
-  for_each                         = local.probation_domains_map
+  for_each                         = local.probation_domains
 
   source                           = "./modules/data_source_secret"
 


### PR DESCRIPTION
- This builds on [Hari's previous cross account secret access work](https://github.com/ministryofjustice/modernisation-platform-environments/pull/16237/changes) and replaces the existing probation secret placeholder setup with a means of granting teams access to automatically update or retrieve their secrets in Cloud Platform
- Creates a data_source_secret module for secrets that represent credentials for a data source
- Makes whether a glue connection is created along with the secret configurable for probation services (glue connections are not required for federated query setups)
- I have not migrated DPS service secrets as there would be risk to the secret contents and it is not currently a requirement for DPS teams
- I have not removed Hari's original cross account shared secret because it is currently still being used