### PR TITLE
TM-2111: delius-mis: allow smb egress to legacy

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -4,6 +4,8 @@ locals {
   environment_config_dev = {
     legacy_engineering_vpc_cidr            = "10.161.98.0/25"
     legacy_counterpart_vpc_cidr            = "10.162.32.0/20"
+    legacy_ad_domain_name                  = null
+    legacy_dns_ip_addrs                    = []
     ad_domain_name                         = "delius-mis-dev.internal"
     ad_trust_domain_name                   = "azure.noms.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.azure.domain_controllers

--- a/terraform/environments/delius-mis/locals_preproduction.tf
+++ b/terraform/environments/delius-mis/locals_preproduction.tf
@@ -4,6 +4,8 @@ locals {
   environment_config_preprod = {
     legacy_engineering_vpc_cidr            = "10.160.98.0/25"
     legacy_counterpart_vpc_cidr            = "10.160.0.0/20"
+    legacy_ad_domain_name                  = "delius-pre-prod.local"
+    legacy_dns_ip_addrs                    = ["10.160.0.163", "10.160.6.66"]
     ad_domain_name                         = "delius-mis-preprod.internal"
     ad_trust_domain_name                   = "azure.hmpp.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.hmpp.domain_controllers

--- a/terraform/environments/delius-mis/locals_stage.tf
+++ b/terraform/environments/delius-mis/locals_stage.tf
@@ -4,6 +4,8 @@ locals {
   environment_config_stage = {
     legacy_engineering_vpc_cidr            = "10.160.98.0/25"
     legacy_counterpart_vpc_cidr            = "10.160.32.0/20"
+    legacy_ad_domain_name                  = "delius-stage.local"
+    legacy_dns_ip_addrs                    = ["10.160.35.243", "10.160.38.128"]
     ad_domain_name                         = "delius-mis-stage.internal"
     ad_trust_domain_name                   = "azure.hmpp.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.hmpp.domain_controllers

--- a/terraform/environments/delius-mis/modules/mis_environment/bcs.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/bcs.tf
@@ -37,11 +37,10 @@ resource "aws_vpc_security_group_egress_rule" "bcs_ec2" {
     smtp-to-internal     = { ip_protocol = "TCP", port = 25, cidr_ipv4 = "10.0.0.0/8" }
     http-to-all          = { ip_protocol = "TCP", port = 80, cidr_ipv4 = "0.0.0.0/0" }
     ntp-to-all           = { ip_protocol = "UDP", port = 123, cidr_ipv4 = "0.0.0.0/0" }
-    ldap-tcp-to-vpc      = { ip_protocol = "TCP", port = 389, cidr_ipv4 = var.account_config.shared_vpc_cidr }
-    ldap-udp-to-vpc      = { ip_protocol = "UDP", port = 389, cidr_ipv4 = var.account_config.shared_vpc_cidr }
+    ldap-tcp-to-internal = { ip_protocol = "TCP", port = 389, cidr_ipv4 = "10.0.0.0/8" }
+    ldap-udp-to-internal = { ip_protocol = "UDP", port = 389, cidr_ipv4 = "10.0.0.0/8" }
     https-to-all         = { ip_protocol = "TCP", port = 443, cidr_ipv4 = "0.0.0.0/0" }
-    smb-to-fsx           = { ip_protocol = "TCP", port = 445, referenced_security_group_id = aws_security_group.fsx.id }
-    smb-to-core-vpc      = { ip_protocol = "TCP", port = 445, cidr_ipv4 = var.environment_config.core_shared_services_vpc_cidr }
+    smb-to-internal      = { ip_protocol = "TCP", port = 445, cidr_ipv4 = "10.0.0.0/8" }
     oracle1521-to-vpc    = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.account_config.shared_vpc_cidr }
     oracle1521-to-legacy = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.environment_config.legacy_counterpart_vpc_cidr }
     nfs-to-efs           = { ip_protocol = "TCP", port = 2049, referenced_security_group_id = aws_security_group.efs.id }

--- a/terraform/environments/delius-mis/modules/mis_environment/bps.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/bps.tf
@@ -31,16 +31,16 @@ resource "aws_vpc_security_group_ingress_rule" "bps_ec2" {
 
 resource "aws_vpc_security_group_egress_rule" "bps_ec2" {
   for_each = {
-    all-to-bcs        = { referenced_security_group_id = aws_security_group.bcs_ec2.id }
-    smtp-to-internal  = { ip_protocol = "TCP", port = 25, cidr_ipv4 = "10.0.0.0/8" }
-    http-to-all       = { ip_protocol = "TCP", port = 80, cidr_ipv4 = "0.0.0.0/0" }
-    ntp-to-all        = { ip_protocol = "UDP", port = 123, cidr_ipv4 = "0.0.0.0/0" }
-    ldap-tcp-to-vpc   = { ip_protocol = "TCP", port = 389, cidr_ipv4 = var.account_config.shared_vpc_cidr }
-    ldap-udp-to-vpc   = { ip_protocol = "UDP", port = 389, cidr_ipv4 = var.account_config.shared_vpc_cidr }
-    https-to-all      = { ip_protocol = "TCP", port = 443, cidr_ipv4 = "0.0.0.0/0" }
-    smb-to-core-vpc   = { ip_protocol = "TCP", port = 445, cidr_ipv4 = var.environment_config.core_shared_services_vpc_cidr }
-    oracle1521-to-vpc = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.account_config.shared_vpc_cidr }
-    nfs-to-efs        = { ip_protocol = "TCP", port = 2049, referenced_security_group_id = aws_security_group.efs.id }
+    all-to-bcs           = { referenced_security_group_id = aws_security_group.bcs_ec2.id }
+    smtp-to-internal     = { ip_protocol = "TCP", port = 25, cidr_ipv4 = "10.0.0.0/8" }
+    http-to-all          = { ip_protocol = "TCP", port = 80, cidr_ipv4 = "0.0.0.0/0" }
+    ntp-to-all           = { ip_protocol = "UDP", port = 123, cidr_ipv4 = "0.0.0.0/0" }
+    ldap-tcp-to-internal = { ip_protocol = "TCP", port = 389, cidr_ipv4 = "10.0.0.0/8" }
+    ldap-udp-to-internal = { ip_protocol = "UDP", port = 389, cidr_ipv4 = "10.0.0.0/8" }
+    https-to-all         = { ip_protocol = "TCP", port = 443, cidr_ipv4 = "0.0.0.0/0" }
+    smb-to-core-internal = { ip_protocol = "TCP", port = 445, cidr_ipv4 = "10.0.0.0/8" }
+    oracle1521-to-vpc    = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.account_config.shared_vpc_cidr }
+    nfs-to-efs           = { ip_protocol = "TCP", port = 2049, referenced_security_group_id = aws_security_group.efs.id }
   }
 
   description       = each.key

--- a/terraform/environments/delius-mis/modules/mis_environment/directory_service.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/directory_service.tf
@@ -111,6 +111,22 @@ resource "aws_security_group_rule" "mis_ad_dns_resolver_security_group_rule_egre
   cidr_blocks       = [var.account_config.shared_vpc_cidr]
 }
 
+resource "aws_security_group_rule" "mis_legacy_ad_dns_resolver_security_group_rule_egress" {
+  provider = aws.core-vpc
+
+  for_each = {
+    tcp = "tcp"
+    udp = "udp"
+  }
+  description       = "VPC to Legacy DNS Endpoint traffic for (${each.key})"
+  from_port         = 53
+  protocol          = each.value
+  security_group_id = aws_security_group.mis_ad_dns_resolver_security_group.id
+  to_port           = 53
+  type              = "egress"
+  cidr_blocks       = [var.environment_config.legacy_counterpart_vpc_cidr]
+}
+
 resource "aws_route53_resolver_endpoint" "resolve_local_entries_using_ad_dns" {
   provider = aws.core-vpc
 
@@ -149,6 +165,34 @@ resource "aws_route53_resolver_rule_association" "vpc_r53_fwd_to_ad" {
   provider = aws.core-vpc
 
   resolver_rule_id = aws_route53_resolver_rule.r53_fwd_to_ad.id
+  vpc_id           = var.account_config.shared_vpc_id
+}
+
+resource "aws_route53_resolver_rule" "r53_fwd_to_legacy_ad" {
+  count = lookup(var.environment_config, "legacy_ad_domain_name", null) != null ? 1 : 0
+
+  provider = aws.core-vpc
+
+  domain_name = var.environment_config.legacy_ad_domain_name
+  name        = replace(var.environment_config.legacy_ad_domain_name, ".", "-")
+  rule_type   = "FORWARD"
+
+  resolver_endpoint_id = aws_route53_resolver_endpoint.resolve_local_entries_using_ad_dns.id
+
+  dynamic "target_ip" {
+    for_each = sort(var.environment_config.legacy_dns_ip_addrs)
+    content {
+      ip = target_ip.value
+    }
+  }
+}
+
+resource "aws_route53_resolver_rule_association" "vpc_r53_fwd_to_legacy_ad" {
+  count = lookup(var.environment_config, "legacy_ad_domain_name", null) != null ? 1 : 0
+
+  provider = aws.core-vpc
+
+  resolver_rule_id = aws_route53_resolver_rule.r53_fwd_to_legacy_ad[0].id
   vpc_id           = var.account_config.shared_vpc_id
 }
 


### PR DESCRIPTION
Required so NDMIS can still access legacy NextCloud:
- update SG egress rules for AD/SMB just for NDMIS BCS/BPS servers
- update DNS resolver to allow DNS resolution of legacy domain