### PR TITLE
update bastion module

### DIFF
--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.5.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.5.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts


### PR DESCRIPTION
This pull request makes a minor update to the `bastion_linux` module version in the `cdpt-chaps` environment’s Terraform configuration, ensuring the use of the latest features and fixes from the upstream module.

- Updated the `bastion_linux` module source reference from version `v4.2.1` to `v4.5.0` in `bastion_linux.tf` to incorporate improvements and bug fixes from the newer release.