### PR TITLE
reduce ttl for faster propagation

### DIFF
--- a/terraform/environments/cdpt-chaps/route53.tf
+++ b/terraform/environments/cdpt-chaps/route53.tf
@@ -88,6 +88,7 @@ resource "aws_route53_record" "external_prod" {
   zone_id  = data.aws_route53_zone.application_zone.zone_id
   name     = "correspondence-handling-and-processing.service.justice.gov.uk"
   type     = "A"
+  ttl      = 10
 
   alias {
     name                   = module.lb_access_logs_enabled.load_balancer.dns_name


### PR DESCRIPTION
This pull request makes a small configuration change to the DNS settings in the `terraform/environments/cdpt-chaps/route53.tf` file. The change sets the TTL (Time to Live) value for the `aws_route53_record.external_prod` record to 10 seconds, which will cause DNS changes to propagate more quickly.