### PR TITLE
:copilot: chore(terraform): upgrade AWS provider to 6.0 in observability-platform [Phase 1]

### DIFF
--- a/terraform/environments/observability-platform/versions.tf
+++ b/terraform/environments/observability-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.8, != 5.86.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     grafana = {


### PR DESCRIPTION
## Phase 1: AWS Provider Upgrade

### Change Summary

Upgrades AWS provider constraint in observability-platform environment from **~> 5.8** to **~> 6.0**.

**File**: `terraform/environments/observability-platform/versions.tf`

**Change**:
```diff
- version = "~> 5.8, != 5.86.0"
+ version = "~> 6.0"
```

### Purpose

This upgrade is a prerequisite for Phase 2 and Phase 3 of the major version upgrade plan:
- **Phase 2**: terraform-aws-modules/lambda/aws v7.20.1 → v8.8.0 (requires AWS provider 6.0+)
- **Phase 3**: terraform-aws-modules/iam/aws v5.52.2 → v6.6.1 (requires AWS provider 6.0+)

See MAJOR_UPGRADE_PLAN.md for full details.

### Breaking Changes in AWS Provider 6.0

**Most Likely to Impact observability-platform**:
- Default AMI data source behavior changed - `aws_ami` requires explicit `owners` filter
- Some endpoint URL specifications now required explicitly
- Review full changelog: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.0.0

### Testing Checklist

- [ ] `terraform init` completes successfully
- [ ] `terraform validate` passes without errors
- [ ] `terraform fmt -check` shows no formatting issues
- [ ] `terraform plan` shows expected changes only
- [ ] Manual review of plan output for resource changes
- [ ] Deploy to staging and monitor for 1-2 days
- [ ] If stable, apply to production

### Rollback Plan

If issues occur:
1. Revert version to ~> 5.8
2. Run `terraform init`
3. Redeploy

### Dependencies

- ✅ No other changes required for this phase
- ⏳ Phase 2 (lambda/aws v8) and Phase 3 (iam/aws v6) depend on this

---
Part of major version upgrade strategy (Option B - Provider-First Approach). See Draft PR #16956 for full plan.