### PR TITLE
ALB listener rule added

### DIFF
--- a/terraform/environments/oas/application_variables.json
+++ b/terraform/environments/oas/application_variables.json
@@ -10,7 +10,7 @@
       "managementcidr": "10.200.0.0/20",
       "allocated_storage": "50",
       "engine": "oracle-ee",
-      "engine_version": "19.0.0.0.ru-2021-10.rur-2021-10.r1",
+      "engine_version": "19.0.0.0.ru-2026-01.rur-2026-01.r3",
       "instance_class": "db.t3.medium",
       "allow_major_version_upgrade": true,
       "auto_minor_version_upgrade": false,

--- a/terraform/environments/oas/new-alb.tf
+++ b/terraform/environments/oas/new-alb.tf
@@ -731,6 +731,25 @@ resource "aws_lb_listener_rule" "biinfer_login_https_rule" {
   }
 }
 
+# Listener rule for /bi-sac-config-mgr on HTTPS
+resource "aws_lb_listener_rule" "bi_sac_config_mgr_https_rule" {
+  count = contains(["preproduction", "development"], local.environment) ? 1 : 0
+
+  listener_arn = aws_lb_listener.https_listener[0].arn
+  priority     = 251
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.oas_analytics_target_group[0].arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/bi-sac-config-mgr*"]
+    }
+  }
+}
+
 # Listener rule for /static on HTTPS
 resource "aws_lb_listener_rule" "static_https_rule" {
   count = contains(["preproduction", "development"], local.environment) ? 1 : 0


### PR DESCRIPTION
This change enables bi-sac-config-mgr functionality to work through the development OAS load balancer URL, providing users with secure HTTPS access to the configuration manager interface instead of requiring direct HTTP connection to the backend server. OAS Dev engine change also included.