### PR TITLE
Feature/transfer family web app

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
@@ -72,13 +72,6 @@ module "transfer_web_app_role" {
 }
 
 resource "aws_transfer_web_app" "this" {
-  endpoint_details {
-    vpc {
-      security_group_ids = [aws_security_group.transfer.id]
-      subnet_ids         = module.isolated_vpc.public_subnets
-      vpc_id             = module.isolated_vpc.vpc_id
-    }
-  }
   identity_provider_details {
     identity_center_config {
       instance_arn = tolist(data.aws_ssoadmin_instances.main.arns)[0]

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
@@ -1,3 +1,7 @@
+data "aws_ssoadmin_instances" "main" {
+  provider = aws.sso-readonly
+}
+
 data "aws_iam_policy_document" "transfer_web_app" {
   statement {
     effect = "Allow"
@@ -77,8 +81,8 @@ resource "aws_transfer_web_app" "this" {
   }
   identity_provider_details {
     identity_center_config {
-      instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
-      role         = aws_iam_role.example.arn
+      instance_arn = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+      role         = module.transfer_web_app_role.arn
     }
   }
   web_app_units {

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
@@ -1,0 +1,87 @@
+data "aws_iam_policy_document" "transfer_web_app" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetDataAccess",
+      "s3:ListCallerAccessGrants",
+    ]
+    resources = ["arn:aws:s3:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:access-grants/*"]
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "s3:ResourceAccount"
+    }
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListAccessGrantsInstances"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "s3:ResourceAccount"
+    }
+  }
+}
+
+module "transfer_web_app_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.0"
+
+  name        = "${local.application_name}-transfer-web-app-policy"
+  description = "AWS Transfer web app access grants policy"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.transfer_web_app.json
+}
+
+module "transfer_web_app_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  create          = true
+  use_name_prefix = false
+  name            = "transfer_web_app"
+  description     = "AWS Transfer web app role"
+
+  trust_policy_permissions = {
+    AllowTransferWebApp = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole", "sts:SetContext"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+      condition = [{
+        test     = "StringEquals"
+        values   = [data.aws_caller_identity.current.account_id]
+        variable = "aws:SourceAccount"
+      }]
+    }
+  }
+
+  policies = {
+    transfer_web_app = module.transfer_web_app_policy.arn
+  }
+}
+
+resource "aws_transfer_web_app" "this" {
+  endpoint_details {
+    vpc {
+      security_group_ids = [aws_security_group.transfer.id]
+      subnet_ids         = module.isolated_vpc.public_subnets
+      vpc_id             = module.isolated_vpc.vpc_id
+    }
+  }
+  identity_provider_details {
+    identity_center_config {
+      instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+      role         = aws_iam_role.example.arn
+    }
+  }
+  web_app_units {
+    provisioned = 1
+  }
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary
- add `transfer-web-app.tf` to define an AWS Transfer Family web app in the managed-file-transfer stack
- add a dedicated identity bearer role and policy for the web app using the `terraform-aws-modules/iam/aws` registry modules
- configure the web app to use the central IAM Identity Center instance ARN together with the local bearer role
- use the default public HTTPS endpoint for the web app rather than a VPC-hosted endpoint

## Endpoint model
- this change creates a public Transfer Family web app endpoint because the resource no longer includes `endpoint_details.vpc`
- “public” here means network-reachable over HTTPS, not anonymously accessible
- end-user access is still gated by IAM Identity Center authentication, Transfer web app user or group assignment, and S3 Access Grants authorisation
- this PR does not add VPC-hosted endpoint plumbing such as dual-stack subnets, S3 Control PrivateLink, or S3 VPC endpoints

## IAM Identity Center interaction
- at Terraform apply time, `data.aws_ssoadmin_instances.main` uses the `aws.sso-readonly` provider to assume `ModernisationPlatformSSOReadOnly` in the organisation-managed delegated account and discover the IAM Identity Center instance ARN
- at runtime, the Transfer web app in the workload account is only configured with that `instance_arn`; AWS Transfer then uses its native integration with IAM Identity Center on the AWS control plane
- nothing in `integration-hub-development` directly assumes a role into the delegated account at runtime to query IAM Identity Center users or groups
- the only workload role managed here is `module.transfer_web_app_role`, which is the web app identity bearer role used for S3 Access Grants on behalf of the authenticated user

## Why this matters
- this change makes the control-plane split clearer: Terraform performs a one-time cross-account lookup for the central Identity Center instance ARN, while AWS Transfer handles the runtime integration with IAM Identity Center
- reviewers should not read this as a customer-managed runtime STS hop from the workload account into the delegated Identity Center account
- reviewers should also not read the public endpoint choice as bypassing identity controls; the security boundary is primarily identity and S3 Access Grants, not VPC reachability

## Validation
- `terraform fmt -check transfer-web-app.tf`

## Follow-up
- S3 Access Grants location role and grant registration are still needed for a fully working end-to-end web app
- if a private/VPC-hosted endpoint is required later, the VPC will need dual-stack subnets and the additional S3 Control and S3 endpoint work described in the AWS documentation

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>