### PR TITLE
PDHD-162: Evaluate lambda access to cross account kms key at runtime and add decrypt access to lambda role

### DIFF
--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
@@ -98,11 +98,10 @@ resource "aws_iam_policy" "athena_federated_query_connector_policy" {
       },
       {
         "Action" : [
+          "kms:Decrypt",
           "kms:GenerateDataKey"
         ],
-        "Resource" : [
-          "arn:aws:kms:*:${var.account_id}:key/*"
-        ],
+        "Resource" : var.allowed_kms_key_arns,
         "Effect" : "Allow"
       }
     ]

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
@@ -98,10 +98,11 @@ resource "aws_iam_policy" "athena_federated_query_connector_policy" {
       },
       {
         "Action" : [
-          "kms:Decrypt",
           "kms:GenerateDataKey"
         ],
-        "Resource" : var.allowed_kms_key_arns,
+        "Resource" : [
+          "arn:aws:kms:*:${var.account_id}:key/*"
+        ],
         "Effect" : "Allow"
       }
     ]

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/iam.tf
@@ -98,6 +98,7 @@ resource "aws_iam_policy" "athena_federated_query_connector_policy" {
       },
       {
         "Action" : [
+          "kms:Decrypt",
           "kms:GenerateDataKey"
         ],
         "Resource" : [

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/variables.tf
@@ -89,3 +89,9 @@ variable "athena_connector_type" {
   type        = string
   description = "The Athena connector type. Example values: oracle, postgresql "
 }
+
+variable "allowed_kms_key_arns" {
+  type        = list(string)
+  description = "ARNs of KMS keys that this lambda should be able to decrypt."
+  default     = []
+}

--- a/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/variables.tf
+++ b/terraform/environments/digital-prison-reporting/modules/athena_federated_query_connectors/variables.tf
@@ -89,9 +89,3 @@ variable "athena_connector_type" {
   type        = string
   description = "The Athena connector type. Example values: oracle, postgresql "
 }
-
-variable "allowed_kms_key_arns" {
-  type        = list(string)
-  description = "ARNs of KMS keys that this lambda should be able to decrypt."
-  default     = []
-}

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -727,8 +727,14 @@ data "aws_iam_policy_document" "crossaccount_secret_kms" {
       principals {
         type = "AWS"
         identifiers = [
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dpr-${statement.key}-federated-query-execution-role"
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         ]
+      }
+
+      condition {
+        test     = "ArnEquals"
+        variable = "aws:PrincipalArn"
+        values   = [ "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dpr-${statement.key}-federated-query-execution-role"]
       }
     }
   }


### PR DESCRIPTION
This change prevents a race condition between the mp-environments repo and domains repo terraform pipelines. MP Environments requries the lambda to exist before it can attach its execution role to the secret's iam policy but domains requires the secret to exist before it can fully create the lambda. Evaluating the condition at runtime prevents AWS eagerly evaluating the lambda arn when it might not yet have been created.

It also adds kms:Decrypt access to our federated query lambdas so they can decrypt KMS keys in our account (only if they have also been added to the policy on the kms key).