### PR TITLE
ldf:update fabric-iam-role

### DIFF
--- a/terraform/environments/data-factory-laa/data.tf
+++ b/terraform/environments/data-factory-laa/data.tf
@@ -1,8 +1,10 @@
 #### This file can be used to store data specific to the member account ####
 data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
+  count     = local.is-development ? 1 : 0
   secret_id = aws_secretsmanager_secret.fabric_tenant_id.id
 }
 
 data "aws_secretsmanager_secret_version" "fabric_enterprise_app_object_id" {
+  count     = local.is-development ? 1 : 0
   secret_id = aws_secretsmanager_secret.fabric_enterprise_app_object_id.id
 }

--- a/terraform/environments/data-factory-laa/data.tf
+++ b/terraform/environments/data-factory-laa/data.tf
@@ -1,10 +1,10 @@
 #### This file can be used to store data specific to the member account ####
 data "aws_secretsmanager_secret_version" "fabric_tenant_id" {
-  count     = local.is-development ? 1 : 0
+  count     = local.fabric_oidc_enabled ? 1 : 0
   secret_id = aws_secretsmanager_secret.fabric_tenant_id.id
 }
 
 data "aws_secretsmanager_secret_version" "fabric_enterprise_app_object_id" {
-  count     = local.is-development ? 1 : 0
+  count     = local.fabric_oidc_enabled ? 1 : 0
   secret_id = aws_secretsmanager_secret.fabric_enterprise_app_object_id.id
 }

--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -2,7 +2,7 @@
 # exposed to Microsoft Fabric via OneLake S3 shortcuts.
 
 module "fabric_oidc_provider" {
-  count  = local.is-development ? 1 : 0
+  count  = local.fabric_oidc_enabled ? 1 : 0
   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
 
   tenant_id          = local.fabric_tenant_id
@@ -12,7 +12,7 @@ module "fabric_oidc_provider" {
 # Curated S3 bucket exposed to Microsoft Fabric via OneLake shortcuts.
 # TODO: Use KMS key for encryption.
 module "fabric_curated_bucket" {
-  count  = local.is-development ? 1 : 0
+  count  = local.fabric_oidc_enabled ? 1 : 0
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=ce9c0c07489e393ce80441aed0fd5bf7798956a3"
 
   bucket_prefix      = "laa-data-factory-curated"
@@ -30,7 +30,7 @@ module "fabric_curated_bucket" {
 }
 
 module "fabric_iam_role" {
-  count  = local.is-development ? 1 : 0
+  count  = local.fabric_oidc_enabled ? 1 : 0
   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
 
   object_id                          = local.fabric_enterprise_app_object_id

--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -2,7 +2,8 @@
 # exposed to Microsoft Fabric via OneLake S3 shortcuts.
 
 module "fabric_oidc_provider" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=36908c4b209427f3a59a8cb4a80e9a577bc069f5"
+  count  = local.is-development ? 1 : 0
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
 
   tenant_id          = local.fabric_tenant_id
   oidc_provider_name = "fabric-s3-access"
@@ -11,6 +12,7 @@ module "fabric_oidc_provider" {
 # Curated S3 bucket exposed to Microsoft Fabric via OneLake shortcuts.
 # TODO: Use KMS key for encryption.
 module "fabric_curated_bucket" {
+  count  = local.is-development ? 1 : 0
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=ce9c0c07489e393ce80441aed0fd5bf7798956a3"
 
   bucket_prefix      = "laa-data-factory-curated"
@@ -28,13 +30,14 @@ module "fabric_curated_bucket" {
 }
 
 module "fabric_iam_role" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=36908c4b209427f3a59a8cb4a80e9a577bc069f5"
+  count  = local.is-development ? 1 : 0
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
 
   object_id                          = local.fabric_enterprise_app_object_id
-  oidc_provider_arn                  = module.fabric_oidc_provider.arn
-  oidc_provider_condition_key_prefix = module.fabric_oidc_provider.condition_key_prefix
+  oidc_provider_arn                  = module.fabric_oidc_provider[0].arn
+  oidc_provider_condition_key_prefix = module.fabric_oidc_provider[0].condition_key_prefix
 
-  bucket_arn       = module.fabric_curated_bucket.bucket.arn
+  bucket_arn       = module.fabric_curated_bucket[0].bucket.arn
   role_name        = "fabric-s3-access"
   role_policy_name = "fabric-s3-read-policy"
 }

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -2,6 +2,6 @@
 locals {
   current_account_id              = data.aws_caller_identity.current.account_id
   current_account_region          = data.aws_region.current.region
-  fabric_tenant_id                = data.aws_secretsmanager_secret_version.fabric_tenant_id.secret_string
-  fabric_enterprise_app_object_id = data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id.secret_string
+  fabric_tenant_id                = local.is-development ? data.aws_secretsmanager_secret_version.fabric_tenant_id[0].secret_string : null
+  fabric_enterprise_app_object_id = local.is-development ? data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id[0].secret_string : null
 }

--- a/terraform/environments/data-factory-laa/locals.tf
+++ b/terraform/environments/data-factory-laa/locals.tf
@@ -1,7 +1,24 @@
 #### This file can be used to store locals specific to the member account ####
 locals {
-  current_account_id              = data.aws_caller_identity.current.account_id
-  current_account_region          = data.aws_region.current.region
-  fabric_tenant_id                = local.is-development ? data.aws_secretsmanager_secret_version.fabric_tenant_id[0].secret_string : null
-  fabric_enterprise_app_object_id = local.is-development ? data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id[0].secret_string : null
+  current_account_id     = data.aws_caller_identity.current.account_id
+  current_account_region = data.aws_region.current.region
+
+  fabric_oidc_enabled_environments = ["development"]
+
+  fabric_oidc_enabled = contains(
+    local.fabric_oidc_enabled_environments,
+    local.environment
+  )
+
+  fabric_tenant_id = (
+    local.fabric_oidc_enabled
+    ? trimspace(data.aws_secretsmanager_secret_version.fabric_tenant_id[0].secret_string)
+    : null
+  )
+
+  fabric_enterprise_app_object_id = (
+    local.fabric_oidc_enabled
+    ? trimspace(data.aws_secretsmanager_secret_version.fabric_enterprise_app_object_id[0].secret_string)
+    : null
+  )
 }


### PR DESCRIPTION
Updated both `fabric-oidc-provider` and `fabric-iam-role` module refs which adds `s3:GetObjectAttributes` to the IAM policy alongside `s3:GetObject` - a non-breaking change required for Fabric OneLake shortcuts. No input/output interface changes, so no other updates needed.