### PR TITLE
✨ feat: add Transfer web app S3 access grants

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/iam.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/iam.tf
@@ -127,7 +127,7 @@ module "iam_for_transfer" {
 
   create          = true
   use_name_prefix = true
-  name            = "iam_for_transfer"
+  name            = "transfer-logging"
 
   trust_policy_permissions = {
     AllowTransferService = {

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -94,7 +94,7 @@ module "transfer_user_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
   version = "6.6.0"
 
-  name            = "${local.application_name}-transfer-user-role"
+  name            = "${local.application_name}-transfer-user"
   description     = "AWS Transfer User role"
   use_name_prefix = true
 

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
@@ -2,6 +2,12 @@ data "aws_ssoadmin_instances" "main" {
   provider = aws.sso-readonly
 }
 
+data "aws_identitystore_group" "integration_hub" {
+  provider          = aws.sso-readonly
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+  group_id          = "8662e2b4-3021-7017-56ba-8794aa2047cd" # "integration-hub" group ID in AWS SSO Identity Store
+}
+
 data "aws_iam_policy_document" "transfer_web_app" {
   statement {
     effect = "Allow"
@@ -47,7 +53,7 @@ module "transfer_web_app_role" {
 
   create          = true
   use_name_prefix = false
-  name            = "transfer_web_app"
+  name            = "transfer-web-app"
   description     = "AWS Transfer web app role"
 
   trust_policy_permissions = {
@@ -80,5 +86,136 @@ resource "aws_transfer_web_app" "this" {
   }
   web_app_units {
     provisioned = 1
+  }
+}
+
+resource "aws_s3control_access_grants_instance" "this" {
+  identity_center_arn = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+}
+
+data "aws_iam_policy_document" "s3_access_grants_location" {
+  statement {
+    sid    = "AllowUnscannedObjectWrites"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "${module.s3_bucket["unscanned"].s3_bucket_arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowUnscannedKMSWrites"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+    ]
+    resources = [
+      module.kms_s3_bucket["unscanned"].key_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "kms:CallerAccount"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
+      variable = "kms:ViaService"
+    }
+  }
+}
+
+module "s3_access_grants_location_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.0"
+
+  name        = "${local.application_name}-s3-access-grants-location-policy"
+  description = "AWS S3 Access Grants write access to the unscanned bucket"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.s3_access_grants_location.json
+}
+
+module "s3_access_grants_location_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
+
+  name            = "transfer-s3-access-grants-location"
+  use_name_prefix = false
+  description     = "Role to allow AWS S3 Access Grants to write to the unscanned bucket"
+
+  trust_policy_permissions = {
+    AllowAccessGrants = {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+        "sts:SetContext",
+        "sts:SetSourceIdentity",
+      ]
+
+      principals = [{
+        type        = "Service"
+        identifiers = ["access-grants.s3.amazonaws.com"]
+      }]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          values   = [data.aws_caller_identity.current.account_id]
+          variable = "aws:SourceAccount"
+        },
+        {
+          test     = "ArnEquals"
+          values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+          variable = "aws:SourceArn"
+        }
+      ]
+    }
+  }
+
+  policies = {
+    unscanned_access = module.s3_access_grants_location_policy.arn
+  }
+}
+
+resource "aws_s3control_access_grants_location" "unscanned" {
+  depends_on = [aws_s3control_access_grants_instance.this]
+
+  iam_role_arn   = module.s3_access_grants_location_role.arn
+  location_scope = "s3://${module.s3_bucket["unscanned"].s3_bucket_id}"
+}
+
+resource "aws_s3control_access_grant" "unscanned_uploaders" {
+  access_grants_location_id = aws_s3control_access_grants_location.unscanned.access_grants_location_id
+  permission                = "WRITE"
+
+  access_grants_location_configuration {
+    s3_sub_prefix = "*"
+  }
+
+  grantee {
+    grantee_type       = "DIRECTORY_GROUP"
+    grantee_identifier = data.aws_identitystore_group.integration_hub.group_id
   }
 }


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary
- Completes more of the AWS Transfer Family Web App configuration.
- Adds S3 Access Grants so the integration-hub group can write objects to the unscanned bucket.
- Adds the supporting IAM roles and policies, including write-only S3/KMS permissions for the Access Grants location.
- Tidies the related IAM role names so they are more consistent.

## Notes
- The Identity Store group lookup currently uses the known integration-hub group ID. The display-name alternate identifier path hits GetGroupId and returns Group not found, even though the group is visible via the list-groups data source. Sad trombone 🎺
- The older filter {} workaround is deprecated, so this keeps the implementation explicit rather than relying on a deprecated provider path.
- If the provider/API behaviour improves, this can be revisited and switched back to a display-name lookup.

## Testing
- terraform fmt transfer-web-app.tf
- terraform validate

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>