### PR TITLE
ELM-4869

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-gdpr.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-gdpr.tf
@@ -1,0 +1,45 @@
+resource "aws_cloudwatch_dashboard" "gdpr_batch_dashboard" {
+  count          = local.is-production || local.is-development || local.is-preproduction ? 1 : 0
+  dashboard_name = "EMDS-GDPR-Batch-Operations-${local.environment_shorthand}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          metrics = [
+            ["AWS/Batch", "JobsSucceed", "JobQueue", aws_batch_job_queue.shred_unstructured_from_zip_batch_queue[0].name],
+            [".", "JobsFailed", ".", "."]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "Job Success vs Failure (Over Time)"
+          period  = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          metrics = [
+            ["AWS/Batch", "JobsRunnable", "JobQueue", aws_batch_job_queue.shred_unstructured_from_zip_batch_queue[0].name],
+            [".", "JobsRunning", ".", "."]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = "eu-west-2"
+          title   = "Queue Depth vs Running Jobs"
+          period  = 300
+        }
+      }
+    ]
+  })
+}

--- a/terraform/environments/electronic-monitoring-data/log-metric-filters-gdpr.tf
+++ b/terraform/environments/electronic-monitoring-data/log-metric-filters-gdpr.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_metric_filter" "batch_jq_error_filter" {
+  name           = "GDPR-Batch-JQ-Error-Filter"
+  pattern        = "\"parse error\"" # The exact text you are looking for in the logs
+  log_group_name = "/aws/batch/job"  # The default AWS Batch log group
+
+  metric_transformation {
+    name      = "ManifestParseErrors"
+    namespace = "GDPR_Batch_Custom_Metrics"
+    value     = "1" # Increment the graph by 1 every time this text is printed
+  }
+}


### PR DESCRIPTION
[ELM-4869](https://dsdmoj.atlassian.net/browse/ELM-4869)

Based on a conversation with Khristiania and discussing dashboarding, I whipped up this really simple dashboard to point at the GDPR batch log queue to offer at a glance updates on running jobs.

- [x] basic draft of simple cloudwatch dashboard looking at the GDPR batch queue

<img width="1913" height="426" alt="Screenshot 2026-05-20 at 11 32 52" src="https://github.com/user-attachments/assets/da99917d-e4ad-40b1-acbf-307dc7581484" />


[ELM-4869]: https://dsdmoj.atlassian.net/browse/ELM-4869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ