### PR TITLE
Clone of Tariff UAT for weblogic build

### DIFF
--- a/terraform/environments/cica-tariff/tariff_ec2_app_uat_clone.tf
+++ b/terraform/environments/cica-tariff/tariff_ec2_app_uat_clone.tf
@@ -1,0 +1,51 @@
+# Clone of UAT App server for Weblogic build: CDI-357
+resource "aws_instance" "tariff_app_uat_clone" {
+  count = local.environment == "test" ? 1 : 0
+  ami   = "ami-08f6f2c21e2f16c68" # created 2am 22-May-2026
+  lifecycle {
+    ignore_changes = [user_data] # ami removed to allow restore
+  }
+  associate_public_ip_address = false
+  ebs_optimized               = true
+
+  iam_instance_profile   = aws_iam_instance_profile.tariff_instance_profile.name
+  instance_type          = "m5.2xlarge"
+  key_name               = aws_key_pair.key_pair_app.key_name
+  monitoring             = true
+  subnet_id              = data.aws_subnet.private_subnets_a.id
+  # vpc_security_group_ids = [module.tariff_app_security_group[0].security_group_id]
+  vpc_security_group_ids = [aws_security_group.temp_uat_ssm_only[0].id] # TEMPORARY ASSIGNMENT FOR NO NETWORK (except SSM)
+
+  # private_ip = ""
+
+  tags = merge(tomap({
+    "Name"     = lower(format("ec2-%s-%s-app-clone", local.application_name, local.environment)),
+    "hostname" = "${local.application_name}-app-poc-clone",
+    }), local.tags, local.environment != "test" ? tomap({ "backup" = "true" }) : tomap({})
+  )
+}
+# Temporary SG to restrict access to/from Clone above during configuration phase
+resource "aws_security_group" "temp_uat_ssm_only" {
+  count       = local.environment == "test" ? 1 : 0
+  name        = "temp-ssm-only"
+  description = "Allow only SSM traffic - temporary rule during Tariff App POC clone intial config"
+  vpc_id      = data.aws_vpc.shared.id
+}
+data "aws_security_group" "core_vpc_protected" {
+  provider = aws.core-vpc
+
+  tags = {
+    Name = "${local.vpc_name}-${local.environment}-int-endpoint"
+  }
+}
+resource "aws_security_group_rule" "temp_uat_ssm_only_egress" {
+  count             = local.environment == "test" ? 1 : 0
+  security_group_id = aws_security_group.temp_uat_ssm_only[0].id
+
+  description              = "${local.application_name}-app-clone_egress_to_interface_endpoints"
+  type                     = "egress"
+  from_port                = "443"
+  to_port                  = "443"
+  protocol                 = "TCP"
+  source_security_group_id = data.aws_security_group.core_vpc_protected.id
+}

--- a/terraform/environments/cica-tariff/tariff_ec2_app_uat_clone.tf
+++ b/terraform/environments/cica-tariff/tariff_ec2_app_uat_clone.tf
@@ -13,8 +13,8 @@ resource "aws_instance" "tariff_app_uat_clone" {
   key_name               = aws_key_pair.key_pair_app.key_name
   monitoring             = true
   subnet_id              = data.aws_subnet.private_subnets_a.id
-  # vpc_security_group_ids = [module.tariff_app_security_group[0].security_group_id]
-  vpc_security_group_ids = [aws_security_group.temp_uat_ssm_only[0].id] # TEMPORARY ASSIGNMENT FOR NO NETWORK (except SSM)
+  vpc_security_group_ids = [module.tariff_app_security_group[0].security_group_id]
+  #vpc_security_group_ids = [aws_security_group.temp_uat_ssm_only[0].id] # TEMPORARY ASSIGNMENT FOR NO NETWORK (except SSM)
 
   # private_ip = ""
 
@@ -25,6 +25,7 @@ resource "aws_instance" "tariff_app_uat_clone" {
   )
 }
 # Temporary SG to restrict access to/from Clone above during configuration phase
+/*
 resource "aws_security_group" "temp_uat_ssm_only" {
   count       = local.environment == "test" ? 1 : 0
   name        = "temp-ssm-only"
@@ -49,3 +50,4 @@ resource "aws_security_group_rule" "temp_uat_ssm_only_egress" {
   protocol                 = "TCP"
   source_security_group_id = data.aws_security_group.core_vpc_protected.id
 }
+*/


### PR DESCRIPTION
This pull request adds infrastructure to provision a temporary clone of the UAT application server in the "test" environment for a Weblogic build proof of concept. The changes include creating a new EC2 instance, a restrictive security group for SSM-only access, and associated security group rules.

New resources for UAT App server clone:

* Added a new `aws_instance` resource (`tariff_app_uat_clone`) to provision a clone of the UAT application server in the "test" environment, using a specific AMI and instance type, and tagging it appropriately.

Temporary security group configuration:

* Created a temporary security group (`aws_security_group.temp_uat_ssm_only`) that restricts access to only allow SSM traffic during the initial configuration phase of the cloned instance.
* Added a security group rule (`aws_security_group_rule.temp_uat_ssm_only_egress`) to allow egress traffic on port 443 (HTTPS) from the temporary security group to interface endpoints, facilitating SSM connectivity.

Supporting data sources:

* Introduced a data source (`data.aws_security_group.core_vpc_protected`) to reference the protected security group for interface endpoints in the core VPC.