### PR TITLE
chore(devcontainer): update feature versions in lock file

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -6,34 +6,34 @@
       "integrity": "sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9"
     },
     "ghcr.io/devcontainers/features/github-cli:": {
-      "version": "1.0.15",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf",
-      "integrity": "sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/astral:": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/astral@sha256:a6df118c6475e79fe15e63b815a5df591a24b0d25517ea941114cb6bee1af9a8",
-      "integrity": "sha256:a6df118c6475e79fe15e63b815a5df591a24b0d25517ea941114cb6bee1af9a8"
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/astral@sha256:8ee1cd600c19e2c6ac841dccdebd135a628680ca4aeca70f1ff74b1afe153645",
+      "integrity": "sha256:8ee1cd600c19e2c6ac841dccdebd135a628680ca4aeca70f1ff74b1afe153645"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:64240f48a66e28fc065d58d2c3aa75319106ec4293b0a0736402290317b256d5",
-      "integrity": "sha256:64240f48a66e28fc065d58d2c3aa75319106ec4293b0a0736402290317b256d5"
+      "version": "1.1.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:3e0021ec6bb7670b36904dee0fe736c6900aa339ad00fe445d6f7529f88d5710",
+      "integrity": "sha256:3e0021ec6bb7670b36904dee0fe736c6900aa339ad00fe445d6f7529f88d5710"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:f58b01629d00cc9105dfda5d54a4ba33dd21e41f9a132e22e2ad12f15bc4f03d",
-      "integrity": "sha256:f58b01629d00cc9105dfda5d54a4ba33dd21e41f9a132e22e2ad12f15bc4f03d"
+      "version": "1.1.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:5ba09d497a9a2886ed20199083b54be90a296ebd916878119b2b049ea9fd61b0",
+      "integrity": "sha256:5ba09d497a9a2886ed20199083b54be90a296ebd916878119b2b049ea9fd61b0"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16",
-      "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
+      "version": "2.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901",
+      "integrity": "sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:": {
-      "version": "1.2.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c",
-      "integrity": "sha256:6343878231decb72427ea2d59d98d0c4bb6f15931d86800330f7c84df8320f6c"
+      "version": "1.3.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:55bade53f374bd8600e59b8333d28bef2ab94f501576ad462c8caddfe977387e",
+      "integrity": "sha256:55bade53f374bd8600e59b8333d28bef2ab94f501576ad462c8caddfe977387e"
     }
   }
 }

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha256:5ba09d497a9a2886ed20199083b54be90a296ebd916878119b2b049ea9fd61b0"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:": {
-      "version": "2.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901",
-      "integrity": "sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901"
+      "version": "1.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16",
+      "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/terraform:": {
       "version": "1.3.0",


### PR DESCRIPTION
## Summary

Updates pinned versions in [.devcontainer/devcontainer-lock.json](../blob/agents/update-devcontainer-versions/.devcontainer/devcontainer-lock.json) to the latest released versions for each devcontainer feature.

## Changes

| Feature | Old | New |
| --- | --- | --- |
| [`devcontainers/features/github-cli`](https://github.com/devcontainers/features/tree/main/src/github-cli) | 1.0.15 | 1.1.0 |
| [`ministryofjustice/devcontainer-feature/astral`](https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/astral) | 1.0.0 | 1.0.1 |
| [`ministryofjustice/devcontainer-feature/aws`](https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/aws) | 1.1.0 | 1.1.2 |
| [`ministryofjustice/devcontainer-feature/kubernetes`](https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/kubernetes) | 1.1.0 | 1.1.2 |
| [`ministryofjustice/devcontainer-feature/terraform`](https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/terraform) | 1.2.0 | 1.3.0 |

The `docker-in-docker` feature was already at the latest version (3.0.1).

## Excluded: static-analysis 2.0.0

The [`ministryofjustice/devcontainer-feature/static-analysis`](https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/static-analysis) feature was initially bumped from 1.0.0 to 2.0.0 but has been reverted because the build fails: the 2.0.0 install script resolves checkov's latest GitHub tag (currently [3.2.534](https://github.com/bridgecrewio/checkov/releases/tag/3.2.534)) and then pins `pip install checkov==3.2.534`, but that version has not been published to [PyPI](https://pypi.org/project/checkov/#history) (the latest there is 3.3.0). This is an upstream bug in the feature's install script and should be raised against [ministryofjustice/.devcontainer](https://github.com/ministryofjustice/.devcontainer); once fixed, static-analysis can be bumped in a follow-up.

## Context

Only [.devcontainer/devcontainer-lock.json](../blob/agents/update-devcontainer-versions/.devcontainer/devcontainer-lock.json) is changed — [.devcontainer/devcontainer.json](../blob/agents/update-devcontainer-versions/.devcontainer/devcontainer.json) continues to use unpinned tags, so the lock file is the source of truth for resolved versions and digests.
