### PR TITLE
PDHD-151: Allow redshift to use cross account kms key to decrypt probation secrets

### DIFF
--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -488,7 +488,8 @@ data "aws_iam_policy_document" "redshift_federated_query" {
     effect = "Allow"
     actions = [
       "kms:Decrypt",
-      "kms:GenerateDataKey"]
+      "kms:GenerateDataKey"
+    ]
     resources = [
       aws_kms_key.crossaccount_secret.arn
     ]

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -482,6 +482,17 @@ data "aws_iam_policy_document" "redshift_federated_query" {
     ]
     resources = [for s in module.probation_source_secret : s.secret_arn]
   }
+
+  statement {
+    sid = "AllowKMSDecryptForCrossPlatformSecrets"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"]
+    resources = [
+      aws_kms_key.crossaccount_secret.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "redshift_federated_query_policy" {

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -710,6 +710,23 @@ data "aws_iam_policy_document" "crossaccount_secret_kms" {
     }
   }
 
+  statement {
+    sid    = "AllowRedshiftToDecryptSecret"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.redshift-federated-query-role]
+    }
+  }
+
   dynamic "statement" {
     for_each = { for k, v in local.probation_domains : k => v if v.share_with_cloud_platform }
 

--- a/terraform/environments/digital-prison-reporting/secrets.tf
+++ b/terraform/environments/digital-prison-reporting/secrets.tf
@@ -723,7 +723,7 @@ data "aws_iam_policy_document" "crossaccount_secret_kms" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.redshift-federated-query-role]
+      identifiers = [aws_iam_role.redshift-federated-query-role.arn]
     }
   }
 


### PR DESCRIPTION
- Redshift federated queries need access to secrets encrypted with the cross account KMS secret
- This attaches a policy allowing that access to the redshift federated query role