### PR TITLE
chore(deps):upgrade terraform modules and provider versions

### DIFF
--- a/terraform/environments/analytical-platform-compute/airflow/alb.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/alb.tf
@@ -4,7 +4,7 @@ module "mwaa_alb" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.17.0"
+  version = "10.5.0"
 
   name    = "mwaa"
   vpc_id  = data.aws_vpc.apc_vpc.id

--- a/terraform/environments/analytical-platform-compute/airflow/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/iam-policies.tf
@@ -105,7 +105,7 @@ data "aws_iam_policy_document" "mwaa_execution_policy" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds"
     ]
-    resources = ["arn:aws:secretsmanager:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:secret:airflow/*"]
+    resources = ["arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:airflow/*"]
   }
 }
 

--- a/terraform/environments/analytical-platform-compute/airflow/iam-policies.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/iam-policies.tf
@@ -113,11 +113,11 @@ module "mwaa_execution_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
-
-  name   = "mwaa-execution"
-  policy = data.aws_iam_policy_document.mwaa_execution_policy.json
+  source      = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version     = "6.6.0"
+  description = "IAM Policy"
+  name        = "mwaa-execution"
+  policy      = data.aws_iam_policy_document.mwaa_execution_policy.json
 
   tags = local.tags
 }
@@ -143,11 +143,11 @@ module "mwaa_ses_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
-
-  name   = "mwaa-ses"
-  policy = data.aws_iam_policy_document.mwaa_ses.json
+  source      = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version     = "6.6.0"
+  description = "IAM Policy"
+  name        = "mwaa-ses"
+  policy      = data.aws_iam_policy_document.mwaa_ses.json
 
   tags = local.tags
 }
@@ -196,8 +196,9 @@ module "gha_moj_ap_airflow_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  source      = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version     = "6.6.0"
+  description = "IAM Policy"
 
   name = "github-actions-ministryofjustice-analytical-platform-airflow"
 
@@ -220,9 +221,10 @@ module "gha_mojas_airflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "6.6.0"
 
   name_prefix = "github-actions-mojas-airflow"
+  description = "IAM Policy"
 
   policy = data.aws_iam_policy_document.gha_mojas_airflow.json
 
@@ -243,9 +245,10 @@ module "create_airflow_token_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "6.6.0"
 
   name_prefix = "create-airflow-token-"
+  description = "IAM Policy"
 
   policy = data.aws_iam_policy_document.create_airflow_token.json
 

--- a/terraform/environments/analytical-platform-compute/airflow/iam-roles.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/iam-roles.tf
@@ -8,20 +8,26 @@ module "mwaa_execution_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.59.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  create_role = true
+  name            = "mwaa-execution"
+  use_name_prefix = false
+  trust_policy_permissions = {
+    MwaaExecutionRole = {
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["airflow.amazonaws.com", "airflow-env.amazonaws.com"]
+        }
+      ]
+    }
+  }
 
-  role_name         = "mwaa-execution"
-  role_requires_mfa = false
-
-  trusted_role_services = [
-    "airflow.amazonaws.com",
-    "airflow-env.amazonaws.com"
-  ]
-
-  custom_role_policy_arns = [module.mwaa_execution_iam_policy.arn]
+  policies = {
+    mwaa_execution_policy = module.mwaa_execution_iam_policy.arn
+  }
 
   tags = local.tags
 }
@@ -30,16 +36,17 @@ module "gha_mojas_airflow_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.59.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  name = "github-actions-mojas-airflow"
+  name            = "github-actions-mojas-airflow"
+  use_name_prefix = false
 
   policies = {
     GHAMoJASAirflow = module.gha_mojas_airflow_iam_policy.arn
   }
-
-  subjects = ["moj-analytical-services/airflow:*"]
+  enable_github_oidc     = true
+  oidc_wildcard_subjects = ["moj-analytical-services/airflow:*"]
 
   tags = local.tags
 }
@@ -48,16 +55,16 @@ module "gha_moj_ap_airflow_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
-  version = "5.59.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  name = "github-actions-ministryofjustice-analytical-platform-airflow"
-
+  name            = "github-actions-ministryofjustice-analytical-platform-airflow"
+  use_name_prefix = false
   policies = {
     gha-moj-ap-airflow = module.gha_moj_ap_airflow_iam_policy.arn
   }
-
-  subjects = ["ministryofjustice/analytical-platform-airflow:*"]
+  enable_github_oidc     = true
+  oidc_wildcard_subjects = ["ministryofjustice/analytical-platform-airflow:*"]
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/airflow/iam-users.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/iam-users.tf
@@ -3,12 +3,14 @@ module "mwaa_ses_iam_user" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "5.59.0"
+  version = "6.6.0"
 
-  name                          = "mwaa-ses"
-  create_iam_user_login_profile = false
+  name                 = "mwaa-ses"
+  create_login_profile = false
 
-  policy_arns = [module.mwaa_ses_policy.arn]
+  policies = {
+    mwaa_ses_policy = module.mwaa_ses_policy.arn
+  }
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/airflow/import.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/import.tf
@@ -1,0 +1,178 @@
+# This file is used to import the existing Kubernetes namespace for actions runners into Terraform state.Will be deleted after the import is complete and the state file is updated.
+
+#### NAMESPACES ######
+# airflow namespace
+import {
+  to = kubernetes_namespace_v1.airflow
+  id = "airflow"
+}
+
+removed {
+  from = kubernetes_namespace.airflow
+  lifecycle {
+    destroy = false
+  }
+}
+
+# mwaa namespace
+import {
+  to = kubernetes_namespace_v1.mwaa
+  id = "mwaa"
+}
+
+removed {
+  from = kubernetes_namespace.mwaa
+  lifecycle {
+    destroy = false
+  }
+}
+
+
+###### ROLES #######
+#kubernetes_role_v1 airflow_execution
+import {
+  to = kubernetes_role_v1.airflow_execution
+  id = "airflow/airflow-execution"
+}
+
+removed {
+  from = kubernetes_role.airflow_execution
+  lifecycle {
+    destroy = false
+  }
+}
+
+#kubernetes_role_v1 airflow_serviceaccount_management
+import {
+  to = kubernetes_role_v1.airflow_serviceaccount_management
+  id = "airflow/airflow-serviceaccount-management"
+}
+
+removed {
+  from = kubernetes_role.airflow_serviceaccount_management
+  lifecycle {
+    destroy = false
+  }
+}
+
+#kubernetes_role_v1 mwaa_execution
+import {
+  to = kubernetes_role_v1.mwaa_execution
+  id = "mwaa/mwaa-execution"
+}
+
+removed {
+  from = kubernetes_role.mwaa_execution
+  lifecycle {
+    destroy = false
+  }
+}
+
+#kubernetes_role_v1 mwaa_serviceaccount_management
+import {
+  to = kubernetes_role_v1.mwaa_serviceaccount_management
+  id = "mwaa/mwaa-serviceaccount-management"
+}
+
+removed {
+  from = kubernetes_role.mwaa_serviceaccount_management
+  lifecycle {
+    destroy = false
+  }
+}
+
+#kubernetes_role_v1 mwaa_external_secrets
+import {
+  to = kubernetes_role_v1.mwaa_external_secrets
+  id = "mwaa/mwaa-external-secrets"
+}
+
+removed {
+  from = kubernetes_role.mwaa_external_secrets
+  lifecycle {
+    destroy = false
+  }
+}
+
+
+
+#### ROLE BINDINGS ######
+# kubernetes_role_binding - airflow_execution
+import {
+  to = kubernetes_role_binding_v1.airflow_execution
+  id = "airflow/airflow-execution"
+}
+
+removed {
+  from = kubernetes_role_binding.airflow_execution
+  lifecycle {
+    destroy = false
+  }
+}
+
+# kubernetes_role_binding - airflow_serviceaccount_management
+import {
+  to = kubernetes_role_binding_v1.airflow_serviceaccount_management
+  id = "airflow/airflow-serviceaccount-management"
+}
+
+removed {
+  from = kubernetes_role_binding.airflow_serviceaccount_management
+  lifecycle {
+    destroy = false
+  }
+}
+
+# kubernetes_role_binding - mwaa_execution
+import {
+  to = kubernetes_role_binding_v1.mwaa_execution
+  id = "mwaa/mwaa-execution"
+}
+
+removed {
+  from = kubernetes_role_binding.mwaa_execution
+  lifecycle {
+    destroy = false
+  }
+}
+
+# kubernetes_role_binding - mwaa_serviceaccount_management
+import {
+  to = kubernetes_role_binding_v1.mwaa_serviceaccount_management
+  id = "mwaa/mwaa-serviceaccount-management"
+}
+
+removed {
+  from = kubernetes_role_binding.mwaa_serviceaccount_management
+  lifecycle {
+    destroy = false
+  }
+}
+# kubernetes_role_binding - mwaa_external_secrets
+import {
+  to = kubernetes_role_binding_v1.mwaa_external_secrets
+  id = "mwaa/mwaa-external-secrets"
+}
+removed {
+  from = kubernetes_role_binding.mwaa_external_secrets
+  lifecycle {
+    destroy = false
+  }
+}
+
+
+
+### Service Account ###
+#kubernetes_service_account - mwaa_external_secrets_analytical_platform_data_production
+import {
+  to = kubernetes_service_account_v1.mwaa_external_secrets_analytical_platform_data_production
+  id = "mwaa/external-secrets-analytical-platform-data-production"
+}
+
+removed {
+  from = kubernetes_service_account.mwaa_external_secrets_analytical_platform_data_production
+  lifecycle {
+    destroy = false
+  }
+}
+

--- a/terraform/environments/analytical-platform-compute/airflow/import.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/import.tf
@@ -1,4 +1,4 @@
-# This file is used to import the existing Kubernetes namespace for actions runners into Terraform state.Will be deleted after the import is complete and the state file is updated.
+# This file is used to import the existing k8s reesources and iam polcies into Terraform state.Will be deleted after the import is complete and the state file is updated.
 
 #### NAMESPACES ######
 # airflow namespace
@@ -176,3 +176,15 @@ removed {
   }
 }
 
+
+
+# moved block for mwaa policy attachment v5 to v6 upgrade
+moved {
+  from = module.mwaa_ses_iam_user.aws_iam_user_policy_attachment.this["0"]
+  to   = module.mwaa_ses_iam_user.aws_iam_user_policy_attachment.additional["mwaa_ses_policy"]
+}
+
+moved {
+  from = module.mwaa_execution_iam_role.aws_iam_role_policy_attachment.custom[0]
+  to   = module.mwaa_execution_iam_role.aws_iam_role_policy_attachment.this["mwaa_execution_policy"]
+}

--- a/terraform/environments/analytical-platform-compute/airflow/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kms-keys.tf
@@ -3,7 +3,7 @@ module "mwaa_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["mwaa/default"]
   enable_default_policy = true

--- a/terraform/environments/analytical-platform-compute/airflow/kubernetes-namespace.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kubernetes-namespace.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "airflow" {
+resource "kubernetes_namespace_v1" "airflow" {
   metadata {
     name = "airflow"
     labels = {
@@ -8,7 +8,7 @@ resource "kubernetes_namespace" "airflow" {
   }
 }
 
-resource "kubernetes_namespace" "mwaa" {
+resource "kubernetes_namespace_v1" "mwaa" {
   metadata {
     name = "mwaa"
     labels = {

--- a/terraform/environments/analytical-platform-compute/airflow/kubernetes-role-bindings.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kubernetes-role-bindings.tf
@@ -1,12 +1,12 @@
-resource "kubernetes_role_binding" "airflow_execution" {
+resource "kubernetes_role_binding_v1" "airflow_execution" {
   metadata {
     name      = "airflow-execution"
-    namespace = kubernetes_namespace.airflow.metadata[0].name
+    namespace = kubernetes_namespace_v1.airflow.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.airflow_execution.metadata[0].name
+    name      = kubernetes_role_v1.airflow_execution.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"
@@ -15,15 +15,15 @@ resource "kubernetes_role_binding" "airflow_execution" {
   }
 }
 
-resource "kubernetes_role_binding" "airflow_serviceaccount_management" {
+resource "kubernetes_role_binding_v1" "airflow_serviceaccount_management" {
   metadata {
     name      = "airflow-serviceaccount-management"
-    namespace = kubernetes_namespace.airflow.metadata[0].name
+    namespace = kubernetes_namespace_v1.airflow.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.airflow_serviceaccount_management.metadata[0].name
+    name      = kubernetes_role_v1.airflow_serviceaccount_management.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"
@@ -32,15 +32,15 @@ resource "kubernetes_role_binding" "airflow_serviceaccount_management" {
   }
 }
 
-resource "kubernetes_role_binding" "mwaa_execution" {
+resource "kubernetes_role_binding_v1" "mwaa_execution" {
   metadata {
     name      = "mwaa-execution"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.mwaa_execution.metadata[0].name
+    name      = kubernetes_role_v1.mwaa_execution.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"
@@ -49,15 +49,15 @@ resource "kubernetes_role_binding" "mwaa_execution" {
   }
 }
 
-resource "kubernetes_role_binding" "mwaa_serviceaccount_management" {
+resource "kubernetes_role_binding_v1" "mwaa_serviceaccount_management" {
   metadata {
     name      = "mwaa-serviceaccount-management"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.mwaa_serviceaccount_management.metadata[0].name
+    name      = kubernetes_role_v1.mwaa_serviceaccount_management.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"
@@ -66,15 +66,15 @@ resource "kubernetes_role_binding" "mwaa_serviceaccount_management" {
   }
 }
 
-resource "kubernetes_role_binding" "mwaa_external_secrets" {
+resource "kubernetes_role_binding_v1" "mwaa_external_secrets" {
   metadata {
     name      = "mwaa-external-secrets"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.mwaa_external_secrets.metadata[0].name
+    name      = kubernetes_role_v1.mwaa_external_secrets.metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"

--- a/terraform/environments/analytical-platform-compute/airflow/kubernetes-roles.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kubernetes-roles.tf
@@ -1,8 +1,8 @@
 // Derived from https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html#eksctl-role
-resource "kubernetes_role" "airflow_execution" {
+resource "kubernetes_role_v1" "airflow_execution" {
   metadata {
     name      = "airflow-execution"
-    namespace = kubernetes_namespace.airflow.metadata[0].name
+    namespace = kubernetes_namespace_v1.airflow.metadata[0].name
   }
   rule {
     api_groups = [
@@ -33,10 +33,10 @@ resource "kubernetes_role" "airflow_execution" {
   }
 }
 
-resource "kubernetes_role" "airflow_serviceaccount_management" {
+resource "kubernetes_role_v1" "airflow_serviceaccount_management" {
   metadata {
     name      = "airflow-serviceaccount-management"
-    namespace = kubernetes_namespace.airflow.metadata[0].name
+    namespace = kubernetes_namespace_v1.airflow.metadata[0].name
   }
   rule {
     api_groups = [""]
@@ -52,10 +52,10 @@ resource "kubernetes_role" "airflow_serviceaccount_management" {
   }
 }
 
-resource "kubernetes_role" "mwaa_execution" {
+resource "kubernetes_role_v1" "mwaa_execution" {
   metadata {
     name      = "mwaa-execution"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
   }
   rule {
     api_groups = [
@@ -86,10 +86,10 @@ resource "kubernetes_role" "mwaa_execution" {
   }
 }
 
-resource "kubernetes_role" "mwaa_serviceaccount_management" {
+resource "kubernetes_role_v1" "mwaa_serviceaccount_management" {
   metadata {
     name      = "mwaa-serviceaccount-management"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
   }
   rule {
     api_groups = [""]
@@ -105,10 +105,10 @@ resource "kubernetes_role" "mwaa_serviceaccount_management" {
   }
 }
 
-resource "kubernetes_role" "mwaa_external_secrets" {
+resource "kubernetes_role_v1" "mwaa_external_secrets" {
   metadata {
     name      = "mwaa-external-secrets"
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
 
   }
   rule {

--- a/terraform/environments/analytical-platform-compute/airflow/kubernetes-secret-stores.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kubernetes-secret-stores.tf
@@ -3,7 +3,7 @@ resource "kubernetes_manifest" "eso_secretstore_data_production" {
     "apiVersion" = "external-secrets.io/v1"
     "kind"       = "SecretStore"
     "metadata" = {
-      "namespace" = kubernetes_namespace.mwaa.metadata[0].name
+      "namespace" = kubernetes_namespace_v1.mwaa.metadata[0].name
       "name"      = "analytical-platform-data-production"
     }
     "spec" = {
@@ -14,7 +14,7 @@ resource "kubernetes_manifest" "eso_secretstore_data_production" {
           "auth" = {
             "jwt" = {
               "serviceAccountRef" = {
-                "name" = kubernetes_service_account.mwaa_external_secrets_analytical_platform_data_production.metadata[0].name
+                "name" = kubernetes_service_account_v1.mwaa_external_secrets_analytical_platform_data_production.metadata[0].name
               }
             }
           }

--- a/terraform/environments/analytical-platform-compute/airflow/kubernetes-service-accounts.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/kubernetes-service-accounts.tf
@@ -1,6 +1,6 @@
-resource "kubernetes_service_account" "mwaa_external_secrets_analytical_platform_data_production" {
+resource "kubernetes_service_account_v1" "mwaa_external_secrets_analytical_platform_data_production" {
   metadata {
-    namespace = kubernetes_namespace.mwaa.metadata[0].name
+    namespace = kubernetes_namespace_v1.mwaa.metadata[0].name
     # namespace = data.kubernetes_namespace.mwaa.metadata[0].name
     name = "external-secrets-analytical-platform-data-production"
     annotations = {

--- a/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
@@ -4,7 +4,7 @@ resource "aws_mwaa_environment" "main" {
   environment_class               = local.environment_configuration.airflow_environment_class
   weekly_maintenance_window_start = "SAT:01:00"
 
-  execution_role_arn = module.mwaa_execution_iam_role.iam_role_arn
+  execution_role_arn = module.mwaa_execution_iam_role.arn
 
   kms_key = module.mwaa_kms.key_arn
 
@@ -28,8 +28,8 @@ resource "aws_mwaa_environment" "main" {
     "smtp.smtp_host"                     = "email-smtp.${data.aws_region.current.region}.amazonaws.com"
     "smtp.smtp_port"                     = 587
     "smtp.smtp_starttls"                 = 1
-    "smtp.smtp_user"                     = module.mwaa_ses_iam_user.iam_access_key_id
-    "smtp.smtp_password"                 = module.mwaa_ses_iam_user.iam_access_key_ses_smtp_password_v4
+    "smtp.smtp_user"                     = module.mwaa_ses_iam_user.access_key_id
+    "smtp.smtp_password"                 = module.mwaa_ses_iam_user.access_key_ses_smtp_password_v4
     "smtp.smtp_mail_from"                = "noreply@${local.environment_configuration.route53_zone}"
     "webserver.warn_deployment_exposure" = 0
     "webserver.base_url"                 = "airflow.${local.environment_configuration.route53_zone}"

--- a/terraform/environments/analytical-platform-compute/airflow/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/s3-buckets.tf
@@ -3,7 +3,7 @@ module "mwaa_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.2.0"
+  version = "5.13.0"
 
   bucket = "mojap-compute-${local.environment}-mwaa"
 

--- a/terraform/environments/analytical-platform-compute/airflow/s3-objects.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/s3-objects.tf
@@ -3,7 +3,7 @@ module "airflow_requirements_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "5.2.0"
+  version = "5.13.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "requirements.txt"
@@ -19,7 +19,7 @@ module "airflow_kube_config_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "5.2.0"
+  version = "5.13.0"
 
   bucket = module.mwaa_bucket.s3_bucket_id
   key    = "dags/.kube/config"
@@ -38,7 +38,7 @@ module "airflow_plugins_object" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/object"
-  version = "5.2.0"
+  version = "5.13.0"
 
   bucket        = module.mwaa_bucket.s3_bucket_id
   key           = "plugins.zip"

--- a/terraform/environments/analytical-platform-compute/airflow/versions.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/versions.tf
@@ -1,25 +1,25 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     archive = {
-      version = "~> 2.0"
+      version = "~> 2.8"
       source  = "hashicorp/archive"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform, all provider constraints, and multiple Terraform AWS modules. Also migrates `kubernetes_namespace` → `kubernetes_namespace_v1` as required by the kubernetes provider 3.x deprecation. IAM module resources updated to v6 API (`iam-role`, `iam-policy`, `iam-user`).

## Version changes

| File | Component | Current | New | |
|---|---|---|---|---|
| `versions.tf` | `hashicorp/aws` | `~> 6.0` | `~> 6.46` | ⬆️ |
| `versions.tf` | `hashicorp/dns` | `~> 3.0` | `~> 3.6` | ⬆️ |
| `versions.tf` | `hashicorp/external` | `~> 2.0` | `~> 2.4` | ⬆️ |
| `versions.tf` | `hashicorp/http` | `~> 3.0` | `~> 3.6` | ⬆️ |
| `versions.tf` | `hashicorp/archive` | `~> 2.0` | `~> 2.8` | ⬆️ |
| `versions.tf` | `terraform` | `~> 1.10` | `~> 1.15` | ⬆️ |
| `alb.tf` | `terraform-aws-modules/alb` | `9.17.0` | `10.5.0` | ⬆️ |
| `iam-*.tf` | `terraform-aws-modules/iam` | `5.59.0` | `6.6.0` | ⬆️ |
| `kms-keys.tf` | `terraform-aws-modules/kms` | `4.0.0` | `4.2.0` | ⬆️ |
| `s3-*.tf` | `terraform-aws-modules/s3-bucket` | `5.2.0` | `5.13.0` | ⬆️ |
| `kubernetes-*.tf` | `kubernetes_namespace` | — | `kubernetes_namespace_v1` | 🔄 |
| `import.tf` | import + removed blocks | — | — | ✨ |

## Release changes

#### `hashicorp/aws` — `~> 6.0` → `~> 6.46`
- **v6.0.0** — feat: per-resource region attribute added to most resources — manage multi-region infra without multiple provider configs
- **v6.42.0** — breaking: `aws_mq_configuration` destroy now actually deletes the resource (previously a no-op)
- **v6.46.0** — breaking: `aws_xray_resource_policy` changes to `policy_name` now force recreation

#### `terraform-aws-modules/iam` — `5.59.0` → `6.6.0`
- **v6.0.0** — breaking: `iam-assumable-role` renamed to `iam-role` with new API
- **v6.0.0** — breaking: `iam-github-oidc-role` merged into `iam-role` (`enable_github_oidc = true`)
- **v6.0.0** — breaking: `iam-user` `policy_arns` → `policies` map; `create_iam_user_login_profile` → `create_login_profile`
- **v6.0.0** — breaking: output renames — `iam_role_arn` → `arn`, `iam_access_key_id` → `access_key_id`, `iam_access_key_ses_smtp_password_v4` → `access_key_ses_smtp_password_v4`

#### `terraform-aws-modules/alb` — `9.17.0` → `10.5.0`
- **v10.0.0** — breaking: requires AWS provider >= 6.0 (satisfied by this upgrade)

#### `terraform-aws-modules/kms` — `4.0.0` → `4.2.0`
- **v4.1.0** — feat: additional key policy statement support

#### `terraform-aws-modules/s3-bucket` — `5.2.0` → `5.13.0`
- **v5.x** — feat: various ACL and lifecycle rule improvements

#### `hashicorp/kubernetes` — `_v1` resource migration
Kubernetes provider 3.x deprecates all non-suffixed resources. Migrated:
`kubernetes_namespace`, `kubernetes_role`, `kubernetes_role_binding`,
`kubernetes_service_account` → `_v1` equivalents.
`import.tf` adds `import` + `removed` blocks to transition state without destroy/recreate.

PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.