### PR TITLE
CC-4517/CC-4546: Add GuardDuty Slack alerting and S3 bucket hardening for MAAT

### DIFF
--- a/terraform/environments/maat/guardduty.tf
+++ b/terraform/environments/maat/guardduty.tf
@@ -1,4 +1,3 @@
-/*
 # ---------------------------------------------
 # GuardDuty Findings → Slack Alerting
 # ---------------------------------------------
@@ -288,4 +287,3 @@ resource "aws_guardduty_malware_protection_plan" "s3_shared" {
 
   depends_on = [module.s3-bucket-shared]
 }
-*/

--- a/terraform/environments/maat/locals.tf
+++ b/terraform/environments/maat/locals.tf
@@ -37,10 +37,10 @@ locals {
 
   xdr_tags = join(", ", [upper(local.application_name), upper(local.environment), upper(var.networking[0].business-unit)])
 
-  # lambda_source_hashes = [
-  #   for f in fileset("./lambda/cloudwatch_alarm_slack_integration", "**") :
-  #   sha256(file("${path.module}/lambda/cloudwatch_alarm_slack_integration/${f}"))
-  # ]
+  lambda_source_hashes = [
+    for f in fileset("./lambda/cloudwatch_alarm_slack_integration", "**") :
+    sha256(file("${path.module}/lambda/cloudwatch_alarm_slack_integration/${f}"))
+  ]
 
-  # lambda_folder_name = ["lambda_delivery", "cloudwatch_sns_layer"]
+  lambda_folder_name = ["lambda_delivery", "cloudwatch_sns_layer"]
 }

--- a/terraform/environments/maat/s3-lambda-delivery.tf
+++ b/terraform/environments/maat/s3-lambda-delivery.tf
@@ -1,4 +1,3 @@
-/*
 # Shared S3 bucket for Lambda layer delivery
 # Note: upload lambda_delivery/cloudwatch_sns_layer/layerV1.zip manually before first apply
 # See: https://dsdmoj.atlassian.net/wiki/spaces/LDD/pages/5975606239/Build+Layered+Function+for+Lambda
@@ -10,12 +9,56 @@ module "s3-bucket-shared" {
   versioning_enabled  = true
   replication_enabled = false
   replication_region  = "eu-west-2"
+  sse_algorithm       = "AES256"
+  custom_kms_key      = ""
+  bucket_policy       = [aws_s3_bucket_policy.shared_bucket_policy.policy]
 
   providers = {
     aws.bucket-replication = aws
   }
 
-  tags = local.tags
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = "Enabled"
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      abort_incomplete_multipart_upload_days = 7
+    }
+  ]
+
+  tags = merge(local.tags,
+    { Name = "${local.application_name}-${local.environment}-shared" }
+  )
+}
+
+resource "aws_s3_bucket_policy" "shared_bucket_policy" {
+  bucket = module.s3-bucket-shared.bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "EnforceTLSv12orHigher",
+        Effect = "Deny",
+        Principal = {
+          AWS = "*"
+        },
+        Action   = "s3:*",
+        Resource = ["${module.s3-bucket-shared.bucket.arn}/*", "${module.s3-bucket-shared.bucket.arn}"],
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
+          }
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_s3_object" "folder" {
@@ -27,4 +70,3 @@ resource "aws_s3_object" "folder" {
 
   key = each.value
 }
-*/


### PR DESCRIPTION
## Summary

### CC-4517 — GuardDuty Slack alerting
- EventBridge rule captures `GuardDuty Finding` events and publishes to an encrypted SNS topic
- SNS subscription triggers a Lambda that forwards findings to Slack via webhook stored in Secrets Manager
- Lambda uses `cloudwatch_alarm_slack_integration` code with `pycurl`-based layer
- GuardDuty S3 Malware Protection Plan enabled for the shared bucket

### CC-4546 — Shared S3 bucket hardening
- Added `sse_algorithm = "AES256"` encryption
- Added lifecycle rule (abort incomplete multipart uploads after 7 days)
- Added TLS enforcement bucket policy (`EnforceTLSv12orHigher`)
- Added `Name` tag to the shared bucket

## Pre-apply steps required
1. Run `terraform apply -target=module.s3-bucket-shared` to create the shared bucket first
2. Upload `layerV1.zip` to the new shared bucket at key `lambda_delivery/cloudwatch_sns_layer/layerV1.zip`
3. Populate the `maat-<env>-guardduty-slack` secret with Slack webhook URLs

## Test plan
- [ ] Terraform plan shows expected resources with no errors
- [ ] Shared S3 bucket created with encryption and TLS policy
- [ ] Lambda layer zip uploaded before apply
- [ ] Apply succeeds in development
- [ ] Slack webhook secrets populated
- [ ] Apply succeeds in preproduction and production