### PR TITLE
use updated bastion module, now that dependencies are cleared. create…

### DIFF
--- a/terraform/environments/cdpt-chaps/bastion_linux.tf
+++ b/terraform/environments/cdpt-chaps/bastion_linux.tf
@@ -3,8 +3,8 @@ locals {
 }
 
 module "bastion_linux" {
-  #source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
+  #source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.1"
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts
     aws.share-tenant = aws          # The default provider (unaliased, `aws`) is the tenant

--- a/terraform/environments/cdpt-chaps/ecs.tf
+++ b/terraform/environments/cdpt-chaps/ecs.tf
@@ -339,15 +339,15 @@ resource "aws_security_group" "cluster_ec2" {
   )
 }
 
-#resource "aws_security_group_rule" "cluster_ec2_rdp_from_bastion" {
-#  type                     = "ingress"
-#  description              = "Allow RDP ingress"
-#  from_port                = 3389
-#  to_port                  = 3389
-#  protocol                 = "tcp"
-#  security_group_id        = aws_security_group.cluster_ec2.id
-#  source_security_group_id = module.bastion_linux.bastion_security_group
-#}
+resource "aws_security_group_rule" "cluster_ec2_rdp_from_bastion" {
+  type                     = "ingress"
+  description              = "Allow RDP ingress"
+  from_port                = 3389
+  to_port                  = 3389
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cluster_ec2.id
+  source_security_group_id = module.bastion_linux.bastion_security_group
+}
 
 # EC2 launch template - settings to use for new EC2s added to the group
 # Note - when updating this you will need to manually terminate the EC2s


### PR DESCRIPTION
This pull request updates the bastion host module version and enables a security group rule to allow RDP access from the bastion to the ECS cluster EC2 instances. These changes improve the environment's security configuration and ensure compatibility with the latest module features.

**Module version update:**

* Updated the `bastion_linux` module source in `bastion_linux.tf` to use version `v4.5.0` (commit `e4a3840d4b7b327228d1397bb684bc79cd4e76cb`), replacing the previous `v4.2.1` reference.

**Security group configuration:**

* Enabled the `aws_security_group_rule.cluster_ec2_rdp_from_bastion` resource in `ecs.tf` to allow RDP (port 3389) ingress from the bastion host's security group to the ECS cluster EC2 instances.… new rdp from bastion sg