### PR TITLE
fix(data-platform): update litellm to 1.88.1 / remove IP from production / update tf modules

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -10,7 +10,7 @@ locals {
       "Jacob.Woffenden@justice.gov.uk"
     ]
     development = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.88.1"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -45,7 +45,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.88.1"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -85,7 +85,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.88.1"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -120,7 +120,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.88.1"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -136,9 +136,7 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24",      # 10SC
-        # Hoose
-        "51.179.193.117/32"
+        "51.149.2.0/24"       # 10SC
       ]
       ai_gateway_models = local.ai_gateway_models
       ai_gateway_autoscaling = {

--- a/terraform/environments/data-platform/ai-gateway/iam-policies.tf
+++ b/terraform/environments/data-platform/ai-gateway/iam-policies.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "ai_gateway" {
 }
 
 module "ai_gateway_iam_policy" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=1d73bcb359419e1b41872ac5ccaf8808b8f1150e" # v6.6.0
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=5b962b1163790398605f2b17447cf5b6cc512237" # v6.6.1
 
   name_prefix = local.component_name
 

--- a/terraform/environments/data-platform/ai-gateway/iam-roles.tf
+++ b/terraform/environments/data-platform/ai-gateway/iam-roles.tf
@@ -1,5 +1,5 @@
 module "iam_role" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role-for-service-accounts?ref=1d73bcb359419e1b41872ac5ccaf8808b8f1150e" # v6.6.0
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role-for-service-accounts?ref=5b962b1163790398605f2b17447cf5b6cc512237" # v6.6.1
 
   name = local.component_name
 

--- a/terraform/environments/data-platform/ai-gateway/s3.tf
+++ b/terraform/environments/data-platform/ai-gateway/s3.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "alb_access_logs_bucket_policy" {
 
 #trivy:ignore:AVD-AWS-0132: ALB access log buckets cannot use SSE-KMS (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html)
 module "alb_access_logs" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=af0286ff37a66c2b79faf360e6e2663744b8e5b5" # v5.13.0
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=0ffe41e66ad5854c637a736e43180c29eb727393" # v5.14.0
 
   bucket = local.alb_access_logs_bucket_name
 
@@ -53,7 +53,7 @@ module "alb_access_logs" {
 }
 
 module "audit_logs" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=af0286ff37a66c2b79faf360e6e2663744b8e5b5" # v5.13.0
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=0ffe41e66ad5854c637a736e43180c29eb727393" # v5.14.0
 
   bucket = local.audit_logs_bucket_name
 


### PR DESCRIPTION
Bundles a set of related updates to the data-platform ai-gateway:

### litellm

- Updates [`litellm_version`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/environment-configuration.tf) to `1.88.1` across all four environments (development, test, preproduction, production).
- Release notes: https://github.com/BerriAI/litellm/releases/tag/v1.88.1

### Production ingress allowlist

- Removes the IP (`51.179.193.117/32`) from the [production `ai_gateway_admin_ingress_allowlist`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L133-L142).

### Terraform module bumps

Audited every `git::` module source in `terraform/environments/data-platform/ai-gateway/`. The following were out of date and are now pinned to the latest release:

| Module | From | To | Release notes |
| --- | --- | --- | --- |
| [terraform-aws-s3-bucket](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/s3.tf) | v5.13.0 | v5.14.0 | https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/releases/tag/v5.14.0 |
| [terraform-aws-iam](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/iam-policies.tf) (iam-policy & iam-role-for-service-accounts) | v6.6.0 | v6.6.1 | https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v6.6.1 |

All other modules (`terraform-aws-kms` v4.2.0, `terraform-aws-cloudwatch` v5.7.2, `terraform-aws-acm` v6.3.0, `terraform-aws-secrets-manager` v2.1.0, `terraform-aws-rds-aurora` v10.2.0, `terraform-aws-elasticache` v1.11.0, `terraform-aws-wafv2` v2.1.0) are already on their latest released versions.

Supersedes #17088 and #17091.