### PR TITLE
Exclude missing columns from CICA Tempus

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPFinishedJobs.json
+++ b/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPFinishedJobs.json
@@ -106,6 +106,10 @@
     },
     {
       "object_name": "dbo.FINISHED_JOB_HISTORY",
+      "column_name": "TARGET_PROCESS_ID"
+    },
+    {
+      "object_name": "dbo.FINISHED_JOB_HISTORY",
       "column_name": "TARGET_TIME_IN_SECONDS"
     },
     {

--- a/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPProcessPlatform.json
+++ b/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPProcessPlatform.json
@@ -466,6 +466,10 @@
     },
     {
       "object_name": "dbo.JOB_HISTORY",
+      "column_name": "TARGET_PROCESS_ID"
+    },
+    {
+      "object_name": "dbo.JOB_HISTORY",
       "column_name": "TARGET_TIME_IN_SECONDS"
     },
     {


### PR DESCRIPTION
Added `TARGET_PROCESS_ID` to the `columns_to_exclude` list for FINISHED_JOB_HISTORY and JOB_HISTORY  in the CICA Tempus metadata mapping.