### PR TITLE
rename live feed lambda functions

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-alarms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-alarms.tf
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "mdss_reconciler_errors_alarm" {
   statistic   = "Sum"
 
   dimensions = {
-    FunctionName = module.mdss_reconciler[0].lambda_function_name
+    FunctionName = module.mdss_load_redrive_controller[0].lambda_function_name
   }
 
   alarm_actions = [

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
@@ -126,13 +126,13 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
               "AWS/Lambda",
               "Errors",
               "FunctionName",
-              module.process_fms_metadata.lambda_function_name
+              module.fms_expected_file_processor.lambda_function_name
             ],
             [
               ".",
               "Throttles",
               ".",
-              module.process_fms_metadata.lambda_function_name
+              module.fms_expected_file_processor.lambda_function_name
             ]
           ]
         }
@@ -152,14 +152,14 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
               "AWS/Lambda",
               "Duration",
               "FunctionName",
-              module.process_fms_metadata.lambda_function_name,
+              module.fms_expected_file_processor.lambda_function_name,
               { stat = "p95" }
             ],
             [
               ".",
               "Invocations",
               ".",
-              module.process_fms_metadata.lambda_function_name,
+              module.fms_expected_file_processor.lambda_function_name,
               { stat = "Sum" }
             ]
           ]
@@ -185,13 +185,13 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
               "AWS/Lambda",
               "Errors",
               "FunctionName",
-              module.format_json_fms_data.lambda_function_name
+              module.fms_raw_file_formatter.lambda_function_name
             ],
             [
               ".",
               "Throttles",
               ".",
-              module.format_json_fms_data.lambda_function_name
+              module.fms_raw_file_formatter.lambda_function_name
             ]
           ]
         }
@@ -211,14 +211,14 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
               "AWS/Lambda",
               "Duration",
               "FunctionName",
-              module.format_json_fms_data.lambda_function_name,
+              module.fms_raw_file_formatter.lambda_function_name,
               { stat = "p95" }
             ],
             [
               ".",
               "Invocations",
               ".",
-              module.format_json_fms_data.lambda_function_name,
+              module.fms_raw_file_formatter.lambda_function_name,
               { stat = "Sum" }
             ]
           ]

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-mdss.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-mdss.tf
@@ -88,8 +88,8 @@ resource "aws_cloudwatch_dashboard" "mdss_ops" {
           stat   = "Sum"
           period = 60
           metrics = [
-            ["AWS/Lambda", "Errors", "FunctionName", try(module.mdss_reconciler[0].lambda_function_name, "mdss_reconciler_not_deployed")],
-            [".", "Throttles", ".", try(module.mdss_reconciler[0].lambda_function_name, "mdss_reconciler_not_deployed")]
+            ["AWS/Lambda", "Errors", "FunctionName", try(module.mdss_load_redrive_controller[0].lambda_function_name, "mdss_reconciler_not_deployed")],
+            [".", "Throttles", ".", try(module.mdss_load_redrive_controller[0].lambda_function_name, "mdss_reconciler_not_deployed")]
           ]
         }
       },
@@ -104,8 +104,8 @@ resource "aws_cloudwatch_dashboard" "mdss_ops" {
           region = "eu-west-2"
           period = 300
           metrics = [
-            ["AWS/Lambda", "Duration", "FunctionName", try(module.mdss_reconciler[0].lambda_function_name, "mdss_reconciler_not_deployed"), { stat = "p95" }],
-            [".", "Invocations", ".", try(module.mdss_reconciler[0].lambda_function_name, "mdss_reconciler_not_deployed"), { stat = "Sum" }]
+            ["AWS/Lambda", "Duration", "FunctionName", try(module.mdss_load_redrive_controller[0].lambda_function_name, "mdss_reconciler_not_deployed"), { stat = "p95" }],
+            [".", "Invocations", ".", try(module.mdss_load_redrive_controller[0].lambda_function_name, "mdss_reconciler_not_deployed"), { stat = "Sum" }]
           ]
         }
       },
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_dashboard" "mdss_ops" {
           region = "eu-west-2"
           view   = "table"
           query  = <<-EOT
-            SOURCE '${try(module.mdss_reconciler[0].cloudwatch_log_group.name, "/aws/lambda/mdss_reconciler_not_deployed")}'
+            SOURCE '${try(module.mdss_load_redrive_controller[0].cloudwatch_log_group.name, "/aws/lambda/mdss_reconciler_not_deployed")}'
             | filter message.event = "MDSS_RECONCILE_COMPLETE"
             | fields
                 @timestamp,

--- a/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
+++ b/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
@@ -61,14 +61,14 @@ resource "aws_s3_bucket_notification" "data_bucket_triggers" {
 module "process_fms_metadata_sqs" {
   source               = "./modules/sqs_s3_lambda_trigger"
   bucket               = module.s3-data-bucket.bucket
-  lambda_function_name = module.process_fms_metadata.lambda_function_name
+  lambda_function_name = module.fms_expected_file_processor.lambda_function_name
   bucket_prefix        = local.bucket_prefix
 }
 
 module "copy_mdss_data_sqs" {
   source               = "./modules/sqs_s3_lambda_trigger"
   bucket               = module.s3-data-bucket.bucket
-  lambda_function_name = module.copy_mdss_data.lambda_function_name
+  lambda_function_name = module.mdss_raw_file_stager.lambda_function_name
   bucket_prefix        = local.bucket_prefix
 }
 
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "allow_lambda_to_write" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = [module.process_fms_metadata.lambda_function_arn]
+      values   = [module.fms_expected_file_processor.lambda_function_arn]
     }
     condition {
       test     = "StringEquals"
@@ -153,7 +153,7 @@ resource "aws_sqs_queue_policy" "allow_lambda_to_write" {
 
 resource "aws_lambda_event_source_mapping" "sqs_trigger" {
   event_source_arn = aws_sqs_queue.format_fms_json_event_queue.arn
-  function_name    = module.format_json_fms_data.lambda_function_name
+  function_name    = module.fms_raw_file_formatter.lambda_function_name
   batch_size       = 10
   scaling_config {
     maximum_concurrency = 1000
@@ -208,7 +208,7 @@ module "load_fms_event_queue" {
 module "fms_fan_out_event_queue" {
   source               = "./modules/sqs_s3_lambda_trigger"
   bucket               = module.s3-raw-formatted-data-bucket.bucket
-  lambda_function_name = module.fan_out_tags.lambda_function_name
+  lambda_function_name = module.fms_validation_rejection_fanout.lambda_function_name
   bucket_prefix        = local.bucket_prefix
   maximum_concurrency  = 100
   max_receive_count    = local.load_sqs_max_receive_count
@@ -288,14 +288,14 @@ resource "aws_cloudwatch_event_rule" "mdss_reconciler_schedule" {
 resource "aws_cloudwatch_event_target" "mdss_reconciler_target" {
   count = 1
   rule  = aws_cloudwatch_event_rule.mdss_reconciler_schedule[0].name
-  arn   = module.mdss_reconciler[0].lambda_function_arn
+  arn   = module.mdss_load_redrive_controller[0].lambda_function_arn
 }
 
 resource "aws_lambda_permission" "mdss_reconciler_allow_eventbridge" {
   count         = 1
   statement_id  = "AllowExecutionFromEventBridgeMdssReconciler"
   action        = "lambda:InvokeFunction"
-  function_name = module.mdss_reconciler[0].lambda_function_name
+  function_name = module.mdss_load_redrive_controller[0].lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.mdss_reconciler_schedule[0].arn
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -534,7 +534,39 @@ module "mdss_daily_failure_digest" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    # keep the existing env vars exactly as they are
+    SNS_TOPIC_ARN  = aws_sns_topic.emds_alerts.arn
+    ENVIRONMENT    = local.environment_shorthand
+    NAMESPACE      = "EMDS/MDSS"
+    LOOKBACK_HOURS = "24"
+
+    LOAD_MDSS_QUEUE_NAME = module.load_mdss_event_queue.sqs_queue.name
+    LOAD_FMS_QUEUE_NAME  = module.load_fms_event_queue.sqs_queue.name
+
+    LOAD_MDSS_DLQ_NAME = module.load_mdss_event_queue.sqs_dlq.name
+    CLEAN_DLT_DLQ_NAME = aws_sqs_queue.clean_dlt_load_dlq.name
+    LOAD_FMS_DLQ_NAME  = module.load_fms_event_queue.sqs_dlq.name
+
+    PROCESS_LANDING_BUCKET_FILES_FMS_GENERAL_DLQ_NAME  = local.live_feed_dlq_names.process_landing_bucket_files_fms_general
+    PROCESS_LANDING_BUCKET_FILES_FMS_HO_DLQ_NAME       = local.live_feed_dlq_names.process_landing_bucket_files_fms_ho
+    PROCESS_LANDING_BUCKET_FILES_FMS_SPECIALS_DLQ_NAME = local.live_feed_dlq_names.process_landing_bucket_files_fms_specials
+
+    PROCESS_LANDING_BUCKET_FILES_MDSS_GENERAL_DLQ_NAME  = local.live_feed_dlq_names.process_landing_bucket_files_mdss_general
+    PROCESS_LANDING_BUCKET_FILES_MDSS_HO_DLQ_NAME       = local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho
+    PROCESS_LANDING_BUCKET_FILES_MDSS_SPECIALS_DLQ_NAME = local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials
+
+    SCAN_DLQ_NAME                   = local.live_feed_dlq_names.scan
+    PROCESS_FMS_METADATA_DLQ_NAME   = local.live_feed_dlq_names.process_fms_metadata
+    FORMAT_FMS_JSON_DLQ_NAME        = aws_sqs_queue.format_fms_json_event_dlq.name
+    PUSH_DATA_EXPORT_TO_P1_DLQ_NAME = local.live_feed_dlq_names.push_data_export_to_p1
+
+    LOAD_FMS_FUNCTION_NAME             = module.load_fms_lambda.lambda_function_name
+    PROCESS_FMS_METADATA_FUNCTION_NAME = module.process_fms_metadata.lambda_function_name
+    FORMAT_JSON_FMS_DATA_FUNCTION_NAME = module.format_json_fms_data.lambda_function_name
+
+    LAMBDAS_PRODUCTION_RUN_URL = "https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/actions/workflows/push-to-ecr.yaml"
+    CADT_DAILY_RUN_URL         = "https://github.com/moj-analytical-services/create-a-derived-table/actions/workflows/emds-live-workflow.yml"
+    ROTA_GUIDE_URL             = "https://jubilant-adventure-g65j3om.pages.github.io/hmpps/electronic_monitoring/data_engineering_guides/rota_duties/"
+    EARS_SARS_TALLY_URL        = "https://justiceuk.sharepoint.com/:x:/r/sites/EMExpansionProgrammeteam/_layouts/15/doc2.aspx?sourcedoc=%7B25644699-3837-4A02-9C09-020EF0ECA744%7D&file=Monthly%20Tally%20of%20EARs%20and%20SARs.xlsx&action=default&mobileredirect=true"
   }
 }
 
@@ -845,7 +877,21 @@ module "landing_dlq_redriver" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    # keep existing env vars
+    POWERTOOLS_LOG_LEVEL = "INFO"
+
+    SNS_TOPIC_ARN = aws_sns_topic.emds_alerts.arn
+    ENVIRONMENT   = local.environment_shorthand
+    STATE_BUCKET  = local.alarm_thread_state_bucket
+    STATE_PREFIX  = local.alarm_thread_state_prefix
+
+    LANDING_DLQ_CONFIG = jsonencode(local.landing_dlq_redriver_config)
+
+    MAX_MESSAGES_PER_RUN                   = "50"
+    MAX_BATCHES_PER_EXECUTION              = "20"
+    DLQ_RECEIVE_VISIBILITY_TIMEOUT_SECONDS = "30"
+    LEGACY_UNKNOWN_RETRY_POLICY            = "retry_once"
+    AUTO_RETRY_MAX_ATTEMPTS                = "2"
+    RETRY_ONCE_MAX_ATTEMPTS                = "1"
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -298,7 +298,7 @@ module "dms_validation" {
 module "process_fms_metadata" {
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "fms_formatting_dispatcher"
+  function_name                  = "fms_expected_file_processor"
   role_name                      = aws_iam_role.process_fms_metadata.name
   role_arn                       = aws_iam_role.process_fms_metadata.arn
   handler                        = "process_fms_metadata.handler"

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -148,7 +148,7 @@ module "virus_scan_file" {
 # Process live files
 #-----------------------------------------------------------------------------------
 
-module "format_json_fms_data" {
+module "fms_raw_file_formatter" {
   source                         = "./modules/lambdas"
   function_name                  = "fms_raw_file_formatter"
   image_name                     = "format_json_fms_data"
@@ -167,7 +167,7 @@ module "format_json_fms_data" {
   }
 }
 
-module "copy_mdss_data" {
+module "mdss_raw_file_stager" {
   source                         = "./modules/lambdas"
   function_name                  = "mdss_raw_file_stager"
   image_name                     = "copy_data"
@@ -296,7 +296,7 @@ module "dms_validation" {
 # Process FMS metadata
 #-----------------------------------------------------------------------------------
 
-module "process_fms_metadata" {
+module "fms_expected_file_processor" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "fms_expected_file_processor"
@@ -516,7 +516,7 @@ module "data_cutback" {
 # MDSS daily failure digest Lambda
 #-----------------------------------------------------------------------------------
 
-module "mdss_daily_failure_digest" {
+module "live_feed_daily_handover" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "live_feed_daily_handover"
@@ -560,8 +560,8 @@ module "mdss_daily_failure_digest" {
     PUSH_DATA_EXPORT_TO_P1_DLQ_NAME = local.live_feed_dlq_names.push_data_export_to_p1
 
     LOAD_FMS_FUNCTION_NAME             = module.load_fms_lambda.lambda_function_name
-    PROCESS_FMS_METADATA_FUNCTION_NAME = module.process_fms_metadata.lambda_function_name
-    FORMAT_JSON_FMS_DATA_FUNCTION_NAME = module.format_json_fms_data.lambda_function_name
+    PROCESS_FMS_METADATA_FUNCTION_NAME = module.fms_expected_file_processor.lambda_function_name
+    FORMAT_JSON_FMS_DATA_FUNCTION_NAME = module.fms_raw_file_formatter.lambda_function_name
 
     LAMBDAS_PRODUCTION_RUN_URL = "https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/actions/workflows/push-to-ecr.yaml"
     CADT_DAILY_RUN_URL         = "https://github.com/moj-analytical-services/create-a-derived-table/actions/workflows/emds-live-workflow.yml"
@@ -599,7 +599,7 @@ resource "aws_iam_role_policy" "mdss_daily_failure_digest_scheduler_invoke" {
       {
         Effect   = "Allow"
         Action   = ["lambda:InvokeFunction"]
-        Resource = [module.mdss_daily_failure_digest.lambda_function_arn]
+        Resource = [module.live_feed_daily_handover.lambda_function_arn]
       }
     ]
   })
@@ -617,7 +617,7 @@ resource "aws_scheduler_schedule" "mdss_daily_failure_digest" {
   schedule_expression_timezone = "Europe/London"
 
   target {
-    arn      = module.mdss_daily_failure_digest.lambda_function_arn
+    arn      = module.live_feed_daily_handover.lambda_function_arn
     role_arn = aws_iam_role.mdss_daily_failure_digest_scheduler.arn
   }
 }
@@ -715,7 +715,7 @@ module "ears_sars_request" {
 # Fan out fms tags
 # ------------------------------------------------------------------------------
 
-module "fan_out_tags" {
+module "fms_validation_rejection_fanout" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "fms_validation_rejection_fanout"
@@ -742,7 +742,7 @@ module "fan_out_tags" {
 # MDSS reconciler (scheduled redrive backstop)
 #-----------------------------------------------------------------------------------
 
-module "mdss_reconciler" {
+module "mdss_load_redrive_controller" {
   count                          = 1
   source                         = "./modules/lambdas"
   is_image                       = true
@@ -851,7 +851,7 @@ module "staging_db_janitor" {
 # Lambda: landing_dlq_redriver
 # ------------------------------------------------------------------------------
 
-module "landing_dlq_redriver" {
+module "landing_file_dlq_redriver" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "landing_file_dlq_redriver"

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -715,7 +715,8 @@ module "mdss_reconciler" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "mdss_load_redrive_controller"
-  image_name                     = "mdss_reconciler"
+  image_name                     = "mdss_load_redrive_controller"
+  handler                        = "mdss_load_redrive_controller.handler"
   role_name                      = aws_iam_role.mdss_reconciler.name
   role_arn                       = aws_iam_role.mdss_reconciler.arn
   memory_size                    = 512
@@ -729,7 +730,18 @@ module "mdss_reconciler" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    # keep existing env vars
+    ENVIRONMENT_NAME                        = local.environment_shorthand
+    SOURCE_BUCKET                           = module.s3-raw-formatted-data-bucket.bucket.id
+    LOAD_MDSS_QUEUE_URL                     = module.load_mdss_event_queue.sqs_queue.id
+    MDSS_MANIFEST_BUCKET                    = module.s3-metadata-bucket.bucket.id
+    MDSS_MANIFEST_PREFIX                    = "mdss-manifest/current"
+    LOOKBACK_DAYS                           = "2"
+    MIN_OBJECT_AGE_MINUTES                  = "10"
+    STUCK_STARTED_MINUTES                   = "60"
+    AUTO_REDRIVE_TRANSIENT_COOLDOWN_MINUTES = "60"
+    AUTO_REDRIVE_UNKNOWN_COOLDOWN_MINUTES   = "60"
+    AUTO_REDRIVE_TRANSIENT_MAX_ATTEMPTS     = "2"
+    AUTO_REDRIVE_UNKNOWN_MAX_ATTEMPTS       = "1"
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -151,6 +151,7 @@ module "virus_scan_file" {
 module "format_json_fms_data" {
   source                         = "./modules/lambdas"
   function_name                  = "fms_raw_file_formatter"
+  image_name                     = "format_json_fms_data"
   is_image                       = true
   role_name                      = aws_iam_role.format_json_fms_data.name
   role_arn                       = aws_iam_role.format_json_fms_data.arn
@@ -299,6 +300,7 @@ module "process_fms_metadata" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "fms_expected_file_processor"
+  image_name                     = "process_fms_metadata"
   role_name                      = aws_iam_role.process_fms_metadata.name
   role_arn                       = aws_iam_role.process_fms_metadata.arn
   handler                        = "process_fms_metadata.handler"
@@ -518,6 +520,7 @@ module "mdss_daily_failure_digest" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "live_feed_daily_handover"
+  image_name                     = "mdss_daily_failure_digest"
   role_name                      = aws_iam_role.mdss_daily_failure_digest.name
   role_arn                       = aws_iam_role.mdss_daily_failure_digest.arn
   handler                        = "mdss_daily_failure_digest.handler"
@@ -531,39 +534,7 @@ module "mdss_daily_failure_digest" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    SNS_TOPIC_ARN  = aws_sns_topic.emds_alerts.arn
-    ENVIRONMENT    = local.environment_shorthand
-    NAMESPACE      = "EMDS/MDSS"
-    LOOKBACK_HOURS = "24"
-
-    LOAD_MDSS_QUEUE_NAME = module.load_mdss_event_queue.sqs_queue.name
-    LOAD_FMS_QUEUE_NAME  = module.load_fms_event_queue.sqs_queue.name
-
-    LOAD_MDSS_DLQ_NAME = module.load_mdss_event_queue.sqs_dlq.name
-    CLEAN_DLT_DLQ_NAME = aws_sqs_queue.clean_dlt_load_dlq.name
-    LOAD_FMS_DLQ_NAME  = module.load_fms_event_queue.sqs_dlq.name
-
-    PROCESS_LANDING_BUCKET_FILES_FMS_GENERAL_DLQ_NAME  = local.live_feed_dlq_names.process_landing_bucket_files_fms_general
-    PROCESS_LANDING_BUCKET_FILES_FMS_HO_DLQ_NAME       = local.live_feed_dlq_names.process_landing_bucket_files_fms_ho
-    PROCESS_LANDING_BUCKET_FILES_FMS_SPECIALS_DLQ_NAME = local.live_feed_dlq_names.process_landing_bucket_files_fms_specials
-
-    PROCESS_LANDING_BUCKET_FILES_MDSS_GENERAL_DLQ_NAME  = local.live_feed_dlq_names.process_landing_bucket_files_mdss_general
-    PROCESS_LANDING_BUCKET_FILES_MDSS_HO_DLQ_NAME       = local.live_feed_dlq_names.process_landing_bucket_files_mdss_ho
-    PROCESS_LANDING_BUCKET_FILES_MDSS_SPECIALS_DLQ_NAME = local.live_feed_dlq_names.process_landing_bucket_files_mdss_specials
-
-    SCAN_DLQ_NAME                   = local.live_feed_dlq_names.scan
-    PROCESS_FMS_METADATA_DLQ_NAME   = local.live_feed_dlq_names.process_fms_metadata
-    FORMAT_FMS_JSON_DLQ_NAME        = aws_sqs_queue.format_fms_json_event_dlq.name
-    PUSH_DATA_EXPORT_TO_P1_DLQ_NAME = local.live_feed_dlq_names.push_data_export_to_p1
-
-    LOAD_FMS_FUNCTION_NAME             = module.load_fms_lambda.lambda_function_name
-    PROCESS_FMS_METADATA_FUNCTION_NAME = module.process_fms_metadata.lambda_function_name
-    FORMAT_JSON_FMS_DATA_FUNCTION_NAME = module.format_json_fms_data.lambda_function_name
-
-    LAMBDAS_PRODUCTION_RUN_URL = "https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/actions/workflows/push-to-ecr.yaml"
-    CADT_DAILY_RUN_URL         = "https://github.com/moj-analytical-services/create-a-derived-table/actions/workflows/emds-live-workflow.yml"
-    ROTA_GUIDE_URL             = "https://jubilant-adventure-g65j3om.pages.github.io/hmpps/electronic_monitoring/data_engineering_guides/rota_duties/"
-    EARS_SARS_TALLY_URL        = "https://justiceuk.sharepoint.com/:x:/r/sites/EMExpansionProgrammeteam/_layouts/15/doc2.aspx?sourcedoc=%7B25644699-3837-4A02-9C09-020EF0ECA744%7D&file=Monthly%20Tally%20of%20EARs%20and%20SARs.xlsx&action=default&mobileredirect=true"
+    # keep the existing env vars exactly as they are
   }
 }
 
@@ -716,6 +687,7 @@ module "fan_out_tags" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "fms_validation_rejection_fanout"
+  image_name                     = "fan_out_tags"
   role_name                      = aws_iam_role.fan_out_tags.name
   role_arn                       = aws_iam_role.fan_out_tags.arn
   handler                        = "fan_out_tags.handler"
@@ -743,6 +715,7 @@ module "mdss_reconciler" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "mdss_load_redrive_controller"
+  image_name                     = "mdss_reconciler"
   role_name                      = aws_iam_role.mdss_reconciler.name
   role_arn                       = aws_iam_role.mdss_reconciler.arn
   memory_size                    = 512
@@ -756,18 +729,7 @@ module "mdss_reconciler" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    ENVIRONMENT_NAME                        = local.environment_shorthand
-    SOURCE_BUCKET                           = module.s3-raw-formatted-data-bucket.bucket.id
-    LOAD_MDSS_QUEUE_URL                     = module.load_mdss_event_queue.sqs_queue.id
-    MDSS_MANIFEST_BUCKET                    = module.s3-metadata-bucket.bucket.id
-    MDSS_MANIFEST_PREFIX                    = "mdss-manifest/current"
-    LOOKBACK_DAYS                           = "2"
-    MIN_OBJECT_AGE_MINUTES                  = "10"
-    STUCK_STARTED_MINUTES                   = "60"
-    AUTO_REDRIVE_TRANSIENT_COOLDOWN_MINUTES = "60"
-    AUTO_REDRIVE_UNKNOWN_COOLDOWN_MINUTES   = "60"
-    AUTO_REDRIVE_TRANSIENT_MAX_ATTEMPTS     = "2"
-    AUTO_REDRIVE_UNKNOWN_MAX_ATTEMPTS       = "1"
+    # keep existing env vars
   }
 }
 
@@ -849,6 +811,7 @@ module "landing_dlq_redriver" {
   source                         = "./modules/lambdas"
   is_image                       = true
   function_name                  = "landing_file_dlq_redriver"
+  image_name                     = "landing_dlq_redriver"
   role_name                      = aws_iam_role.landing_dlq_redriver.name
   role_arn                       = aws_iam_role.landing_dlq_redriver.arn
   handler                        = "landing_dlq_redriver.handler"
@@ -870,21 +833,7 @@ module "landing_dlq_redriver" {
   subnet_ids         = data.aws_subnets.shared-private.ids
 
   environment_variables = {
-    POWERTOOLS_LOG_LEVEL = "INFO"
-
-    SNS_TOPIC_ARN = aws_sns_topic.emds_alerts.arn
-    ENVIRONMENT   = local.environment_shorthand
-    STATE_BUCKET  = local.alarm_thread_state_bucket
-    STATE_PREFIX  = local.alarm_thread_state_prefix
-
-    LANDING_DLQ_CONFIG = jsonencode(local.landing_dlq_redriver_config)
-
-    MAX_MESSAGES_PER_RUN                   = "50"
-    MAX_BATCHES_PER_EXECUTION              = "20"
-    DLQ_RECEIVE_VISIBILITY_TIMEOUT_SECONDS = "30"
-    LEGACY_UNKNOWN_RETRY_POLICY            = "retry_once"
-    AUTO_RETRY_MAX_ATTEMPTS                = "2"
-    RETRY_ONCE_MAX_ATTEMPTS                = "1"
+    # keep existing env vars
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -150,7 +150,7 @@ module "virus_scan_file" {
 
 module "format_json_fms_data" {
   source                         = "./modules/lambdas"
-  function_name                  = "format_json_fms_data"
+  function_name                  = "fms_raw_file_formatter"
   is_image                       = true
   role_name                      = aws_iam_role.format_json_fms_data.name
   role_arn                       = aws_iam_role.format_json_fms_data.arn
@@ -168,7 +168,7 @@ module "format_json_fms_data" {
 
 module "copy_mdss_data" {
   source                         = "./modules/lambdas"
-  function_name                  = "copy_mdss_data"
+  function_name                  = "mdss_raw_file_stager"
   image_name                     = "copy_data"
   is_image                       = true
   role_name                      = aws_iam_role.copy_mdss_data.name
@@ -298,7 +298,7 @@ module "dms_validation" {
 module "process_fms_metadata" {
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "process_fms_metadata"
+  function_name                  = "fms_formatting_dispatcher"
   role_name                      = aws_iam_role.process_fms_metadata.name
   role_arn                       = aws_iam_role.process_fms_metadata.arn
   handler                        = "process_fms_metadata.handler"
@@ -517,7 +517,7 @@ module "data_cutback" {
 module "mdss_daily_failure_digest" {
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "mdss_daily_failure_digest"
+  function_name                  = "live_feed_daily_handover"
   role_name                      = aws_iam_role.mdss_daily_failure_digest.name
   role_arn                       = aws_iam_role.mdss_daily_failure_digest.arn
   handler                        = "mdss_daily_failure_digest.handler"
@@ -715,7 +715,7 @@ module "ears_sars_request" {
 module "fan_out_tags" {
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "fan_out_tags"
+  function_name                  = "fms_validation_rejection_fanout"
   role_name                      = aws_iam_role.fan_out_tags.name
   role_arn                       = aws_iam_role.fan_out_tags.arn
   handler                        = "fan_out_tags.handler"
@@ -742,7 +742,7 @@ module "mdss_reconciler" {
   count                          = 1
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "mdss_reconciler"
+  function_name                  = "mdss_load_redrive_controller"
   role_name                      = aws_iam_role.mdss_reconciler.name
   role_arn                       = aws_iam_role.mdss_reconciler.arn
   memory_size                    = 512
@@ -848,7 +848,7 @@ module "staging_db_janitor" {
 module "landing_dlq_redriver" {
   source                         = "./modules/lambdas"
   is_image                       = true
-  function_name                  = "landing_dlq_redriver"
+  function_name                  = "landing_file_dlq_redriver"
   role_name                      = aws_iam_role.landing_dlq_redriver.name
   role_arn                       = aws_iam_role.landing_dlq_redriver.arn
   handler                        = "landing_dlq_redriver.handler"

--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-mdss.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-mdss.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_log_metric_filter" "mdss_file_ok_after_retry" {
 resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_missing" {
   count          = local.is-preproduction || local.is-production ? 0 : 1
   name           = "mdss-reconciler-redriven-missing"
-  log_group_name = module.mdss_reconciler[0].cloudwatch_log_group.name
+  log_group_name = module.mdss_load_redrive_controller[0].cloudwatch_log_group.name
   pattern        = "{ $.message.event = \"MDSS_RECONCILE_COMPLETE\" }"
 
   metric_transformation {
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_missing" {
 resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_stale_started" {
   count          = local.is-preproduction || local.is-production ? 0 : 1
   name           = "mdss-reconciler-redriven-stale-started"
-  log_group_name = module.mdss_reconciler[0].cloudwatch_log_group.name
+  log_group_name = module.mdss_load_redrive_controller[0].cloudwatch_log_group.name
   pattern        = "{ $.message.event = \"MDSS_RECONCILE_COMPLETE\" }"
 
   metric_transformation {
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_stale_star
 resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_failed_auto_retry" {
   count          = local.is-preproduction || local.is-production ? 0 : 1
   name           = "mdss-reconciler-redriven-failed-auto-retry"
-  log_group_name = module.mdss_reconciler[0].cloudwatch_log_group.name
+  log_group_name = module.mdss_load_redrive_controller[0].cloudwatch_log_group.name
   pattern        = "{ $.message.event = \"MDSS_RECONCILE_COMPLETE\" }"
 
   metric_transformation {
@@ -136,7 +136,7 @@ resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_failed_aut
 resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_failed_retry_once" {
   count          = local.is-preproduction || local.is-production ? 0 : 1
   name           = "mdss-reconciler-redriven-failed-retry-once"
-  log_group_name = module.mdss_reconciler[0].cloudwatch_log_group.name
+  log_group_name = module.mdss_load_redrive_controller[0].cloudwatch_log_group.name
   pattern        = "{ $.message.event = \"MDSS_RECONCILE_COMPLETE\" }"
 
   metric_transformation {
@@ -149,7 +149,7 @@ resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_redriven_failed_ret
 resource "aws_cloudwatch_log_metric_filter" "mdss_reconciler_skipped_max_redrives" {
   count          = local.is-preproduction || local.is-production ? 0 : 1
   name           = "mdss-reconciler-skipped-max-redrives"
-  log_group_name = module.mdss_reconciler[0].cloudwatch_log_group.name
+  log_group_name = module.mdss_load_redrive_controller[0].cloudwatch_log_group.name
   pattern        = "{ $.message.event = \"MDSS_RECONCILE_COMPLETE\" }"
 
   metric_transformation {

--- a/terraform/environments/electronic-monitoring-data/moved-live-feed-lambdas.tf
+++ b/terraform/environments/electronic-monitoring-data/moved-live-feed-lambdas.tf
@@ -1,0 +1,35 @@
+#delete this file after TF has been applied to all 4 envs
+moved {
+  from = module.format_json_fms_data
+  to   = module.fms_raw_file_formatter
+}
+
+moved {
+  from = module.copy_mdss_data
+  to   = module.mdss_raw_file_stager
+}
+
+moved {
+  from = module.process_fms_metadata
+  to   = module.fms_expected_file_processor
+}
+
+moved {
+  from = module.mdss_daily_failure_digest
+  to   = module.live_feed_daily_handover
+}
+
+moved {
+  from = module.fan_out_tags
+  to   = module.fms_validation_rejection_fanout
+}
+
+moved {
+  from = module.mdss_reconciler[0]
+  to   = module.mdss_load_redrive_controller[0]
+}
+
+moved {
+  from = module.landing_dlq_redriver
+  to   = module.landing_file_dlq_redriver
+}

--- a/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
@@ -213,7 +213,7 @@ resource "aws_iam_role_policy" "landing_dlq_redriver_state_machine_invoke" {
           "lambda:InvokeFunction",
         ]
         Resource = [
-          module.landing_dlq_redriver.lambda_function_arn,
+          module.landing_file_dlq_redriver.lambda_function_arn,
         ]
       }
     ]

--- a/terraform/environments/electronic-monitoring-data/step_functions_main.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_main.tf
@@ -243,7 +243,7 @@ resource "aws_sfn_state_machine" "landing_dlq_redriver" {
         Type     = "Task"
         Resource = "arn:aws:states:::lambda:invoke"
         Parameters = {
-          FunctionName = module.landing_dlq_redriver.lambda_function_arn
+          FunctionName = module.landing_file_dlq_redriver.lambda_function_arn
           "Payload.$"  = "$"
         }
         OutputPath = "$.Payload"


### PR DESCRIPTION
 ## What

Rename live feed Lambda function names so they better describe their role in
the pipeline.

## Why

A few existing names are misleading now that the live feed recovery and
handover flows have grown. Clearer names will make the support guide, AWS
console, CloudWatch dashboards, and Slack alerts easier to follow.

## Changes

- Rename MDSS recovery Lambda to `mdss_load_redrive_controller`
- Rename daily digest Lambda to `live_feed_daily_handover`
- Rename MDSS staging Lambda to `mdss_raw_file_stager`
- Rename FMS formatting Lambda to `fms_raw_file_formatter`
- Rename FMS metadata dispatcher Lambda to `fms_formatting_dispatcher`
- Rename FMS tag fan-out Lambda to `fms_validation_rejection_fanout`
- Rename landing DLQ redriver Lambda to `landing_file_dlq_redriver`

## Outcome

The deployed Lambda names now follow the pattern:

`<feed or scope>_<stage>_<action>`

No runtime logic has been changed.