### PR TITLE
Clean up legacy object prefix for guard duty scanning

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -4,19 +4,67 @@
       "bucket_configuration": {
         "clean": {
           "bucket_prefix": "integration-hub-clean-",
-          "lifecycle_rule": []
+          "lifecycle_rule": [
+            {
+              "id": "rule-one-day",
+              "status": "Enabled",
+              "filter": {},
+              "expiration": {
+                "days": 1
+              },
+              "abort_incomplete_multipart_upload": {
+                "days_after_initiation": 1
+              }
+            }
+          ]
         },
         "investigation": {
           "bucket_prefix": "integration-hub-investigation-",
-          "lifecycle_rule": []
+          "lifecycle_rule": [
+            {
+              "id": "rule-one-day",
+              "status": "Enabled",
+              "filter": {},
+              "expiration": {
+                "days": 1
+              },
+              "abort_incomplete_multipart_upload": {
+                "days_after_initiation": 1
+              }
+            }
+          ]
         },
         "processing": {
           "bucket_prefix": "integration-hub-processing-",
-          "lifecycle_rule": []
+          "lifecycle_rule": [
+            {
+              "id": "rule-one-day",
+              "status": "Enabled",
+              "filter": {},
+              "expiration": {
+                "days": 1
+              },
+              "abort_incomplete_multipart_upload": {
+                "days_after_initiation": 1
+              }
+            }
+          ]
         },
         "quarantine": {
           "bucket_prefix": "integration-hub-quarantine-",
-          "lifecycle_rule": []
+          "lifecycle_rule": [
+            {
+              "id": "rule-one-day",
+              "status": "Enabled",
+              "filter": {},
+              "expiration": {
+                "days": 1
+              },
+              "abort_incomplete_multipart_upload": {
+                "days_after_initiation": 1
+              }
+            }
+          ]
         },
         "unscanned": {
           "bucket_prefix": "integration-hub-unscanned-",

--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -39,7 +39,6 @@
         "guardduty_role_name": "integration-hub-development-guardduty-s3-plan",
         "guardduty_policy_name": "integration-hub-development-guardduty-s3-plan",
         "malware_scanning_processing_bucket_key": "processing",
-        "malware_scanning_object_prefix": ["incoming/"],
         "kms_key_arn_list": [
           "arn:aws:kms:eu-west-2:111111111111:key/00000000-0000-0000-0000-000000000000"
         ]

--- a/terraform/environments/integration-hub/managed-file-transfer/guard-duty.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/guard-duty.tf
@@ -3,8 +3,7 @@ resource "aws_guardduty_malware_protection_plan" "this" {
 
   protected_resource {
     s3_bucket {
-      bucket_name     = module.s3_bucket["processing"].s3_bucket_id
-      object_prefixes = local.iam_configuration.malware_scanning_object_prefix
+      bucket_name = module.s3_bucket["processing"].s3_bucket_id
     }
   }
 

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -13,6 +13,7 @@ s3 = boto3.client("s3")
 BUCKET_NAMES_BY_KEY = json.loads(os.environ["BUCKET_NAMES_BY_KEY"])
 DEFAULT_SOURCE_BUCKET_KEY = os.environ["DEFAULT_SOURCE_BUCKET_KEY"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
+GUARDDUTY_MALWARE_SCAN_STATUS_TAG = "GuardDutyMalwareScanStatus"
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use the resolved source and destination buckets so transport-level duplicates
@@ -41,6 +42,13 @@ def get_object_details(event):
         return unquote_plus(object_details["objectKey"]), object_details.get("versionId")
 
     return unquote_plus(event["object_key"]), event.get("version_id")
+
+
+def get_scan_result_status(event):
+    if "detail" in event and "scanResultDetails" in event["detail"]:
+        return event["detail"]["scanResultDetails"].get("scanResultStatus")
+
+    return event.get("scan_result_status")
 
 
 def as_bool(value):
@@ -74,7 +82,44 @@ def normalise_payload(payload):
         "source_version_id": version_id,
         "destination_bucket_name": destination_bucket_name,
         "delete_source": as_bool(payload.get("delete_source", False)),
+        "scan_result_status": get_scan_result_status(payload),
     }
+
+
+def get_source_tags(operation):
+    tagging_kwargs = {
+        "Bucket": operation["source_bucket_name"],
+        "Key": operation["source_key"],
+    }
+
+    if operation["source_version_id"]:
+        tagging_kwargs["VersionId"] = operation["source_version_id"]
+
+    tag_set = s3.get_object_tagging(**tagging_kwargs).get("TagSet", [])
+    return {tag["Key"]: tag["Value"] for tag in tag_set}
+
+
+def put_destination_tags(operation, destination_version_id):
+    tags = get_source_tags(operation)
+
+    if operation["scan_result_status"]:
+        tags[GUARDDUTY_MALWARE_SCAN_STATUS_TAG] = operation["scan_result_status"]
+
+    tagging_kwargs = {
+        "Bucket": operation["destination_bucket_name"],
+        "Key": operation["source_key"],
+        "Tagging": {
+            "TagSet": [
+                {"Key": key, "Value": value}
+                for key, value in sorted(tags.items())
+            ]
+        },
+    }
+
+    if destination_version_id:
+        tagging_kwargs["VersionId"] = destination_version_id
+
+    s3.put_object_tagging(**tagging_kwargs)
 
 
 @idempotent_function(
@@ -92,13 +137,14 @@ def process_record(*, operation):
     if operation["source_version_id"]:
         copy_source["VersionId"] = operation["source_version_id"]
 
-    s3.copy_object(
+    copy_response = s3.copy_object(
         Bucket=operation["destination_bucket_name"],
         Key=operation["source_key"],
         CopySource=copy_source,
         MetadataDirective="COPY",
         TaggingDirective="COPY",
     )
+    put_destination_tags(operation, copy_response.get("VersionId"))
 
     if operation["delete_source"]:
         delete_kwargs = {
@@ -117,6 +163,7 @@ def process_record(*, operation):
         "source_bucket_name": operation["source_bucket_name"],
         "source_key": operation["source_key"],
         "source_version_id": operation["source_version_id"],
+        "scan_result_status": operation["scan_result_status"],
     }
 
 

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "transfer_user_session" {
     resources = [module.kms_s3_bucket["unscanned"].key_arn]
   }
   statement {
-    sid    = "AllowListOwnIncomingDirectory"
+    sid    = "AllowListOwnHomeDirectory"
     effect = "Allow"
     actions = [
       "s3:GetBucketLocation",


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What
- removes the legacy `incoming/` GuardDuty malware protection object prefix so all objects copied into `processing` are eligible for scanning
- updates the GuardDuty post-scan Lambda to preserve source tags and explicitly set `GuardDutyMalwareScanStatus` on destination objects
- renames the Transfer user session policy SID from `AllowListOwnIncomingDirectory` to `AllowListOwnHomeDirectory`
- adds one-day lifecycle rules to the `clean`, `investigation`, `processing` and `quarantine` buckets to keep the proof-of-concept footprint small

## Why
- the previous prefix filter no longer matched the `unscanned > processing > clean|quarantine|investigation` flow, which prevented GuardDuty from scanning copied objects outside `incoming/`
- carrying the GuardDuty status tag to the destination bucket provides an extra guardrail for downstream access controls and handling
- the wording cleanup aligns the Terraform with the current object flow

## Testing
- `terraform fmt -check -recursive terraform/environments/integration-hub/managed-file-transfer`
- `terraform -chdir=terraform/environments/integration-hub/managed-file-transfer validate`
- `python3 -m py_compile terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py`
- not run: end-to-end upload and GuardDuty scan verification

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>