### PR TITLE
chore(deps): upgrade terraform providers, helm/k8s to 3.x, and sm

### DIFF
--- a/terraform/environments/analytical-platform-compute/actions-runner/helm-charts-actions-runners.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/helm-charts-actions-runners.tf
@@ -8,7 +8,7 @@ resource "helm_release" "actions_runner_mojas_airflow" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/airflow/values.yml.tftpl",
@@ -34,7 +34,7 @@ resource "helm_release" "actions_runner_mojas_airflow_create_a_pipeline" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/airflow-create-a-pipeline/values.yml.tftpl",
@@ -59,7 +59,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -83,7 +83,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -97,10 +97,10 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_non_spot" {
       }
     )
   ]
-  set {
+  set = [{
     name  = "ephemeral.karpenter.nodePool"
     value = "general-on-demand"
-  }
+  }]
 }
 
 resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a" {
@@ -111,7 +111,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a" 
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -135,7 +135,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a_n
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -149,10 +149,11 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_sandbox_a_n
       }
     )
   ]
-  set {
+  set = [{
     name  = "ephemeral.karpenter.nodePool"
     value = "general-on-demand"
-  }
+    }
+  ]
 }
 
 resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
@@ -163,7 +164,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -187,7 +188,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_pp" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -211,7 +212,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_test" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -235,7 +236,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_dpr_dev" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -259,7 +260,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_dev" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -284,7 +285,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_test" 
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -308,7 +309,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds_pp" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -332,7 +333,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_emds" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -356,7 +357,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_property_de
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -380,7 +381,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_property_pr
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -404,7 +405,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_probation_d
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -428,7 +429,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_probation_p
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -452,7 +453,7 @@ resource "helm_release" "actions_runner_mojas_create_a_derived_table_probation_p
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/create-a-derived-table/values.yml.tftpl",
@@ -478,7 +479,7 @@ resource "helm_release" "actions_runner_moj_data_catalogue" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "2.330.0-7"
   chart      = "actions-runner"
-  namespace  = kubernetes_namespace.actions_runners[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/actions-runners/data-catalogue/values.yml.tftpl",

--- a/terraform/environments/analytical-platform-compute/actions-runner/import.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/import.tf
@@ -1,7 +1,8 @@
 # This file is used to import the existing Kubernetes namespace for actions runners into Terraform state.Will be deleted after the import is complete and the state file is updated.
 import {
-  to = kubernetes_namespace_v1.actions_runners[0]
-  id = "actions-runners"
+  for_each = terraform.workspace == "analytical-platform-compute-production" ? { "0" = "actions-runners" } : {}
+  to       = kubernetes_namespace_v1.actions_runners[0]
+  id       = each.value
 }
 
 removed {

--- a/terraform/environments/analytical-platform-compute/actions-runner/import.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/import.tf
@@ -1,0 +1,13 @@
+# This file is used to import the existing Kubernetes namespace for actions runners into Terraform state.Will be deleted after the import is complete and the state file is updated.
+import {
+  to = kubernetes_namespace_v1.actions_runners[0]
+  id = "actions-runners"
+}
+
+removed {
+  from = kubernetes_namespace.actions_runners
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-external-secrets.tf
@@ -8,7 +8,7 @@ resource "kubernetes_manifest" "actions_runners_token_apc_self_hosted_runners_se
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-token-apc-self-hosted-runners"
-      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+      "namespace" = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
     }
     "spec" = {
       "refreshInterval" = "1m"
@@ -41,7 +41,7 @@ resource "kubernetes_manifest" "actions_runners_token_moj_apc_self_hosted_runner
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-token-moj-apc-self-hosted-runners"
-      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+      "namespace" = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
     }
     "spec" = {
       "refreshInterval" = "1m"
@@ -74,7 +74,7 @@ resource "kubernetes_manifest" "actions_runners_github_app_apc_self_hosted_runne
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "actions-runners-github-app-apc-self-hosted-runners"
-      "namespace" = kubernetes_namespace.actions_runners[0].metadata[0].name
+      "namespace" = kubernetes_namespace_v1.actions_runners[0].metadata[0].name
     }
     "spec" = {
       "refreshInterval" = "1m"

--- a/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-namespaces.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/kubernetes-namespaces.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "actions_runners" {
+resource "kubernetes_namespace_v1" "actions_runners" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   metadata {

--- a/terraform/environments/analytical-platform-compute/actions-runner/providers.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/providers.tf
@@ -7,7 +7,7 @@ provider "kubernetes" {
 
 # Provider for interacting with the EKS cluster using Helm
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.apc_cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.apc_cluster.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.apc_cluster.token

--- a/terraform/environments/analytical-platform-compute/actions-runner/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/secrets.tf
@@ -5,7 +5,7 @@ module "actions_runners_token_apc_self_hosted_runners_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name        = "actions-runners/token/apc-self-hosted-runners"
   description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/4282353"
@@ -29,7 +29,7 @@ module "actions_runners_token_moj_apc_self_hosted_runners_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name        = "actions-runners/token/moj-apc-self-hosted-runners"
   description = "moj-data-platform-robot: https://github.com/settings/personal-access-tokens/5605162"
@@ -54,7 +54,7 @@ module "actions_runners_github_app_apc_self_hosted_runners_secret" {
   count = terraform.workspace == "analytical-platform-compute-production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name        = "actions-runners/app/apc-self-hosted-runners"
   description = "https://github.com/organizations/moj-analytical-services/settings/apps/analytical-platform-runners"

--- a/terraform/environments/analytical-platform-compute/actions-runner/versions.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/versions.tf
@@ -1,29 +1,29 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     kubernetes = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/kubernetes"
     }
     helm = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/helm"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform, all provider constraints, and the secrets-manager module. Also migrates `kubernetes_namespace` → `kubernetes_namespace_v1` as required by the kubernetes provider 3.x  deprecation. Provider block syntax in `provider.tf` updated for helm 3.x breaking changes.

---

### Version changes

| File | Component | Current | New | |
|---|---|---|---|---|
| `version.tf` | `hashicorp/aws` | `~> 6.0` | `~> 6.46` | ⬆️ |
| `version.tf` | `hashicorp/kubernetes` | `~> 2.0` | `~> 3.1` | ⬆️ |
| `version.tf` | `hashicorp/helm` | `~> 2.0` | `~> 3.1` | ⬆️ |
| `version.tf` | `hashicorp/dns` | `~> 3.0` | `~> 3.6` | ⬆️ |
| `version.tf` | `hashicorp/external` | `~> 2.0` | `~> 2.4` | ⬆️ |
| `version.tf` | `hashicorp/http` | `~> 3.0` | `~> 3.6` | ⬆️ |
| `version.tf` | `terraform` | `~> 1.10` | `~> 1.15` | ⬆️ |
| `secrets.tf` | `terraform-aws-modules/secrets-manager/aws` | `1.3.1` | `2.1.0` | ⬆️ |
| `namespace.tf` | `kubernetes_namespace` | — | `kubernetes_namespace_v1` | 🔄 |
| `import.tf` *(new)* | import + removed blocks | — | — | ✨ |

---

### Release changes

#### `hashicorp/aws` — `~> 6.0 → ~> 6.46`
**v6.0.0**
- feat: per-resource `region` attribute added to most resources — manage multi-region infra without multiple provider configs
 
**v6.42.0**
- breaking: `aws_mq_configuration` destroy now actually deletes the resource (previously a no-op)

**v6.46.0**
- breaking: `aws_xray_resource_policy` changes to `policy_name` now force recreation

#### `hashicorp/kubernetes` — `~> 2.0 → ~> 3.1`
**v3.0.0**
- breaking: all non-suffixed resources deprecated — must migrate to `_v1` equivalents (e.g. `kubernetes_namespace` → `kubernetes_namespace_v1`)

#### `hashicorp/helm` — `~> 2.0 → ~> 3.1`
**v3.0.0**
- breaking: migrated from Plugin SDKv2 to Plugin Framework
- breaking: `kubernetes {}` block → `kubernetes = {}` nested object in provider block
- breaking: `set {}`, `set_list {}`, `set_sensitive {}` blocks → list syntax `set = [{}]`

#### `terraform-aws-modules/secrets-manager` — `1.3.1 → 2.1.0`
**v2.0.0**
- breaking: requires Terraform >= 1.11 and AWS provider >= 6.0 (both satisfied by this upgrade)
- feat: secrets now use write-only attribute (`secret_string_wo`) — no longer persisted in state

PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.