### PR TITLE
feat(data-factory-laa): add Fabric OIDC IAM role

### DIFF
--- a/terraform/environments/data-factory-laa/data.tf
+++ b/terraform/environments/data-factory-laa/data.tf
@@ -1,1 +1,8 @@
 #### This file can be used to store data specific to the member account ####
+data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
+  secret_id = aws_secretsmanager_secret.fabric_tenant_id.id
+}
+
+data "aws_secretsmanager_secret_version" "fabric_enterprise_app_object_id" {
+  secret_id = aws_secretsmanager_secret.fabric_enterprise_app_object_id.id
+}

--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -1,0 +1,40 @@
+# Microsoft Fabric integration: OIDC trust, IAM role, and curated S3 bucket
+# exposed to Microsoft Fabric via OneLake S3 shortcuts.
+
+module "fabric_oidc_provider" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=36908c4b209427f3a59a8cb4a80e9a577bc069f5"
+
+  tenant_id          = local.fabric_tenant_id
+  oidc_provider_name = "fabric-s3-access"
+}
+
+# Curated S3 bucket exposed to Microsoft Fabric via OneLake shortcuts.
+# TODO: Use KMS key for encryption.
+module "fabric_curated_bucket" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=ce9c0c07489e393ce80441aed0fd5bf7798956a3"
+
+  bucket_prefix      = "laa-data-factory-curated"
+  versioning_enabled = true
+  ownership_controls = "BucketOwnerEnforced"
+
+  replication_enabled = false
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  sse_algorithm = "AES256"
+
+  tags = local.tags
+}
+
+module "fabric_iam_role" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=36908c4b209427f3a59a8cb4a80e9a577bc069f5"
+
+  object_id                          = local.fabric_enterprise_app_object_id
+  oidc_provider_arn                  = module.fabric_oidc_provider.arn
+  oidc_provider_condition_key_prefix = module.fabric_oidc_provider.condition_key_prefix
+
+  bucket_arn       = module.fabric_curated_bucket.bucket.arn
+  role_name        = "fabric-s3-access"
+  role_policy_name = "fabric-s3-read-policy"
+}

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,5 +1,7 @@
 #### This file can be used to store locals specific to the member account ####
 locals {
-  current_account_id     = data.aws_caller_identity.current.account_id
-  current_account_region = data.aws_region.current.region
+  current_account_id              = data.aws_caller_identity.current.account_id
+  current_account_region          = data.aws_region.current.region
+  fabric_tenant_id                = data.aws_secretsmanager_secret_version.fabric_tenant_id.secret_string
+  fabric_enterprise_app_object_id = data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id.secret_string
 }


### PR DESCRIPTION
# Summary

Implements the AWS identity foundation for Microsoft Fabric S3 Shortcuts in data-factory-laa-development.

## Changes
- Adds Microsoft Entra OIDC provider for Fabric.
- Adds Fabric IAM role with OIDC trust relationship.
- Restricts role assumption to the configured Entra tenant, Enterprise Application Object ID, and Fabric S3 connector audience.
- Grants read-only access to the Fabric curated S3 bucket.
- Adds Secrets Manager integration for tenant ID and Enterprise Application Object ID.