### PR TITLE
Chaps s3 backup

### DIFF
--- a/terraform/environments/cdpt-chaps/application_variables.json
+++ b/terraform/environments/cdpt-chaps/application_variables.json
@@ -40,6 +40,7 @@
       "dotnet_client_id": "efdcd721-93a1-46c1-b0da-29532763b12d",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
+      "enable_cp_db_migration_copy_access": false,
       "cp_db_migration_copy_irsa_role_arn": "",
       "db_migration_prefix": "native-backups/staging",
       "db_migration_name": "staging"
@@ -62,6 +63,7 @@
       "dotnet_client_id": "7361e073-5dc6-43a2-80fb-6cbb742166bb",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
+      "enable_cp_db_migration_copy_access": false,
       "cp_db_migration_copy_irsa_role_arn": "",
       "db_migration_prefix": "native-backups/prod",
       "db_migration_name": "prod"

--- a/terraform/environments/cdpt-chaps/application_variables.json
+++ b/terraform/environments/cdpt-chaps/application_variables.json
@@ -18,7 +18,7 @@
       "dotnet_client_id": "37156e23-43dd-4325-ae36-f998ce4c32ff",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
-      "enable_cp_db_migration_copy_access": false,
+      "enable_cp_db_migration_copy_access": true,
       "cp_db_migration_copy_irsa_role_arn": "arn:aws:iam::754256621582:role/cloud-platform-irsa-c5c488d70a0c0af2-live",
       "db_migration_prefix": "native-backups/dev",
       "db_migration_name": "dev"

--- a/terraform/environments/cdpt-chaps/application_variables.json
+++ b/terraform/environments/cdpt-chaps/application_variables.json
@@ -18,6 +18,7 @@
       "dotnet_client_id": "37156e23-43dd-4325-ae36-f998ce4c32ff",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
+      "enable_cp_db_migration_copy_access": false,
       "cp_db_migration_copy_irsa_role_arn": "arn:aws:iam::754256621582:role/cloud-platform-irsa-c5c488d70a0c0af2-live",
       "db_migration_prefix": "native-backups/dev",
       "db_migration_name": "dev"

--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -339,15 +339,15 @@ resource "aws_security_group" "cluster_ec2" {
   )
 }
 
-resource "aws_security_group_rule" "cluster_ec2_rdp_from_bastion" {
-  type                     = "ingress"
-  description              = "Allow RDP ingress"
-  from_port                = 3389
-  to_port                  = 3389
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.cluster_ec2.id
-  source_security_group_id = module.bastion_linux.bastion_security_group
-}
+#resource "aws_security_group_rule" "cluster_ec2_rdp_from_bastion" {
+#  type                     = "ingress"
+#  description              = "Allow RDP ingress"
+#  from_port                = 3389
+#  to_port                  = 3389
+#  protocol                 = "tcp"
+#  security_group_id        = aws_security_group.cluster_ec2.id
+#  source_security_group_id = module.bastion_linux.bastion_security_group
+#}
 
 # EC2 launch template - settings to use for new EC2s added to the group
 # Note - when updating this you will need to manually terminate the EC2s

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
   }
 }
 
-dyanmic "statement" {
+dynamic "statement" {
   for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
   content {
@@ -197,7 +197,7 @@ dyanmic "statement" {
   }
 }
 
-dyanmic "statement" {
+dynamic "statement" {
   for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
   content {

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -141,7 +141,10 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
     }
   }
 
-  statement {
+dynamic "statement" {
+  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+
+  content {
     sid = "AllowCpMigrationCopyRoleToGetBucketLocation"
 
     principals {
@@ -159,8 +162,12 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
       aws_s3_bucket.db_migration.arn
     ]
   }
+}
 
-  statement {
+dyanmic "statement" {
+  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+
+  content {
     sid = "AllowCpMigrationCopyRoleToListBackupPrefix"
 
     principals {
@@ -188,8 +195,12 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
       ]
     }
   }
+}
 
-  statement {
+dyanmic "statement" {
+  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+
+  content {
     sid = "AllowCpMigrationCopyRoleToReadBackupObjects"
 
     principals {
@@ -248,16 +259,12 @@ data "aws_iam_policy_document" "db_migration_kms" {
     }
   }
 
-  statement {
+dynamic "statement" {
+  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+
+  content {
     sid = "AllowCpMigrationCopyRoleToDecrypt"
     effect = "Allow"
-
-    actions = [
-      "kms:Decrypt",
-      "kms:DescribeKey"
-    ]
-
-    resources = ["*"]
 
     principals {
       type = "AWS"
@@ -265,6 +272,13 @@ data "aws_iam_policy_document" "db_migration_kms" {
         local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
       ]
     }
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
   }
 }
 

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -141,8 +141,8 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
     }
   }
 
-dynamic "statement" {
-  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+  dynamic "statement" {
+    for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
   content {
     sid = "AllowCpMigrationCopyRoleToGetBucketLocation"
@@ -150,7 +150,7 @@ dynamic "statement" {
     principals {
       type        = "AWS"
       identifiers = [
-        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+        local.cp_db_migration_copy_irsa_role_arn
       ]
     }
 
@@ -173,7 +173,7 @@ dyanmic "statement" {
     principals {
       type = "AWS"
       identifiers = [
-        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+        local.cp_db_migration_copy_irsa_role_arn
       ]
     }
 
@@ -206,7 +206,7 @@ dyanmic "statement" {
     principals {
       type    = "AWS"
       identifiers = [
-        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+        local.cp_db_migration_copy_irsa_role_arn
       ]
     }
 
@@ -218,6 +218,7 @@ dyanmic "statement" {
     resources = [
       "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
       ]
+    }
   }
 }
 
@@ -236,7 +237,9 @@ data "aws_iam_policy_document" "db_migration_kms" {
 
     principals {
       type = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
     }
   }
 
@@ -255,30 +258,33 @@ data "aws_iam_policy_document" "db_migration_kms" {
 
     principals {
       type = "AWS"
-      identifiers = [aws_iam_role.rds_native_backup.arn]
+      identifiers = [
+        aws_iam_role.rds_native_backup.arn
+      ]
     }
   }
 
-dynamic "statement" {
-  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+  dynamic "statement" {
+    for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
-  content {
-    sid = "AllowCpMigrationCopyRoleToDecrypt"
-    effect = "Allow"
+    content {
+      sid = "AllowCpMigrationCopyRoleToDecrypt"
+      effect = "Allow"
 
-    principals {
-      type = "AWS"
-      identifiers = [
-        local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+      principals {
+        type = "AWS"
+        identifiers = [
+          local.cp_db_migration_copy_irsa_role_arn
+        ]
+      }
+
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey"
       ]
+
+      resources = ["*"]
     }
-
-    actions = [
-      "kms:Decrypt",
-      "kms:DescribeKey"
-    ]
-
-    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
This pull request introduces conditional access controls for database migration copy operations by adding a new feature flag and updating related IAM policies and security group rules. The main goal is to allow enabling or disabling cross-platform database migration copy access per environment, improving security and flexibility.

**Feature flag and IAM policy updates:**

* Added a new boolean flag `enable_cp_db_migration_copy_access` to `application_variables.json` for each environment (dev, staging, prod) to control whether cross-platform database migration copy access is enabled. [[1]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56R21) [[2]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56R44) [[3]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56R67)
* Updated `s3_db_migration_policy.tf` to use dynamic IAM policy statements that are only included if `enable_cp_db_migration_copy_access` is set to true, ensuring that the apply will work without the necessary values from the cloud-platform irsa role. [[1]](diffhunk://#diff-a72ab161ed99930eb3f52d6c0f4c081630c4f0ce0031e02f4b8e7ca4935a5345L144-R147) [[2]](diffhunk://#diff-a72ab161ed99930eb3f52d6c0f4c081630c4f0ce0031e02f4b8e7ca4935a5345R165-R170) [[3]](diffhunk://#diff-a72ab161ed99930eb3f52d6c0f4c081630c4f0ce0031e02f4b8e7ca4935a5345R198-R203) [[4]](diffhunk://#diff-a72ab161ed99930eb3f52d6c0f4c081630c4f0ce0031e02f4b8e7ca4935a5345L251-R281)

**Security group changes:**

* Commented out the security group rule allowing RDP ingress from the bastion host to the cluster EC2 instances, - this will be re-enabled and re-applied once the bastion RDP sg has been removed.