### PR TITLE
chore(deps):upgrade terraform modules and provider versions

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
+++ b/terraform/environments/analytical-platform-ingestion/cloudwatch-log-groups.tf
@@ -2,7 +2,7 @@ module "transfer_structured_logs" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.7.2"
 
   name              = "/aws/transfer-structured-logs"
   kms_key_id        = module.transfer_logs_kms.key_arn
@@ -13,7 +13,7 @@ module "connected_vpc_route53_resolver_logs" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.7.2"
 
   name              = "/aws/route53-resolver/connected-vpc"
   retention_in_days = 400
@@ -23,7 +23,7 @@ module "datasync_task_logs" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.7.2"
 
   name              = "/aws/datasync/tasks"
   retention_in_days = 400
@@ -34,7 +34,7 @@ module "datasync_enhanced_logs" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.6.0"
+  version = "5.7.2"
 
   name              = "/aws/datasync"
   retention_in_days = 400

--- a/terraform/environments/analytical-platform-ingestion/dms/data.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/data.tf
@@ -5,7 +5,7 @@ data "aws_region" "this" {}
 data "aws_availability_zones" "available" {
   filter {
     name   = "region-name"
-    values = [data.aws_region.this.name]
+    values = [data.aws_region.this.region]
   }
 }
 

--- a/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/eventbridge-scheduler.tf
@@ -11,7 +11,7 @@ resource "aws_scheduler_schedule" "tariff_dms_nightly_full_load" {
 
   target {
     arn      = "arn:aws:scheduler:::aws-sdk:databasemigration:startReplicationTask"
-    role_arn = module.tariff_eventbridge_dms_full_load_task_role.iam_role_arn
+    role_arn = module.tariff_eventbridge_dms_full_load_task_role.arn
 
     input = jsonencode({
       ReplicationTaskArn       = module.cica_dms_tariff_dms_implementation.dms_full_load_task_arn
@@ -39,7 +39,7 @@ resource "aws_scheduler_schedule" "tempus_dms_nightly_full_load" {
 
   target {
     arn      = "arn:aws:scheduler:::aws-sdk:databasemigration:startReplicationTask"
-    role_arn = module.tempus_eventbridge_dms_full_load_task_role.iam_role_arn
+    role_arn = module.tempus_eventbridge_dms_full_load_task_role.arn
 
     input = jsonencode({
       ReplicationTaskArn       = each.value.dms_full_load_task_arn

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-policies.tf
@@ -56,9 +56,10 @@ module "production_replication_cica_dms_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.54.1"
+  version = "6.6.0"
 
   name_prefix = "cica-dms-ingress-replication"
+  description = "IAM Policy"
 
   policy = data.aws_iam_policy_document.production_cica_dms_replication.json
 }
@@ -77,9 +78,10 @@ module "tariff_eventbridge_dms_full_load_task_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.54.1"
+  version = "6.6.0"
 
   name_prefix = "tariff-cica-dms-eventbridge-full-load-task"
+  description = "IAM Policy"
 
   policy = data.aws_iam_policy_document.tariff_eventbridge_dms_full_load_task_policy.json
 }
@@ -98,9 +100,10 @@ module "tempus_eventbridge_dms_full_load_task_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.54.1"
+  version = "6.6.0"
 
   name_prefix = "tempus-cica-dms-eventbridge-full-load-task"
+  description = "IAM Policy"
 
   policy = data.aws_iam_policy_document.tempus_eventbridge_dms_full_load_task_policy.json
 }

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
@@ -60,7 +60,7 @@ module "tariff_eventbridge_dms_full_load_task_role" {
       ]
     }
   }
-  policy = {
+  policies = {
     tariff_eventbridge_dms_full_load_task_policy = module.tariff_eventbridge_dms_full_load_task_policy.arn
   }
 }

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
@@ -44,7 +44,7 @@ module "tariff_eventbridge_dms_full_load_task_role" {
           identifiers = ["scheduler.amazonaws.com", "apidestinations.events.amazonaws.com"]
         }
       ]
-      conditions = [
+      condition = [
         {
           test     = "StringEquals"
           variable = "aws:SourceAccount"
@@ -58,8 +58,9 @@ module "tariff_eventbridge_dms_full_load_task_role" {
           ]
         }
       ]
-    }
-  }
+  } }
+
+
   policies = {
     tariff_eventbridge_dms_full_load_task_policy = module.tariff_eventbridge_dms_full_load_task_policy.arn
   }
@@ -84,7 +85,7 @@ module "tempus_eventbridge_dms_full_load_task_role" {
           identifiers = ["scheduler.amazonaws.com", "apidestinations.events.amazonaws.com"]
         }
       ]
-      conditions = [
+      condition = [
         {
           test     = "StringEquals"
           variable = "aws:SourceAccount"

--- a/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/iam-roles.tf
@@ -3,83 +3,105 @@ module "production_replication_cica_dms_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
   count = local.environment == "production" ? 1 : 0
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.2"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  create_role = true
 
-  role_name         = "cica-dms-ingress-production-replication"
-  role_requires_mfa = false
-
-  trusted_role_services = ["s3.amazonaws.com"]
-
-  custom_role_policy_arns = [module.production_replication_cica_dms_iam_policy.arn]
+  name            = "cica-dms-ingress-production-replication"
+  use_name_prefix = false
+  trust_policy_permissions = {
+    dmsExecutionRole = {
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["s3.amazonaws.com"]
+        }
+      ]
+    }
+  }
+  policies = {
+    production_replication_cica_dms_iam_policy = module.production_replication_cica_dms_iam_policy.arn
+  }
 }
 
 module "tariff_eventbridge_dms_full_load_task_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.2"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  create_role = true
+  name = "tariff-dms-eventbridge-full-load-task-role"
 
-  role_name         = "tariff-dms-eventbridge-full-load-task-role"
-  role_requires_mfa = false
-
-  trusted_role_services = [
-    "scheduler.amazonaws.com",
-    "apidestinations.events.amazonaws.com"
-  ]
-
-  custom_role_policy_arns = [module.tariff_eventbridge_dms_full_load_task_policy.arn]
-  trust_policy_conditions = [
-    {
-      test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values   = [data.aws_caller_identity.current.account_id]
-    },
-    {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values = [
-        aws_scheduler_schedule_group.tariff_dms_nightly_full_load.arn,
+  use_name_prefix = false
+  trust_policy_permissions = {
+    dmsExecutionRole = {
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["scheduler.amazonaws.com", "apidestinations.events.amazonaws.com"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        },
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceArn"
+          values = [
+            aws_scheduler_schedule_group.tariff_dms_nightly_full_load.arn,
+          ]
+        }
       ]
     }
-  ]
+  }
+  policy = {
+    tariff_eventbridge_dms_full_load_task_policy = module.tariff_eventbridge_dms_full_load_task_policy.arn
+  }
 }
 
 module "tempus_eventbridge_dms_full_load_task_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "5.52.2"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.0"
 
-  create_role = true
+  name = "tempus-dms-eventbridge-full-load-task-role"
 
-  role_name         = "tempus-dms-eventbridge-full-load-task-role"
-  role_requires_mfa = false
-
-  trusted_role_services = [
-    "scheduler.amazonaws.com",
-    "apidestinations.events.amazonaws.com"
-  ]
-
-  custom_role_policy_arns = [module.tempus_eventbridge_dms_full_load_task_policy.arn]
-  trust_policy_conditions = [
-    {
-      test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values   = [data.aws_caller_identity.current.account_id]
-    },
-    {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values = [
-        aws_scheduler_schedule_group.tempus_dms_nightly_full_load.arn
+  use_name_prefix = false
+  trust_policy_permissions = {
+    dmsExecutionRole = {
+      actions = ["sts:AssumeRole", "sts:TagSession"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["scheduler.amazonaws.com", "apidestinations.events.amazonaws.com"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        },
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceArn"
+          values = [
+            aws_scheduler_schedule_group.tempus_dms_nightly_full_load.arn
+          ]
+        }
       ]
     }
-  ]
+  }
+
+  policies = {
+    tempus_eventbridge_dms_full_load_task_policy = module.tempus_eventbridge_dms_full_load_task_policy.arn
+  }
 }

--- a/terraform/environments/analytical-platform-ingestion/dms/import.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/import.tf
@@ -1,0 +1,9 @@
+moved {
+  from = module.tariff_eventbridge_dms_full_load_task_role.aws_iam_role_policy_attachment.custom[0]
+  to   = module.tariff_eventbridge_dms_full_load_task_role.aws_iam_role_policy_attachment.this["tariff_eventbridge_dms_full_load_task_policy"]
+}
+
+moved {
+  from = module.tempus_eventbridge_dms_full_load_task_role.aws_iam_role_policy_attachment.custom[0]
+  to   = module.tempus_eventbridge_dms_full_load_task_role.aws_iam_role_policy_attachment.this["tempus_eventbridge_dms_full_load_task_policy"]
+}

--- a/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
@@ -64,11 +64,11 @@ module "cica_dms_eventscheduler_kms" {
   # Grants
   grants = {
     tariff_dms_source = {
-      grantee_principal = module.tariff_eventbridge_dms_full_load_task_role.iam_role_arn
+      grantee_principal = module.tariff_eventbridge_dms_full_load_task_role.arn
       operations        = ["Encrypt", "Decrypt", "GenerateDataKey"]
     }
     tempus_dms_source = {
-      grantee_principal = module.tempus_eventbridge_dms_full_load_task_role.iam_role_arn
+      grantee_principal = module.tempus_eventbridge_dms_full_load_task_role.arn
       operations        = ["Encrypt", "Decrypt", "GenerateDataKey"]
     }
   }

--- a/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/kms-keys.tf
@@ -2,7 +2,7 @@ module "s3_cica_dms_ingress_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["s3/cica-dms-ingress"]
   description           = "Used in the CICA DMS Ingress Solution"
@@ -18,7 +18,7 @@ module "cica_dms_credentials_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["dms/cica-source-credentials"]
   description           = "Used in the CICA DMS Solution to encode secrets"
@@ -53,7 +53,7 @@ module "cica_dms_eventscheduler_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["dms/cica-eventscheduler"]
   description           = "Used in the CICA DMS Solution EventScheduler to encode EventBridge Scheduler"

--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -27,7 +27,7 @@ module "cica_dms_ingress_bucket" {
 
 resource "aws_s3_bucket_replication_configuration" "cica_dms_ingress_bucket_replication" {
   count  = local.environment == "production" ? 1 : 0
-  role   = module.production_replication_cica_dms_iam_role[0].iam_role_arn
+  role   = module.production_replication_cica_dms_iam_role[0].arn
   bucket = module.cica_dms_ingress_bucket.s3_bucket_id
   rule {
     id     = "mojap-ingestion-cica-dms-ingress"

--- a/terraform/environments/analytical-platform-ingestion/dms/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/s3.tf
@@ -4,7 +4,7 @@ module "cica_dms_ingress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.3.0"
+  version = "5.14.0"
 
   bucket = "mojap-ingestion-${local.environment}-cica-dms-ingress"
 

--- a/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/secrets.tf
@@ -5,7 +5,7 @@ module "cica_dms_tariff_database_credentials" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "ingestion/dms/tariff-credentials"
   kms_key_id = module.cica_dms_credentials_kms.key_arn
@@ -40,7 +40,7 @@ module "cica_dms_tempus_database_credentials" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "ingestion/dms/tempus-credentials"
   kms_key_id = module.cica_dms_credentials_kms.key_arn

--- a/terraform/environments/analytical-platform-ingestion/dms/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/versions.tf
@@ -1,21 +1,21 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0, != 5.86.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
+++ b/terraform/environments/analytical-platform-ingestion/ec2-instances.tf
@@ -4,7 +4,7 @@ module "datasync_instance" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "6.2.0"
+  version = "6.4.0"
 
   name = "${local.application_name}-${local.environment}-datasync"
   # ami                    = data.aws_ssm_parameter.datasync_ami.value

--- a/terraform/environments/analytical-platform-ingestion/iam-policies.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-policies.tf
@@ -17,7 +17,7 @@ module "transfer_server_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "transfer-server"
   description = "IAM Policy"
@@ -73,7 +73,7 @@ module "datasync_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "datasync"
   description = "IAM Policy"
@@ -140,7 +140,7 @@ module "datasync_replication_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "datasync-replication"
   description = "IAM Policy"
@@ -207,7 +207,7 @@ module "datasync_opg_replication_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "datasync-opg-ingress-${local.environment}-replication"
   description = "IAM Policy"
@@ -355,7 +355,7 @@ module "guard_duty_s3_malware_protection_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "guard-duty-s3-malware-protection-${local.environment}-scan"
   description = "IAM Policy"
@@ -454,7 +454,7 @@ module "laa_data_analysis_iam_policy" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "laa-data-analysis"
   description = "IAM Policy"
@@ -540,7 +540,7 @@ module "laa_data_analysis_replication_iam_policy" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "laa-data-analysis-${local.environment}-replication"
   description = "IAM Policy"

--- a/terraform/environments/analytical-platform-ingestion/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/iam-roles.tf
@@ -2,7 +2,7 @@ module "transfer_server_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -30,7 +30,7 @@ module "datasync_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -57,7 +57,7 @@ module "datasync_replication_iam_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -84,7 +84,7 @@ module "datasync_opg_replication_iam_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -113,7 +113,7 @@ module "guard_duty_malware_s3_scan_iam_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -141,7 +141,7 @@ module "datasync_laa_data_analysis_iam_role" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 
@@ -169,7 +169,7 @@ module "laa_data_analysis_replication_iam_role" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 

--- a/terraform/environments/analytical-platform-ingestion/import.tf
+++ b/terraform/environments/analytical-platform-ingestion/import.tf
@@ -1,0 +1,60 @@
+# This file is used to import the existing SG rules into Terraform state.Will be deleted after the import is complete and the state file is updated.
+
+locals {
+  sg_rule_ids = {
+    "analytical-platform-ingestion-development" = {
+      ingress_udp_connected_vpc = "sgr-0e9409b3a1402394f"
+      ingress_tcp_connected_vpc = "sgr-08fbca30d2db58e27"
+      egress_tcp_resolver1      = "sgr-00095bced315afcb1"
+      egress_tcp_resolver2      = "sgr-03b98cdabeaa67c5f"
+      egress_udp_resolver1      = "sgr-07109865a194eb192"
+      egress_udp_resolver2      = "sgr-08135da9f21631148"
+    }
+    "analytical-platform-ingestion-production" = {
+      ingress_udp_connected_vpc = "sgr-0f519600c12aaebf2"
+      ingress_tcp_connected_vpc = "sgr-04fadfb61b71624c6"
+      egress_tcp_resolver1      = "sgr-0b13d84ca666b2fd8"
+      egress_tcp_resolver2      = "sgr-0ed7fa353d3cd9e7f"
+      egress_udp_resolver1      = "sgr-045f1ca051f76fa96"
+      egress_udp_resolver2      = "sgr-0858ddf3ab5917c9b"
+    }
+  }
+
+  current_sg_rule_ids = lookup(local.sg_rule_ids, terraform.workspace, null)
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.ingress_udp_connected_vpc } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_ingress_rule.udp["connected_vpc"]
+  id       = each.value
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.ingress_tcp_connected_vpc } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_ingress_rule.tcp["connected_vpc"]
+  id       = each.value
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.egress_tcp_resolver1 } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_egress_rule.tcp["moj_service_resolver1"]
+  id       = each.value
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.egress_tcp_resolver2 } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_egress_rule.tcp["moj_service_resolver2"]
+  id       = each.value
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.egress_udp_resolver1 } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_egress_rule.udp["moj_service_resolver1"]
+  id       = each.value
+}
+
+import {
+  for_each = local.current_sg_rule_ids != null ? { "0" = local.current_sg_rule_ids.egress_udp_resolver2 } : {}
+  to       = module.connected_vpc_outbound_route53_resolver_endpoint.aws_vpc_security_group_egress_rule.udp["moj_service_resolver2"]
+  id       = each.value
+}

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -153,7 +153,7 @@ module "transferred_sns_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["sns/transferred"]
   description           = "Key for transferred notifications"
@@ -179,7 +179,7 @@ module "supplier_data_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["secretsmanager/supplier-data"]
   description           = "Key for SFTP supplier data"
@@ -205,7 +205,7 @@ module "ec2_ebs_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["ec2/ebs"]
   description           = "EC2 EBS KMS Key"
@@ -231,7 +231,7 @@ module "s3_datasync_opg_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["s3/datasync-opg"]
   description           = "DataSync OPG S3 KMS Key"
@@ -269,7 +269,7 @@ module "secretsmanager_common_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["secretsmanager/common"]
   description           = "Common secretsmanager KMS Key"
@@ -283,7 +283,7 @@ module "s3_laa_data_analysis_kms" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["s3/laa-data-analysis"]
   description           = "LAA Data Analysis S3 KMS Key"
@@ -298,7 +298,7 @@ module "shared_services_client_team_gov_29148_egress_kms" {
   count = local.is-production ? 1 : 0
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["s3/ssct-gov-29148-egress"]
   description           = "Shared Services Client Team GOV-29148 Egress"

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -17,6 +17,7 @@ module "definition_upload_lambda" {
   vpc_subnet_ids         = module.isolated_vpc.private_subnets
   vpc_security_group_ids = [module.definition_upload_lambda_security_group.security_group_id]
   attach_network_policy  = true
+  ignore_source_code_hash = true
 
   environment_variables = {
     MODE                         = "definition-upload",
@@ -76,6 +77,7 @@ module "scan_lambda" {
   vpc_subnet_ids         = module.isolated_vpc.private_subnets
   vpc_security_group_ids = [module.scan_lambda_security_group.security_group_id]
   attach_network_policy  = true
+  ignore_source_code_hash = true
 
   environment_variables = {
     MODE                         = "scan",
@@ -152,6 +154,7 @@ module "transfer_lambda" {
   vpc_subnet_ids         = module.isolated_vpc.private_subnets
   vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
   attach_network_policy  = true
+  ignore_source_code_hash = true
 
   environment_variables = {
     PROCESSED_BUCKET_NAME = module.processed_bucket.s3_bucket_id
@@ -260,6 +263,8 @@ module "notify_quarantined_lambda" {
   vpc_subnet_ids         = module.isolated_vpc.private_subnets
   vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
   attach_network_policy  = true
+  ignore_source_code_hash = true
+
 
   environment_variables = {
     MODE = "quarantined"
@@ -326,6 +331,7 @@ module "notify_transferred_lambda" {
   vpc_subnet_ids         = module.isolated_vpc.private_subnets
   vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
   attach_network_policy  = true
+  ignore_source_code_hash = true
 
   environment_variables = {
     MODE                          = "transferred"

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -14,9 +14,9 @@ module "definition_upload_lambda" {
   timeout       = 900
   image_uri     = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-scan:${local.environment_configuration.scan_image_version}"
 
-  vpc_subnet_ids         = module.isolated_vpc.private_subnets
-  vpc_security_group_ids = [module.definition_upload_lambda_security_group.security_group_id]
-  attach_network_policy  = true
+  vpc_subnet_ids          = module.isolated_vpc.private_subnets
+  vpc_security_group_ids  = [module.definition_upload_lambda_security_group.security_group_id]
+  attach_network_policy   = true
   ignore_source_code_hash = true
 
   environment_variables = {
@@ -74,9 +74,9 @@ module "scan_lambda" {
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-scan:${local.environment_configuration.scan_image_version}"
 
-  vpc_subnet_ids         = module.isolated_vpc.private_subnets
-  vpc_security_group_ids = [module.scan_lambda_security_group.security_group_id]
-  attach_network_policy  = true
+  vpc_subnet_ids          = module.isolated_vpc.private_subnets
+  vpc_security_group_ids  = [module.scan_lambda_security_group.security_group_id]
+  attach_network_policy   = true
   ignore_source_code_hash = true
 
   environment_variables = {
@@ -151,9 +151,9 @@ module "transfer_lambda" {
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-transfer:${local.environment_configuration.transfer_image_version}"
 
-  vpc_subnet_ids         = module.isolated_vpc.private_subnets
-  vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
-  attach_network_policy  = true
+  vpc_subnet_ids          = module.isolated_vpc.private_subnets
+  vpc_security_group_ids  = [module.transfer_lambda_security_group.security_group_id]
+  attach_network_policy   = true
   ignore_source_code_hash = true
 
   environment_variables = {
@@ -260,9 +260,9 @@ module "notify_quarantined_lambda" {
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-notify:${local.environment_configuration.notify_image_version}"
 
-  vpc_subnet_ids         = module.isolated_vpc.private_subnets
-  vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
-  attach_network_policy  = true
+  vpc_subnet_ids          = module.isolated_vpc.private_subnets
+  vpc_security_group_ids  = [module.transfer_lambda_security_group.security_group_id]
+  attach_network_policy   = true
   ignore_source_code_hash = true
 
 
@@ -328,9 +328,9 @@ module "notify_transferred_lambda" {
   timeout                = 900
   image_uri              = "374269020027.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-ingestion-notify:${local.environment_configuration.notify_image_version}"
 
-  vpc_subnet_ids         = module.isolated_vpc.private_subnets
-  vpc_security_group_ids = [module.transfer_lambda_security_group.security_group_id]
-  attach_network_policy  = true
+  vpc_subnet_ids          = module.isolated_vpc.private_subnets
+  vpc_security_group_ids  = [module.transfer_lambda_security_group.security_group_id]
+  attach_network_policy   = true
   ignore_source_code_hash = true
 
   environment_variables = {

--- a/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
+++ b/terraform/environments/analytical-platform-ingestion/lambda-functions.tf
@@ -2,7 +2,7 @@ module "definition_upload_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.8.0"
 
   publish        = true
   create_package = false
@@ -60,7 +60,7 @@ module "scan_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.8.0"
 
   publish        = true
   create_package = false
@@ -136,7 +136,7 @@ module "transfer_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.8.0"
 
   publish        = true
   create_package = false
@@ -244,7 +244,7 @@ module "notify_quarantined_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.8.0"
 
   publish        = true
   create_package = false
@@ -310,7 +310,7 @@ module "notify_transferred_lambda" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.0.1"
+  version = "8.8.0"
 
   publish        = true
   create_package = false

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/endpoints.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 # DMS Source Endpoint
 resource "aws_dms_endpoint" "source" {
   #checkov:skip=CKV_AWS_296: Use AWS managed KMS key
-  endpoint_id   = "${var.db}-source-${data.aws_region.current.name}-${var.environment}"
+  endpoint_id   = "${var.db}-source-${data.aws_region.current.region}-${var.environment}"
   endpoint_type = "source"
   engine_name   = var.dms_source.engine_name
 
@@ -13,7 +13,7 @@ resource "aws_dms_endpoint" "source" {
   extra_connection_attributes     = var.dms_source.extra_connection_attributes
 
   tags = merge(
-    { Name = "${var.db}-source-${data.aws_region.current.name}-${var.environment}" },
+    { Name = "${var.db}-source-${data.aws_region.current.region}-${var.environment}" },
     var.tags
   )
 }
@@ -21,7 +21,7 @@ resource "aws_dms_endpoint" "source" {
 # DMS S3 Target Endpoint
 resource "aws_dms_s3_endpoint" "s3_target" {
   # checkov:skip=CKV_AWS_298: Use AWS managed KMS key
-  endpoint_id                      = "${var.db}-target-${data.aws_region.current.name}-${var.environment}"
+  endpoint_id                      = "${var.db}-target-${data.aws_region.current.region}-${var.environment}"
   endpoint_type                    = "target"
   bucket_name                      = aws_s3_bucket.landing.bucket
   bucket_folder                    = var.dms_target_prefix
@@ -40,7 +40,7 @@ resource "aws_dms_s3_endpoint" "s3_target" {
   timestamp_column_name            = var.s3_target_config.timestamp_column_name
 
   tags = merge(
-    { Name = "${var.db}-target-${data.aws_region.current.name}-${var.environment}" },
+    { Name = "${var.db}-target-${data.aws_region.current.region}-${var.environment}" },
     var.tags
   )
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/iam-roles.tf
@@ -76,7 +76,7 @@ resource "aws_iam_role_policy" "dms" {
           "secretsmanager:GetSecretValue"
         ],
         "Effect" : "Allow",
-        "Resource" : "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:secret:managed_pipelines/${var.environment}/slack_notifications*",
+        "Resource" : "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:secret:managed_pipelines/${var.environment}/slack_notifications*",
         "Sid" : "AllowGetSecretValue"
       }
     ]
@@ -91,7 +91,7 @@ resource "aws_iam_role" "dms_source" {
       {
         "Effect" : "Allow",
         "Principal" : {
-          "Service" : "dms.${data.aws_region.current.name}.amazonaws.com"
+          "Service" : "dms.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" : "sts:AssumeRole"
       }

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/kms-keys.tf
@@ -2,7 +2,7 @@ module "bucket_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "3.1.1"
+  version = "4.2.0"
 
   aliases               = ["dms/${var.db}/bucket-kms"]
   description           = "Used to encrypt internal buckets for ${var.db} DMS module"

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/metadata-generator.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/metadata-generator.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "metadata_generator_lambda_function" {
       test     = "StringLike"
       variable = "kms:ViaService"
       values = [
-        "secretsmanager.${data.aws_region.current.name}.amazonaws.com",
+        "secretsmanager.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
   }

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/outputs.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/outputs.tf
@@ -7,7 +7,6 @@ output "dms_role_arn" {
 output "dms_source_role_arn" {
   value       = aws_iam_role.dms_source.arn
   description = "The ARN for the AWS role created for the DMS source endpoint"
-  sensitive   = true
 }
 
 output "dms_full_load_task_arn" {

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/replication-instance.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/replication-instance.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "replication_instance" {
-  name        = "${var.db}-${data.aws_region.current.name}-${var.environment}"
+  name        = "${var.db}-${data.aws_region.current.region}-${var.environment}"
   description = "Security group for DMS replication instances. Managed by Terraform"
   vpc_id      = var.vpc_id
   tags = merge(
-    { Name = "${var.db}-${data.aws_region.current.name}-${var.environment}" },
+    { Name = "${var.db}-${data.aws_region.current.region}-${var.environment}" },
     var.tags
   )
 }
@@ -39,13 +39,13 @@ resource "aws_vpc_security_group_egress_rule" "replication_instance_outbound" {
 resource "aws_dms_replication_subnet_group" "replication_subnet_group" {
   count                                = var.dms_replication_instance.subnet_group_id == null ? 1 : 0
   replication_subnet_group_description = "Subnet group for DMS replication instances"
-  replication_subnet_group_id          = var.dms_replication_instance.subnet_group_name == null ? "${data.aws_region.current.name}-${var.environment}" : var.dms_replication_instance.subnet_group_name
+  replication_subnet_group_id          = var.dms_replication_instance.subnet_group_name == null ? "${data.aws_region.current.region}-${var.environment}" : var.dms_replication_instance.subnet_group_name
   # these would come from the core stack once created
   subnet_ids = data.aws_subnets.subnet_ids_vpc_subnets.ids
 
   tags = merge(var.tags,
     {
-      Name        = "${data.aws_region.current.name}-${var.environment}"
+      Name        = "${data.aws_region.current.region}-${var.environment}"
       application = "Data Engineering"
     }
   )

--- a/terraform/environments/analytical-platform-ingestion/modules/dms/terraform.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.0.0, < 2.0.0"
+  required_version = "~> 1.15"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.46"
     }
   }
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/routes/providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/routes/providers.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.46"
     }
   }
-  required_version = "~> 1.0"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
@@ -51,7 +51,7 @@ module "policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "transfer-user-${var.name}"
   description = "IAM Policy"
@@ -63,7 +63,7 @@ module "role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
 
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/main.tf
@@ -38,7 +38,7 @@ module "policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.4.0"
+  version = "6.6.0"
 
   name_prefix = "transfer-user-${var.name}"
   description = "IAM Policy"
@@ -50,7 +50,7 @@ module "role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
 
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -19,19 +19,19 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   ]
 
   security_group_ingress_rules = {
-  connected_vpc =  {
-   cidr_ipv4 = module.connected_vpc.vpc_cidr_block
+    connected_vpc = {
+      cidr_ipv4 = module.connected_vpc.vpc_cidr_block
+    }
   }
-}
 
   security_group_egress_rules = {
     /* MoJO DNS Resolver Service */
     moj_service_resolver1 = {
-     cidr_ipv4 = "10.180.80.5/32"
+      cidr_ipv4 = "10.180.80.5/32"
     }
     moj_service_resolver2 = {
-    cidr_ipv4 = "10.180.81.5/32"
-  }
+      cidr_ipv4 = "10.180.81.5/32"
+    }
   }
 
   tags = local.tags

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -1,8 +1,8 @@
 module "connected_vpc_outbound_route53_resolver_endpoint" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
-  source  = "terraform-aws-modules/route53/aws//modules/resolver-endpoints"
-  version = "5.0.0"
+  source  = "terraform-aws-modules/route53/aws//modules/resolver-endpoint"
+  version = "6.5.0"
 
   name      = "connected-vpc-outbound"
   vpc_id    = module.connected_vpc.vpc_id
@@ -18,12 +18,21 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
     }
   ]
 
-  security_group_ingress_cidr_blocks = [module.connected_vpc.vpc_cidr_block]
-  security_group_egress_cidr_blocks = [
+  security_group_ingress_rules = {
+  connected_vpc =  {
+   cidr_ipv4 = module.connected_vpc.vpc_cidr_block
+  }
+}
+
+  security_group_egress_rules = {
     /* MoJO DNS Resolver Service */
-    "10.180.80.5/32",
-    "10.180.81.5/32"
-  ]
+    moj_service_resolver1 = {
+     cidr_ipv4 = "10.180.80.5/32"
+    }
+    moj_service_resolver2 = {
+    cidr_ipv4 = "10.180.81.5/32"
+  }
+  }
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -4,10 +4,10 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   source  = "terraform-aws-modules/route53/aws//modules/resolver-endpoint"
   version = "6.5.0"
 
-  name      = "connected-vpc-outbound"
-  vpc_id    = module.connected_vpc.vpc_id
-  direction = "OUTBOUND"
-  protocols = ["Do53"]
+  name                           = "connected-vpc-outbound"
+  vpc_id                         = module.connected_vpc.vpc_id
+  direction                      = "OUTBOUND"
+  protocols                      = ["Do53"]
   security_group_use_name_prefix = false
 
   ip_address = [
@@ -21,7 +21,7 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
 
   security_group_ingress_rules = {
     connected_vpc = {
-      cidr_ipv4 = module.connected_vpc.vpc_cidr_block
+      cidr_ipv4   = module.connected_vpc.vpc_cidr_block
       description = "Allow VPC range"
     }
   }
@@ -29,11 +29,11 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   security_group_egress_rules = {
     /* MoJO DNS Resolver Service */
     moj_service_resolver1 = {
-      cidr_ipv4 = "10.180.80.5/32"
+      cidr_ipv4   = "10.180.80.5/32"
       description = "Allow MoJ service resolver1"
     }
     moj_service_resolver2 = {
-      cidr_ipv4 = "10.180.81.5/32"
+      cidr_ipv4   = "10.180.81.5/32"
       description = "Allow MoJ service resolver2"
     }
   }

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -8,6 +8,7 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   vpc_id    = module.connected_vpc.vpc_id
   direction = "OUTBOUND"
   protocols = ["Do53"]
+  security_group_use_name_prefix = false
 
   ip_address = [
     {

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-endpoints.tf
@@ -22,6 +22,7 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
   security_group_ingress_rules = {
     connected_vpc = {
       cidr_ipv4 = module.connected_vpc.vpc_cidr_block
+      description = "Allow VPC range"
     }
   }
 
@@ -29,9 +30,11 @@ module "connected_vpc_outbound_route53_resolver_endpoint" {
     /* MoJO DNS Resolver Service */
     moj_service_resolver1 = {
       cidr_ipv4 = "10.180.80.5/32"
+      description = "Allow MoJ service resolver1"
     }
     moj_service_resolver2 = {
       cidr_ipv4 = "10.180.81.5/32"
+      description = "Allow MoJ service resolver2"
     }
   }
 

--- a/terraform/environments/analytical-platform-ingestion/route53-resolver-rules.tf
+++ b/terraform/environments/analytical-platform-ingestion/route53-resolver-rules.tf
@@ -2,7 +2,7 @@ resource "aws_route53_resolver_rule" "mojo_dns_resolver_dom1_infra_int" {
   name                 = "mojo-dns-resolver-dom1-infra-int"
   domain_name          = "dom1.infra.int"
   rule_type            = "FORWARD"
-  resolver_endpoint_id = module.connected_vpc_outbound_route53_resolver_endpoint.route53_resolver_endpoint_id
+  resolver_endpoint_id = module.connected_vpc_outbound_route53_resolver_endpoint.id
 
   /* MoJO DNS Resolver Service */
   target_ip {

--- a/terraform/environments/analytical-platform-ingestion/s3-notifications.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3-notifications.tf
@@ -2,7 +2,7 @@ module "ingestion_landing_bucket_notification" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = module.landing_bucket.s3_bucket_id
 
@@ -21,7 +21,7 @@ module "ingestion_transfer_bucket_notification" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = module.processed_bucket.s3_bucket_id
 
@@ -38,7 +38,7 @@ module "ingestion_quarantine_bucket_notification" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = module.quarantine_bucket.s3_bucket_id
 

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -19,7 +19,7 @@ module "landing_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-landing"
 
@@ -77,7 +77,7 @@ module "quarantine_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-quarantine"
 
@@ -112,7 +112,7 @@ module "definitions_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-definitions"
 
@@ -150,7 +150,7 @@ module "processed_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-processed"
 
@@ -209,7 +209,7 @@ module "bold_egress_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-bold-egress"
 
@@ -296,7 +296,7 @@ module "datasync_opg_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-datasync-opg"
 
@@ -379,7 +379,7 @@ module "laa_data_analysis_bucket" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-laa-data-analysis"
 
@@ -558,7 +558,7 @@ module "shared_services_client_team_gov_29148_egress_bucket" {
   count = local.is-production ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.10.0"
+  version = "5.13.0"
 
   bucket = "mojap-ingestion-${local.environment}-ssct-gov-29148-egress"
 

--- a/terraform/environments/analytical-platform-ingestion/secrets.tf
+++ b/terraform/environments/analytical-platform-ingestion/secrets.tf
@@ -25,7 +25,7 @@ module "datasync_dom1_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "datasync/dom1"
   kms_key_id = module.datasync_credentials_kms.key_arn
@@ -44,7 +44,7 @@ module "datasync_include_paths_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "datasync/include-paths"
   kms_key_id = module.secretsmanager_common_kms.key_arn
@@ -60,7 +60,7 @@ module "datasync_exclude_path_secret" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "datasync/exclude-paths"
   kms_key_id = module.secretsmanager_common_kms.key_arn
@@ -77,7 +77,7 @@ module "laa_data_analysis_bucket_list" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "laa/bucket-list"
   kms_key_id = module.secretsmanager_common_kms.key_arn
@@ -94,7 +94,7 @@ module "laa_data_analysis_keys" {
   count = local.environment == "production" ? 1 : 0
 
   source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "1.3.1"
+  version = "2.1.0"
 
   name       = "laa/keys"
   kms_key_id = module.secretsmanager_common_kms.key_arn

--- a/terraform/environments/analytical-platform-ingestion/transfer-family/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-family/versions.tf
@@ -1,21 +1,21 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/transform-iam-roles.tf
+++ b/terraform/environments/analytical-platform-ingestion/transform-iam-roles.tf
@@ -2,7 +2,7 @@ module "transfer_family_service_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.4.0"
+  version = "6.6.0"
 
   create = true
 

--- a/terraform/environments/analytical-platform-ingestion/versions.tf
+++ b/terraform/environments/analytical-platform-ingestion/versions.tf
@@ -1,21 +1,21 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }

--- a/terraform/environments/analytical-platform-ingestion/vpc-endpoints.tf
+++ b/terraform/environments/analytical-platform-ingestion/vpc-endpoints.tf
@@ -2,7 +2,7 @@ module "connected_vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "6.0.1"
+  version = "6.6.1"
 
   vpc_id     = module.connected_vpc.vpc_id
   subnet_ids = module.connected_vpc.private_subnets
@@ -59,7 +59,7 @@ module "isolated_vpc_endpoints" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "6.0.1"
+  version = "6.6.1"
 
   vpc_id             = module.isolated_vpc.vpc_id
   subnet_ids         = module.isolated_vpc.private_subnets

--- a/terraform/environments/analytical-platform-ingestion/vpc.tf
+++ b/terraform/environments/analytical-platform-ingestion/vpc.tf
@@ -2,7 +2,7 @@ module "connected_vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name            = "${local.application_name}-${local.environment}-connected"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -26,7 +26,7 @@ module "isolated_vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name            = "${local.application_name}-${local.environment}-isolated"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
Upgrades Terraform binary, all provider version constraints, and multiple Terraform AWS modules across the analytical-platform-ingestion stack.

---

### Version Changes

#### Terraform Binary

| File | Current | New |
|------|---------|-----|
| `versions.tf` | `~> 1.10` | `~> 1.15` |

---

#### Providers

| Provider | Current | New |
|----------|---------|-----|
| `hashicorp/aws` | `~> 5.0, != 5.86.0` | `~> 6.46` |
| `hashicorp/dns` | `~> 3.0` | `~> 3.6` |
| `hashicorp/external` | `~> 2.0` | `~> 2.4` |
| `hashicorp/http` | `~> 3.0` | `~> 3.6` |

---

#### Terraform AWS Modules

| File | Module | Current | New |
|------|--------|---------|-----|
| `dms/kms-keys.tf` | `terraform-aws-modules/kms/aws` | `3.1.1` | `4.2.0` |
| `modules/dms/kms-keys.tf` | `terraform-aws-modules/kms/aws` | `3.1.1` | `4.2.0` |
| `dms/s3.tf` | `terraform-aws-modules/s3-bucket/aws` | `4.3.0` | `5.14.0` |
| `s3.tf` | `terraform-aws-modules/s3-bucket/aws` | *(various)* | `5.14.0` |
| `dms/iam-policies.tf` | `terraform-aws-modules/iam/aws//modules/iam-policy` | `5.54.1` | `6.6.0` |
| `dms/iam-roles.tf` | `terraform-aws-modules/iam/aws//modules/iam-assumable-role` → `iam-role` | `5.52.2` | `6.6.0` |
| `iam-policies.tf` | `terraform-aws-modules/iam/aws//modules/iam-policy` | `6.4.0` | `6.6.0` |
| `iam-roles.tf` | `terraform-aws-modules/iam/aws//modules/iam-role` | `6.4.0` | `6.6.0` |
| `cloudwatch-log-groups.tf` | `terraform-aws-modules/cloudwatch/aws//modules/log-group` | `5.6.0` | `5.7.2` |
| `ec2-instances.tf` | `terraform-aws-modules/ec2-instance/aws` | `6.2.0` | `6.4.0` |
| `dms/secrets.tf` | `terraform-aws-modules/secrets-manager/aws` | `1.3.1` | `2.1.0` |
| `secrets.tf` | `terraform-aws-modules/secrets-manager/aws` | *(various)* | `2.1.0` |
| `modules/transfer-family/user/main.tf` | `terraform-aws-modules/iam/aws//modules/iam-policy` & `iam-role` | `6.4.0` | `6.6.0` |
| `modules/transfer-family/user-with-egress/main.tf` | `terraform-aws-modules/iam/aws//modules/iam-policy` & `iam-role` | `6.4.0` | `6.6.0` |

---

### Additional Changes

- **`data.tf` / `endpoints.tf` / `replication-instance.tf` / `iam-roles.tf` (and others):** Replaced all instances of `data.aws_region.current.name` with `data.aws_region.current.region`, as required by `hashicorp/aws` 6.x.
- **`dms/iam-roles.tf`:** Migrated from `iam-assumable-role` submodule to `iam-role` submodule to align with the updated module structure in `terraform-aws-modules/iam/aws` 6.x. Updated input variable names accordingly (`role_name` → `name`, `trusted_role_services` → `trust_policy_permissions`, `custom_role_policy_arns` → `policies`, `trust_policy_conditions` → condition blocks within `trust_policy_permissions`).
- **`dms/import.tf`:** Added `moved` blocks to handle the state address changes resulting from the `iam-assumable-role` → `iam-role` migration for `tariff_eventbridge_dms_full_load_task_role` and `tempus_eventbridge_dms_full_load_task_role`.
- **`import.tf`:** Added `import` blocks for existing security group rules associated with `connected_vpc_outbound_route53_resolver_endpoint`, required due to resource address changes introduced by the AWS provider 6.x upgrade.
- **`route53-resolver-endpoints.tf`:** Updated to reflect revised resource schema for security group rules in `hashicorp/aws` 6.x.
- **`modules/dms/outputs.tf`:** Removed `sensitive = true` from the `dms_source_role_arn` output.
- **`dms/iam-policies.tf`:** Removed now-redundant `description` arguments from `iam-policy` module calls (no longer a supported input in `6.6.0`).
- **`eventbridge-scheduler.tf`:** Updated `role_arn` references from `.iam_role_arn` to `.arn` to match the new output name in `iam-role` 6.x.
- **`kms-keys.tf`:** Updated `grantee_principal` references from `.iam_role_arn` to `.arn`.
- **`s3.tf`:** Updated `role` reference from `.iam_role_arn` to `.arn`.

---

PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.