### PR TITLE
feat(terraform): add initial Transfer Family service-managed user for managed file transfer

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/kms.tf
@@ -5,6 +5,7 @@ module "kms_s3_bucket" {
   source  = "terraform-aws-modules/kms/aws"
   version = "4.2.0"
 
+  aliases             = ["transfer/s3/${each.key}"]
   description         = "Key for cryptographic functions on ${trimsuffix(each.value.bucket_prefix, "-")} S3 bucket"
   multi_region        = false
   is_enabled          = true
@@ -13,4 +14,69 @@ module "kms_s3_bucket" {
 
   # Allow the root account as administrator
   key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+}
+
+module "kms_secrets" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 4.1.0"
+
+  aliases                 = ["transfer/secrets"]
+  description             = "KMS CMK for Secrets Manager encryption"
+  enable_default_policy   = true
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  key_usage               = "ENCRYPT_DECRYPT"
+  is_enabled              = true
+
+  # Allow the root account as administrator
+  key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+
+  # Explicitly allow only necessary roles to use the key
+  key_users = concat(
+    [
+      "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+    ]
+  )
+
+  # Allow Secrets Manager to use the key
+  key_statements = [
+    {
+      sid = "AllowSecretsManagerService"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["secretsmanager.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "AllowCIRoles"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -39,7 +39,6 @@ module "s3_bucket_notification" {
     unscanned = {
       queue_arn     = module.sqs_unscanned_s3_notifications.queue_arn
       events        = ["s3:ObjectCreated:*"]
-      filter_prefix = "incoming/"
     }
   }
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -37,8 +37,8 @@ module "s3_bucket_notification" {
 
   sqs_notifications = {
     unscanned = {
-      queue_arn     = module.sqs_unscanned_s3_notifications.queue_arn
-      events        = ["s3:ObjectCreated:*"]
+      queue_arn = module.sqs_unscanned_s3_notifications.queue_arn
+      events    = ["s3:ObjectCreated:*"]
     }
   }
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -1,0 +1,35 @@
+module "secrets_transfer_user_ssh" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-transfer-user-ssh-keys"
+  description             = "${local.application_name} Transfer User SSH Keys"
+  recovery_window_in_days = 7
+  kms_key_id              = module.kms_secrets.key_arn
+  create_policy           = true
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  policy_statements = {
+    read = {
+      sid = "AllowCIRolesToRead"
+      principals = [{
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+        ]
+      }]
+      actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      resources = ["*"]
+    }
+  }
+  # This value will be manually populated in AWS and will be ignored due to ignore_secret_changes = true
+  secret_string = jsonencode({
+    username = "123456789012"
+  })
+}
+
+data "aws_secretsmanager_secret_version" "secrets_transfer_user_ssh" {
+  depends_on = [module.secrets_transfer_user_ssh]
+  secret_id  = module.secrets_transfer_user_ssh.secret_id
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
@@ -23,6 +23,6 @@ resource "aws_transfer_server" "this" {
 }
 
 resource "aws_eip" "this" {
-  count = length(module.isolated_vpc.public_subnets)
+  count  = length(module.isolated_vpc.public_subnets)
   domain = "vpc"
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -16,17 +16,63 @@ data "aws_iam_policy_document" "transfer_user" {
     effect  = "Allow"
     actions = ["s3:ListBucket"]
     resources = [
-      module.s3_bucket["unscanned"].s3_bucket_arn,
-      "${module.s3_bucket["unscanned"].s3_bucket_arn}/*"
+      module.s3_bucket["unscanned"].s3_bucket_arn
     ]
   }
   statement {
     sid    = "AllowS3LandingBucketObjectActions"
     effect = "Allow"
     actions = [
-      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:PutObject"
     ]
     resources = ["${module.s3_bucket["unscanned"].s3_bucket_arn}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "transfer_user_session" {
+  statement {
+    sid    = "AllowKMS"
+    effect = "Allow"
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+    ]
+    resources = [module.kms_s3_bucket["unscanned"].key_arn]
+  }
+  statement {
+    sid    = "AllowListOwnIncomingDirectory"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      module.s3_bucket["unscanned"].s3_bucket_arn,
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "&{transfer:UserName}",
+        "&{transfer:UserName}/*",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowUploadOnlyToHomeDirectory"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+    ]
+    resources = [
+      "${module.s3_bucket["unscanned"].s3_bucket_arn}/&{transfer:UserName}/*",
+    ]
   }
 }
 
@@ -69,14 +115,20 @@ module "transfer_user_role" {
 
 # POC user based on my GitHub username
 resource "aws_transfer_user" "dms1981" {
-  role      = module.transfer_user_role.arn
-  server_id = aws_transfer_server.this.id
-  user_name = "dms1981"
+  role                = module.transfer_user_role.arn
+  server_id           = aws_transfer_server.this.id
+  user_name           = "dms1981"
+  home_directory_type = "LOGICAL"
+  home_directory      = "/"
+  home_directory_mappings {
+    entry  = "/"
+    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/$${transfer:UserName}"
+  }
+  policy = data.aws_iam_policy_document.transfer_user_session.json
 }
 
 resource "aws_transfer_ssh_key" "dms1981" {
-  body      = "value"
+  body      = data.aws_secretsmanager_secret_version.secrets_transfer_user_ssh.secret_string
   server_id = aws_transfer_server.this.id
   user_name = aws_transfer_user.dms1981.user_name
-
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -116,7 +116,8 @@ module "transfer_user_role" {
 }
 
 # POC user based on my GitHub username
-resource "aws_transfer_user" "dms1981" {
+resource "aws_transfer_user" "this" {
+  for_each            = toset(["dms1981"])
   role                = module.transfer_user_role.arn
   server_id           = aws_transfer_server.this.id
   user_name           = "dms1981"
@@ -124,13 +125,14 @@ resource "aws_transfer_user" "dms1981" {
   home_directory      = "/"
   home_directory_mappings {
     entry  = "/"
-    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/$${transfer:UserName}"
+    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/${each.key}"
   }
   policy = data.aws_iam_policy_document.transfer_user_session.json
 }
 
-resource "aws_transfer_ssh_key" "dms1981" {
+resource "aws_transfer_ssh_key" "this" {
+  for_each            = toset(["dms1981"])
   body      = data.aws_secretsmanager_secret_version.secrets_transfer_user_ssh.secret_string
   server_id = aws_transfer_server.this.id
-  user_name = aws_transfer_user.dms1981.user_name
+  user_name = aws_transfer_user.this[each.key].user_name
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -1,0 +1,82 @@
+data "aws_iam_policy_document" "transfer_user" {
+  statement {
+    sid    = "AllowKMS"
+    effect = "Allow"
+    actions = [
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+    ]
+    resources = [module.kms_s3_bucket["unscanned"].key_arn]
+  }
+  statement {
+    sid     = "AllowS3ListBucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = [
+      module.s3_bucket["unscanned"].s3_bucket_arn,
+      "${module.s3_bucket["unscanned"].s3_bucket_arn}/*"
+    ]
+  }
+  statement {
+    sid    = "AllowS3LandingBucketObjectActions"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = ["${module.s3_bucket["unscanned"].s3_bucket_arn}/*"]
+  }
+}
+
+module "transfer_user_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.0"
+
+  name        = "${local.application_name}-transfer-user-policy"
+  description = "AWS Transfer User policy"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.transfer_user.json
+
+  tags = local.tags
+}
+
+module "transfer_user_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  name            = "${local.application_name}-transfer-user-role"
+  description     = "AWS Transfer User role"
+  use_name_prefix = true
+
+  trust_policy_permissions = {
+    AllowTransferService = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+    }
+  }
+
+  policies = {
+    transfer_user_policy = module.transfer_user_policy.arn
+  }
+}
+
+# POC user based on my GitHub username
+resource "aws_transfer_user" "dms1981" {
+  role      = module.transfer_user_role.arn
+  server_id = aws_transfer_server.this.id
+  user_name = "dms1981"
+}
+
+resource "aws_transfer_ssh_key" "dms1981" {
+  body      = "value"
+  server_id = aws_transfer_server.this.id
+  user_name = aws_transfer_user.dms1981.user_name
+
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "transfer_user_session" {
     sid    = "AllowListOwnIncomingDirectory"
     effect = "Allow"
     actions = [
-      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
     ]
 
     resources = [
@@ -57,8 +58,9 @@ data "aws_iam_policy_document" "transfer_user_session" {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
-        "&{transfer:UserName}",
-        "&{transfer:UserName}/*",
+        "$${transfer:UserName}",
+        "$${transfer:UserName}/",
+        "$${transfer:UserName}/*",
       ]
     }
   }
@@ -71,7 +73,7 @@ data "aws_iam_policy_document" "transfer_user_session" {
       "s3:AbortMultipartUpload",
     ]
     resources = [
-      "${module.s3_bucket["unscanned"].s3_bucket_arn}/&{transfer:UserName}/*",
+      "${module.s3_bucket["unscanned"].s3_bucket_arn}/$${transfer:UserName}/*",
     ]
   }
 }


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary
- add a service-managed AWS Transfer Family SFTP server definition for the integration hub managed file transfer stack
- add an initial `dms1981` Transfer user with logical home directory mapping and session policy so uploads land in the `unscanned` bucket path for that user
- add a Secrets Manager secret and dedicated KMS key for storing the user's SSH key material, with access scoped to the infrastructure role
- remove the S3 notification `filter_prefix` so uploaded files from the Transfer user path continue to trigger downstream processing

## Testing
- Terraform plan
- Local apply successful

## Notes
- no linked issue was provided
- the SSH key material is intended to be populated manually in AWS and then ignored by Terraform

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>
