### PR TITLE
Maintenance analytical-platform-common - June 26

### DIFF
--- a/terraform/environments/analytical-platform-common/iam-policies.tf
+++ b/terraform/environments/analytical-platform-common/iam-policies.tf
@@ -72,7 +72,7 @@ module "ecr_access_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "ecr-access"
   description = "IAM Policy"
@@ -96,7 +96,7 @@ module "snyk_analytical_platform_airflow_container_scanning_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "snyk-analytical-platform-airflow-container-scanning"
   description = "IAM Policy"
@@ -111,7 +111,7 @@ module "trivy_analytical_platform_airflow_container_scanning_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "trivy-analytical-platform-airflow-container-scanning"
   description = "IAM Policy"
@@ -170,7 +170,7 @@ module "analytical_platform_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "analytical-platform-terraform"
   description = "IAM Policy"
@@ -232,7 +232,7 @@ module "analytical_platform_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "analytical-platform-github-actions"
   description = "IAM Policy"
@@ -271,7 +271,7 @@ module "data_engineering_datalake_access_github_actions_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "data-engineering-datalake-access-github-actions"
   description = "IAM Policy"
@@ -315,7 +315,7 @@ module "data_engineering_datalake_access_terraform_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name_prefix = "data-engineering-datalake-access-terraform"
   description = "IAM Policy"

--- a/terraform/environments/analytical-platform-common/iam-roles.tf
+++ b/terraform/environments/analytical-platform-common/iam-roles.tf
@@ -3,7 +3,7 @@ module "ecr_access_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -27,7 +27,7 @@ module "snyk_analytical_platform_airflow_container_scanning_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -66,7 +66,7 @@ module "trivy_analytical_platform_airflow_container_scanning_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -90,7 +90,7 @@ module "analytical_platform_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -111,7 +111,7 @@ module "analytical_platform_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   create          = true
   use_name_prefix = false
@@ -153,7 +153,7 @@ module "data_engineering_datalake_access_github_actions_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   enable_github_oidc = true
   use_name_prefix    = false
@@ -174,7 +174,7 @@ module "data_engineering_datalake_access_terraform_iam_role" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   create          = true
   use_name_prefix = false

--- a/terraform/environments/analytical-platform-common/s3-buckets.tf
+++ b/terraform/environments/analytical-platform-common/s3-buckets.tf
@@ -3,7 +3,7 @@ module "terraform_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.13.0"
+  version = "5.14.0"
 
   bucket = "mojap-common-${local.environment}-tfstate"
 
@@ -31,7 +31,7 @@ module "artifacts_bucket" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.13.0"
+  version = "5.14.0"
 
   bucket = "mojap-common-${local.environment}-artifacts"
 


### PR DESCRIPTION
This work is been tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?reload=1&pane=issue&itemId=182645444&issue=ministryofjustice%7Canalytical-platform%7C10188)



This pull request updates the versions of several Terraform AWS modules used for IAM policies, IAM roles, and S3 buckets in the `analytical-platform-common` environment. The changes ensure that the infrastructure uses the latest bug fixes and improvements from the upstream modules.

**Terraform module version upgrades:**

*IAM Policy module updates:*
- Upgraded `terraform-aws-modules/iam/aws//modules/iam-policy` from version `6.6.0` to `6.6.1` for all IAM policy modules in `iam-policies.tf`. [[1]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L75-R75) [[2]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L99-R99) [[3]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L114-R114) [[4]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L173-R173) [[5]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L235-R235) [[6]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L274-R274) [[7]](diffhunk://#diff-77ec46ab75c12caf6070c945024a54b00280809569e5a69ca5a8cb2e3c93f1c0L318-R318)

*IAM Role module updates:*
- Upgraded `terraform-aws-modules/iam/aws//modules/iam-role` from version `6.6.0` to `6.6.1` for all IAM role modules in `iam-roles.tf`. [[1]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL6-R6) [[2]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL30-R30) [[3]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL69-R69) [[4]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL93-R93) [[5]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL114-R114) [[6]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL156-R156) [[7]](diffhunk://#diff-a0bee217279cf11e781bf8e96d6e9a2a28938f94f2ff54dcfa940a9f8de8fbdaL177-R177)

*S3 Bucket module updates:*
- Upgraded `terraform-aws-modules/s3-bucket/aws` from version `5.13.0` to `5.14.0` for all S3 bucket modules in `s3-buckets.tf`. [[1]](diffhunk://#diff-17d471a2df6981809cb9fe6da7d0ccb971280f6cd83724969abfa0825bedc87fL6-R6) [[2]](diffhunk://#diff-17d471a2df6981809cb9fe6da7d0ccb971280f6cd83724969abfa0825bedc87fL34-R34)