### PR TITLE
add tag backup false

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/eks-cluster.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/eks-cluster.tf
@@ -95,6 +95,10 @@ module "eks" {
       desired_size   = 3
       instance_types = ["m6a.xlarge"]
 
+      launch_template_tags = merge(local.tags, {
+        backup = "false"
+      })
+
       use_latest_ami_release_version = false
       ami_release_version            = local.environment_configuration.eks_node_version
       ami_type                       = "BOTTLEROCKET_x86_64"
@@ -139,6 +143,11 @@ module "eks" {
       max_size       = 1
       desired_size   = 0
       instance_types = ["r7i.8xlarge"]
+
+      launch_template_tags = merge(local.tags, {
+        backup = "false"
+      })
+
       labels = {
         high-memory = "true"
       }

--- a/terraform/environments/analytical-platform-compute/cluster/src/helm/charts/karpenter-configuration/templates/ec2-node-class-bottlerocket-general.yaml
+++ b/terraform/environments/analytical-platform-compute/cluster/src/helm/charts/karpenter-configuration/templates/ec2-node-class-bottlerocket-general.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   amiFamily: Bottlerocket
   role: {{ .Values.nodeRole }}
+  tags:
+    backup: "false"
   subnetSelectorTerms:
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}

--- a/terraform/environments/analytical-platform-compute/cluster/src/helm/charts/karpenter-configuration/templates/ec2-node-class-bottlerocket-gpu.yaml
+++ b/terraform/environments/analytical-platform-compute/cluster/src/helm/charts/karpenter-configuration/templates/ec2-node-class-bottlerocket-gpu.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   amiFamily: Bottlerocket
   role: {{ .Values.nodeRole }}
+  tags:
+    backup: "false"
   subnetSelectorTerms:
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}


### PR DESCRIPTION
This pull request introduces updates to both Terraform and Helm configuration files to ensure that EKS nodes and Karpenter-managed node classes are tagged with `backup: "false"`. This change standardizes the backup tagging policy across different node groups, making it explicit that these nodes should not be included in backup processes.

**Tagging updates for EKS node groups and Karpenter node classes:**

*Terraform EKS node group updates:*
- Added `launch_template_tags` with `backup = "false"` to the general-purpose node group in `eks-cluster.tf`, ensuring these nodes are excluded from backup routines.
- Added `launch_template_tags` with `backup = "false"` to the high-memory node group in `eks-cluster.tf`, applying the same backup exclusion policy.

*Helm Karpenter node class updates:*
- Added `tags: backup: "false"` to the Bottlerocket general node class Helm template, so Karpenter-managed nodes are also excluded from backups.
- Added `tags: backup: "false"` to the Bottlerocket GPU node class Helm template for consistent backup exclusion.

This work is been tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?reload=1&pane=issue&itemId=118770543&issue=ministryofjustice%7Canalytical-platform%7C8078)