### PR TITLE
TM-2097: fixing-removed-dns-zone

### DIFF
--- a/terraform/environments/oasys/locals_test.tf
+++ b/terraform/environments/oasys/locals_test.tf
@@ -23,7 +23,6 @@ locals {
         external_validation_records_created = true
         subject_alternate_names = [
           "*.oasys.service.justice.gov.uk",
-          "*.hmpp-azdt.justice.gov.uk",
           "ords.t2.oasys.service.justice.gov.uk",
           "ords.t1.oasys.service.justice.gov.uk",
         ]
@@ -447,7 +446,6 @@ locals {
                       values = [
                         "t2-int.oasys.service.justice.gov.uk",
                         "t2-a-int.oasys.service.justice.gov.uk",
-                        "t2-oasys.hmpp-azdt.justice.gov.uk",
                       ]
                     }
                   }
@@ -481,7 +479,6 @@ locals {
                       values = [
                         "t1-int.oasys.service.justice.gov.uk",
                         "t1-a-int.oasys.service.justice.gov.uk",
-                        "t1-oasys.hmpp-azdt.justice.gov.uk",
                       ]
                     }
                   }


### PR DESCRIPTION
Fixing the ACM certificate to allow auto-renew to work.