### PR TITLE
patch: litellm `1.86.2` -> `1.87.0`

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -10,7 +10,7 @@ locals {
       "Jacob.Woffenden@justice.gov.uk"
     ]
     development = {
-      litellm_version     = "1.86.2"
+      litellm_version     = "1.87.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -48,7 +48,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.86.2"
+      litellm_version     = "1.87.0"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -88,7 +88,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.86.2"
+      litellm_version     = "1.87.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -126,7 +126,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.86.2"
+      litellm_version     = "1.87.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -168,7 +168,7 @@ envVars: {
     LITELLM_MODE: "PRODUCTION",
     LITELLM_UI_PATH: "/app/var/litellm/ui",
     PRISMA_BINARY_CACHE_DIR: "/app/cache/prisma-python/binaries",
-    PROXY_BASE_URL: "https://${proxyHostname}",
+    PROXY_BASE_URL: "https://${ingressHostname}",
     REDIS_SSL: "True",
     USE_PRISMA_MIGRATE: "True",
     XDG_CACHE_HOME: "/app/cache"


### PR DESCRIPTION
This pull request updates the AI Gateway environment configuration and Helm chart values to use a newer version of the `litellm` service and to improve consistency in environment variable usage. The most important changes are:

**litellm Version Upgrade:**

* Updated the `litellm_version` from `1.86.2` to `1.87.0` across all environments (`development`, `test`, `preproduction`, and `production`) in `environment-configuration.tf`. [[1]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL13-R13) [[2]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL51-R51) [[3]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL91-R91) [[4]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL129-R129)

**Helm Chart Configuration:**

* Changed the `PROXY_BASE_URL` to temporarily permit access to the UI. This is not strictly correct, but is a workaround whilst I figure out how to properly make this work.