### PR TITLE
LASB-5060: Add AL2023 config for MAAT

### DIFF
--- a/terraform/environments/maat/cloudwatch-agent.json
+++ b/terraform/environments/maat/cloudwatch-agent.json
@@ -1,0 +1,22 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "${maat_ec2_log_group}",
+            "log_stream_name": "secure/{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "${maat_ec2_log_group}",
+            "log_stream_name": "messages/{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/terraform/environments/maat/maat-ec2-user-data-al2023.sh
+++ b/terraform/environments/maat/maat-ec2-user-data-al2023.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 echo ECS_CLUSTER=${app_ecs_cluster} >> /etc/ecs/ecs.config
 # Install CloudWatch Agent
-yum install -y aws-cfn-bootstrap amazon-cloudwatch-agent
+yum install -y amazon-cloudwatch-agent
 # Write CloudWatch Agent config (provided via Terraform)
 cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<-EOF
 ${cw_agent_config}
@@ -35,7 +35,7 @@ else
   AGENT_PATH="pre-prod/cortex-agent.tar.gz"
 fi
 
-aws s3 cp $${XDR_AGENT_BUCKET}$${AGENT_PATH} ${xdr_tar}
+aws s3 cp "$${XDR_AGENT_BUCKET}$${AGENT_PATH}" "${xdr_tar}"
 
 if [[ -f ${xdr_tar} ]]; then
   mkdir -p ${xdr_dir}

--- a/terraform/environments/maat/maat-ec2-user-data-al2023.sh
+++ b/terraform/environments/maat/maat-ec2-user-data-al2023.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -xe
+echo ECS_CLUSTER=${app_ecs_cluster} >> /etc/ecs/ecs.config
+# Install CloudWatch Agent
+yum install -y aws-cfn-bootstrap amazon-cloudwatch-agent
+# Write CloudWatch Agent config (provided via Terraform)
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<-EOF
+${cw_agent_config}
+EOF
+
+chmod 644 /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# Start rsyslog
+sudo yum install -y rsyslog
+sudo systemctl enable rsyslog
+sudo systemctl start rsyslog
+
+# Start CloudWatch Agent
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+sudo systemctl enable amazon-cloudwatch-agent
+sudo systemctl start amazon-cloudwatch-agent
+
+
+# Install prerequisites for Cortex agent
+sudo yum install -y selinux-policy-devel
+
+# Install XDR agent stored in S3 bucket
+XDR_AGENT_BUCKET="s3://modernisation-platform-laa-shared20250605080758955300000001/laa-platform/xdr-agent/"
+if [[ "production" = "${environment}" ]]; then
+  AGENT_PATH="prod/cortex-agent.tar.gz"
+else
+  AGENT_PATH="pre-prod/cortex-agent.tar.gz"
+fi
+
+aws s3 cp $${XDR_AGENT_BUCKET}$${AGENT_PATH} ${xdr_tar}
+
+if [[ -f ${xdr_tar} ]]; then
+  mkdir -p ${xdr_dir}
+  tar -xzf ${xdr_tar} -C ${xdr_dir}
+
+  if [[ -f ${xdr_dir}/cortex.conf ]]; then
+    sudo mkdir -p /etc/panw
+    sudo cp ${xdr_dir}/cortex.conf /etc/panw/
+  else
+    echo "Missing cortex.conf in extracted archive" >&2
+    exit 1
+  fi
+
+  sudo yum install -y ${xdr_dir}/*.rpm
+  sudo /opt/traps/bin/cytool endpoint_tags add "${xdr_tags}"
+
+else
+  echo "XDR agent download failed" >&2
+  exit 1
+fi
+

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -114,23 +114,35 @@ resource "aws_ecs_cluster" "maat_ecs_cluster" {
   )
 }
 
-# always use the recommended ECS optimized linux 2 base image; used to obtain its AMI ID
-data "aws_ssm_parameter" "ecs_optimized_ami" {
+# remove after migration
+data "aws_ssm_parameter" "ecs_optimized_ami_al2" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended"
 }
 
+# always use the recommended ECS optimized linux 2023 base image; used to obtain its AMI ID
+data "aws_ssm_parameter" "ecs_optimized_ami_al2023" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
+}
+
+# remove after migration
+output "ami_id_al2" {
+  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
+  sensitive = true
+}
+
 # if the AMI is used elsewhere it can be obtained here
-output "ami_id" {
-  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value)["image_id"]
+output "ami_id_al2023" {
+  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   sensitive = true
 }
 
 ##### EC2 launch config/template -----
 
+# remove after migration
 resource "aws_launch_template" "maat_ec2_launch_template" {
   #checkov:skip=AVD-AWS-0130: "Ignore - Launch template does not require IMDS access to require a token"
   name_prefix   = "${local.application_name}-ec2-launch-template"
-  image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value)["image_id"]
+  image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
   instance_type = local.application_data.accounts[local.environment].instance_type
 
   monitoring {
@@ -179,8 +191,68 @@ resource "aws_launch_template" "maat_ec2_launch_template" {
   }), local.tags)
 }
 
+resource "aws_launch_template" "maat_ec2_launch_template_al2023" {
+  #checkov:skip=AVD-AWS-0130: "Ignore - Launch template does not require IMDS access to require a token"
+  name_prefix   = "${local.application_name}-ec2-launch-template-al2023"
+  image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
+  instance_type = local.application_data.accounts[local.environment].instance_type
+
+  monitoring {
+    enabled = true
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "optional"
+    http_put_response_hop_limit = "2"
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.maat_ec2_instance_profile.name
+  }
+
+  network_interfaces {
+    security_groups = [aws_security_group.maat_ecs_security_group.id]
+  }
+
+  user_data = base64encode(templatefile("maat-ec2-user-data-al2023.sh", {
+    maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group,
+    app_ecs_cluster    = aws_ecs_cluster.maat_ecs_cluster.name,
+    environment        = local.environment,
+    xdr_dir            = "/tmp/cortex-agent",
+    xdr_tar            = "/tmp/cortex-agent.tar.gz",
+    xdr_tags           = local.xdr_tags
+
+    cw_agent_config = templatefile(
+      "${path.module}/cloudwatch-agent.json",
+      {
+        maat_ec2_log_group = local.application_data.accounts[local.environment].maat_ec2_log_group
+      }
+    )
+  }))
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(tomap({
+      "Name" = "${local.application_name}-ecs-cluster"
+    }), local.tags)
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(tomap({
+      "Name" = "${local.application_name}-ecs-cluster"
+    }), local.tags)
+  }
+
+  tags = merge(tomap({
+    "Name" = "${local.application_name}-ecs-cluster-template"
+  }), local.tags)
+}
+
 #### EC2 Scaling Group  -----
 
+# remove after migration
 resource "aws_autoscaling_group" "maat_ec2_scaling_group" {
   vpc_zone_identifier = sort(data.aws_subnets.shared-private.ids)
   name                = "${local.application_name}-EC2-asg"
@@ -192,6 +264,33 @@ resource "aws_autoscaling_group" "maat_ec2_scaling_group" {
 
   launch_template {
     id      = aws_launch_template.maat_ec2_launch_template.id
+    version = "$Latest"
+  }
+
+  dynamic "tag" {
+    for_each = local.tags
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "maat_ec2_scaling_group_al2023" {
+  vpc_zone_identifier = sort(data.aws_subnets.shared-private.ids)
+  name                = "${local.application_name}-EC2-asg-al2023"
+  # New ASG, set capacity to 0 - will be scaled manually during migration.
+  # Follow-up Terraform PR will update to desired final capacity.
+  desired_capacity    = 0
+  max_size            = local.application_data.accounts[local.environment].maat_ec2_asg_max_size
+  min_size            = 0
+  metrics_granularity = "1Minute"
+
+
+  launch_template {
+    id      = aws_launch_template.maat_ec2_launch_template_al2023.id
     version = "$Latest"
   }
 

--- a/terraform/environments/maat/maat-ecs.tf
+++ b/terraform/environments/maat/maat-ecs.tf
@@ -124,13 +124,14 @@ data "aws_ssm_parameter" "ecs_optimized_ami_al2023" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
 }
 
-# remove after migration
-output "ami_id_al2" {
+# update to reference AL2023 ID after migration
+# if the AMI is used elsewhere it can be obtained here
+output "ami_id" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
   sensitive = true
 }
 
-# if the AMI is used elsewhere it can be obtained here
+# move to ami_id after migration
 output "ami_id_al2023" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   sensitive = true
@@ -193,7 +194,7 @@ resource "aws_launch_template" "maat_ec2_launch_template" {
 
 resource "aws_launch_template" "maat_ec2_launch_template_al2023" {
   #checkov:skip=AVD-AWS-0130: "Ignore - Launch template does not require IMDS access to require a token"
-  name_prefix   = "${local.application_name}-ec2-launch-template-al2023"
+  name_prefix   = "${local.application_name}-ec2-al2023-"
   image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   instance_type = local.application_data.accounts[local.environment].instance_type
 
@@ -280,7 +281,7 @@ resource "aws_autoscaling_group" "maat_ec2_scaling_group" {
 
 resource "aws_autoscaling_group" "maat_ec2_scaling_group_al2023" {
   vpc_zone_identifier = sort(data.aws_subnets.shared-private.ids)
-  name                = "${local.application_name}-EC2-asg-al2023"
+  name_prefix         = "${local.application_name}-ec2-al2023-"
   # New ASG, set capacity to 0 - will be scaled manually during migration.
   # Follow-up Terraform PR will update to desired final capacity.
   desired_capacity    = 0


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LASB-5060)

This PR introduces support for Amazon Linux 2023 (AL2023) for ECS on EC2 capacity used by MAAT, in preparation for the Amazon Linux 2 end-of-life (30 June 2026).
A blue/green capacity approach is used to allow a controlled and reversible migration, with no impact to existing workloads until explicitly triggered.

- Introduce AL2023 ECS‑optimised AMI via SSM parameter
- Add new launch template for AL2023 with updated user data
- Create new Auto Scaling Group for AL2023 with desired capacity set to 0 for controlled rollout
- Update user data script to install/configure CloudWatch Agent and remove awslogs dependencies
  - Replace deprecated awslogs with Amazon CloudWatch Agent
  - Add CloudWatch Agent JSON configuration equivalent to existing awslogs setup
- Maintain existing AL2 infrastructure for blue/green migration
- Add new Terraform output for AL2023 AMI ID