### PR TITLE
add cp irsa roles. formatting

### DIFF
--- a/terraform/environments/cdpt-chaps/application_variables.json
+++ b/terraform/environments/cdpt-chaps/application_variables.json
@@ -41,8 +41,8 @@
       "dotnet_client_id": "efdcd721-93a1-46c1-b0da-29532763b12d",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
-      "enable_cp_db_migration_copy_access": false,
-      "cp_db_migration_copy_irsa_role_arn": "",
+      "enable_cp_db_migration_copy_access": true,
+      "cp_db_migration_copy_irsa_role_arn": "arn:aws:iam::754256621582:role/cloud-platform-irsa-fe83b7b809aee6b4-live",
       "db_migration_prefix": "native-backups/staging",
       "db_migration_name": "staging"
     },
@@ -64,8 +64,8 @@
       "dotnet_client_id": "7361e073-5dc6-43a2-80fb-6cbb742166bb",
       "TenantId": "c6874728-71e6-41fe-a9e1-2e8c36776ad8",
       "CallbackPath": "/signin-oidc",
-      "enable_cp_db_migration_copy_access": false,
-      "cp_db_migration_copy_irsa_role_arn": "",
+      "enable_cp_db_migration_copy_access": true,
+      "cp_db_migration_copy_irsa_role_arn": "arn:aws:iam::754256621582:role/cloud-platform-irsa-e58a85df36ca23a9-live",
       "db_migration_prefix": "native-backups/prod",
       "db_migration_name": "prod"
     }

--- a/terraform/environments/cdpt-chaps/route53.tfvars
+++ b/terraform/environments/cdpt-chaps/route53.tfvars
@@ -1,2 +1,2 @@
 subdomain_name = "cdpt-chaps.hq-development"
-domain_name     = "modernisation-platform.service.justice.gov.uk"
+domain_name    = "modernisation-platform.service.justice.gov.uk"

--- a/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
+++ b/terraform/environments/cdpt-chaps/s3_db_migration_policy.tf
@@ -1,8 +1,8 @@
 locals {
-  source_db_identifier                = local.application_data.accounts[local.environment].db_instance_identifier
-  native_backup_option_group          = "chaps-${local.environment}-sqlserver-native-backup"
-  mp_rds_native_backup_role_name      = "chaps-${local.environment}-rds-native-backup"
-  cp_db_migration_copy_irsa_role_arn  = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
+  source_db_identifier               = local.application_data.accounts[local.environment].db_instance_identifier
+  native_backup_option_group         = "chaps-${local.environment}-sqlserver-native-backup"
+  mp_rds_native_backup_role_name     = "chaps-${local.environment}-rds-native-backup"
+  cp_db_migration_copy_irsa_role_arn = local.application_data.accounts[local.environment].cp_db_migration_copy_irsa_role_arn
 }
 
 data "aws_iam_policy_document" "rds_native_backup_assume_role" {
@@ -65,8 +65,8 @@ data "aws_iam_policy_document" "rds_native_backup_s3_kms" {
     ]
 
     condition {
-      test      = "StringLike"
-      variable  = "s3:prefix"
+      test     = "StringLike"
+      variable = "s3:prefix"
       values = [
         local.db_migration_prefix,
         "${local.db_migration_prefix}/",
@@ -119,11 +119,11 @@ resource "aws_iam_role_policy_attachment" "rds_native_backup_s3_kms" {
 
 data "aws_iam_policy_document" "db_migration_bucket_policy" {
   statement {
-    sid = "DenyInsecureTransport"
+    sid    = "DenyInsecureTransport"
     effect = "Deny"
 
     principals {
-      type = "*"
+      type        = "*"
       identifiers = ["*"]
     }
 
@@ -135,88 +135,88 @@ data "aws_iam_policy_document" "db_migration_bucket_policy" {
     ]
 
     condition {
-      test = "Bool"
+      test     = "Bool"
       variable = "aws:SecureTransport"
-      values = ["false"]
+      values   = ["false"]
     }
   }
 
   dynamic "statement" {
     for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
-  content {
-    sid = "AllowCpMigrationCopyRoleToGetBucketLocation"
+    content {
+      sid = "AllowCpMigrationCopyRoleToGetBucketLocation"
 
-    principals {
-      type        = "AWS"
-      identifiers = [
-        local.cp_db_migration_copy_irsa_role_arn
+      principals {
+        type = "AWS"
+        identifiers = [
+          local.cp_db_migration_copy_irsa_role_arn
+        ]
+      }
+
+      actions = [
+        "s3:GetBucketLocation"
       ]
-    }
 
-    actions = [
-      "s3:GetBucketLocation"
-    ]
-
-    resources = [
-      aws_s3_bucket.db_migration.arn
-    ]
-  }
-}
-
-dynamic "statement" {
-  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
-
-  content {
-    sid = "AllowCpMigrationCopyRoleToListBackupPrefix"
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        local.cp_db_migration_copy_irsa_role_arn
-      ]
-    }
-
-    actions = [
-      "s3:ListBucket"
-    ]
-
-    resources = [
-      aws_s3_bucket.db_migration.arn
-    ]
-
-    condition {
-      test = "StringLike"
-      variable = "s3:prefix"
-      values = [
-        local.db_migration_prefix,
-        "${local.db_migration_prefix}/",
-        "${local.db_migration_prefix}/*"
+      resources = [
+        aws_s3_bucket.db_migration.arn
       ]
     }
   }
-}
 
-dynamic "statement" {
-  for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
+  dynamic "statement" {
+    for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
-  content {
-    sid = "AllowCpMigrationCopyRoleToReadBackupObjects"
+    content {
+      sid = "AllowCpMigrationCopyRoleToListBackupPrefix"
 
-    principals {
-      type    = "AWS"
-      identifiers = [
-        local.cp_db_migration_copy_irsa_role_arn
+      principals {
+        type = "AWS"
+        identifiers = [
+          local.cp_db_migration_copy_irsa_role_arn
+        ]
+      }
+
+      actions = [
+        "s3:ListBucket"
       ]
+
+      resources = [
+        aws_s3_bucket.db_migration.arn
+      ]
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values = [
+          local.db_migration_prefix,
+          "${local.db_migration_prefix}/",
+          "${local.db_migration_prefix}/*"
+        ]
+      }
     }
+  }
 
-    actions = [
-      "s3:GetObject",
-      "s3:GetObjectAttributes"
-    ]
+  dynamic "statement" {
+    for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
-    resources = [
-      "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
+    content {
+      sid = "AllowCpMigrationCopyRoleToReadBackupObjects"
+
+      principals {
+        type = "AWS"
+        identifiers = [
+          local.cp_db_migration_copy_irsa_role_arn
+        ]
+      }
+
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectAttributes"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.db_migration.arn}/${local.db_migration_prefix}/*"
       ]
     }
   }
@@ -229,8 +229,8 @@ resource "aws_s3_bucket_policy" "db_migration" {
 
 data "aws_iam_policy_document" "db_migration_kms" {
   statement {
-    sid = "allowAccountRoot"
-    effect = "Allow"
+    sid     = "allowAccountRoot"
+    effect  = "Allow"
     actions = ["kms:*"]
 
     resources = ["*"]
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "db_migration_kms" {
   }
 
   statement {
-    sid = "AllowMpRdsNativeBackupRole"
+    sid    = "AllowMpRdsNativeBackupRole"
     effect = "Allow"
 
     actions = [
@@ -268,7 +268,7 @@ data "aws_iam_policy_document" "db_migration_kms" {
     for_each = local.application_data.accounts[local.environment].enable_cp_db_migration_copy_access ? [1] : []
 
     content {
-      sid = "AllowCpMigrationCopyRoleToDecrypt"
+      sid    = "AllowCpMigrationCopyRoleToDecrypt"
       effect = "Allow"
 
       principals {


### PR DESCRIPTION
This pull request updates the `application_variables.json` configuration for the `cdpt-chaps` environment to enable database migration copy access and specify the appropriate AWS IRSA role ARNs for both the staging and production environments.

Configuration updates for database migration:

* Enabled `enable_cp_db_migration_copy_access` by setting it to `true` for both staging and production, allowing database migration copy access. [[1]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56L44-R45) [[2]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56L67-R68)
* Set the `cp_db_migration_copy_irsa_role_arn` to the correct AWS IAM role for staging (`cloud-platform-irsa-fe83b7b809aee6b4-live`) and production (`cloud-platform-irsa-e58a85df36ca23a9-live`). [[1]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56L44-R45) [[2]](diffhunk://#diff-0820e356e1ab41a0ede46e39f219c3f42794056e4fc43bdef3ece755c464fc56L67-R68)