### PR TITLE
Remove development from the CP workflow

### DIFF
--- a/.github/workflows/cloud-platform.yml
+++ b/.github/workflows/cloud-platform.yml
@@ -29,9 +29,6 @@ jobs:
       matrix:
         include:
           - application: cloud-platform
-            environment: development
-            action: "plan_apply"
-          - application: cloud-platform
             environment: preproduction
             action: "plan"
           - application: cloud-platform


### PR DESCRIPTION
We are only using the development environment for temporary clusters, we do not need a permanent development cluster here.  Removing so that we can simplify the terraform by not needing counts to avoid dev instances.