### PR TITLE
chore(deps):upgrade terraform modules and provider versions

### DIFF
--- a/terraform/environments/analytical-platform-compute/next/import.tf
+++ b/terraform/environments/analytical-platform-compute/next/import.tf
@@ -1,0 +1,29 @@
+# This file is used to import the existing k8s reesources into Terraform state.Will be deleted after the import is complete and the state file is updated.
+
+# secret 
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? toset(["0"]) : toset([])
+  to       = kubernetes_secret_v1.rds[0]
+  id       = "next/rds"
+}
+
+removed {
+  from = kubernetes_secret.rds
+  lifecycle {
+    destroy = false
+  }
+}
+
+
+# next namespace
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? toset(["0"]) : toset([])
+  to       = kubernetes_namespace_v1.main[0]
+  id       = local.component_name
+}
+removed {
+  from = kubernetes_namespace.main
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/environments/analytical-platform-compute/next/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/next/kms-keys.tf
@@ -5,7 +5,7 @@ module "rds_kms" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["rds/${local.component_name}"]
   enable_default_policy = true

--- a/terraform/environments/analytical-platform-compute/next/kubernetes-external-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/next/kubernetes-external-secrets.tf
@@ -8,7 +8,7 @@ resource "kubernetes_manifest" "azure_secrets" {
     "kind"       = "ExternalSecret"
     "metadata" = {
       "name"      = "azure"
-      "namespace" = kubernetes_namespace.main[0].metadata[0].name
+      "namespace" = kubernetes_namespace_v1.main[0].metadata[0].name
     }
     "spec" = {
       "secretStoreRef" = {

--- a/terraform/environments/analytical-platform-compute/next/kubernetes-namespaces.tf
+++ b/terraform/environments/analytical-platform-compute/next/kubernetes-namespaces.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "main" {
+resource "kubernetes_namespace_v1" "main" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
@@ -10,7 +10,3 @@ resource "kubernetes_namespace" "main" {
   }
 }
 
-moved {
-  from = kubernetes_namespace.next
-  to   = kubernetes_namespace.main
-}

--- a/terraform/environments/analytical-platform-compute/next/kubernetes-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/next/kubernetes-secrets.tf
@@ -1,10 +1,10 @@
-resource "kubernetes_secret" "rds" {
+resource "kubernetes_secret_v1" "rds" {
 
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
     name      = "rds"
-    namespace = kubernetes_namespace.main[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.main[0].metadata[0].name
   }
 
   type = "Opaque"

--- a/terraform/environments/analytical-platform-compute/next/providers.tf
+++ b/terraform/environments/analytical-platform-compute/next/providers.tf
@@ -5,7 +5,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.cluster.token

--- a/terraform/environments/analytical-platform-compute/next/rds.tf
+++ b/terraform/environments/analytical-platform-compute/next/rds.tf
@@ -5,7 +5,7 @@ module "rds" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.12.0"
+  version = "7.2.0"
 
   identifier = local.component_name
 
@@ -25,7 +25,8 @@ module "rds" {
   username                    = local.db_dbuser
   db_name                     = local.db_dbname
   manage_master_user_password = false
-  password                    = random_password.rds[0].result
+  password_wo                 = random_password.rds[0].result
+  password_wo_version         = 1
   kms_key_id                  = module.rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/next/rds.tf
+++ b/terraform/environments/analytical-platform-compute/next/rds.tf
@@ -2,10 +2,11 @@ module "rds" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
+  # module (version 7.2.0) is currently unsupported due to this open issue: https://github.com/hashicorp/terraform-provider-aws/issues/42582
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "7.2.0"
+  version = "6.12.0"
 
   identifier = local.component_name
 
@@ -25,8 +26,7 @@ module "rds" {
   username                    = local.db_dbuser
   db_name                     = local.db_dbname
   manage_master_user_password = false
-  password_wo                 = random_password.rds[0].result
-  password_wo_version         = 1
+  password                    = random_password.rds[0].result
   kms_key_id                  = module.rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/next/secrets.tf
+++ b/terraform/environments/analytical-platform-compute/next/secrets.tf
@@ -5,7 +5,7 @@ module "azure_secrets" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.0.0"
+  version = "2.1.0"
 
   name       = "${local.component_name}/azure"
   kms_key_id = data.aws_kms_key.secrets_manager_common.arn

--- a/terraform/environments/analytical-platform-compute/next/security-groups.tf
+++ b/terraform/environments/analytical-platform-compute/next/security-groups.tf
@@ -5,7 +5,7 @@ module "rds_security_group" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   source  = "terraform-aws-modules/security-group/aws"
-  version = "5.3.0"
+  version = "5.3.1"
 
   name            = "${local.component_name}-rds"
   use_name_prefix = true

--- a/terraform/environments/analytical-platform-compute/next/versions.tf
+++ b/terraform/environments/analytical-platform-compute/next/versions.tf
@@ -1,33 +1,33 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     kubernetes = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/kubernetes"
     }
     helm = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/helm"
     }
     random = {
-      version = "~> 3.0"
+      version = "~> 3.9"
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform binary, all provider version constraints, and multiple Terraform AWS modules across the analytical-platform-compute/next stack.

### Version Changes

#### Terraform Binary

| File | Current | New |
|------|---------|-----|
| versions.tf | ~> 1.0 | ~> 1.15 |

#### Providers

| Provider | Current | New |
|----------|---------|-----|
| hashicorp/aws | ~> 6.0 | ~> 6.46 |
| hashicorp/dns | ~> 3.0 | ~> 3.6 |
| hashicorp/external | ~> 2.0 | ~> 2.4 |
| hashicorp/http | ~> 3.0 | ~> 3.6 |
| hashicorp/kubernetes | ~> 2.0 | ~> 3.1 |
| hashicorp/helm | ~> 2.0 | ~> 3.1 |
| hashicorp/random | ~> 3.0 | ~> 3.9 |

#### Terraform AWS Modules

| File | Module | Current | New |
|------|--------|---------|-----|
| kms-keys.tf | terraform-aws-modules/kms/aws | 4.0.0 | 4.2.0 |
| secrets.tf | terraform-aws-modules/secrets-manager/aws | 2.0.0 | 2.1.0 |
| security-groups.tf | terraform-aws-modules/security-group/aws | 5.3.0 | 5.3.1 |

### Resource Migrations (hashicorp/kubernetes 3.x)

The hashicorp/kubernetes provider 3.x deprecates all non-versioned resource types. The following resources have been migrated to their `_v1` equivalents:

| Old Resource | New Resource |
|---|---|
| kubernetes_namespace | kubernetes_namespace_v1 |
| kubernetes_secret | kubernetes_secret_v1 |

All namespace references in `kubernetes-external-secrets.tf` and `kubernetes-secrets.tf` have been updated to point to the new `_v1` resource addresses accordingly.

The helm provider `kubernetes` block has also been updated from nested block to assignment syntax (`kubernetes = { ... }`) as required by helm ~> 3.x.


### State Migration (import.tf)

A new `import.tf` file has been added to handle in-place state migration for all affected resources using Terraform's native `import` + `removed` block pattern. This ensures existing live Kubernetes resources are adopted into the new resource addresses without destruction or recreation. This file will be removed once the import is complete and the state file has been updated.


PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.