### PR TITLE
Add logging to lambdas

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -24,13 +24,15 @@ module "lambda_unscanned_to_processing" {
 
   attach_policy_statements = true
   policy_statements = {
-    source_bucket_read = {
+    source_bucket_get_delete = {
       effect = "Allow"
       actions = [
         "s3:GetObject",
         "s3:GetObjectVersion",
         "s3:GetObjectTagging",
         "s3:GetObjectVersionTagging",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
       ]
       resources = [
         "${module.s3_bucket["unscanned"].s3_bucket_arn}/*",

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -3,6 +3,7 @@ import os
 from urllib.parse import unquote_plus
 
 import boto3
+from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
@@ -14,6 +15,7 @@ BUCKET_NAMES_BY_KEY = json.loads(os.environ["BUCKET_NAMES_BY_KEY"])
 DEFAULT_SOURCE_BUCKET_KEY = os.environ["DEFAULT_SOURCE_BUCKET_KEY"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 GUARDDUTY_MALWARE_SCAN_STATUS_TAG = "GuardDutyMalwareScanStatus"
+logger = Logger(service="managed-file-transfer-processing-to-post-scan")
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use the resolved source and destination buckets so transport-level duplicates
@@ -122,6 +124,14 @@ def put_destination_tags(operation, destination_version_id):
     s3.put_object_tagging(**tagging_kwargs)
 
 
+def get_log_fields(operation):
+    return {
+        "object_key": operation["source_key"],
+        "source_bucket_name": operation["source_bucket_name"],
+        "destination_bucket_name": operation["destination_bucket_name"],
+    }
+
+
 @idempotent_function(
     data_keyword_argument="operation",
     persistence_store=persistence_layer,
@@ -129,6 +139,8 @@ def put_destination_tags(operation, destination_version_id):
     key_prefix="managed-file-transfer/processing-to-post-scan",
 )
 def process_record(*, operation):
+    logger.info("Moving S3 object", extra=get_log_fields(operation))
+
     copy_source = {
         "Bucket": operation["source_bucket_name"],
         "Key": operation["source_key"],
@@ -145,6 +157,8 @@ def process_record(*, operation):
         TaggingDirective="COPY",
     )
     put_destination_tags(operation, copy_response.get("VersionId"))
+
+    logger.info("Moved S3 object", extra=get_log_fields(operation))
 
     if operation["delete_source"]:
         delete_kwargs = {
@@ -167,8 +181,19 @@ def process_record(*, operation):
     }
 
 
+@logger.inject_lambda_context(clear_state=True, log_event=False)
 def lambda_handler(event, context):
     idempotency_config.register_lambda_context(context)
 
     for payload in iter_events(event):
-        process_record(operation=normalise_payload(payload))
+        operation = None
+
+        try:
+            operation = normalise_payload(payload)
+            process_record(operation=operation)
+        except Exception:
+            logger.exception(
+                "Failed to move S3 object",
+                extra=get_log_fields(operation) if operation else {},
+            )
+            raise

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from urllib.parse import unquote_plus
 
 import boto3
@@ -16,6 +17,7 @@ DEFAULT_SOURCE_BUCKET_KEY = os.environ["DEFAULT_SOURCE_BUCKET_KEY"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 GUARDDUTY_MALWARE_SCAN_STATUS_TAG = "GuardDutyMalwareScanStatus"
 logger = Logger(service="managed-file-transfer-processing-to-post-scan")
+LOG_KEY_PATH_HASH_LENGTH = 12
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use the resolved source and destination buckets so transport-level duplicates
@@ -125,8 +127,11 @@ def put_destination_tags(operation, destination_version_id):
 
 
 def get_log_fields(operation):
+    source_key = operation["source_key"]
+
     return {
-        "object_key": operation["source_key"],
+        "object_key": source_key.rsplit("/", 1)[-1],
+        "object_key_path_hash": hashlib.sha256(source_key.encode("utf-8")).hexdigest()[:LOG_KEY_PATH_HASH_LENGTH],
         "source_bucket_name": operation["source_bucket_name"],
         "destination_bucket_name": operation["destination_bucket_name"],
     }

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -17,6 +17,8 @@ DEFAULT_SOURCE_BUCKET_KEY = os.environ["DEFAULT_SOURCE_BUCKET_KEY"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 GUARDDUTY_MALWARE_SCAN_STATUS_TAG = "GuardDutyMalwareScanStatus"
 logger = Logger(service="managed-file-transfer-processing-to-post-scan")
+# Keep the truncated hash short enough for readable logs while still providing
+# a stable discriminator for same-named objects under different prefixes.
 LOG_KEY_PATH_HASH_LENGTH = 12
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/guard-duty-file-mover/lambda_function.py
@@ -146,7 +146,7 @@ def get_log_fields(operation):
     key_prefix="managed-file-transfer/processing-to-post-scan",
 )
 def process_record(*, operation):
-    logger.info("Moving S3 object", extra=get_log_fields(operation))
+    logger.info("Processing S3 object", extra=get_log_fields(operation))
 
     copy_source = {
         "Bucket": operation["source_bucket_name"],
@@ -165,7 +165,7 @@ def process_record(*, operation):
     )
     put_destination_tags(operation, copy_response.get("VersionId"))
 
-    logger.info("Moved S3 object", extra=get_log_fields(operation))
+    logger.info("Copied S3 object", extra=get_log_fields(operation))
 
     if operation["delete_source"]:
         delete_kwargs = {
@@ -177,6 +177,7 @@ def process_record(*, operation):
             delete_kwargs["VersionId"] = operation["source_version_id"]
 
         s3.delete_object(**delete_kwargs)
+        logger.info("Moved S3 object", extra=get_log_fields(operation))
 
     return {
         "delete_source": operation["delete_source"],

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -16,6 +16,8 @@ DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 SOURCE_BUCKET_NAME = os.getenv("SOURCE_BUCKET_NAME")
 logger = Logger(service="managed-file-transfer-unscanned-to-processing")
+# Keep the truncated hash short enough for readable logs while still providing
+# a stable discriminator for same-named objects under different prefixes.
 LOG_KEY_PATH_HASH_LENGTH = 12
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from urllib.parse import unquote_plus
 
 import boto3
@@ -15,6 +16,7 @@ DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 SOURCE_BUCKET_NAME = os.getenv("SOURCE_BUCKET_NAME")
 logger = Logger(service="managed-file-transfer-unscanned-to-processing")
+LOG_KEY_PATH_HASH_LENGTH = 12
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use object identity rather than transport metadata so duplicate SQS deliveries
@@ -95,8 +97,11 @@ def normalise_record(record):
 
 
 def get_log_fields(operation):
+    source_key = operation["source_key"]
+
     return {
-        "object_key": operation["source_key"],
+        "object_key": source_key.rsplit("/", 1)[-1],
+        "object_key_path_hash": hashlib.sha256(source_key.encode("utf-8")).hexdigest()[:LOG_KEY_PATH_HASH_LENGTH],
         "source_bucket_name": operation["source_bucket_name"],
         "destination_bucket_name": operation["destination_bucket_name"],
     }

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -134,6 +134,18 @@ def process_record(*, operation):
         TaggingDirective="COPY",
     )
 
+    if operation["source_version_id"]:
+        s3.delete_object(
+            Bucket=operation["source_bucket_name"],
+            Key=operation["source_key"],
+            VersionId=operation["source_version_id"],
+        )
+    else:
+        s3.delete_object(
+            Bucket=operation["source_bucket_name"],
+            Key=operation["source_key"],
+        )
+
     logger.info("Moved S3 object", extra=get_log_fields(operation))
 
     return {

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/s3-file-mover/lambda_function.py
@@ -3,6 +3,7 @@ import os
 from urllib.parse import unquote_plus
 
 import boto3
+from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
@@ -13,6 +14,7 @@ s3 = boto3.client("s3")
 DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 SOURCE_BUCKET_NAME = os.getenv("SOURCE_BUCKET_NAME")
+logger = Logger(service="managed-file-transfer-unscanned-to-processing")
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 # Use object identity rather than transport metadata so duplicate SQS deliveries
@@ -92,6 +94,14 @@ def normalise_record(record):
     }
 
 
+def get_log_fields(operation):
+    return {
+        "object_key": operation["source_key"],
+        "source_bucket_name": operation["source_bucket_name"],
+        "destination_bucket_name": operation["destination_bucket_name"],
+    }
+
+
 @idempotent_function(
     data_keyword_argument="operation",
     persistence_store=persistence_layer,
@@ -99,6 +109,8 @@ def normalise_record(record):
     key_prefix="managed-file-transfer/unscanned-to-processing",
 )
 def process_record(*, operation):
+    logger.info("Moving S3 object", extra=get_log_fields(operation))
+
     copy_source = {
         "Bucket": operation["source_bucket_name"],
         "Key": operation["source_key"],
@@ -115,6 +127,8 @@ def process_record(*, operation):
         TaggingDirective="COPY",
     )
 
+    logger.info("Moved S3 object", extra=get_log_fields(operation))
+
     return {
         "destination_bucket_name": operation["destination_bucket_name"],
         "source_bucket_name": operation["source_bucket_name"],
@@ -123,8 +137,19 @@ def process_record(*, operation):
     }
 
 
+@logger.inject_lambda_context(clear_state=True, log_event=False)
 def lambda_handler(event, context):
     idempotency_config.register_lambda_context(context)
 
     for record in iter_records(event):
-        process_record(operation=normalise_record(record))
+        operation = None
+
+        try:
+            operation = normalise_record(record)
+            process_record(operation=operation)
+        except Exception:
+            logger.exception(
+                "Failed to move S3 object",
+                extra=get_log_fields(operation) if operation else {},
+            )
+            raise

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -19,11 +19,13 @@ data "aws_iam_policy_document" "transfer_user" {
       module.s3_bucket["unscanned"].s3_bucket_arn
     ]
   }
+  # s3:GetObject is required to so that AWS Transfer can issue HeadObject
   statement {
     sid    = "AllowS3LandingBucketObjectActions"
     effect = "Allow"
     actions = [
       "s3:AbortMultipartUpload",
+      "s3:GetObject",
       "s3:PutObject"
     ]
     resources = ["${module.s3_bucket["unscanned"].s3_bucket_arn}/*"]
@@ -64,12 +66,14 @@ data "aws_iam_policy_document" "transfer_user_session" {
     }
   }
 
+  # s3:GetObject is required to so that AWS Transfer can issue HeadObject
   statement {
     sid    = "AllowUploadOnlyToHomeDirectory"
     effect = "Allow"
     actions = [
-      "s3:PutObject",
       "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:PutObject",
     ]
     resources = [
       "${module.s3_bucket["unscanned"].s3_bucket_arn}/$${transfer:UserName}/*",

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -19,13 +19,11 @@ data "aws_iam_policy_document" "transfer_user" {
       module.s3_bucket["unscanned"].s3_bucket_arn
     ]
   }
-  # s3:GetObject is required to so that AWS Transfer can issue HeadObject
   statement {
     sid    = "AllowS3LandingBucketObjectActions"
     effect = "Allow"
     actions = [
       "s3:AbortMultipartUpload",
-      "s3:GetObject",
       "s3:PutObject"
     ]
     resources = ["${module.s3_bucket["unscanned"].s3_bucket_arn}/*"]
@@ -66,13 +64,11 @@ data "aws_iam_policy_document" "transfer_user_session" {
     }
   }
 
-  # s3:GetObject is required to so that AWS Transfer can issue HeadObject
   statement {
     sid    = "AllowUploadOnlyToHomeDirectory"
     effect = "Allow"
     actions = [
       "s3:AbortMultipartUpload",
-      "s3:GetObject",
       "s3:PutObject",
     ]
     resources = [


### PR DESCRIPTION
This PR enriches the file mover lambda functions with some simple logging, and moves from copy only to a copy-then-delete-source flow.
