### PR TITLE
Updated lf perms and removed duplicated perm

### DIFF
--- a/terraform/environments/electronic-monitoring-data/gdpr_jobs.tf
+++ b/terraform/environments/electronic-monitoring-data/gdpr_jobs.tf
@@ -184,16 +184,6 @@ resource "aws_ecs_cluster_capacity_providers" "ecd-gdpr-fargate" {
   }
 }
 
-resource "aws_lakeformation_permissions" "gdpr_iceberg_table_db_permissions" {
-  for_each  = local.is-development || local.is-preproduction || local.is-production ? toset(local.target_gdpr_dbs) : []
-  principal = aws_iam_role.gdpr_structured_job_role[0].arn
-
-  database {
-    name = each.value
-  }
-
-  permissions = ["DESCRIBE"]
-}
 resource "aws_lakeformation_permissions" "gdpr_iceberg_table_table_permissions" {
   for_each  = local.is-development || local.is-preproduction || local.is-production ? toset(local.target_gdpr_dbs) : []
   principal = aws_iam_role.gdpr_structured_job_role[0].arn

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -14,6 +14,7 @@ locals {
     "acquisitive_crime${local.dbt_suffix}",
     "allied_mdss_${local.environment_shorthand}",
   ]
+
 }
 
 # ------------------------------------------
@@ -2734,7 +2735,7 @@ resource "aws_iam_role_policy_attachment" "gdpr_unstructured_control_lambda_iam_
 module "share_dbs_with_control_lambda_role" {
   count                   = local.is-test ? 0 : 1
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = toset(local.historic_source_dbs)
+  dbs_to_grant            = toset(local.historic_source_dbs, local.ears_sars_athena_dbs)
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.gdpr_unstructured_control_lambda_iam_role[0].arn
   db_exists               = true

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -2735,7 +2735,7 @@ resource "aws_iam_role_policy_attachment" "gdpr_unstructured_control_lambda_iam_
 module "share_dbs_with_control_lambda_role" {
   count                   = local.is-test ? 0 : 1
   source                  = "./modules/lakeformation_database_share"
-  dbs_to_grant            = toset(local.historic_source_dbs, local.ears_sars_athena_dbs)
+  dbs_to_grant            = toset(concat(local.historic_source_dbs, local.ears_sars_athena_dbs))
   data_bucket_lf_resource = aws_lakeformation_resource.data_bucket.arn
   role_arn                = aws_iam_role.gdpr_unstructured_control_lambda_iam_role[0].arn
   db_exists               = true


### PR DESCRIPTION
- Removed Duplicated **_gdpr_iceberg_table_db_permissions_** resource (please double check)
- Updated LF perms for control lambda to include extra athena dbs