### PR TITLE
Add default tag blocks to AWS `platform_providers.tf` files

### DIFF
--- a/terraform/environments/analytical-platform-compute/actions-runner/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/platform_providers.tf
@@ -2,6 +2,7 @@
 provider "aws" {
   alias  = "original-session"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
@@ -10,6 +11,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
@@ -19,6 +21,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
@@ -28,6 +31,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for creating resources in us-east-1, eg ACM resources for CloudFront
@@ -37,6 +41,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for reading resources from root account IdentityStore
@@ -46,4 +51,5 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
+  default_tags { tags = local.tags }
 }


### PR DESCRIPTION
## Issue

As part of https://github.com/ministryofjustice/modernisation-platform/issues/12605 we are looking to standardise Mod Platform's use of default tags in provider blocks.  

In March 2025 we updated the [platform_providers.tf](https://github.com/ministryofjustice/modernisation-platform/commit/431bab9c6fe356062c33f60b959630edffd7bf43) file templates to have default tag blocks but accounts that pre-date that change do not have them.

We are looking to apply the default blocks to standardise our setup and help enforce the platform to comply with the Hosting [Tagging Standard](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html#tagging-standard). 

Adding default tagging blocks to providers will ensure all resources (that are taggable) are tagged with the values in `local.tags`. Many teams are already making use of `local.tags` without adding it to providers so it may have no adverse affect, but others may see changes required to incorporate the tags to their existing infrastructure.

## Changes

- In this PR we have added the default tag blocks for the AWS provider configurations in the `platform_providers.tf` file e.g. `default_tags { tags = local.tags }`

- This change could cause unintended changes to infrastructure for teams and in the worst event trigger destructive changes e.g. rebuild of important infrastructure.

## What do I need to do?

MP team **will contact teams directly** to get your approval before we merge this PR just so that we can mitigate any potential impact this may have on your infrastructure.

We'd be grateful if you could **review the impact of this PR on your environments** so that we can get these changes deployed ASAP.

If you have any questions or issues please [#ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1)
