### PR TITLE
chore(deps):upgrade terraform modules and provider versions

### DIFF
--- a/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/helm-charts-dashboard-service.tf
@@ -6,7 +6,7 @@ resource "helm_release" "dashboard_service" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "0.2.21"
   chart      = "dashboard-service"
-  namespace  = kubernetes_namespace.dashboard_service[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.dashboard_service[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/dashboard-service/values.yml.tftpl",

--- a/terraform/environments/analytical-platform-compute/dashboard-service/import.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/import.tf
@@ -1,0 +1,27 @@
+# This file is used to import the existing k8s reesources and iam polcies into Terraform state.Will be deleted after the import is complete and the state file is updated.
+
+#### NAMESPACE ######
+import {
+  to = kubernetes_namespace_v1.dashboard_service[0]
+  id = "dashboard-service"
+}
+
+removed {
+  from = kubernetes_namespace.dashboard_service
+  lifecycle {
+    destroy = false
+  }
+}
+
+#external secrets
+import {
+  to = kubernetes_secret_v1.dashboard_service_rds[0]
+  id = "dashboard-service/dashboard-service-rds"
+}
+
+removed {
+  from = kubernetes_secret.dashboard_service_rds
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/environments/analytical-platform-compute/dashboard-service/import.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/import.tf
@@ -2,8 +2,9 @@
 
 #### NAMESPACE ######
 import {
-  to = kubernetes_namespace_v1.dashboard_service[0]
-  id = "dashboard-service"
+  for_each = terraform.workspace != "analytical-platform-compute-test" ? { "0" = "dashboard-service" } : {}
+  to       = kubernetes_namespace_v1.dashboard_service[0]
+  id       = each.value
 }
 
 removed {
@@ -15,8 +16,10 @@ removed {
 
 #external secrets
 import {
-  to = kubernetes_secret_v1.dashboard_service_rds[0]
-  id = "dashboard-service/dashboard-service-rds"
+  for_each = terraform.workspace != "analytical-platform-compute-test" ? { "0" = "dashboard-service/dashboard-service-rds" } : {}
+  to       = kubernetes_secret_v1.dashboard_service_rds[0]
+  id       = each.value
+
 }
 
 removed {

--- a/terraform/environments/analytical-platform-compute/dashboard-service/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/kms-keys.tf
@@ -5,7 +5,7 @@ module "dashboard_service_rds_kms" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["rds/dashboard-service"]
   description           = "Dashboard Service RDS KMS key"

--- a/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-external-secrets.tf
@@ -8,7 +8,7 @@ resource "kubernetes_manifest" "dashboard_service_app_secrets_secret" {
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "dashboard-service-app-secrets"
-      "namespace" = kubernetes_namespace.dashboard_service[0].metadata[0].name
+      "namespace" = kubernetes_namespace_v1.dashboard_service[0].metadata[0].name
     }
     "spec" = {
       "refreshInterval" = "1m"

--- a/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-namespaces.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-namespaces.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "dashboard_service" {
+resource "kubernetes_namespace_v1" "dashboard_service" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   metadata {

--- a/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/kubernetes-secrets.tf
@@ -1,9 +1,9 @@
-resource "kubernetes_secret" "dashboard_service_rds" {
+resource "kubernetes_secret_v1" "dashboard_service_rds" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   metadata {
     name      = "dashboard-service-rds"
-    namespace = kubernetes_namespace.dashboard_service[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.dashboard_service[0].metadata[0].name
   }
 
   type = "Opaque"

--- a/terraform/environments/analytical-platform-compute/dashboard-service/providers.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/providers.tf
@@ -14,7 +14,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.eks.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.eks.token

--- a/terraform/environments/analytical-platform-compute/dashboard-service/rds.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/rds.tf
@@ -2,10 +2,11 @@ module "dashboard_service_rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
+  # module (version 7.2.0) is currently unsupported due to this open issue: https://github.com/hashicorp/terraform-provider-aws/issues/42582.
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "7.2.0"
+  version = "6.12.0"
 
   identifier = "dashboard-service"
 
@@ -29,8 +30,7 @@ module "dashboard_service_rds" {
   username                    = "dashboard_service"
   db_name                     = "dashboard_service"
   manage_master_user_password = false
-  password_wo                 = random_password.dashboard_service_rds[0].result
-  password_wo_version         = 1
+  password                    = random_password.dashboard_service_rds[0].result
   kms_key_id                  = module.dashboard_service_rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/rds.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/rds.tf
@@ -5,7 +5,7 @@ module "dashboard_service_rds" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.12.0"
+  version = "7.2.0"
 
   identifier = "dashboard-service"
 
@@ -29,7 +29,8 @@ module "dashboard_service_rds" {
   username                    = "dashboard_service"
   db_name                     = "dashboard_service"
   manage_master_user_password = false
-  password                    = random_password.dashboard_service_rds[0].result
+  password_wo                 = random_password.dashboard_service_rds[0].result
+  password_wo_version         = 1
   kms_key_id                  = module.dashboard_service_rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/dashboard-service/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/secrets.tf
@@ -5,7 +5,7 @@ module "dashboard_service_app_secrets" {
   count = terraform.workspace == "analytical-platform-compute-test" ? 0 : 1
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "dashboard-service/app-secrets"
   kms_key_id = data.aws_kms_key.common_secrets_manager_kms.arn

--- a/terraform/environments/analytical-platform-compute/dashboard-service/security-groups.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/security-groups.tf
@@ -4,7 +4,7 @@ module "rds_security_group" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/security-group/aws"
-  version = "5.3.0"
+  version = "5.3.1"
 
   name = "dashboard-service"
 

--- a/terraform/environments/analytical-platform-compute/dashboard-service/versions.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/versions.tf
@@ -1,33 +1,33 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     kubernetes = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/kubernetes"
     }
     helm = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/helm"
     }
     random = {
-      version = "~> 3.0"
+      version = "~> 3.9"
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform binary, all provider version constraints, and multiple Terraform AWS modules across the `analytical-platform-compute/dashboard-service` stack.

#### Version Changes

##### Terraform Binary

| File | Current | New |
|------|---------|-----|
| versions.tf | `~> 1.10` | `~> 1.15` |

##### Providers

| Provider | Current | New |
|----------|---------|-----|
| hashicorp/aws | `~> 6.0` | `~> 6.46` |
| hashicorp/dns | `~> 3.0` | `~> 3.6` |
| hashicorp/external | `~> 2.0` | `~> 2.4` |
| hashicorp/http | `~> 3.0` | `~> 3.6` |
| hashicorp/kubernetes | `~> 2.0` | `~> 3.1` |
| hashicorp/helm | `~> 2.0` | `~> 3.1` |
| hashicorp/random | `~> 3.0` | `~> 3.9` |

##### Terraform AWS Modules

| File | Module | Current | New |
|------|--------|---------|-----|
| kms-keys.tf | terraform-aws-modules/kms/aws | `4.0.0` | `4.2.0` |
| secrets.tf | terraform-aws-modules/secrets-manager/aws | `1.3.1` | `2.1.0` |
| security-groups.tf | terraform-aws-modules/security-group/aws | `5.3.0` | `5.3.1` |

---

#### Resource Migrations (hashicorp/kubernetes 3.x)

The `hashicorp/kubernetes` provider 3.x deprecates all non-versioned resource types. The following resources have been migrated to their `_v1` equivalents across `kubernetes-namespaces.tf` and `kubernetes-secrets.tf`:

| Old Resource | New Resource |
|--------------|--------------|
| `kubernetes_namespace` | `kubernetes_namespace_v1` |
| `kubernetes_secret` | `kubernetes_secret_v1` |

All namespace and secret references in `helm-charts-dashboard-service.tf`, `kubernetes-external-secrets.tf`, and `kubernetes-secrets.tf` have been updated to point to the new `_v1` resource addresses accordingly.

##### Helm Provider (3.x)

The `helm` provider 3.x changes the `kubernetes` block inside the `provider "helm"` configuration from a block-style argument to an assignment (`kubernetes = { ... }`). This has been updated in `providers.tf`.

---

### State Migration (import.tf)

A new `import.tf` file has been added to handle in-place state migration for all affected resources using Terraform's native `import` + `removed` block pattern. This ensures existing live Kubernetes resources are adopted into the new resource addresses without destruction or recreation. This file will be removed once the import is complete and the state file has been updated.

---

PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.