### PR TITLE
Fix SQL Server integer metadata generation for TEMPUS DMS metadata

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/modules/dms/lambda-functions/metadata_generator/main.py
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/lambda-functions/metadata_generator/main.py
@@ -244,6 +244,16 @@ class MetadataExtractor:
         if self.dialect in self.upper_case_dialects:
             etlmeta.location = etlmeta.location.upper()
         etl_dict = etlmeta.to_dict()
+
+        if self._dialect_is_mssql():
+            for column in etl_dict.get("columns", []):
+                if str(column.get("type", "")).lower() == "int":
+                    logger.info(
+                        "Converting ETL metadata column %s type from int to decimal",
+                        column.get("name"),
+                    )
+                    column["type"] = "decimal"
+                    
         etl_dict["partitions"] = None
         return json.dumps(etl_dict)
 


### PR DESCRIPTION
Updated convert_metadata() so, after EtlManagerConverter produces the final ETL metadata JSON, SQL Server columns with "type": "int" are rewritten to "type": "decimal".