### PR TITLE
Add Claude Opus 4.7 to LLM Gateway

### DIFF
--- a/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
@@ -70,6 +70,10 @@ locals {
             model_id = "eu.anthropic.claude-opus-4-6-v1"
             region   = "eu-west-2"
           }
+          claude-opus-4-7 = {
+            model_id = "eu.anthropic.claude-opus-4-7"
+            region   = "eu-west-2"
+          }
           claude-sonnet-4 = {
             model_id = "eu.anthropic.claude-sonnet-4-20250514-v1:0"
             region   = "eu-west-1"


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` (model ID `eu.anthropic.claude-opus-4-7`) to the bedrock models in the development environment configuration for the LLM Gateway

## Test plan
- [ ] Verify Terraform plan shows the new model added to the LiteLLM Helm values
- [ ] Confirm the model is accessible via the LLM Gateway after deploy