### PR TITLE
Set integration-hub Transfer endpoint type as VPC

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer.tf
@@ -1,5 +1,6 @@
 resource "aws_transfer_server" "this" {
   domain                 = "S3"
+  endpoint_type          = "VPC"
   identity_provider_type = "SERVICE_MANAGED"
   logging_role           = module.iam_for_transfer.arn
   protocols              = ["SFTP"]


### PR DESCRIPTION
Self explanatory, but using a VPC with endpoints for AWS Transfer requires that the endpoint type be set as `VPC` otherwise it's treated as a public endpoint, and obviously that doesn't work with VPC private endpoints.