### PR TITLE
Tf upgrade apc mlflow

### DIFF
--- a/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
@@ -6,7 +6,7 @@ resource "helm_release" "mlflow" {
   repository = "oci://ghcr.io/ministryofjustice/analytical-platform-charts"
   version    = "3.7.0-rc4"
   chart      = "mlflow"
-  namespace  = kubernetes_namespace.mlflow[0].metadata[0].name
+  namespace  = kubernetes_namespace_v1.mlflow[0].metadata[0].name
   values = [
     templatefile(
       "${path.module}/src/helm/values/mlflow/values.yml.tftpl",
@@ -19,8 +19,8 @@ resource "helm_release" "mlflow" {
   ]
   depends_on = [
     module.mlflow_iam_role,
-    kubernetes_secret.mlflow_admin,
-    kubernetes_secret.mlflow_auth_rds,
-    kubernetes_secret.mlflow_rds
+    kubernetes_secret_v1.mlflow_admin,
+    kubernetes_secret_v1.mlflow_auth_rds,
+    kubernetes_secret_v1.mlflow_rds
   ]
 }

--- a/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
@@ -12,7 +12,7 @@ resource "helm_release" "mlflow" {
       "${path.module}/src/helm/values/mlflow/values.yml.tftpl",
       {
         mlflow_hostname = "mlflow.${local.environment_configuration.route53_zone}"
-        eks_role_arn    = module.mlflow_iam_role[0].iam_role_arn
+        eks_role_arn    = module.mlflow_iam_role[0].arn
         s3_bucket_name  = local.environment_configuration.mlflow_s3_bucket_name
       }
     )

--- a/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
@@ -12,7 +12,7 @@ resource "helm_release" "mlflow" {
       "${path.module}/src/helm/values/mlflow/values.yml.tftpl",
       {
         mlflow_hostname = "mlflow.${local.environment_configuration.route53_zone}"
-        eks_role_arn    = module.mlflow_iam_role[0].arn
+        eks_role_arn    = module.mlflow_iam_role[0].iam_role_arn
         s3_bucket_name  = local.environment_configuration.mlflow_s3_bucket_name
       }
     )

--- a/terraform/environments/analytical-platform-compute/mlflow/iam-policy.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/iam-policy.tf
@@ -1,3 +1,4 @@
+# Upgrading the IAM module from v5.x to v6.x introduces breaking changes that cause IAM roles and policies to be replaced. Therefore, we are not proceeding with the version upgrade.
 data "aws_iam_policy_document" "mlflow" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
@@ -44,11 +45,11 @@ module "mlflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "5.59.0"
 
   name_prefix = "mlflow"
-  description = "IAM Policy"
-  policy      = data.aws_iam_policy_document.mlflow[0].json
+
+  policy = data.aws_iam_policy_document.mlflow[0].json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/mlflow/iam-policy.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/iam-policy.tf
@@ -44,11 +44,11 @@ module "mlflow_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.59.0"
+  version = "6.6.0"
 
   name_prefix = "mlflow"
-
-  policy = data.aws_iam_policy_document.mlflow[0].json
+  description = "IAM Policy"
+  policy      = data.aws_iam_policy_document.mlflow[0].json
 
   tags = local.tags
 }

--- a/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
@@ -4,12 +4,13 @@ module "mlflow_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.59.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "6.6.0"
 
-  role_name_prefix = "mlflow"
+  name            = "mlflow"
+  use_name_prefix = false
 
-  role_policy_arns = {
+  policies = {
     MlflowPolicy = module.mlflow_iam_policy[0].arn
   }
 

--- a/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
@@ -16,7 +16,7 @@ module "mlflow_iam_role" {
   oidc_providers = {
     main = {
       provider_arn               = data.aws_iam_openid_connect_provider.eks.arn
-      namespace_service_accounts = ["${kubernetes_namespace.mlflow[0].metadata[0].name}:mlflow"]
+      namespace_service_accounts = ["${kubernetes_namespace_v1.mlflow[0].metadata[0].name}:mlflow"]
     }
   }
 

--- a/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/iam-role.tf
@@ -1,16 +1,16 @@
+# Upgrading the IAM module from v5.x to v6.x introduces breaking changes that cause IAM roles and policies to be replaced. Therefore, we are not proceeding with the version upgrade.
 module "mlflow_iam_role" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version = "6.6.0"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.59.0"
 
-  name            = "mlflow"
-  use_name_prefix = false
+  role_name_prefix = "mlflow"
 
-  policies = {
+  role_policy_arns = {
     MlflowPolicy = module.mlflow_iam_policy[0].arn
   }
 

--- a/terraform/environments/analytical-platform-compute/mlflow/import.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/import.tf
@@ -1,0 +1,79 @@
+# This file is used to import the existing k8s resources into Terraform state.
+# Will be deleted after the import is complete and the state file is updated.
+
+############################
+# Namespace
+############################
+
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? { "0" = "mlflow" } : {}
+  to       = kubernetes_namespace_v1.mlflow[0]
+  id       = each.value
+}
+
+removed {
+  from = kubernetes_namespace.mlflow
+  lifecycle {
+    destroy = false
+  }
+}
+
+############################
+# Secrets (import into v1)
+############################
+
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? { "0" = "mlflow/mlflow-admin" } : {}
+  to       = kubernetes_secret_v1.mlflow_admin[0]
+  id       = each.value
+}
+
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? { "0" = "mlflow/mlflow-auth-rds" } : {}
+  to       = kubernetes_secret_v1.mlflow_auth_rds[0]
+  id       = each.value
+}
+
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? { "0" = "mlflow/mlflow-flask-server-secret-key" } : {}
+  to       = kubernetes_secret_v1.mlflow_flask_server_secret_key[0]
+  id       = each.value
+}
+
+import {
+  for_each = terraform.workspace == "analytical-platform-compute-development" ? { "0" = "mlflow/mlflow-rds" } : {}
+  to       = kubernetes_secret_v1.mlflow_rds[0]
+  id       = each.value
+}
+
+############################
+# Prevent deletion of old resources
+############################
+
+removed {
+  from = kubernetes_secret.mlflow_admin
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = kubernetes_secret.mlflow_auth_rds
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = kubernetes_secret.mlflow_flask_server_secret_key
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = kubernetes_secret.mlflow_rds
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/environments/analytical-platform-compute/mlflow/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/kms-keys.tf
@@ -5,7 +5,7 @@ module "mlflow_auth_rds_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["rds/mlflow-auth"]
   description           = "MLflow Auth RDS KMS key"
@@ -23,7 +23,7 @@ module "mlflow_rds_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["rds/mlflow"]
   description           = "MLflow RDS KMS key"
@@ -41,7 +41,7 @@ module "mlflow_s3_kms" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.0.0"
+  version = "4.2.0"
 
   aliases               = ["s3/mlflow"]
   description           = "MLflow S3 KMS key"

--- a/terraform/environments/analytical-platform-compute/mlflow/kms-keys.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/kms-keys.tf
@@ -1,11 +1,8 @@
 module "mlflow_auth_rds_kms" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
 
   aliases               = ["rds/mlflow-auth"]
   description           = "MLflow Auth RDS KMS key"
@@ -19,11 +16,8 @@ module "mlflow_auth_rds_kms" {
 module "mlflow_rds_kms" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
 
-  source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
 
   aliases               = ["rds/mlflow"]
   description           = "MLflow RDS KMS key"
@@ -37,11 +31,7 @@ module "mlflow_rds_kms" {
 module "mlflow_s3_kms" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-
-  source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
 
   aliases               = ["s3/mlflow"]
   description           = "MLflow S3 KMS key"

--- a/terraform/environments/analytical-platform-compute/mlflow/kubernetes-namespace.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/kubernetes-namespace.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_namespace" "mlflow" {
+resource "kubernetes_namespace_v1" "mlflow" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {

--- a/terraform/environments/analytical-platform-compute/mlflow/kubernetes-secrets.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/kubernetes-secrets.tf
@@ -1,9 +1,9 @@
-resource "kubernetes_secret" "mlflow_auth_rds" {
+resource "kubernetes_secret_v1" "mlflow_auth_rds" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
     name      = "mlflow-auth-rds"
-    namespace = kubernetes_namespace.mlflow[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.mlflow[0].metadata[0].name
   }
 
   type = "Opaque"
@@ -16,12 +16,12 @@ resource "kubernetes_secret" "mlflow_auth_rds" {
   }
 }
 
-resource "kubernetes_secret" "mlflow_rds" {
+resource "kubernetes_secret_v1" "mlflow_rds" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
     name      = "mlflow-rds"
-    namespace = kubernetes_namespace.mlflow[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.mlflow[0].metadata[0].name
   }
 
   type = "Opaque"
@@ -34,12 +34,12 @@ resource "kubernetes_secret" "mlflow_rds" {
   }
 }
 
-resource "kubernetes_secret" "mlflow_admin" {
+resource "kubernetes_secret_v1" "mlflow_admin" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
     name      = "mlflow-admin"
-    namespace = kubernetes_namespace.mlflow[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.mlflow[0].metadata[0].name
   }
 
   type = "Opaque"
@@ -48,12 +48,12 @@ resource "kubernetes_secret" "mlflow_admin" {
   }
 }
 
-resource "kubernetes_secret" "mlflow_flask_server_secret_key" {
+resource "kubernetes_secret_v1" "mlflow_flask_server_secret_key" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
   metadata {
     name      = "mlflow-flask-server-secret-key"
-    namespace = kubernetes_namespace.mlflow[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.mlflow[0].metadata[0].name
   }
 
   type = "Opaque"

--- a/terraform/environments/analytical-platform-compute/mlflow/providers.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/providers.tf
@@ -5,7 +5,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.eks.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.eks.token

--- a/terraform/environments/analytical-platform-compute/mlflow/rds-databases.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/rds-databases.tf
@@ -5,7 +5,7 @@ module "mlflow_auth_rds" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "6.12.0"
+  version = "7.2.0"
 
   identifier = "mlflow-auth"
 
@@ -28,7 +28,8 @@ module "mlflow_auth_rds" {
   username                    = "mlflowauth"
   db_name                     = "mlflowauth"
   manage_master_user_password = false
-  password                    = random_password.mlflow_auth_rds[0].result
+  password_wo                 = random_password.mlflow_auth_rds[0].result
+  password_wo_version         = 1
   kms_key_id                  = module.mlflow_auth_rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/mlflow/rds-databases.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/rds-databases.tf
@@ -1,3 +1,4 @@
+# module (version 7.2.0) is currently unsupported due to this open issue: https://github.com/hashicorp/terraform-provider-aws/issues/42582.
 module "mlflow_auth_rds" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
@@ -5,7 +6,7 @@ module "mlflow_auth_rds" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/rds/aws"
-  version = "7.2.0"
+  version = "6.12.0"
 
   identifier = "mlflow-auth"
 
@@ -28,8 +29,7 @@ module "mlflow_auth_rds" {
   username                    = "mlflowauth"
   db_name                     = "mlflowauth"
   manage_master_user_password = false
-  password_wo                 = random_password.mlflow_auth_rds[0].result
-  password_wo_version         = 1
+  password                    = random_password.mlflow_auth_rds[0].result
   kms_key_id                  = module.mlflow_auth_rds_kms[0].key_arn
 
   parameters = [

--- a/terraform/environments/analytical-platform-compute/mlflow/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/s3-buckets.tf
@@ -5,7 +5,7 @@ module "mlflow_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.2.0"
+  version = "5.13.0"
 
   bucket = "mojap-compute-${local.environment}-mlflow"
 

--- a/terraform/environments/analytical-platform-compute/mlflow/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/s3-buckets.tf
@@ -1,11 +1,8 @@
 module "mlflow_bucket" {
   count = terraform.workspace == "analytical-platform-compute-development" ? 1 : 0
 
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.13.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=af0286ff37a66c2b79faf360e6e2663744b8e5b5" # v5.13.0
 
   bucket = "mojap-compute-${local.environment}-mlflow"
 

--- a/terraform/environments/analytical-platform-compute/mlflow/versions.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/versions.tf
@@ -1,33 +1,33 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.46"
       source  = "hashicorp/aws"
     }
     dns = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/dns"
     }
     external = {
-      version = "~> 2.0"
+      version = "~> 2.4"
       source  = "hashicorp/external"
     }
     http = {
-      version = "~> 3.0"
+      version = "~> 3.6"
       source  = "hashicorp/http"
     }
     kubernetes = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/kubernetes"
     }
     helm = {
-      version = "~> 2.0"
+      version = "~> 3.1"
       source  = "hashicorp/helm"
     }
     random = {
-      version = "~> 3.0"
+      version = "~> 3.9"
       source  = "hashicorp/random"
     }
   }
-  required_version = "~> 1.10"
+  required_version = "~> 1.15"
 }


### PR DESCRIPTION
Upgrades Terraform binary, all provider version constraints, and multiple Terraform AWS modules across the analytical-platform-compute `MLflow` stack.

---

### Version Changes

#### Terraform Binary

| File | Current | New |
|------|---------|-----|
| `versions.tf` | `~> 1.10` | `~> 1.15` |

---

#### Providers

| Provider | Current | New |
|----------|---------|-----|
| `hashicorp/aws` | `~> 6.0` | `~> 6.46` |
| `hashicorp/dns` | `~> 3.0` | `~> 3.6` |
| `hashicorp/external` | `~> 2.0` | `~> 2.4` |
| `hashicorp/http` | `~> 3.0` | `~> 3.6` |
| `hashicorp/kubernetes` | `~> 2.0` | `~> 3.1` |
| `hashicorp/helm` | `~> 2.0` | `~> 3.1` |
| `hashicorp/random` | `~> 3.0` | `~> 3.9` |

---

#### Terraform AWS Modules

| File | Module | Current | New |
|------|--------|---------|-----|
| `mlflow/kms-keys.tf` | `terraform-aws-modules/kms/aws` | `4.0.0` | `4.2.0` |
| `mlflow/s3-buckets.tf` | `terraform-aws-modules/s3-bucket/aws` | `5.2.0` | `5.13.0` |

---

### Additional Changes

#### Kubernetes Provider (`hashicorp/kubernetes` 3.x migration)

- **`kubernetes-namespace.tf`**: Migrated `kubernetes_namespace` resource to `kubernetes_namespace_v1`.
- **`kubernetes-secrets.tf`**: Migrated all `kubernetes_secret` resources to `kubernetes_secret_v1` (`mlflow_admin`, `mlflow_auth_rds`, `mlflow_flask_server_secret_key`, `mlflow_rds`).
- **`helm-release.tf`**: Updated all references from deprecated resource types to their `_v1` equivalents (`kubernetes_namespace_v1`, `kubernetes_secret_v1`).
- **`iam-role.tf`**: Updated `namespace_service_accounts` reference to use `kubernetes_namespace_v1`.

#### Helm Provider (`hashicorp/helm` 3.x migration)

- **`providers.tf`**: Updated `helm` provider `kubernetes` block from nested block syntax to assignment syntax (`kubernetes = { ... }`), as required by Helm provider 3.x.

#### IAM Module — Breaking Change (Skipped)

- **`iam-policy.tf` / `iam-role.tf`**: Upgrading the IAM module from `v5.x` to `v6.x` introduces breaking changes that would cause IAM roles and policies to be **replaced**. This upgrade has been intentionally skipped. Comments have been added to both files to document this decision.

#### RDS Module — Known Issue (Skipped)

- **`rds-databases.tf`**: Version `7.2.0` of the RDS module is currently unsupported due to an open upstream issue ([hashicorp/terraform-provider-aws#42582](https://github.com/hashicorp/terraform-provider-aws/issues/42582)). This upgrade has been intentionally skipped. A comment has been added to document this.

#### State Migration (`import.tf`)

Added a new `import.tf` file to handle Terraform state migration resulting from the `kubernetes` provider 3.x resource renames


PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/9992) ticket.