### PR TITLE
fix: partial fix to playground functionality

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -166,6 +166,7 @@ envVars: {
     LITELLM_LOG: "ERROR",
     LITELLM_MIGRATION_DIR: "/app/migrations",
     LITELLM_MODE: "PRODUCTION",
+    LITELLM_UI_API_DOC_BASE_URL: "https://${proxyHostname}",
     LITELLM_UI_PATH: "/app/var/litellm/ui",
     PRISMA_BINARY_CACHE_DIR: "/app/cache/prisma-python/binaries",
     PROXY_BASE_URL: "https://${ingressHostname}",


### PR DESCRIPTION
This PR resolves [this](https://github.com/ministryofjustice/data-platform/issues/319) bug. 

In effect in the Playground it adds this Fill button for users to use. When clicked it gives the correct URL per environment. 


<img width="673" height="393" alt="Screenshot 2026-06-04 at 14 13 17" src="https://github.com/user-attachments/assets/8fb44909-c5d0-4202-bf0c-bba4b88f6ea1" />

I declare this a 'partial' fix as I believe the name `PROXY_BASE_URL` is not correct and needs to be refactored in litellm itself.
