### PR TITLE
feat(ai-gateway): configure ElastiCache log delivery to CloudWatch

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/cloudwatch.tf
+++ b/terraform/environments/data-platform/ai-gateway/cloudwatch.tf
@@ -5,3 +5,19 @@ module "waf_ai_gateway_log_group" {
   retention_in_days = 365
   kms_key_id        = module.ai_gateway_cloudwatch_kms_key.key_arn
 }
+
+module "ai_gateway_elasticache_slow_log_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-cloudwatch.git//modules/log-group?ref=a2a5f9d15e30d0d24b667933599e5e1bef24a8b8" # v5.7.2
+
+  name              = "/aws/elasticache/${local.component_name}/slow-log"
+  retention_in_days = 365
+  kms_key_id        = module.ai_gateway_cloudwatch_kms_key.key_arn
+}
+
+module "ai_gateway_elasticache_engine_log_group" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-cloudwatch.git//modules/log-group?ref=a2a5f9d15e30d0d24b667933599e5e1bef24a8b8" # v5.7.2
+
+  name              = "/aws/elasticache/${local.component_name}/engine-log"
+  retention_in_days = 365
+  kms_key_id        = module.ai_gateway_cloudwatch_kms_key.key_arn
+}

--- a/terraform/environments/data-platform/ai-gateway/cloudwatch.tf
+++ b/terraform/environments/data-platform/ai-gateway/cloudwatch.tf
@@ -11,7 +11,7 @@ module "ai_gateway_elasticache_slow_log_group" {
 
   name              = "/aws/elasticache/${local.component_name}/slow-log"
   retention_in_days = 365
-  kms_key_id        = module.ai_gateway_cloudwatch_kms_key.key_arn
+  kms_key_id        = module.ai_gateway_elasticache_logs_kms_key.key_arn
 }
 
 module "ai_gateway_elasticache_engine_log_group" {
@@ -19,5 +19,5 @@ module "ai_gateway_elasticache_engine_log_group" {
 
   name              = "/aws/elasticache/${local.component_name}/engine-log"
   retention_in_days = 365
-  kms_key_id        = module.ai_gateway_cloudwatch_kms_key.key_arn
+  kms_key_id        = module.ai_gateway_elasticache_logs_kms_key.key_arn
 }

--- a/terraform/environments/data-platform/ai-gateway/elasticache.tf
+++ b/terraform/environments/data-platform/ai-gateway/elasticache.tf
@@ -35,16 +35,18 @@ module "ai_gateway_elasticache" {
 
   log_delivery_configuration = {
     slow_log = {
-      destination      = module.ai_gateway_elasticache_slow_log_group.cloudwatch_log_group_name
-      destination_type = "cloudwatch-logs"
-      log_format       = "json"
-      log_type         = "slow-log"
+      create_cloudwatch_log_group = false
+      destination                 = module.ai_gateway_elasticache_slow_log_group.cloudwatch_log_group_name
+      destination_type            = "cloudwatch-logs"
+      log_format                  = "json"
+      log_type                    = "slow-log"
     }
     engine_log = {
-      destination      = module.ai_gateway_elasticache_engine_log_group.cloudwatch_log_group_name
-      destination_type = "cloudwatch-logs"
-      log_format       = "json"
-      log_type         = "engine-log"
+      create_cloudwatch_log_group = false
+      destination                 = module.ai_gateway_elasticache_engine_log_group.cloudwatch_log_group_name
+      destination_type            = "cloudwatch-logs"
+      log_format                  = "json"
+      log_type                    = "engine-log"
     }
   }
 }

--- a/terraform/environments/data-platform/ai-gateway/elasticache.tf
+++ b/terraform/environments/data-platform/ai-gateway/elasticache.tf
@@ -19,6 +19,7 @@ module "ai_gateway_elasticache" {
   transit_encryption_enabled = true
   auth_token                 = random_password.elasticache.result
 
+  apply_immediately    = true
   parameter_group_name = "default.valkey9"
 
   # Security group

--- a/terraform/environments/data-platform/ai-gateway/elasticache.tf
+++ b/terraform/environments/data-platform/ai-gateway/elasticache.tf
@@ -19,7 +19,6 @@ module "ai_gateway_elasticache" {
   transit_encryption_enabled = true
   auth_token                 = random_password.elasticache.result
 
-  apply_immediately    = true
   parameter_group_name = "default.valkey9"
 
   # Security group

--- a/terraform/environments/data-platform/ai-gateway/elasticache.tf
+++ b/terraform/environments/data-platform/ai-gateway/elasticache.tf
@@ -33,7 +33,20 @@ module "ai_gateway_elasticache" {
     }
   }
 
-  log_delivery_configuration = {} # TODO: this
+  log_delivery_configuration = {
+    slow_log = {
+      destination      = module.ai_gateway_elasticache_slow_log_group.cloudwatch_log_group_name
+      destination_type = "cloudwatch-logs"
+      log_format       = "json"
+      log_type         = "slow-log"
+    }
+    engine_log = {
+      destination      = module.ai_gateway_elasticache_engine_log_group.cloudwatch_log_group_name
+      destination_type = "cloudwatch-logs"
+      log_format       = "json"
+      log_type         = "engine-log"
+    }
+  }
 }
 
 module "ai_gateway_elasticache_secret" {

--- a/terraform/environments/data-platform/ai-gateway/kms-keys.tf
+++ b/terraform/environments/data-platform/ai-gateway/kms-keys.tf
@@ -39,6 +39,49 @@ module "ai_gateway_cloudwatch_kms_key" {
   deletion_window_in_days = 7
 }
 
+module "ai_gateway_elasticache_logs_kms_key" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
+
+  description           = "KMS key for AI Gateway ElastiCache CloudWatch Logs encryption"
+  enable_default_policy = true
+
+  aliases = ["cloudwatch/${local.component_name}-elasticache"]
+
+  key_statements = [
+    {
+      sid = "AllowCloudWatchLogsEncryption"
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncryptFrom",
+        "kms:ReEncryptTo",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:DescribeKey",
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "ArnLike"
+          variable = "kms:EncryptionContext:aws:logs:arn"
+          values = [
+            "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/elasticache/${local.component_name}/*"
+          ]
+        }
+      ]
+    }
+  ]
+
+  deletion_window_in_days = 7
+}
+
 module "ai_gateway_audit_logs_kms_key" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
 


### PR DESCRIPTION
This PR is related to [this](https://github.com/ministryofjustice/data-platform/issues/310) piece of work.

The AI Gateway Valkey (ElastiCache) cluster previously had no log delivery configured, leaving us without visibility into slow commands or engine-level events (authentication failures, failovers, replication issues).

This PR enables both Valkey log streams:

- **slow-log** — captures commands exceeding the `slowlog-log-slower-than` threshold, useful for identifying performance bottlenecks
- **engine-log** — captures operational/security events such as auth failures, parameter changes, and failovers

### What's changed

- Added a [dedicated KMS key](https://github.com/ministryofjustice/modernisation-platform-environments/blob/feat/ai-gateway-elasticache-log-delivery/terraform/environments/data-platform/ai-gateway/kms-keys.tf#L42-L82) (`cloudwatch/${component_name}-elasticache`) scoped to the ElastiCache log group ARN pattern, rather than reusing the WAF-scoped key
- Added two new CloudWatch log group modules in [`cloudwatch.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/feat/ai-gateway-elasticache-log-delivery/terraform/environments/data-platform/ai-gateway/cloudwatch.tf#L9-L23) (`/aws/elasticache/${component_name}/slow-log` and `/aws/elasticache/${component_name}/engine-log`), encrypted with the new dedicated key and 365-day retention
- Populated the [`log_delivery_configuration`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/feat/ai-gateway-elasticache-log-delivery/terraform/environments/data-platform/ai-gateway/elasticache.tf#L36-L47) block to deliver JSON-formatted logs to the respective CloudWatch log groups

### Design decisions

- Dedicated KMS key with a wildcard condition on `/aws/elasticache/${component_name}/*` covers both log groups without needing per-group entries
- JSON format chosen over text for structured querying via CloudWatch Insights
- 365-day retention matches the existing WAF log group policy
- Reuses the same `terraform-aws-cloudwatch//modules/log-group` and `terraform-aws-kms` modules (pinned to the same SHAs) already used in this stack