### PR TITLE
feat(data-platform): create `app` namespace

### DIFF
--- a/terraform/environments/data-platform/app/data.tf
+++ b/terraform/environments/data-platform/app/data.tf
@@ -1,0 +1,7 @@
+data "aws_eks_cluster" "cluster" {
+  name = "${local.application_name}-${local.environment}"
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = data.aws_eks_cluster.cluster.name
+}

--- a/terraform/environments/data-platform/app/kubernetes-namespace.tf
+++ b/terraform/environments/data-platform/app/kubernetes-namespace.tf
@@ -1,0 +1,7 @@
+module "app_namespace" {
+  source = "../cluster/modules/kubernetes/namespace"
+
+  name              = local.component_name
+  workload          = "application"
+  pod_security_mode = "restricted"
+}

--- a/terraform/environments/data-platform/app/providers.tf
+++ b/terraform/environments/data-platform/app/providers.tf
@@ -1,0 +1,5 @@
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}


### PR DESCRIPTION
## Summary

Create the [`app` Kubernetes namespace](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/app/kubernetes-namespace.tf) on the data-platform EKS cluster.

## Why

Satisfies ministryofjustice/data-platform#343 — acceptance criterion: `app namespace exists`.

## Changes

- [`terraform/environments/data-platform/app/kubernetes-namespace.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/app/kubernetes-namespace.tf) — instantiates the shared [`namespace` module](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/cluster/modules/kubernetes/namespace/main.tf) with `workload = application` and `pod_security_mode = restricted`, mirroring the pattern used by [`ai-gateway`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/ai-gateway/kubernetes-namespace.tf).
- [`terraform/environments/data-platform/app/providers.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/app/providers.tf) — Kubernetes provider wired to the data-platform EKS cluster.
- [`terraform/environments/data-platform/app/data.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/agents/terraform-add-namespace/terraform/environments/data-platform/app/data.tf) — EKS cluster + auth data sources required by the provider.
