### PR TITLE
add s3 bucket for db migration

### DIFF
--- a/terraform/environments/cdpt-chaps/application_variables.json
+++ b/terraform/environments/cdpt-chaps/application_variables.json
@@ -17,7 +17,10 @@
       "container_port": 80,
       "dotnet_client_id": "37156e23-43dd-4325-ae36-f998ce4c32ff",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
-      "CallbackPath": "/signin-oidc"
+      "CallbackPath": "/signin-oidc",
+      "cp_db_migration_copy_irsa_role_arn": "arn:aws:iam::754256621582:role/cloud-platform-irsa-c5c488d70a0c0af2-live",
+      "db_migration_prefix": "native-backups/dev",
+      "db_migration_name": "dev"
     },
     "preproduction": {
       "db_instance_class": "db.t3.2xlarge",
@@ -36,7 +39,10 @@
       "container_port": 80,
       "dotnet_client_id": "efdcd721-93a1-46c1-b0da-29532763b12d",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
-      "CallbackPath": "/signin-oidc"
+      "CallbackPath": "/signin-oidc",
+      "cp_db_migration_copy_irsa_role_arn": "",
+      "db_migration_prefix": "native-backups/staging",
+      "db_migration_name": "staging"
     },
     "production": {
       "db_instance_class": "db.t3.2xlarge",
@@ -55,7 +61,10 @@
       "container_port": 80,
       "dotnet_client_id": "7361e073-5dc6-43a2-80fb-6cbb742166bb",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
-      "CallbackPath": "/signin-oidc"
+      "CallbackPath": "/signin-oidc",
+      "cp_db_migration_copy_irsa_role_arn": "",
+      "db_migration_prefix": "native-backups/prod",
+      "db_migration_name": "prod"
     }
   }
 }

--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,8 +3,8 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
-
+  #source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
     aws.share-tenant = aws          # The default provider (unaliased, `aws`) is the tenant

--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,7 +3,6 @@ locals {
 }
 
 module "bastion_linux" {
-  #source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
   source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
     aws.share-tenant = aws          # The default provider (unaliased, `aws`) is the tenant

--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/cdpt-chaps/database.tf
+++ b/terraform/environments/cdpt-chaps/database.tf
@@ -17,8 +17,7 @@ resource "aws_db_instance" "database" {
   publicly_accessible       = false
   ca_cert_identifier        = "rds-ca-rsa2048-g1"
   apply_immediately         = true
-
-
+  option_group_name         = aws_db_option_group.sqlserver_native_backup.name
 }
 
 resource "aws_db_subnet_group" "db" {
@@ -50,6 +49,7 @@ resource "aws_security_group" "db" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
 
 #--------------------------
 # KMS setup for RDS

--- a/terraform/environments/cdpt-chaps/database.tf
+++ b/terraform/environments/cdpt-chaps/database.tf
@@ -50,7 +50,6 @@ resource "aws_security_group" "db" {
   }
 }
 
-
 #--------------------------
 # KMS setup for RDS
 #--------------------------

--- a/terraform/environments/cdpt-chaps/db_native_backup.tf
+++ b/terraform/environments/cdpt-chaps/db_native_backup.tf
@@ -1,6 +1,6 @@
 resource "aws_db_option_group" "sqlserver_native_backup" {
   name                     = local.native_backup_option_group
-  option_group_description = "CHAPS prod SQL Server native backup to S3"
+  option_group_description = "CHAPS dev SQL Server native backup to S3"
   engine_name              = "sqlserver-web"
   major_engine_version     = "14.00"
 

--- a/terraform/environments/cdpt-chaps/db_native_backup.tf
+++ b/terraform/environments/cdpt-chaps/db_native_backup.tf
@@ -14,4 +14,7 @@ resource "aws_db_option_group" "sqlserver_native_backup" {
   }
 
   tags = local.tags
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform/environments/cdpt-chaps/db_native_backup.tf
+++ b/terraform/environments/cdpt-chaps/db_native_backup.tf
@@ -1,6 +1,6 @@
 resource "aws_db_option_group" "sqlserver_native_backup" {
   name                     = local.native_backup_option_group
-  option_group_description = "CHAPS dev SQL Server native backup to S3"
+  option_group_description = "CHAPS ${local.environment} SQL Server native backup to S3"
   engine_name              = "sqlserver-web"
   major_engine_version     = "14.00"
 

--- a/terraform/environments/cdpt-chaps/db_native_backup.tf
+++ b/terraform/environments/cdpt-chaps/db_native_backup.tf
@@ -1,0 +1,17 @@
+resource "aws_db_option_group" "sqlserver_native_backup" {
+  name                     = local.native_backup_option_group
+  option_group_description = "CHAPS prod SQL Server native backup to S3"
+  engine_name              = "sqlserver-web"
+  major_engine_version     = "14.00"
+
+  option {
+    option_name = "SQLSERVER_BACKUP_RESTORE"
+
+    option_settings {
+      name  = "IAM_ROLE_ARN"
+      value = aws_iam_role.rds_native_backup.arn
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -339,15 +339,15 @@ resource "aws_security_group" "cluster_ec2" {
   )
 }
 
-resource "aws_security_group_rule" "cluster_ec2_rpd_from_bastion" {
-  type                      = "ingress"
-  description               = "Allow RDP ingress"
-  from_port                 = "3389"
-  to_port                   = "3389"
-  protocol                  = "tcp"
-  security_group_id         = aws_security_group.cluster_ec2.id
-  source_security_group_id  = module.bastion_linux.bastion_security_group
-}
+#resource "aws_security_group_rule" "cluster_ec2_rpd_from_bastion" {
+  #type                      = "ingress"
+ # description               = "Allow RDP ingress"
+  #from_port                 = "3389"
+  #to_port                   = "3389"
+  #protocol                  = "tcp"
+ # security_group_id         = aws_security_group.cluster_ec2.id
+  #source_security_group_id  = module.bastion_linux.bastion_security_group
+#}
 
 # EC2 launch template - settings to use for new EC2s added to the group
 # Note - when updating this you will need to manually terminate the EC2s

--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -339,15 +339,15 @@ resource "aws_security_group" "cluster_ec2" {
   )
 }
 
-#resource "aws_security_group_rule" "cluster_ec2_rpd_from_bastion" {
-  #type                      = "ingress"
- # description               = "Allow RDP ingress"
-  #from_port                 = "3389"
-  #to_port                   = "3389"
-  #protocol                  = "tcp"
- # security_group_id         = aws_security_group.cluster_ec2.id
-  #source_security_group_id  = module.bastion_linux.bastion_security_group
-#}
+resource "aws_security_group_rule" "cluster_ec2_rdp_from_bastion" {
+  type                     = "ingress"
+  description              = "Allow RDP ingress"
+  from_port                = 3389
+  to_port                  = 3389
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cluster_ec2.id
+  source_security_group_id = module.bastion_linux.bastion_security_group
+}
 
 # EC2 launch template - settings to use for new EC2s added to the group
 # Note - when updating this you will need to manually terminate the EC2s

--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -323,14 +323,6 @@ resource "aws_security_group" "cluster_ec2" {
     security_groups = [module.lb_access_logs_enabled.security_group.id]
   }
 
-  ingress {
-    description     = "Allow RDP ingress"
-    from_port       = 3389
-    to_port         = 3389
-    protocol        = "tcp"
-    security_groups = [module.bastion_linux.bastion_security_group]
-  }
-
   egress {
     description = "Cluster EC2 loadbalancer egress rule"
     from_port   = 0
@@ -345,6 +337,16 @@ resource "aws_security_group" "cluster_ec2" {
       Name = "${local.application_name}-cluster-ec2-security-group"
     }
   )
+}
+
+resource "aws_security_group_rule" "cluster_ec2_rpd_from_bastion" {
+  type                      = "ingress"
+  description               = "Allow RDP ingress"
+  from_port                 = "3389"
+  to_port                   = "3389"
+  protocol                  = "tcp"
+  security_group_id         = aws_security_group.cluster_ec2.id
+  source_security_group_id  = module.bastion_linux.bastion_security_group
 }
 
 # EC2 launch template - settings to use for new EC2s added to the group

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -67,7 +67,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
   bucket = aws_s3_bucket.db_migration.id
 
   rule {
-    id     = "expire-prod-db-migration-backups"
+    id     = "expire-dev-db-migration-backups"
     status = "Enabled"
 
     filter {

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -1,10 +1,10 @@
 locals {
-  db_migration_bucket_name = "cdpt-chaps-prod-db-migration-${data.aws_caller_identity.current.account_id}"
-  db_migration_prefix      = "native-backups/prod"
+  db_migration_bucket_name = "cdpt-chaps-dev-db-migration-${data.aws_caller_identity.current.account_id}"
+  db_migration_prefix      = "native-backups/dev"
 }
 
 resource "aws_kms_key" "db_migration" {
-  description             = "CHAPS production database migration S3 encryption key"
+  description             = "CHAPS dev database migration S3 encryption key"
   deletion_window_in_days = 30
   enable_key_rotation     = true
 
@@ -12,7 +12,7 @@ resource "aws_kms_key" "db_migration" {
 }
 
 resource "aws_kms_alias" "db_migration" {
-  name          = "alias/chaps-prod-db-migration"
+  name          = "alias/chaps-dev-db-migration"
   target_key_id = aws_kms_key.db_migration.key_id
 }
 
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "db_migration" {
 
   tags = merge(local.tags, {
     Name    = local.db_migration_bucket_name
-    Purpose = "CHAPS production database migration"
+    Purpose = "CHAPS dev database migration"
   })
 }
 

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -4,9 +4,10 @@ locals {
 }
 
 resource "aws_kms_key" "db_migration" {
-  description             = "CHAPS dev database migration S3 encryption key"
+  description             = "CHAPS ${local.environment} database migration S3 encryption key"
   deletion_window_in_days = 30
   enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.db_migration_kms.json
 
   tags = local.tags
 }

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -1,6 +1,6 @@
 locals {
   db_migration_name        = local.application_data.accounts[local.environment].db_migration_name
-  db_migration_bucket_name = "cdpt-chaps-${local.application_data.accounts[local.environment].environment_name}-db-migration-${data.aws_caller_identity.current.account_id}"
+  db_migration_bucket_name = "cdpt-chaps-${local.db_migration_name}-db-migration-${data.aws_caller_identity.current.account_id}"
   db_migration_prefix      = local.application_data.accounts[local.environment].db_migration_prefix
 }
 
@@ -14,7 +14,7 @@ resource "aws_kms_key" "db_migration" {
 }
 
 resource "aws_kms_alias" "db_migration" {
-  name          = "alias/chaps-dev-db-migration"
+  name          = "alias/chaps-${local.db_migration_name}-db-migration"
   target_key_id = aws_kms_key.db_migration.key_id
 }
 

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -1,0 +1,85 @@
+locals {
+  db_migration_bucket_name = "cdpt-chaps-prod-db-migration-${data.aws_caller_identity.current.account_id}"
+  db_migration_prefix      = "native-backups/prod"
+}
+
+resource "aws_kms_key" "db_migration" {
+  description             = "CHAPS production database migration S3 encryption key"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+resource "aws_kms_alias" "db_migration" {
+  name          = "alias/chaps-prod-db-migration"
+  target_key_id = aws_kms_key.db_migration.key_id
+}
+
+resource "aws_s3_bucket" "db_migration" {
+  bucket = local.db_migration_bucket_name
+
+  tags = merge(local.tags, {
+    Name    = local.db_migration_bucket_name
+    Purpose = "CHAPS production database migration"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.db_migration.arn
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+
+  rule {
+    id     = "expire-prod-db-migration-backups"
+    status = "Enabled"
+
+    filter {
+      prefix = "${local.db_migration_prefix}/"
+    }
+
+    expiration {
+      days = 14
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+  }
+}

--- a/terraform/environments/cdpt-chaps/s3_db_migration.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration.tf
@@ -1,6 +1,7 @@
 locals {
-  db_migration_bucket_name = "cdpt-chaps-dev-db-migration-${data.aws_caller_identity.current.account_id}"
-  db_migration_prefix      = "native-backups/dev"
+  db_migration_name        = local.application_data.accounts[local.environment].db_migration_name
+  db_migration_bucket_name = "cdpt-chaps-${local.application_data.accounts[local.environment].environment_name}-db-migration-${data.aws_caller_identity.current.account_id}"
+  db_migration_prefix      = local.application_data.accounts[local.environment].db_migration_prefix
 }
 
 resource "aws_kms_key" "db_migration" {
@@ -22,7 +23,7 @@ resource "aws_s3_bucket" "db_migration" {
 
   tags = merge(local.tags, {
     Name    = local.db_migration_bucket_name
-    Purpose = "CHAPS dev database migration"
+    Purpose = "CHAPS ${local.application_data.accounts[local.environment].environment_name} database migration"
   })
 }
 
@@ -68,7 +69,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "db_migration" {
   bucket = aws_s3_bucket.db_migration.id
 
   rule {
-    id     = "expire-dev-db-migration-backups"
+    id     = "expire-${local.application_data.accounts[local.environment].environment_name}-db-migration-backups"
     status = "Enabled"
 
     filter {

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -141,6 +141,23 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
   }
 
   statement {
+    sid = "AllowCpMigrationCopyRoleToGetBucketLocation"
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+    }
+
+    actions = [
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+  }
+
+  statement {
     sid = "AllowCpMigrationCopyRoleToListBackupPrefix"
 
     principals {
@@ -149,7 +166,6 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
     }
 
     actions = [
-      "s3:GetBucketLocation",
       "s3:ListBucket"
     ]
 

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,7 +1,7 @@
 locals {
-  source_db_identifier           = "chaps-prod-instance"
-  native_backup_option_group     = "chaps-prod-sqlserver-native-backup"
-  mp_rds_native_backup_role_name = "chaps-prod-rds-native-backup"
+  source_db_identifier           = "db-chaps-dev"
+  native_backup_option_group     = "chaps-dev-sqlserver-native-backup"
+  mp_rds_native_backup_role_name = "chaps-dev-rds-native-backup"
 }
 
 data "aws_iam_policy_document" "rds_native_backup_assume_role" {
@@ -144,3 +144,14 @@ resource "aws_s3_bucket_policy" "db_migration" {
   bucket = aws_s3_bucket.db_migration.id
   policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
 }
+
+output "db_migration_kms_key_arn" {
+  value       = aws_kms_key.db_migration.arn
+  description = "KMS key ARN for the CHAPS dev DB migration S3 bucket"
+}
+
+output "db_migration_bucket_name" {
+  value       = aws_s3_bucket.db_migration.bucket
+  description = "S3 bucket containing CHAPS dev DB migration backups"
+}
+

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,8 +1,8 @@
 locals {
-  source_db_identifier                = "db-chaps-dev"
+  source_db_identifier                = local.application_data.accounts[local.environment].db_instance_identifier
   native_backup_option_group          = "chaps-${local.environment}-sqlserver-native-backup"
   mp_rds_native_backup_role_name      = "chaps-${local.environment}-rds-native-backup"
-  cp_db_migration_copy_irsa_role_arn  = "arn:aws:iam::754256621582:role/cloud-platform-irsa-c5c488d70a0c0af2-live"
+  cp_db_migration_copy_irsa_role_arn  = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
 }
 
 data "aws_iam_policy_document" "rds_native_backup_assume_role" {
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
 }
 
 resource "aws_iam_policy" "rds_native_backup_s3_kms" {
-  name   = "chaps-dev-rds-native-backup-s3-kms"
+  name   = "chaps-${local.db_migration_name}-rds-native-backup-s3-kms"
   policy = data.aws_iam_policy_document.rds_native_backup_s3_kms.json
 }
 
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
     }
 
     actions = [
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type = "AWS"
-      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
     }
 
     actions = [
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type    = "AWS"
-      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
     }
 
     actions = [
@@ -255,17 +255,17 @@ data "aws_iam_policy_document" "db_migration_kms" {
 
     principals {
       type = "AWS"
-      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
     }
   }
 }
 
 output "db_migration_kms_key_arn" {
   value       = aws_kms_key.db_migration.arn
-  description = "KMS key ARN for the CHAPS dev DB migration S3 bucket"
+  description = "KMS key ARN for the CHAPS DB migration S3 bucket"
 }
 
 output "db_migration_bucket_name" {
   value       = aws_s3_bucket.db_migration.bucket
-  description = "S3 bucket containing CHAPS dev DB migration backups"
+  description = "S3 bucket containing CHAPS DB migration backups"
 }

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
 
     actions = [
       "s3:GetObject",
-      "s3.GetObjectAttributes",
+      "s3:GetObjectAttributes",
       "s3:PutObject",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload"

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,7 +1,7 @@
 locals {
   source_db_identifier           = "db-chaps-dev"
-  native_backup_option_group     = "chaps-dev-sqlserver-native-backup"
-  mp_rds_native_backup_role_name = "chaps-dev-rds-native-backup"
+  native_backup_option_group     = "chaps-${local.environment}-sqlserver-native-backup"
+  mp_rds_native_backup_role_name = "chaps-${local.environment}-rds-native-backup"
 }
 
 data "aws_iam_policy_document" "rds_native_backup_assume_role" {
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
 }
 
 resource "aws_iam_policy" "rds_native_backup_s3_kms" {
-  name   = "chaps-prod-rds-native-backup-s3-kms"
+  name   = "chaps-dev-rds-native-backup-s3-kms"
   policy = data.aws_iam_policy_document.rds_native_backup_s3_kms.json
 }
 

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,7 +1,8 @@
 locals {
-  source_db_identifier           = "db-chaps-dev"
-  native_backup_option_group     = "chaps-${local.environment}-sqlserver-native-backup"
-  mp_rds_native_backup_role_name = "chaps-${local.environment}-rds-native-backup"
+  source_db_identifier                = "db-chaps-dev"
+  native_backup_option_group          = "chaps-${local.environment}-sqlserver-native-backup"
+  mp_rds_native_backup_role_name      = "chaps-${local.environment}-rds-native-backup"
+  cp_db_migration_copy_irsa_role_arn  = "arn:aws:iam::754256621582:role/cloud-platform-irsa-c5c488d70a0c0af2-live"
 }
 
 data "aws_iam_policy_document" "rds_native_backup_assume_role" {
@@ -138,11 +139,107 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
       values = ["false"]
     }
   }
+
+  statement {
+    sid = "AllowCpMigrationCopyRoleToListBackupPrefix"
+
+    principals {
+      type = "AWS"
+      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+    }
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+
+    condition {
+      test = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/*"
+      ]
+    }
+  }
+
+  statement {
+    sid = "AllowCpMigrationCopyRoleToReadBackupObjects"
+
+    principals {
+      type    = "AWS"
+      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+      ]
+  }
 }
 
 resource "aws_s3_bucket_policy" "db_migration" {
   bucket = aws_s3_bucket.db_migration.id
   policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "db_migration_kms" {
+  statement {
+    sid = "allowAccountRoot"
+    effect = "Allow"
+    actions = ["kms:*"]
+
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid = "AllowMpRdsNativeBackupRole"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [aws_iam_role.rds_native_backup.arn]
+    }
+  }
+
+  statement {
+    sid = "AllowCpMigrationCopyRoleToDecrypt"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [local.cp_db_migration_copy_irsa_role_arn]
+    }
+  }
 }
 
 output "db_migration_kms_key_arn" {

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -146,7 +146,9 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      identifiers = [
+        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      ]
     }
 
     actions = [
@@ -163,7 +165,9 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type = "AWS"
-      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      identifiers = [
+        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      ]
     }
 
     actions = [
@@ -190,7 +194,9 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
 
     principals {
       type    = "AWS"
-      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      identifiers = [
+        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      ]
     }
 
     actions = [
@@ -255,7 +261,9 @@ data "aws_iam_policy_document" "db_migration_kms" {
 
     principals {
       type = "AWS"
-      identifiers = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      identifiers = [
+        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      ]
     }
   }
 }

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,0 +1,146 @@
+locals {
+  source_db_identifier           = "chaps-prod-instance"
+  native_backup_option_group     = "chaps-prod-sqlserver-native-backup"
+  mp_rds_native_backup_role_name = "chaps-prod-rds-native-backup"
+}
+
+data "aws_iam_policy_document" "rds_native_backup_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${local.source_db_identifier}",
+        "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:og:${local.native_backup_option_group}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_native_backup" {
+  name               = local.mp_rds_native_backup_role_name
+  assume_role_policy = data.aws_iam_policy_document.rds_native_backup_assume_role.json
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
+  statement {
+    sid = "GetMigrationBucketLocation"
+
+    actions = [
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+  }
+
+  statement {
+    sid = "ListMigrationBucketPrefix"
+
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn
+    ]
+
+    condition {
+      test      = "StringLike"
+      variable  = "s3:prefix"
+      values = [
+        local.db_migration_prefix,
+        "${local.db_migration_prefix}/*"
+      ]
+    }
+  }
+
+  statement {
+    sid = "ReadWriteMigrationObjects"
+
+    actions = [
+      "s3:GetObject",
+      "s3.GetObjectAttributes",
+      "s3:PutObject",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+    ]
+  }
+
+  statement {
+    sid = "UseMigrationKmsKeyForBackup"
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      aws_kms_key.db_migration.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "rds_native_backup_s3" {
+  name   = "chaps-prod-rds-native-backup-s3-kms"
+  policy = data.aws_iam_policy_document.rds_native_backup_s3_kms.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_native_backup_s3_kms" {
+  role       = aws_iam_role.rds_native_backup.name
+  policy_arn = aws_iam_policy.rds_native_backup_s3_kms.arn
+}
+
+data "aws_iam_policy_document" "db_migration_bucket_policy" {
+  statement {
+    sid = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.db_migration.arn,
+      "${aws_s3_bucket.db_migration.arn}/*"
+    ]
+
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "db_migration" {
+  bucket = aws_s3_bucket.db_migration.id
+  policy = data.aws_iam_policy_document.db_migration_bucket_policy.json
+}

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -105,7 +105,7 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
   }
 }
 
-resource "aws_iam_policy" "rds_native_backup_s3" {
+resource "aws_iam_policy" "rds_native_backup_s3_kms" {
   name   = "chaps-prod-rds-native-backup-s3-kms"
   policy = data.aws_iam_policy_document.rds_native_backup_s3_kms.json
 }

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -269,4 +269,3 @@ output "db_migration_bucket_name" {
   value       = aws_s3_bucket.db_migration.bucket
   description = "S3 bucket containing CHAPS dev DB migration backups"
 }
-

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -179,7 +179,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
       variable = "s3:prefix"
       values = [
         local.db_migration_prefix,
-        "${local.db_migration_prefix}/"
+        "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"
       ]
     }

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -69,6 +69,7 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
       variable  = "s3:prefix"
       values = [
         local.db_migration_prefix,
+        "${local.db_migration_prefix}/",
         "${local.db_migration_prefix}/*"
       ]
     }
@@ -178,6 +179,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
       variable = "s3:prefix"
       values = [
         local.db_migration_prefix,
+        "${local.db_migration_prefix}/"
         "${local.db_migration_prefix}/*"
       ]
     }


### PR DESCRIPTION
**Summary**

Adds the Modernisation Platform side of the CHAPS database migration path from MP RDS SQL Server to Cloud Platform RDS SQL Server.

This introduces native SQL Server backup support for RDS, creates an encrypted temporary S3/KMS migration bucket, and grants the matching Cloud Platform IRSA copy role read/decrypt access so .bak files can be copied securely into the CP migration bucket for restore.

**Changes**
Adds an environment-aware S3 migration bucket for native SQL Server backups.
Adds a KMS key and alias for encrypting migration backup objects.
Adds lifecycle expiry for temporary migration backup objects.
Adds an RDS native backup IAM role and policy.
Adds an RDS option group with SQLSERVER_BACKUP_RESTORE.
Attaches the option group to the existing RDS instance.
Adds bucket policy permissions for the CP IRSA copy role.
Adds KMS key policy permissions for the CP IRSA copy role to decrypt backup objects.
Refactors migration naming/prefixes to use per-environment values rather than hardcoded dev values.
Includes the bastion module fix/pin and security group rule refactor needed to keep the bastion working after the module update.
Why

The previous dev/staging migration route used local backup/export handling, which is not suitable for production data.

The new route is:

MP RDS SQL Server
→ native .bak backup to MP S3/KMS
→ CP IRSA copy job copies .bak to CP S3/KMS
→ CP RDS SQL Server restores from CP S3

This keeps production database backup files out of local machines and OneDrive.

**Validation**

Tested successfully in development:

MP RDS native backup completed successfully.
Backup file appeared in the MP S3 migration bucket.
CP IRSA role successfully copied the backup from MP S3/KMS to CP S3/KMS.
CP RDS restored the copied .bak successfully.
Restored database contents were checked against the expected source DB.
Confirmed the restore created a separate database on the same CP RDS endpoint.
Confirmed the old CP database was not being inspected by mistake.
Bastion issue caused by the older module/AMI architecture mismatch was fixed and the dev bastion is now running.
Deployment notes

For each environment, the order is:

1. Apply MP base resources to create MP S3/KMS and RDS native backup support.
2. Apply CP resources to create CP S3/KMS, CP RDS restore access, and the CP IRSA copy role.
3. Add the CP IRSA role ARN back into the relevant MP environment variables.
4. Apply MP again to grant CP read/decrypt access to the MP bucket and KMS key.
5. Run backup/copy/restore.

For staging/prod, confirm the CP IRSA role ARN and KMS key ARN are environment-specific before applying.

**Risk**

Low risk to the existing RDS instance: the RDS change is an in-place option group update to enable native backup/restore. The development apply confirmed this works without replacing the DB.

The main operational risk is accidental replacement of migration S3 buckets if naming is changed after objects exist. Bucket names/prefixes have been made environment-aware while preserving the existing dev bucket naming pattern.