### PR TITLE
chore(deps):upgrade terraform modules and provider versions

### DIFF
--- a/terraform/environments/analytical-platform-compute/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/kms-keys.tf
@@ -3,7 +3,7 @@ module "mojap_compute_logs_s3_kms_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["s3/mojap-compute-logs-eu-west-2"]
   description           = "mojap-compute-logs eu-west-2 S3 KMS key"
@@ -31,7 +31,7 @@ module "mojap_compute_logs_s3_kms_eu_west_2" {
           identifiers = ["logging.s3.amazonaws.com"]
         }
       ]
-      conditions = [
+      condition = [
         {
           test     = "StringEquals"
           variable = "kms:ViaService"
@@ -47,7 +47,7 @@ module "mojap_compute_logs_s3_kms_eu_west_1" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   providers = {
     aws = aws.analytical-platform-compute-eu-west-1
@@ -79,7 +79,7 @@ module "mojap_compute_logs_s3_kms_eu_west_1" {
           identifiers = ["logging.s3.amazonaws.com"]
         }
       ]
-      conditions = [
+      condition = [
         {
           test     = "StringEquals"
           variable = "kms:ViaService"

--- a/terraform/environments/analytical-platform-compute/locals.tf
+++ b/terraform/environments/analytical-platform-compute/locals.tf
@@ -16,6 +16,6 @@ locals {
   /* Private subnet arns */
   private_subnet_arns = [
     for subnet_id in data.aws_subnets.apc_private.ids :
-    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/${subnet_id}"
+    "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:subnet/${subnet_id}"
   ]
 }

--- a/terraform/environments/analytical-platform-compute/modules/network-monitoring/providers.tf
+++ b/terraform/environments/analytical-platform-compute/modules/network-monitoring/providers.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.46"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
+++ b/terraform/environments/analytical-platform-compute/modules/routes/providers.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.46"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-compute/observability.tf
+++ b/terraform/environments/analytical-platform-compute/observability.tf
@@ -3,7 +3,7 @@ module "observability_platform_tenant" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "ministryofjustice/observability-platform-tenant/aws"
-  version = "1.2.0"
+  version = "2.0.0"
 
   observability_platform_account_id = local.environment_management.account_ids["observability-platform-production"]
   enable_prometheus                 = true
@@ -16,7 +16,7 @@ module "observability_platform_tenant" {
 }
 
 module "analytical_platform_observability" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=ccefcbdcecd3c5dfd25474b66ac06a58bd810928" # 2.0.0
+  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-observability?ref=4b9c9013bff6035e8e3b77a00d124e62bbb4de56" # 4.2.0
 
   enable_amazon_prometheus_query_access = true
   enable_aws_xray_read_only_access      = true

--- a/terraform/environments/analytical-platform-compute/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/s3-buckets.tf
@@ -22,7 +22,7 @@ module "mojap_compute_logs_bucket_eu_west_2" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.10.1"
+  version = "5.13.0"
 
   bucket = "mojap-compute-${local.environment}-logs-eu-west-2"
 
@@ -77,7 +77,7 @@ module "mojap_compute_logs_bucket_eu_west_1" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.10.1"
+  version = "5.13.0"
 
   providers = {
     aws = aws.analytical-platform-compute-eu-west-1

--- a/terraform/environments/analytical-platform-compute/versions.tf
+++ b/terraform/environments/analytical-platform-compute/versions.tf
@@ -1,45 +1,45 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     kubernetes = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/kubernetes"
     }
     helm = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/helm"
     }
     random = {
-      version = "~> 3.0"
+      version = "~> 3.9"
       source  = "hashicorp/random"
     }
     null = {
-      version = "~> 3.0"
+      version = "~> 3.3"
       source  = "hashicorp/null"
     }
     archive = {
-      version = "~> 2.0"
+      version = "~> 2.8"
       source  = "hashicorp/archive"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.9"
+      version = "~> 0.14"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0"
+      version = "~> 4.3"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform binary, all provider version constraints, and multiple Terraform AWS modules across the analytical-platform-compute stack.

### Version Changes

#### Terraform Binary

| File | Current | New |
|------|---------|-----|
| versions.tf | `~> 1.0` | `~> 1.15` |

#### Providers

| Provider | Current | New |
|----------|---------|-----|
| hashicorp/aws | `~> 5.0, != 5.86.0` | `~> 6.46` |
| hashicorp/dns | `~> 3.0` | `~> 3.6` |
| hashicorp/http | `~> 3.0` | `~> 3.6` |
| hashicorp/kubernetes | `~> 2.0` | `~> 3.1` |
| hashicorp/helm | `~> 2.0` | `~> 3.1` |
| hashicorp/random | `~> 3.0` | `~> 3.9` |
| hashicorp/null | `~> 3.0` | `~> 3.3` |
| hashicorp/archive | `~> 2.0` | `~> 2.8` |
| hashicorp/time | `~> 0.9` | `~> 0.14` |
| hashicorp/tls | `~> 4.0` | `~> 4.3` |

#### Terraform AWS Modules

| File | Module | Current | New |
|------|--------|---------|-----|
| kms-keys.tf | terraform-aws-modules/kms/aws | `3.1.1` | `4.2.0` |
| s3-buckets.tf | terraform-aws-modules/s3-bucket/aws | `4.10.1` | `5.13.0` |
| observability.tf | ministryofjustice/observability-platform-tenant/aws | `1.2.0` | `2.0.0` |
| observability.tf | terraform-aws-analytical-platform-observability | `2.0.0` (ccefcbd) | `4.2.0` (4b9c901) |

### Additional Changes

- `locals.tf`: Updated `data.aws_region.current.name` to `data.aws_region.current.region` as required by hashicorp/aws 6.x
- `kms-keys.tf`: Renamed `conditions` block to `condition` to align with updated module schema in terraform-aws-modules/kms/aws 4.x

PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.