### PR TITLE
datalake-access ap role allowed to assume laa share role

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -260,6 +260,8 @@ data "aws_iam_policy_document" "data_engineering_datalake_access_github_actions"
       "arn:aws:iam::${local.environment_management.account_ids["property-cafm-data-migration-development"]}:role/lakeformation-share-role",
       "arn:aws:iam::${local.environment_management.account_ids["property-cafm-data-migration-preproduction"]}:role/lakeformation-share-role",
       "arn:aws:iam::${local.environment_management.account_ids["property-cafm-data-migration-production"]}:role/lakeformation-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["data-factory-laa-development"]}:role/lakeformation-share-role",
+      "arn:aws:iam::${local.environment_management.account_ids["data-factory-laa-test"]}:role/lakeformation-share-role",
     ]
   }
 }


### PR DESCRIPTION
- Allow AP data lake access role to assume LAA Lake Formation share role.