### PR TITLE
chore(deps):upgrade terraform-aws-modules/iam and s3-bucket versions

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -72,7 +72,7 @@ module "ecr_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "ecr-access"
   description = "IAM Policy"
@@ -96,7 +96,7 @@ module "snyk_analytical_platform_airflow_container_scanning_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "snyk-analytical-platform-airflow-container-scanning"
   description = "IAM Policy"
@@ -111,7 +111,7 @@ module "trivy_analytical_platform_airflow_container_scanning_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "trivy-analytical-platform-airflow-container-scanning"
   description = "IAM Policy"
@@ -170,7 +170,7 @@ module "analytical_platform_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "analytical-platform-terraform"
   description = "IAM Policy"
@@ -232,7 +232,7 @@ module "analytical_platform_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "analytical-platform-github-actions"
   description = "IAM Policy"
@@ -269,7 +269,7 @@ module "data_engineering_datalake_access_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "data-engineering-datalake-access-github-actions"
   description = "IAM Policy"
@@ -313,7 +313,7 @@ module "data_engineering_datalake_access_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "data-engineering-datalake-access-terraform"
   description = "IAM Policy"

--- a/terraform/environments/analytical-platform-common/iam-roles.tf
+++ b/terraform/environments/analytical-platform-common/iam-roles.tf
@@ -3,7 +3,7 @@ module "ecr_access_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -27,7 +27,7 @@ module "snyk_analytical_platform_airflow_container_scanning_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -66,7 +66,7 @@ module "trivy_analytical_platform_airflow_container_scanning_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -90,7 +90,7 @@ module "analytical_platform_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -111,7 +111,7 @@ module "analytical_platform_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create          = true
   use_name_prefix = false
@@ -153,7 +153,7 @@ module "data_engineering_datalake_access_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -174,7 +174,7 @@ module "data_engineering_datalake_access_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create          = true
   use_name_prefix = false

--- a/terraform/environments/analytical-platform-common/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-common/s3-buckets.tf
@@ -3,7 +3,7 @@ module "terraform_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-common-${local.environment}-tfstate"
 
@@ -31,7 +31,7 @@ module "artifacts_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-common-${local.environment}-artifacts"
 


### PR DESCRIPTION
Upgrades two Terraform modules to their latest versions across three files. Provider constraints in `versions.tf` are unchanged — `~> 6.0` (AWS) and `~> 3.0` (HTTP) already permit the latest provider releases. All other modules are already at latest.

### Module versions

| File | Module | Current | New | |
|---|---|---|---|---|
| `iam-policies.tf` | `terraform-aws-modules/iam/aws` `// modules/iam-policy` | `6.4.0` | `6.6.0` | ⬆️ |
| `iam-roles.tf` | `terraform-aws-modules/iam/aws` `// modules/iam-role` | `6.4.0` | `6.6.0` | ⬆️ |
| `s3-buckets.tf` | `terraform-aws-modules/s3-bucket/aws` | `5.10.0` | `5.13.0` | ⬆️ |
| `kms-keys.tf` | `terraform-aws-modules/kms/aws` | `4.2.0` | `4.2.0` | — |
| `secrets.tf` | `terraform-aws-modules/secrets-manager/aws` | `2.1.0` | `2.1.0` | — |
| `dynamodb-tables.tf` | `terraform-aws-modules/dynamodb-table/aws` | `5.5.0` | `5.5.0` | — |
| `observability.tf` | `ministryofjustice/observability-platform-tenant/aws` | `2.0.0` | `2.0.0` | — |
| `observability.tf` | `terraform-aws-analytical-platform-observability` `ref=4b9c9013 (4.2.0)` | `4.2.0` | `4.2.0` | — |
| `versions.tf` | `hashicorp/aws` | `~> 6.0` | `~> 6.0` | — |
| `versions.tf` | `hashicorp/http` | `~> 3.0` | `~> 3.0` | — |

---

### Release changes

#### `terraform-aws-modules/iam/aws` — `6.4.0 → 6.6.0`

**v6.5.0** (2026-04-24)
- feat: add `ec2:DescribeInstanceTypes` to EBS CSI driver policy ([#641](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/641))
  > No impact — EBS CSI policy applies to the `iam-role-for-service-accounts` submodule only, which is not used in this repo

**v6.6.0** (2026-04-29)
- feat: add support for merging trust policy documents ([#643](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/643))
  > No impact — new opt-in `trust_policy_documents` arg on `iam-role`; existing `trust_policy_permissions` and `trust_policy_conditions` args are unaffected

---

#### `terraform-aws-modules/s3-bucket/aws` — `5.10.0 → 5.13.0`

**v5.11.0** (2026-03-19)
- feat: add `bucket_namespace` input variable for S3 Express directory buckets ([#382](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/382))
  > No impact — directory bucket feature only; not used by `terraform_bucket` or `artifacts_bucket`

**v5.12.0** (2026-04-02)
- feat: directory bucket metrics support ([#384](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/384))
  > No impact — directory bucket feature only

**v5.13.0** (2026-05-04)
- feat: S3 Inventory for directory buckets ([#387](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/387))
  > No impact — directory bucket feature only
  
PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.