### PR TITLE
correct snapshot reference

### DIFF
--- a/terraform/environments/xhibit-portal/application_variables.json
+++ b/terraform/environments/xhibit-portal/application_variables.json
@@ -93,7 +93,7 @@
       "suprig04-ami": "ami-0f806990f55fe5b7d",
       "suprig04-disk-1-snapshot": "snap-0760f5b4930750da0",
       "suprig05-ami": "ami-0dd639d2acdb56b99",
-      "suprig05-disk-1-snapshot": "snap-0a33812f3689b05fb",
+      "suprig05-disk-1-snapshot": "snap-0a82a1a062d4910cf",
       "XHBPRESMS01-ami": "ami-03ad19f47c6725480",
       "importmachine-ami": "ami-0ec63a243d33a93b6",
       "importmachine-data-snapshot": "snap-03b55fd1c88eb7945",


### PR DESCRIPTION
**What**
- Updates the production value of suprig05-disk-1-snapshot in `application_variables.json:96`
- Changes snapshot from `snap-0a33812f3689b05fb` to `snap-0a82a1a062d4910cf`

**Why**
- Terraform state was imported to the live CJIP volume attached in production
- The previous snapshot value did not match the live volume metadata, which caused Terraform to plan a destroy/create replacement of the CJIP EBS volume and attachment
- This change aligns the configuration with reality to prevent unintended replacement

**Validation**
- Re-ran Terraform plan in xhibit-portal production context
- Result moved from replacement actions to in-place updates only
- Current plan summary: `0 to add, 4 to change, 0 to destroy`

**Risk**
- Low
- This is a configuration alignment change to avoid destructive behaviour on the production CJIP data disk