### PR TITLE
TM-2125: prisonretail: update security group

### DIFF
--- a/terraform/environments/prison-retail/locals_security_groups.tf
+++ b/terraform/environments/prison-retail/locals_security_groups.tf
@@ -29,18 +29,32 @@ locals {
           protocol    = -1
           self        = true
         }
-        TCP_3389 = {
-          description = "Allow RDP ingress 3389"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "TCP"
+        ICMP = {
+          description = "Allow ping for client host availability check and MTU calculation"
+          from_port   = -1
+          to_port     = -1
+          protocol    = "icmp"
+          cidr_blocks = local.security_group_cidrs.enduserclient
+        }
+        TCP_80 = {
+          description = "Allow HTTP ingress 80 for WebDav check"
+          from_port   = 445
+          to_port     = 445
+          protocol    = "tcp"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
         TCP_445 = {
           description = "Allow SMB ingress 445"
           from_port   = 445
           to_port     = 445
-          protocol    = "TCP"
+          protocol    = "tcp"
+          cidr_blocks = local.security_group_cidrs.enduserclient
+        }
+        TCP_3389 = {
+          description = "Allow RDP ingress 3389"
+          from_port   = 3389
+          to_port     = 3389
+          protocol    = "tcp"
           cidr_blocks = local.security_group_cidrs.enduserclient
         }
       }

--- a/terraform/environments/prison-retail/locals_security_groups.tf
+++ b/terraform/environments/prison-retail/locals_security_groups.tf
@@ -20,6 +20,7 @@ locals {
 
   security_groups = {
     prison-retail = {
+      # application specific ports; standard windows ports are in ec2-windows SG
       description = "Security group for prisoner retail"
       ingress = {
         all-from-self = {
@@ -49,23 +50,6 @@ locals {
           to_port     = 445
           protocol    = "tcp"
           cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-        TCP_3389 = {
-          description = "Allow RDP ingress 3389"
-          from_port   = 3389
-          to_port     = 3389
-          protocol    = "tcp"
-          cidr_blocks = local.security_group_cidrs.enduserclient
-        }
-      }
-      egress = {
-        all = {
-          description     = "Allow all egress"
-          from_port       = 0
-          to_port         = 0
-          protocol        = "-1"
-          cidr_blocks     = ["0.0.0.0/0"]
-          security_groups = []
         }
       }
     }


### PR DESCRIPTION
Remove RDP from all clients - this should be locked down to jump servers and is covered by ec2-windows SG
Allow some additional ports currently showing as rejected in flow logs. Ping + HTTP (for WebDav check)