### PR TITLE
patch: litellm `1.84.0-rc.1` -> `1.86.2`

### DIFF
--- a/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/llm-gateway/environment-configuration.tf
@@ -3,8 +3,8 @@ locals {
   environment_configurations = {
     development = {
       litellm_versions = {
-        application = "1.84.0-rc.1"
-        chart       = "1.84.0-rc.1"
+        application = "1.86.2"
+        chart       = "1.86.2"
       }
       llm_gateway_hostname = "llm-gateway.development.data-platform.service.justice.gov.uk"
       llm_gateway_ingress_allowlist = [


### PR DESCRIPTION
This pull request updates the `litellm_versions` used in the development environment configuration for the LLM Gateway. The version for both the application and the chart has been upgraded.

- **Dependency Upgrades:**
  * Updated the `litellm_versions` for the development environment from `1.84.0-rc.1` to `1.86.2` for both the `application` and `chart` in `environment-configuration.tf`.