### PR TITLE
Update helm-charts-dashboard-service.tf version to 0.3.0

### DIFF
--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.3.1"
+  version    = "0.3.2"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.3.0"
+  version    = "0.3.1"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -4,7 +4,7 @@ resource "helm_release" "dashboard_service" {
   /* https://github.com/ministryofjustice/analytical-platform-dashboard-service */
   name       = "dashboard-service"
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
-  version    = "0.2.21"
+  version    = "0.3.0"
   chart      = "dashboard-service"
   namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
   values = [


### PR DESCRIPTION
Deploy [Dashboard Service 0.3.2](https://github.com/ministryofjustice/analytical-platform-dashboard-service/releases/tag/0.3.2)

This will deploy the new designs, as tracked in https://github.com/ministryofjustice/analytical-platform/issues/9704

Full details of changes between versions can be found here https://github.com/ministryofjustice/analytical-platform-dashboard-service/compare/0.2.23...0.3.2