### PR TITLE
feat: add responses to the update p1 export api

### DIFF
--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -333,3 +333,51 @@ resource "aws_cloudwatch_log_group" "update_p1_export_waf_log_group" {
   name              = "aws-waf-logs-update_p1_export"
   retention_in_days = 400
 }
+
+resource "aws_api_gateway_method_response" "add_response_200" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_add[0].id
+  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method_response" "add_status_200" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_add[0].id
+  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method_response" "add_status_404" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_add[0].id
+  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
+  status_code = "404"
+}
+
+resource "aws_api_gateway_method_response" "remove_response_200" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_remove[0].id
+  http_method = aws_api_gateway_method.update_p1_export_remove_post[0].http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method_response" "remove_status_200" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_remove[0].id
+  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method_response" "remove_status_404" {
+  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  resource_id = aws_api_gateway_resource.update_p1_export_remove[0].id
+  http_method = aws_api_gateway_method.update_p1_export_remove_post[0].http_method
+  status_code = "404"
+}

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -123,6 +123,45 @@ resource "aws_iam_role_policy" "cloudwatch" {
 # update_p1_export
 # --------------------------------------------------------------------------------
 
+data "aws_vpc_endpoint" "api_gateway" {
+  service_name = "com.amazonaws.eu-west-2.execute-api"
+}
+
+data "aws_iam_policy_document" "update_p1_export_vpc" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.emd_update_p1_cp_role.iam_role.this_iam_role_arn]
+    }
+
+    actions   = ["execute-api:Invoke"]
+    resources = ["${aws_api_gateway_rest_api.update_p1_export.execution_arn}/*"]
+  }
+  statement {
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions   = ["execute-api:Invoke"]
+    condition {
+      test = "StringNotEquals"
+      variable = "aws:sourceVpce"
+      values = [
+        data.aws_vpc_endpoint.api_gateway.id
+      ]
+    }
+  }
+}
+
+resource "aws_api_gateway_rest_api_policy" "update_p1_export_vpc" {
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export.id
+  policy      = data.aws_iam_policy_document.update_p1_export_vpc.json
+}
+
+
 resource "aws_api_gateway_rest_api" "update_p1_export" {
   count       = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
   name        = "update_p1_export"
@@ -130,6 +169,11 @@ resource "aws_api_gateway_rest_api" "update_p1_export" {
 
   lifecycle {
     create_before_destroy = true
+  }
+
+  endpoint_configuration {
+    types = ["PRIVATE"]
+    vpc_endpoint_ids = [data.aws_vpc_endpoint.api_gateway.id]
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -123,7 +123,7 @@ resource "aws_iam_role_policy" "cloudwatch" {
 # update_p1_export
 # --------------------------------------------------------------------------------
 locals {
-  endpoint_type = local.is-development ? {"REGIONAL": null} : {"PRIVATE": [data.aws_vpc_endpoint.api_gateway.id]}
+  endpoint_type = local.is-development ? {"REGIONAL": null} : {"PRIVATE": data.aws_vpc_endpoint.api_gateway.cidr_blocks}
 }
 
 
@@ -185,6 +185,7 @@ resource "aws_api_gateway_rest_api" "update_p1_export" {
 endpoint_configuration {
   types            = [local.is-development ? "REGIONAL" : "PRIVATE"]
   vpc_endpoint_ids = local.is-development ? null : [data.aws_vpc_endpoint.api_gateway.id]
+  ip_address_type  = local.is-development ? null : "dualstack"
 }
 }
 

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -137,7 +137,7 @@ data "aws_vpc_endpoint" "api_gateway" {
 }
 
 data "aws_iam_policy_document" "update_p1_export_vpc" {
-  count = local.is-test ? 0 : 1
+  count = local.is-test || local.is-development ? 0 : 1
   statement {
     effect = "Allow"
 
@@ -167,6 +167,7 @@ data "aws_iam_policy_document" "update_p1_export_vpc" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "update_p1_export_vpc" {
+  count = local.is-test || local.is-development ? 0 : 1
   rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
   policy      = data.aws_iam_policy_document.update_p1_export_vpc[0].json
 }

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -137,7 +137,7 @@ data "aws_iam_policy_document" "update_p1_export_vpc" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.emd_update_p1_cp_role.iam_role.this_iam_role_arn]
+      identifiers = [module.emd_update_p1_cp_role[0].iam_role.this_iam_role_arn]
     }
 
     actions   = ["execute-api:Invoke"]

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -141,7 +141,7 @@ data "aws_iam_policy_document" "update_p1_export_vpc" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["${aws_api_gateway_rest_api.update_p1_export.execution_arn}/*"]
+    resources = ["${aws_api_gateway_rest_api.update_p1_export[0].execution_arn}/*"]
   }
   statement {
     effect = "Deny"

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -128,7 +128,12 @@ locals {
 
 
 data "aws_vpc_endpoint" "api_gateway" {
+  provider     = aws.core-vpc
   service_name = "com.amazonaws.eu-west-2.execute-api"
+  vpc_id       = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-com.amazonaws.${data.aws_region.current.name}.execute-api"
+  }
 }
 
 data "aws_iam_policy_document" "update_p1_export_vpc" {

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -137,7 +137,7 @@ data "aws_iam_policy_document" "update_p1_export_vpc" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.emd_update_p1_cp_role[0].iam_role.this_iam_role_arn]
+      identifiers = [module.emd_update_p1_cp_role[0].iam_role_arn]
     }
 
     actions   = ["execute-api:Invoke"]

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -132,6 +132,7 @@ data "aws_vpc_endpoint" "api_gateway" {
 }
 
 data "aws_iam_policy_document" "update_p1_export_vpc" {
+  count = local.is-test ? 0 : 1
   statement {
     effect = "Allow"
 
@@ -161,8 +162,8 @@ data "aws_iam_policy_document" "update_p1_export_vpc" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "update_p1_export_vpc" {
-  rest_api_id = aws_api_gateway_rest_api.update_p1_export.id
-  policy      = data.aws_iam_policy_document.update_p1_export_vpc.json
+  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
+  policy      = data.aws_iam_policy_document.update_p1_export_vpc[0].json
 }
 
 

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -342,14 +342,6 @@ resource "aws_api_gateway_method_response" "add_response_200" {
   status_code = "200"
 }
 
-resource "aws_api_gateway_method_response" "add_status_200" {
-  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
-  resource_id = aws_api_gateway_resource.update_p1_export_add[0].id
-  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
-  status_code = "200"
-}
-
 resource "aws_api_gateway_method_response" "add_status_404" {
   count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
   rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
@@ -366,13 +358,6 @@ resource "aws_api_gateway_method_response" "remove_response_200" {
   status_code = "200"
 }
 
-resource "aws_api_gateway_method_response" "remove_status_200" {
-  count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0
-  rest_api_id = aws_api_gateway_rest_api.update_p1_export[0].id
-  resource_id = aws_api_gateway_resource.update_p1_export_remove[0].id
-  http_method = aws_api_gateway_method.update_p1_export_add_post[0].http_method
-  status_code = "200"
-}
 
 resource "aws_api_gateway_method_response" "remove_status_404" {
   count = local.is-development || local.is-preproduction || local.is-production ? 1 : 0

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -175,13 +175,10 @@ resource "aws_api_gateway_rest_api" "update_p1_export" {
     create_before_destroy = true
   }
 
-  dynamic "endpoint_configuration" {
-    for_each = local.endpoint_type
-    content {
-      types = [each.key]
-      vpc_endpoint_ids = each.value
-    }
-  }
+endpoint_configuration {
+  types            = [local.is-development ? "REGIONAL" : "PRIVATE"]
+  vpc_endpoint_ids = local.is-development ? null : [data.aws_vpc_endpoint.api_gateway.id]
+}
 }
 
 resource "aws_api_gateway_resource" "update_p1_export_add" {

--- a/terraform/environments/electronic-monitoring-data/api_gateway.tf
+++ b/terraform/environments/electronic-monitoring-data/api_gateway.tf
@@ -122,6 +122,10 @@ resource "aws_iam_role_policy" "cloudwatch" {
 # --------------------------------------------------------------------------------
 # update_p1_export
 # --------------------------------------------------------------------------------
+locals {
+  endpoint_type = local.is-development ? {"REGIONAL": null} : {"PRIVATE": [data.aws_vpc_endpoint.api_gateway.id]}
+}
+
 
 data "aws_vpc_endpoint" "api_gateway" {
   service_name = "com.amazonaws.eu-west-2.execute-api"
@@ -171,9 +175,12 @@ resource "aws_api_gateway_rest_api" "update_p1_export" {
     create_before_destroy = true
   }
 
-  endpoint_configuration {
-    types = ["PRIVATE"]
-    vpc_endpoint_ids = [data.aws_vpc_endpoint.api_gateway.id]
+  dynamic "endpoint_configuration" {
+    for_each = local.endpoint_type
+    content {
+      types = [each.key]
+      vpc_endpoint_ids = each.value
+    }
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -192,6 +192,65 @@ module "emd_validation_db_role" {
   tags = local.tags
 }
 
+module "emd_update_p1_cp_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  count   = local.is-preproduction ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.48.0"
+
+  trusted_role_arns = flatten([
+    data.aws_iam_roles.mod_plat_roles.arns,
+    local.iam_role_ear_sar_db,
+  ])
+
+  create_role       = true
+  role_requires_mfa = false
+
+  role_name = "emd_update_p1_${local.environment_shorthand}"
+
+  tags = local.tags
+}
+
+
+data "aws_iam_policy_document" "em_dashboard_update_p1_permissions" {
+  count = local.is-preproduction ? 1 : 0
+  statement {
+    sid       = "AllowAccessToTriggerUpdateP1API"
+    effect    = "Allow"
+    actions   = ["execute-api:Invoke"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${local.env_account_id}:${aws_api_gateway_rest_api.update_p1_export[0].execution_arn}/*"]
+  }
+  statement {
+    sid       = "ListAccountAliasForEnvironmentClass"
+    effect    = "Allow"
+    actions   = ["iam:ListAccountAliases"]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "ListAllBucketsForEnvironmentClass"
+    effect = "Allow"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "em_dashboard_update_p1_permissions" {
+  count       = local.is-preproduction ? 1 : 0
+  name_prefix = "em_dashboard_update_p1_permissions"
+  description = "Permissions for updating p1 export."
+  policy      = data.aws_iam_policy_document.em_dashboard_update_p1_permissions[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "em_dashboard_update_p1_permissions" {
+  count      = local.is-preproduction ? 1 : 0
+  policy_arn = aws_iam_policy.em_dashboard_update_p1_permissions[0].arn
+  role       = module.emd_update_p1_cp_role[0].iam_role_name
+}
+
 resource "aws_lakeformation_permissions" "em_data_validation_db" {
   count       = local.is-test || local.is-production ? 1 : 0
   principal   = module.emd_validation_db_role[0].iam_role_arn

--- a/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
+++ b/terraform/environments/electronic-monitoring-data/share_cloud_platform.tf
@@ -195,7 +195,7 @@ module "emd_validation_db_role" {
 module "emd_update_p1_cp_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-  count   = local.is-preproduction ? 1 : 0
+  count   = local.is-preproduction || local.is-production ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.48.0"
 


### PR DESCRIPTION
Adds:
- responses to the api
- makes it private in pp and prod so can only be triggered from inside the vpc
- a role to be assumed by cp