### PR TITLE
feat: add AWS Transfer frontend for managed file transfer

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -1,15 +1,6 @@
 {
   "accounts": {
     "development": {
-      "iam_configuration": {
-        "guardduty_role_name": "integration-hub-development-guardduty-s3-plan",
-        "guardduty_policy_name": "integration-hub-development-guardduty-s3-plan",
-        "malware_scanning_processing_bucket_key": "processing",
-        "malware_scanning_object_prefix": ["incoming/"],
-        "kms_key_arn_list": [
-          "arn:aws:kms:eu-west-2:111111111111:key/00000000-0000-0000-0000-000000000000"
-        ]
-      },
       "bucket_configuration": {
         "clean": {
           "bucket_prefix": "integration-hub-clean-",
@@ -43,6 +34,22 @@
             }
           ]
         }
+      },
+      "iam_configuration": {
+        "guardduty_role_name": "integration-hub-development-guardduty-s3-plan",
+        "guardduty_policy_name": "integration-hub-development-guardduty-s3-plan",
+        "malware_scanning_processing_bucket_key": "processing",
+        "malware_scanning_object_prefix": ["incoming/"],
+        "kms_key_arn_list": [
+          "arn:aws:kms:eu-west-2:111111111111:key/00000000-0000-0000-0000-000000000000"
+        ]
+      },
+      "vpc_configuration": {
+        "isolated_vpc_cidr": "10.0.0.0/23",
+        "isolated_vpc_private_subnet_cidrs": ["10.0.0.0/27", "10.0.0.32/27", "10.0.0.64/27"],
+        "isolated_vpc_public_subnet_cidrs": ["10.0.0.128/27", "10.0.0.160/27", "10.0.0.192/27"],
+        "isolated_vpc_enable_nat_gateway": true,
+        "isolated_vpc_one_nat_gateway_per_az": true
       }
     },
     "test": {

--- a/terraform/environments/integration-hub/managed-file-transfer/cloudwatch.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "transfer" {
+  name_prefix = "transfer-"
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/data.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/data.tf
@@ -1,0 +1,3 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/iam.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/iam.tf
@@ -120,3 +120,29 @@ data "aws_iam_policy_document" "guardduty_s3_plan_permission_policy" {
     resources = [module.kms_s3_bucket["processing"].key_arn]
   }
 }
+
+module "iam_for_transfer" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  create          = true
+  use_name_prefix = true
+  name            = "iam_for_transfer"
+
+  trust_policy_permissions = {
+    AllowTransferService = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+    }
+  }
+
+  policies = {
+    transfer_logging = "arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/locals.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/locals.tf
@@ -1,4 +1,5 @@
 locals {
   bucket_configuration = local.application_data.accounts[local.environment].bucket_configuration
   iam_configuration    = local.application_data.accounts[local.environment].iam_configuration
+  vpc_configuration    = local.application_data.accounts[local.environment].vpc_configuration
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
@@ -4,6 +4,7 @@ resource "aws_security_group" "transfer" {
   vpc_id      = module.isolated_vpc.vpc_id
 }
 
+/*
 resource "aws_security_group_rule" "transfer_inbound_sftp" {
   description       = "Inbound rule for SFTP protocol on port 22"
   type              = "ingress"
@@ -23,3 +24,4 @@ resource "aws_security_group_rule" "transfer_inbound_ftps" {
   security_group_id = aws_security_group.transfer.id
   cidr_blocks       = ["0.0.0.0/0"]
 }
+*/

--- a/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
@@ -1,0 +1,25 @@
+resource "aws_security_group" "transfer" {
+  description = "Inbound ports for AWS Transfer VPC endpoints"
+  name        = "transfer"
+  vpc_id      = module.isolated_vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "transfer_inbound_sftp" {
+  description       = "Inbound rule for SFTP protocol on port 22"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.transfer.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "transfer_inbound_ftps" {
+  description       = "Inbound rule for FTPS protocol on port 443"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.transfer.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
@@ -1,0 +1,26 @@
+resource "aws_transfer_server" "this" {
+  domain                 = "S3"
+  identity_provider_type = "SERVICE_MANAGED"
+  protocols              = ["SFTP"]
+  security_policy_name   = "TransferSecurityPolicy-2025-03"
+  structured_log_destinations = [
+    "${aws_cloudwatch_log_group.transfer.arn}:*"
+  ]
+  endpoint_details {
+    vpc_id     = module.isolated_vpc.vpc_id
+    subnet_ids = module.isolated_vpc.public_subnets
+    address_allocation_ids = [
+      aws_eip.this[0].id,
+      aws_eip.this[1].id,
+      aws_eip.this[2].id,
+    ]
+    security_group_ids = [
+      aws_security_group.transfer.id
+    ]
+  }
+}
+
+resource "aws_eip" "this" {
+  count = length(module.isolated_vpc.public_subnets)
+  domain = "vpc"
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
@@ -1,6 +1,7 @@
 resource "aws_transfer_server" "this" {
   domain                 = "S3"
   identity_provider_type = "SERVICE_MANAGED"
+  logging_role           = module.iam_for_transfer.arn
   protocols              = ["SFTP"]
   security_policy_name   = "TransferSecurityPolicy-2025-03"
   structured_log_destinations = [

--- a/terraform/environments/integration-hub/managed-file-transfer/vpc.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/vpc.tf
@@ -1,0 +1,22 @@
+module "isolated_vpc" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.6.0"
+
+  name            = "${local.application_name}-${local.environment}-isolated"
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  cidr            = local.vpc_configuration.isolated_vpc_cidr
+  public_subnets  = local.vpc_configuration.isolated_vpc_public_subnet_cidrs
+  private_subnets = local.vpc_configuration.isolated_vpc_private_subnet_cidrs
+
+  enable_nat_gateway     = local.vpc_configuration.isolated_vpc_enable_nat_gateway
+  one_nat_gateway_per_az = local.vpc_configuration.isolated_vpc_one_nat_gateway_per_az
+
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+  flow_log_max_aggregation_interval    = 60
+
+  tags = local.tags
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary
Adds the first pass of the Integration Hub managed file transfer frontend for AWS Transfer Family :truck:
- provisions the Transfer server and its VPC-facing endpoint configuration
- adds Elastic IPs, security groups, IAM and supporting VPC wiring
- enables structured logging to CloudWatch so the service has a clear audit trail :mag:

## Validation
- `terraform validate -no-color` in `terraform/environments/integration-hub/managed-file-transfer` :white_check_mark:

## Notes
- opening as a draft while the wider integration is still being checked :construction:

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>