### PR TITLE
Add CP root TF back in for dev

### DIFF
--- a/.github/workflows/cloud-platform.yml
+++ b/.github/workflows/cloud-platform.yml
@@ -22,6 +22,18 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
+
+  development-root-terraform:
+    uses: ./.github/workflows/reusable_terraform_components_plan_apply.yml
+    with:
+      application: cloud-platform
+      environment: development
+      action: "plan_apply"
+      component: "root"
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
   terraform-pr:
     if: github.event_name == 'pull_request'
     strategy:


### PR DESCRIPTION
We still need to run the root Terraform for the development environment, adding this back in.