### PR TITLE
Integrate COAT Tag Validator (standalone workflow)

### DIFF
--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -33,33 +33,33 @@ jobs:
           echo "Detected: $applications"
 
       - name: Get environment list for each application
-      id: envs
-      run: |
-        set -x                       # trace every command
-        apps='${{ steps.apps.outputs.applications }}'
-        if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
-          echo "environments=[]" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        result='[]'
-        for app in $(echo "$apps" | jq -r '.[]'); do
-          echo "Fetching environments for $app"
-          url="https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json"
+        id: envs
+        run: |
+          set -x                       # trace every command
+          apps='${{ steps.apps.outputs.applications }}'
+          if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
+            echo "environments=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          result='[]'
+          for app in $(echo "$apps" | jq -r '.[]'); do
+            echo "Fetching environments for $app"
+            url="https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json"
 
-          # Separate curl + jq so we can see which one is failing
-          raw=$(curl -sSL -w "HTTP %{http_code}\n" "$url")
-          echo "----- raw response -----"
-          echo "$raw"
-          echo "------------------------"
+            # Separate curl + jq so we can see which one is failing
+            raw=$(curl -sSL -w "HTTP %{http_code}\n" "$url")
+            echo "----- raw response -----"
+            echo "$raw"
+            echo "------------------------"
 
-          envs=$(curl -sSL "$url" | jq -c --arg app "$app" \
-            '[.environments[].name | {application: $app, environment: .}]')
-          echo "envs=$envs"
+            envs=$(curl -sSL "$url" | jq -c --arg app "$app" \
+              '[.environments[].name | {application: $app, environment: .}]')
+            echo "envs=$envs"
 
-          result=$(jq -c -s 'add' <<< "$result"$'\n'"$envs")
-          echo "result=$result"
-        done
-        echo "environments=$result" >> "$GITHUB_OUTPUT"
+            result=$(jq -c -s 'add' <<< "$result"$'\n'"$envs")
+            echo "result=$result"
+          done
+          echo "environments=$result" >> "$GITHUB_OUTPUT"
 
   validate-tags:
     name: Tag Validation

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -107,6 +107,7 @@ jobs:
         with:
           terraform_directory: ./terraform
           soft_fail: false
+          terraform_workspace: ${{ env.WORKSPACE_NAME }}
 
       - name: Post Results to PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Validate Tags
         id: validate
-        uses: ministryofjustice/coat-tag-validator@e0cccd30f5f5f01aa0902d42d79e5c7b32b78cbf #v2.1.0
+        uses: ministryofjustice/coat-tag-validator@716f30ebd82b1ab87df7fbeb64d876fe6395eaff #v2.1.4
         with:
           terraform_directory: ./terraform
           soft_fail: false

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -105,7 +105,7 @@ jobs:
         id: validate
         uses: ministryofjustice/coat-tag-validator@716f30ebd82b1ab87df7fbeb64d876fe6395eaff #v2.1.4
         with:
-          terraform_directory: ./terraform
+          terraform_directory: "terraform/environments/${{ matrix.application }}"
           soft_fail: false
           terraform_workspace: ${{ env.WORKSPACE_NAME }}
 

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Get environment list for each application
         id: envs
         run: |
-          set -x                       # trace every command
           apps='${{ steps.apps.outputs.applications }}'
           if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
             echo "environments=[]" >> "$GITHUB_OUTPUT"
@@ -43,18 +42,8 @@ jobs:
           fi
           result='[]'
           for app in $(echo "$apps" | jq -r '.[]'); do
-            echo "Fetching environments for $app"
-            url="https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json"
-
-            # Separate curl + jq so we can see which one is failing
-            raw=$(curl -sSL -w "HTTP %{http_code}\n" "$url")
-            echo "----- raw response -----"
-            echo "$raw"
-            echo "------------------------"
-
-            envs=$(curl -sSL "$url" | jq -c --arg app "$app" \
+            envs=$(curl -sSL "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" | jq -c --arg app "$app" \
               '[.environments[].name | {application: $app, environment: .}]')
-            echo "envs=$envs"
 
             result=$(jq -c -s 'add' <<< "$result"$'\n'"$envs")
             echo "result=$result"

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -126,3 +126,13 @@ jobs:
               repo: context.repo.repo,
               body: `## 🏷️ Tag Validation ${icon}\n\n${summary}`
             });
+      
+      - name: Hide Previous PR comment
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: "scripts/minimise-comments"
+        env:
+          COMMENT_BODY_CONTAINS: "**`Tag Validation`**"
+          PR_NUMBER: "${{ github.event.pull_request.number }}"
+        run: |
+          go build
+          ./minimise-comments

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -33,22 +33,33 @@ jobs:
           echo "Detected: $applications"
 
       - name: Get environment list for each application
-        id: envs
-        run: |
-          apps='${{ steps.apps.outputs.applications }}'
-          if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
-            echo "No applications detected — skipping."
-            echo "environments=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          result='[]'
-          for app in $(echo "$apps" | jq -r '.[]'); do
-            echo "Fetching environments for $app"
-            envs=$(curl -sf "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" \
-              | jq -c --arg app "$app" '[.environments[].name | {application: $app, environment: .}]')
-            result=$(echo "$result $envs" | jq -c -s 'add')
-          done
-          echo "environments=$result" >> "$GITHUB_OUTPUT"
+      id: envs
+      run: |
+        set -x                       # trace every command
+        apps='${{ steps.apps.outputs.applications }}'
+        if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
+          echo "environments=[]" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        result='[]'
+        for app in $(echo "$apps" | jq -r '.[]'); do
+          echo "Fetching environments for $app"
+          url="https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json"
+
+          # Separate curl + jq so we can see which one is failing
+          raw=$(curl -sSL -w "HTTP %{http_code}\n" "$url")
+          echo "----- raw response -----"
+          echo "$raw"
+          echo "------------------------"
+
+          envs=$(curl -sSL "$url" | jq -c --arg app "$app" \
+            '[.environments[].name | {application: $app, environment: .}]')
+          echo "envs=$envs"
+
+          result=$(jq -c -s 'add' <<< "$result"$'\n'"$envs")
+          echo "result=$result"
+        done
+        echo "environments=$result" >> "$GITHUB_OUTPUT"
 
   validate-tags:
     name: Tag Validation

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -10,20 +10,58 @@ permissions:
   pull-requests: write
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.envs.outputs.environments }}
+    steps:
+      - name: Get changed applications
+        id: apps
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          applications=$(gh pr view ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --json files --jq '
+                [.files[].path
+                  | capture("^terraform/environments/(?<app>[^/]+)/")
+                  | .app
+                ] | unique
+              ')
+          echo "applications=$applications" >> "$GITHUB_OUTPUT"
+          echo "Detected: $applications"
+
+      - name: Get environment list for each application
+        id: envs
+        run: |
+          result='[]'
+          for app in $(echo '${{ steps.apps.outputs.applications }}' | jq -r '.[]'); do
+            envs=$(curl -s "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" \
+              | jq -c "[.environments[].name | {application: \"$app\", environment: .}]")
+            result=$(echo "$result $envs" | jq -c -s 'add')
+          done
+          echo "environments=$result" >> "$GITHUB_OUTPUT"
+
   validate-tags:
     name: Tag Validation
+    needs: generate-matrix
     runs-on: ubuntu-latest
-    with:
-      application: "${{ github.workflow }}"
-      environment: "${{ matrix.target }}"
-      action: "${{ matrix.action }}"
-      component: "${{ matrix.component }}"     # If your strategy workflow also outputs "matrix.component"
-    secrets:
-      MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
-      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.generate-matrix.outputs.environments) }}
+    env:
+      ACCOUNT_NAME: "${{ matrix.application }}-${{ matrix.environment }}"
+      WORKSPACE_NAME: "${{ matrix.application }}-${{ matrix.environment }}"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get AWS Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885  # v6.1.1

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -108,31 +108,3 @@ jobs:
           terraform_directory: "terraform/environments/${{ matrix.application }}"
           soft_fail: false
           terraform_workspace: ${{ env.WORKSPACE_NAME }}
-
-      - name: Post Results to PR
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          SUMMARY: ${{ steps.validate.outputs.violations_summary }}
-          PASSED: ${{ steps.validate.outputs.passed }}
-        with:
-          script: |
-            const summary = process.env.SUMMARY || '✅ All resources have required tags';
-            const passed = process.env.PASSED === 'true';
-            const icon = passed ? '✅' : '⚠️';
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## 🏷️ Tag Validation ${icon}\n\n${summary}`
-            });
-      
-      - name: Hide Previous PR comment
-        if: always() && github.event_name == 'pull_request'
-        working-directory: "scripts/minimise-comments"
-        env:
-          COMMENT_BODY_CONTAINS: "**`Tag Validation`**"
-          PR_NUMBER: "${{ github.event.pull_request.number }}"
-        run: |
-          go build
-          ./minimise-comments

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -43,6 +43,7 @@ jobs:
           fi
           result='[]'
           for app in $(echo "$apps" | jq -r '.[]'); do
+            echo "Fetching environments for $app"
             envs=$(curl -sf "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" \
               | jq -c --arg app "$app" '[.environments[].name | {application: $app, environment: .}]')
             result=$(echo "$result $envs" | jq -c -s 'add')

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  
 
 jobs:
   generate-matrix:
@@ -34,10 +35,16 @@ jobs:
       - name: Get environment list for each application
         id: envs
         run: |
+          apps='${{ steps.apps.outputs.applications }}'
+          if [ -z "$apps" ] || [ "$apps" = "[]" ]; then
+            echo "No applications detected — skipping."
+            echo "environments=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           result='[]'
-          for app in $(echo '${{ steps.apps.outputs.applications }}' | jq -r '.[]'); do
-            envs=$(curl -s "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" \
-              | jq -c "[.environments[].name | {application: \"$app\", environment: .}]")
+          for app in $(echo "$apps" | jq -r '.[]'); do
+            envs=$(curl -sf "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${app}.json" \
+              | jq -c --arg app "$app" '[.environments[].name | {application: $app, environment: .}]')
             result=$(echo "$result $envs" | jq -c -s 'add')
           done
           echo "environments=$result" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -128,7 +128,7 @@ jobs:
             });
       
       - name: Hide Previous PR comment
-        if: ${{ github.event_name == 'pull_request' }}
+        if: always() && github.event_name == 'pull_request'
         working-directory: "scripts/minimise-comments"
         env:
           COMMENT_BODY_CONTAINS: "**`Tag Validation`**"

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -1,0 +1,58 @@
+name: Validate Tags
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/environments/**/*.tf'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-tags:
+    name: Tag Validation
+    runs-on: ubuntu-latest
+    with:
+      application: "${{ github.workflow }}"
+      environment: "${{ matrix.target }}"
+      action: "${{ matrix.action }}"
+      component: "${{ matrix.component }}"     # If your strategy workflow also outputs "matrix.component"
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885  # v6.1.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan"
+          role-session-name: "githubactionsplanrolesession"
+          aws-region: "eu-west-2"
+
+      - name: Validate Tags
+        id: validate
+        uses: ministryofjustice/coat-tag-validator@e0cccd30f5f5f01aa0902d42d79e5c7b32b78cbf #v2.1.0
+        with:
+          terraform_directory: ./terraform
+          soft_fail: false
+
+      - name: Post Results to PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SUMMARY: ${{ steps.validate.outputs.violations_summary }}
+          PASSED: ${{ steps.validate.outputs.passed }}
+        with:
+          script: |
+            const summary = process.env.SUMMARY || '✅ All resources have required tags';
+            const passed = process.env.PASSED === 'true';
+            const icon = passed ? '✅' : '⚠️';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🏷️ Tag Validation ${icon}\n\n${summary}`
+            });

--- a/.github/workflows/validate-tags.yml
+++ b/.github/workflows/validate-tags.yml
@@ -50,9 +50,15 @@ jobs:
           done
           echo "environments=$result" >> "$GITHUB_OUTPUT"
 
+  fetch-secrets:
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
   validate-tags:
     name: Tag Validation
-    needs: generate-matrix
+    needs: [generate-matrix, fetch-secrets]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -65,11 +71,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Decrypt Secrets
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@d2d07632db53d17c9760c0c2c06f22a37bd3f0a1 # v6.0.1
+        with:
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management }}
+          github_ci_user_environments_repo_pat: ${{ needs.fetch-secrets.outputs.github_ci_user_environments_repo_pat }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: Set Environment Variables
+        run: |
+          echo "GITHUB_TOKEN=$GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT" >> $GITHUB_ENV
+
       - name: Get AWS Account Number
         run: |
           ACCOUNT_NUMBER=$(jq -r -e --arg account_name "${ACCOUNT_NAME}" '.account_ids[$account_name]' <<< $ENVIRONMENT_MANAGEMENT)
           echo "::add-mask::$ACCOUNT_NUMBER"
           echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> $GITHUB_ENV
+
+      - name: Get Backend AWS Account Number
+        run: |
+          BACKEND_NUMBER=$(jq -r -e '.modernisation_platform_account_id' <<< $ENVIRONMENT_MANAGEMENT)
+          echo "::add-mask::$BACKEND_NUMBER"
+          echo "BACKEND_NUMBER=${BACKEND_NUMBER}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885  # v6.1.1

--- a/terraform/environments/coat/platform_locals.tf
+++ b/terraform/environments/coat/platform_locals.tf
@@ -17,7 +17,6 @@ locals {
   # Merge tags from the environment json file with additional ones
   tags = merge(
     jsondecode(data.http.environments_file.response_body).tags,
-    { "is-production" = local.is-production },
     { "service-area" = "Hosting" },
     { "environment-name" = terraform.workspace },
     { "source-code" = "https://github.com/ministryofjustice/modernisation-platform-environments" }


### PR DESCRIPTION
PR to integrate the COAT tag validator tool (https://github.com/ministryofjustice/coat-tag-validator) as a standalone workflow that runs on pull request creation.

Uses a matrix strategy to account for the application/environment structure of the modernisation platform.

Outline of jobs:

**Generate Matrix Job**

- Uses PR metadata and environment JSON file from the modernisation platform repository (https://github.com/ministryofjustice/modernisation-platform) to construct key-value pairs of all environment and applications modified by the PR.

**Fetch Secrets Job**

- Used to get secrets necessary to run a terraform plan

**Validate Tags Job**
- Executes pre-plan steps (same as reusable terraform plan apply pipeline)
- Executes the tag validator github action