### PR TITLE
Use transfer events to trigger file moves

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
@@ -73,7 +73,7 @@ module "eventbridge_transfer_upload" {
     (each.value.name) = [
       {
         name = "${each.value.name}-to-sqs"
-        arn  = module.sqs_unscanned_s3_notifications.queue_arn
+        arn  = module.sqs_transfer_notifications.queue_arn
         input_transformer = {
           input_paths = {
             file_path   = "$.detail.file-path"

--- a/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/eventbridge.tf
@@ -47,3 +47,56 @@ module "eventbridge_guard_duty_malware_protection_for_s3" {
 
   tags = local.tags
 }
+
+module "eventbridge_transfer_upload" {
+  for_each = local.eventbridge_transfer_sftp_upload_rules
+
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "4.3.0"
+
+  create_bus                 = false
+  create_role                = false
+  create_log_delivery_source = false
+  create_log_delivery        = false
+
+  bus_name            = "default"
+  append_rule_postfix = false
+
+  rules = {
+    (each.value.name) = {
+      description   = each.value.description
+      event_pattern = jsonencode(each.value.event_pattern)
+    }
+  }
+
+  targets = {
+    (each.value.name) = [
+      {
+        name = "${each.value.name}-to-sqs"
+        arn  = module.sqs_unscanned_s3_notifications.queue_arn
+        input_transformer = {
+          input_paths = {
+            file_path   = "$.detail.file-path"
+            username    = "$.detail.username"
+            server_id   = "$.detail.server-id"
+            status_code = "$.detail.status-code"
+          }
+          input_template = <<-EOF
+          {
+            "source": "aws.transfer",
+            "detail-type": "SFTP Server File Upload Completed",
+            "detail": {
+              "file-path": "<file_path>",
+              "username": "<username>",
+              "server-id": "<server_id>",
+              "status-code": "<status_code>"
+            }
+          }
+          EOF
+        }
+      }
+    ]
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/eventbridge_rules.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/eventbridge_rules.tf
@@ -1,4 +1,21 @@
 locals {
+  eventbridge_transfer_sftp_upload_rules = {
+    sftp_upload_completed = {
+      name        = "${local.application_name}-transfer-sftp-upload-completed"
+      description = "Forward completed Transfer Family uploads to the unscanned file mover queue"
+      event_pattern = {
+        source        = ["aws.transfer"]
+        "detail-type" = ["SFTP Server File Upload Completed"]
+        resources     = [aws_transfer_server.this.arn]
+        detail = {
+          protocol      = ["SFTP"]
+          "server-id"   = [aws_transfer_server.this.id]
+          "status-code" = ["COMPLETED"]
+        }
+      }
+    }
+  }
+
   eventbridge_guard_duty_malware_protection_for_s3_rules = {
     no_threats_found = {
       name                   = "${local.application_name}-guardduty-no-threats-found"

--- a/terraform/environments/integration-hub/managed-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/kms.tf
@@ -5,7 +5,7 @@ module "kms_s3_bucket" {
   source  = "terraform-aws-modules/kms/aws"
   version = "4.2.0"
 
-  aliases             = ["transfer/s3/${each.key}"]
+  aliases             = ["s3/${each.key}"]
   description         = "Key for cryptographic functions on ${trimsuffix(each.value.bucket_prefix, "-")} S3 bucket"
   multi_region        = false
   is_enabled          = true

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -11,7 +11,7 @@ module "lambda_unscanned_to_processing" {
 
   event_source_mapping = {
     sqs = {
-      event_source_arn = module.sqs_unscanned_s3_notifications.queue_arn
+      event_source_arn = module.sqs_transfer_notifications.queue_arn
       batch_size       = 1
     }
   }

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -19,6 +19,7 @@ module "lambda_unscanned_to_processing" {
   environment_variables = {
     DESTINATION_BUCKET_NAME = module.s3_bucket["processing"].s3_bucket_id
     IDEMPOTENCY_TABLE       = module.dynamodb_idempotency.dynamodb_table_id
+    SOURCE_BUCKET_NAME      = module.s3_bucket["unscanned"].s3_bucket_id
   }
 
   attach_policy_statements = true

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -12,6 +12,7 @@ from aws_lambda_powertools.utilities.idempotency import (
 s3 = boto3.client("s3")
 DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
+SOURCE_BUCKET_NAME = os.getenv("SOURCE_BUCKET_NAME")
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use object identity rather than transport metadata so duplicate SQS deliveries
@@ -21,7 +22,11 @@ idempotency_config = IdempotencyConfig(
 )
 
 
-def iter_s3_records(event):
+def iter_records(event):
+    if "Records" not in event:
+        yield event
+        return
+
     for record in event["Records"]:
         if "body" not in record:
             yield record
@@ -29,11 +34,53 @@ def iter_s3_records(event):
 
         payload = json.loads(record["body"])
 
-        for s3_record in payload.get("Records", []):
-            yield s3_record
+        if "Records" in payload:
+            for nested_record in payload["Records"]:
+                yield nested_record
+            continue
+
+        yield payload
+
+
+def normalise_transfer_record(record):
+    if record.get("source") != "aws.transfer":
+        raise KeyError("source")
+
+    if record.get("detail-type") != "SFTP Server File Upload Completed":
+        raise ValueError(f"Unsupported Transfer event type: {record.get('detail-type')}")
+
+    detail = record["detail"]
+    file_path = detail["file-path"].lstrip("/")
+    bucket_name, separator, source_key = file_path.partition("/")
+
+    if not separator or not bucket_name or not source_key:
+        raise ValueError(f"Unsupported Transfer file path: {detail['file-path']}")
+
+    username = detail["username"]
+    expected_prefix = f"{username}/"
+    if not source_key.startswith(expected_prefix):
+        raise ValueError(
+            f"Transfer file path is outside the user's home directory: {detail['file-path']}"
+        )
+
+    if SOURCE_BUCKET_NAME and bucket_name != SOURCE_BUCKET_NAME:
+        raise ValueError(
+            f"Transfer file path bucket {bucket_name} did not match expected source bucket {SOURCE_BUCKET_NAME}"
+        )
+
+    return {
+        "operation": "unscanned-to-processing",
+        "source_bucket_name": bucket_name,
+        "source_key": source_key,
+        "source_version_id": None,
+        "destination_bucket_name": DESTINATION_BUCKET_NAME,
+    }
 
 
 def normalise_record(record):
+    if "detail" in record and "detail-type" in record:
+        return normalise_transfer_record(record)
+
     object_details = record["s3"]["object"]
 
     return {
@@ -79,5 +126,5 @@ def process_record(*, operation):
 def lambda_handler(event, context):
     idempotency_config.register_lambda_context(context)
 
-    for record in iter_s3_records(event):
+    for record in iter_records(event):
         process_record(operation=normalise_record(record))

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -27,18 +27,3 @@ module "s3_bucket" {
     mfa_delete = false
   }
 }
-
-module "s3_bucket_notification" {
-  source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"
-  version = "5.13.0"
-
-  bucket     = module.s3_bucket["unscanned"].s3_bucket_id
-  bucket_arn = module.s3_bucket["unscanned"].s3_bucket_arn
-
-  sqs_notifications = {
-    unscanned = {
-      queue_arn = module.sqs_unscanned_s3_notifications.queue_arn
-      events    = ["s3:ObjectCreated:*"]
-    }
-  }
-}

--- a/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
@@ -12,7 +12,7 @@ module "sqs_transfer_notifications" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "5.2.1"
 
-  name            = "${local.application_name}-unscanned-s3-notifications"
+  name            = "${local.application_name}-transfer-notifications"
   use_name_prefix = false
 
   create_queue_policy = true
@@ -39,7 +39,7 @@ module "sqs_transfer_notifications" {
   }
 
   create_dlq = true
-  dlq_name   = "${local.application_name}-unscanned-s3-notifications-dlq"
+  dlq_name   = "${local.application_name}-transfer-notifications-dlq"
 
   message_retention_seconds     = 1209600
   visibility_timeout_seconds    = 180

--- a/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
@@ -1,4 +1,14 @@
-module "sqs_unscanned_s3_notifications" {
+locals {
+  sqs_transfer_notifications_source_arns = [
+    for rule_key, rule in local.eventbridge_transfer_sftp_upload_rules : module.eventbridge_transfer_upload[rule_key].eventbridge_rule_arns[rule.name]
+  ]
+
+  sqs_guard_duty_malware_protection_for_s3_source_arns = [
+    for rule_key, rule in local.eventbridge_guard_duty_malware_protection_for_s3_rules : module.eventbridge_guard_duty_malware_protection_for_s3[rule_key].eventbridge_rule_arns[rule.name]
+  ]
+}
+
+module "sqs_transfer_notifications" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "5.2.1"
 
@@ -22,9 +32,7 @@ module "sqs_unscanned_s3_notifications" {
         {
           test     = "ArnEquals"
           variable = "aws:SourceArn"
-          values = [
-            for rule_key, rule in local.eventbridge_transfer_sftp_upload_rules : module.eventbridge_transfer_sftp_upload[rule_key].eventbridge_rule_arns[rule.name]
-          ]
+          values   = local.sqs_transfer_notifications_source_arns
         }
       ]
     }
@@ -69,9 +77,7 @@ module "sqs_guard_duty_malware_protection_for_s3_events" {
         {
           test     = "ArnEquals"
           variable = "aws:SourceArn"
-          values = [
-            for rule_key, rule in local.eventbridge_guard_duty_malware_protection_for_s3_rules : module.eventbridge_guard_duty_malware_protection_for_s3[rule_key].eventbridge_rule_arns[rule.name]
-          ]
+          values   = local.sqs_guard_duty_malware_protection_for_s3_source_arns
         }
       ]
     }

--- a/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
@@ -5,7 +5,30 @@ module "sqs_unscanned_s3_notifications" {
   name            = "${local.application_name}-unscanned-s3-notifications"
   use_name_prefix = false
 
-  create_queue_policy = false
+  create_queue_policy = true
+  queue_policy_statements = {
+    eventbridge = {
+      sid     = "AllowTransferEventBridgeSendMessage"
+      actions = ["sqs:SendMessage"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "ArnEquals"
+          variable = "aws:SourceArn"
+          values = [
+            for rule_key, rule in local.eventbridge_transfer_sftp_upload_rules : module.eventbridge_transfer_sftp_upload[rule_key].eventbridge_rule_arns[rule.name]
+          ]
+        }
+      ]
+    }
+  }
 
   create_dlq = true
   dlq_name   = "${local.application_name}-unscanned-s3-notifications-dlq"

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -57,8 +57,6 @@ data "aws_iam_policy_document" "transfer_user_session" {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
-        "",
-        "/",
         "$${transfer:UserName}",
         "$${transfer:UserName}/",
         "$${transfer:UserName}/*",

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -131,7 +131,7 @@ resource "aws_transfer_user" "this" {
 }
 
 resource "aws_transfer_ssh_key" "this" {
-  for_each            = toset(["dms1981"])
+  for_each  = toset(["dms1981"])
   body      = data.aws_secretsmanager_secret_version.secrets_transfer_user_ssh.secret_string
   server_id = aws_transfer_server.this.id
   user_name = aws_transfer_user.this[each.key].user_name

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -50,7 +50,6 @@ data "aws_iam_policy_document" "transfer_user_session" {
       "s3:GetBucketLocation",
       "s3:ListBucket"
     ]
-
     resources = [
       module.s3_bucket["unscanned"].s3_bucket_arn,
     ]
@@ -58,6 +57,8 @@ data "aws_iam_policy_document" "transfer_user_session" {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
+        "",
+        "/",
         "$${transfer:UserName}",
         "$${transfer:UserName}/",
         "$${transfer:UserName}/*",


### PR DESCRIPTION
This PR replaces the S3 Bucket Object notification approach with one based around AWS Transfer events.

The file move lambda has been updated for the POC to handle messages that go through this flow:
AWS Transfer > Default Event Bus > SQS Queue > Lambda consumer

Consequentially this PR makes the following changes:
1. EventBridge rule for successful SFTP transfers
2. SQS queue to hold events
3. Lambda updates to use successful SFTP transfers to kick off file moves