### PR TITLE
Enable Object Lock for Pre-Production Backups

### DIFF
--- a/terraform/environments/delius-core/locals_preproduction.tf
+++ b/terraform/environments/delius-core/locals_preproduction.tf
@@ -207,7 +207,7 @@ locals {
   }
 
   db_backup_config_preprod = {
-    object_lock_days             = 0
+    object_lock_days             = 10
     expire_current_after_days    = 200
     expire_noncurrent_after_days = 10
     transition = [


### PR DESCRIPTION
We are not too concerned about malicious actions against these backups since they are not production but they should behave in a way similar to production so any issues with object locking are reproducible.