### PR TITLE
Feature/add name tag

### DIFF
--- a/.github/workflows/cloud-platform-reusable.yml
+++ b/.github/workflows/cloud-platform-reusable.yml
@@ -58,6 +58,7 @@ jobs:
       application: ${{ inputs.application }}
       environment: ${{ inputs.environment }}
       action: ${{ inputs.action }}
+      plan_apply_tfargs: ${{ format('-var=created_by={0}/{1}/actions/runs/{2}/', github.server_url, github.repository, github.run_id) }}
       component: "cluster"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -165,5 +165,8 @@ module "eks" {
     }
   }
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    null_resource.created_by_tag.triggers.created_by == "__unset__" ? {} : { "created-by" = null_resource.created_by_tag.triggers.created_by }
+  )
 }

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -1,0 +1,21 @@
+variable "created_by" {
+  type        = string
+  default     = null
+  description = "User or system identifier to stamp into the immutable created-by tag (set via TF_VAR_created_by on first apply)."
+
+  validation {
+    condition     = var.created_by == null || length(trimspace(var.created_by)) > 0
+    error_message = "created_by must not be empty."
+  }
+}
+
+resource "null_resource" "created_by_tag" {
+  triggers = {
+    # Persist the initial creator value in state; ignore future tf var changes.
+    created_by = coalesce(var.created_by, "__unset__")
+  }
+
+  lifecycle {
+    ignore_changes = [triggers["created_by"]]
+  }
+}


### PR DESCRIPTION
Add a created_by tag for CP clusters and update the CP workflow to pass in the job ID of the workflow which created the cluster.

- add created_by input with null default and validation
- persist first created_by value via null_resource trigger 
- merge created-by into EKS module tags only when provided