### PR TITLE
Increase ccms-ebs payment-load Lambda timeout to 15 minutes

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-lambda.tf
+++ b/terraform/environments/ccms-ebs/ccms-lambda.tf
@@ -51,7 +51,7 @@ resource "aws_lambda_function" "lambda_function" {
   layers           = [aws_lambda_layer_version.lambda_layer.arn]
   architectures    = ["x86_64"]
   memory_size      = 128
-  timeout          = 120
+  timeout          = 900
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary
- Increases the `ccms-ebs-<env>-payment-load` Lambda function timeout from 120 seconds (2 min) to 900 seconds (15 min)

## Test plan
- [ ] Verify Terraform plan shows only the timeout change for `aws_lambda_function.lambda_function`
- [ ] Confirm apply succeeds across all environments