### PR TITLE
Laa fabric OIDC setup

### DIFF
--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -1,9 +1,13 @@
-module "fabric_oidc_provider" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=36908c4"
-
-  tenant_id          = local.fabric_tenant_id
-  oidc_provider_name = "fabric-s3-access"
-}
+# Phase 1 of a two-phase deployment: the Fabric OIDC provider and IAM role
+# are commented out until the secrets created in secrets.tf have been
+# populated out-of-band. A follow-up change will re-enable these modules
+# and switch the Fabric locals to read from aws_secretsmanager_secret_version.
+# module "fabric_oidc_provider" {
+#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=36908c4"
+#
+#   tenant_id          = local.fabric_tenant_id
+#   oidc_provider_name = "fabric-s3-access"
+# }
 
 # Curated S3 bucket exposed to Microsoft Fabric via OneLake shortcuts.
 # TODO: Use KMS key for encryption.
@@ -24,14 +28,14 @@ module "fabric_curated_bucket" {
   tags = local.tags
 }
 
-module "fabric_iam_role" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=36908c4"
-
-  object_id                          = local.fabric_enterprise_app_object_id
-  oidc_provider_arn                  = module.fabric_oidc_provider.arn
-  oidc_provider_condition_key_prefix = module.fabric_oidc_provider.condition_key_prefix
-
-  bucket_arn       = module.fabric_curated_bucket.bucket.arn
-  role_name        = "fabric-s3-access"
-  role_policy_name = "fabric-s3-read-policy"
-}
+# module "fabric_iam_role" {
+#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=36908c4"
+#
+#   object_id                          = local.fabric_enterprise_app_object_id
+#   oidc_provider_arn                  = module.fabric_oidc_provider.arn
+#   oidc_provider_condition_key_prefix = module.fabric_oidc_provider.condition_key_prefix
+#
+#   bucket_arn       = module.fabric_curated_bucket.bucket.arn
+#   role_name        = "fabric-s3-access"
+#   role_policy_name = "fabric-s3-read-policy"
+# }

--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -1,6 +1,37 @@
 module "fabric_oidc_provider" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=15cea29"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=36908c4"
 
   tenant_id          = local.fabric_tenant_id
   oidc_provider_name = "fabric-s3-access"
+}
+
+# Curated S3 bucket exposed to Microsoft Fabric via OneLake shortcuts.
+# TODO: Use KMS key for encryption.
+module "fabric_curated_bucket" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=ce9c0c07489e393ce80441aed0fd5bf7798956a3"
+
+  bucket_prefix      = "laa-data-factory-curated"
+  versioning_enabled = true
+  ownership_controls = "BucketOwnerEnforced"
+
+  replication_enabled = false
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  sse_algorithm = "AES256"
+
+  tags = local.tags
+}
+
+module "fabric_iam_role" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=36908c4"
+
+  object_id                          = local.fabric_enterprise_app_object_id
+  oidc_provider_arn                  = module.fabric_oidc_provider.arn
+  oidc_provider_condition_key_prefix = module.fabric_oidc_provider.condition_key_prefix
+
+  bucket_arn       = module.fabric_curated_bucket.bucket.arn
+  role_name        = "fabric-s3-access"
+  role_policy_name = "fabric-s3-read-policy"
 }

--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -1,0 +1,6 @@
+module "fabric_oidc_provider" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=15cea29"
+
+  tenant_id          = local.fabric_tenant_id
+  oidc_provider_name = "fabric-s3-access"
+}

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,1 +1,3 @@
-#### This file can be used to store locals specific to the member account ####
+locals {
+  fabric_tenant_id = var.fabric_tenant_id
+}

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  fabric_tenant_id = data.aws_secretsmanager_secret_version.fabric_tenant_id.secret_string
+  fabric_tenant_id                = data.aws_secretsmanager_secret_version.fabric_tenant_id.secret_string
+  fabric_enterprise_app_object_id = data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id.secret_string
 }

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  fabric_tenant_id = var.fabric_tenant_id
+  fabric_tenant_id = data.aws_secretsmanager_secret_version.fabric_tenant_id.secret_string
 }

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,4 +1,3 @@
-#### This file can be used to store locals specific to the member account ####
 locals {
   current_account_id     = data.aws_caller_identity.current.account_id
   current_account_region = data.aws_region.current.region

--- a/terraform/environments/data-factory-laa/outputs.tf
+++ b/terraform/environments/data-factory-laa/outputs.tf
@@ -1,0 +1,9 @@
+output "fabric_oidc_provider_arn" {
+  description = "ARN of the Microsoft Entra OIDC provider for Fabric."
+  value       = module.fabric_oidc_provider.arn
+}
+
+output "fabric_iam_role_arn" {
+  description = "ARN of the IAM role for Fabric."
+  value       = module.fabric_iam_role.arn
+}

--- a/terraform/environments/data-factory-laa/outputs.tf
+++ b/terraform/environments/data-factory-laa/outputs.tf
@@ -1,9 +1,11 @@
-output "fabric_oidc_provider_arn" {
-  description = "ARN of the Microsoft Entra OIDC provider for Fabric."
-  value       = module.fabric_oidc_provider.arn
-}
-
-output "fabric_iam_role_arn" {
-  description = "ARN of the IAM role for Fabric."
-  value       = module.fabric_iam_role.arn
-}
+# Phase 1 of a two-phase deployment: these outputs are disabled until the
+# fabric_oidc_provider and fabric_iam_role modules in fabric.tf are re-enabled.
+# output "fabric_oidc_provider_arn" {
+#   description = "ARN of the Microsoft Entra OIDC provider for Fabric."
+#   value       = module.fabric_oidc_provider.arn
+# }
+#
+# output "fabric_iam_role_arn" {
+#   description = "ARN of the IAM role for Fabric."
+#   value       = module.fabric_iam_role.arn
+# }

--- a/terraform/environments/data-factory-laa/secrets.tf
+++ b/terraform/environments/data-factory-laa/secrets.tf
@@ -5,3 +5,11 @@ data "aws_secretsmanager_secret" "fabric_tenant_id" {
 data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
   secret_id = data.aws_secretsmanager_secret.fabric_tenant_id.id
 }
+
+data "aws_secretsmanager_secret" "fabric_enterprise_app_object_id" {
+  name = "data-factory-laa-development/fabric-enterprise-app-object-id"
+}
+
+data "aws_secretsmanager_secret_version" "fabric_enterprise_app_object_id" {
+  secret_id = data.aws_secretsmanager_secret.fabric_enterprise_app_object_id.id
+}

--- a/terraform/environments/data-factory-laa/secrets.tf
+++ b/terraform/environments/data-factory-laa/secrets.tf
@@ -1,1 +1,7 @@
-#### This file can be used to store secrets specific to the member account ####
+data "aws_secretsmanager_secret" "fabric_tenant_id" {
+  name = "data-factory-laa-development/fabric-tenant-id"
+}
+
+data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
+  secret_id = data.aws_secretsmanager_secret.fabric_tenant_id.id
+}

--- a/terraform/environments/data-factory-laa/secrets.tf
+++ b/terraform/environments/data-factory-laa/secrets.tf
@@ -1,15 +1,11 @@
-data "aws_secretsmanager_secret" "fabric_tenant_id" {
-  name = "data-factory-laa-development/fabric-tenant-id"
+# Managed secret resource for the Microsoft Fabric tenant ID.
+resource "aws_secretsmanager_secret" "fabric_tenant_id" {
+  name = "data-factory-laa-${local.environment}/fabric-tenant-id"
+  tags = local.tags
 }
 
-data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
-  secret_id = data.aws_secretsmanager_secret.fabric_tenant_id.id
-}
-
-data "aws_secretsmanager_secret" "fabric_enterprise_app_object_id" {
-  name = "data-factory-laa-development/fabric-enterprise-app-object-id"
-}
-
-data "aws_secretsmanager_secret_version" "fabric_enterprise_app_object_id" {
-  secret_id = data.aws_secretsmanager_secret.fabric_enterprise_app_object_id.id
+# Managed secret resource for the Fabric enterprise application object ID.
+resource "aws_secretsmanager_secret" "fabric_enterprise_app_object_id" {
+  name = "data-factory-laa-${local.environment}/fabric-enterprise-app-object-id"
+  tags = local.tags
 }

--- a/terraform/environments/data-factory-laa/variables.tf
+++ b/terraform/environments/data-factory-laa/variables.tf
@@ -1,0 +1,5 @@
+variable "fabric_tenant_id" {
+  type        = string
+  description = "Microsoft Entra tenant ID for the OIDC provider URL."
+  sensitive   = false
+}

--- a/terraform/environments/data-factory-laa/variables.tf
+++ b/terraform/environments/data-factory-laa/variables.tf
@@ -1,5 +1,0 @@
-variable "fabric_tenant_id" {
-  type        = string
-  description = "Microsoft Entra tenant ID for the OIDC provider URL."
-  sensitive   = false
-}


### PR DESCRIPTION
## Summary

Implements Microsoft Fabric OIDC federation into the data-factory-laa-development AWS account so OneLake S3 shortcuts can read curated data using short-lived STS credentials. No static AWS access keys are used.

The PR adds
- Microsoft Entra OIDC provider - via `modules/fabric-oidc-provider`
- Fabric IAM role + constrained trust policy + S3 read policy
- New curated S3 bucket (`laa-data-factory-curated*`) using the MoJ standard S3 module
- Secrets Manager lookups for tenant ID and Enterprise App Object ID
- Terraform outputs for OIDC provider ARN and Fabric IAM role ARN.