### PR TITLE
LASB-5060: Add AL2023 config for MLRA

### DIFF
--- a/terraform/environments/mlra/cloudwatch-agent.json
+++ b/terraform/environments/mlra/cloudwatch-agent.json
@@ -1,0 +1,34 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "${app_name}-EC2",
+            "log_stream_name": "secure/{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "${app_name}-EC2",
+            "log_stream_name": "messages/{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/ecs/ecs-init.log",
+            "log_group_name": "${app_name}-EC2",
+            "log_stream_name": "ecs-init/{instance_id}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ecs/ecs-agent.log.*",
+            "log_group_name": "${app_name}-EC2",
+            "log_stream_name": "ecs-agent/{instance_id}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/terraform/environments/mlra/ecs.tf
+++ b/terraform/environments/mlra/ecs.tf
@@ -11,7 +11,9 @@ module "mlra-ecs" {
   app_name                       = local.application_name
   container_instance_type        = local.application_data.accounts[local.environment].container_instance_type
   instance_type                  = local.application_data.accounts[local.environment].instance_type
+  # replace with AL2023 user data after migration
   user_data                      = local.user_data
+  user_data_al2023               = local.user_data_al2023
   key_name                       = local.application_data.accounts[local.environment].key_name
   task_definition                = local.task_definition
   ec2_desired_capacity           = local.application_data.accounts[local.environment].ec2_desired_capacity

--- a/terraform/environments/mlra/locals.tf
+++ b/terraform/environments/mlra/locals.tf
@@ -12,12 +12,28 @@ locals {
 
   alb_security_group_id = module.alb.security_group.id
 
+  # remove after migration
   user_data = base64encode(templatefile("user_data.sh", {
     app_name    = local.application_name,
     environment = local.environment,
     xdr_dir     = "/tmp/cortex-agent",
     xdr_tar     = "/tmp/cortex-agent.tar.gz",
     xdr_tags    = local.xdr_tags
+  }))
+
+  user_data_al2023 = base64encode(templatefile("user_data_al2023.sh", {
+    app_name    = local.application_name,
+    environment = local.environment,
+    xdr_dir     = "/tmp/cortex-agent",
+    xdr_tar     = "/tmp/cortex-agent.tar.gz",
+    xdr_tags    = local.xdr_tags
+
+    cw_agent_config = templatefile(
+      "${path.module}/cloudwatch-agent.json",
+      {
+        app_name = local.application_name
+      }
+    )
   }))
 
   maatdb_password_secret_name    = "APP_MAATDB_DBPASSWORD_MLA1"

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -832,7 +832,8 @@ resource "aws_ecs_cluster_capacity_providers" "mlra" {
   cluster_name = aws_ecs_cluster.ecs_cluster.name
 
   capacity_providers = [
-    aws_ecs_capacity_provider.mlra.name
+    aws_ecs_capacity_provider.mlra.name,
+    aws_ecs_capacity_provider.mlra-al2023.name
   ]
 }
 

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -22,6 +22,7 @@ data "aws_subnets" "shared-private" {
   }
 }
 
+# remove after migration
 resource "aws_autoscaling_group" "cluster-scaling-group" {
   vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
   name                  = "${var.app_name}-cluster-scaling-group"
@@ -55,6 +56,67 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 
   launch_template {
     id      = aws_launch_template.ec2-launch-template.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.app_name}-cluster-scaling-group"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = true
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.tags_common
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
+  vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
+  name                  = "${var.app_name}-cluster-scaling-group-al2023"
+  # New ASG, set capacity to 0 - will be scaled manually during migration.
+  # Follow-up Terraform PR will update to desired final capacity.
+  desired_capacity      = 0
+  max_size              = var.ec2_max_size
+  min_size              = 0
+  protect_from_scale_in = true
+  metrics_granularity   = "1Minute"
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+    "GroupInServiceCapacity",
+    "GroupPendingCapacity",
+    "GroupStandbyCapacity",
+    "GroupTerminatingCapacity",
+    "GroupTotalCapacity",
+    "WarmPoolDesiredCapacity",
+    "WarmPoolWarmedCapacity",
+    "WarmPoolPendingCapacity",
+    "WarmPoolTerminatingCapacity",
+    "WarmPoolTotalCapacity",
+    "GroupAndWarmPoolDesiredCapacity",
+    "GroupAndWarmPoolTotalCapacity"
+  ]
+
+  launch_template {
+    id      = aws_launch_template.ec2-launch-template-al2023.id
     version = "$Latest"
   }
 
@@ -140,14 +202,25 @@ resource "aws_security_group_rule" "mlra_to_maatdb_sg_rule_outbound" {
   source_security_group_id = var.maatdb_rds_sec_group_id
 }
 
-# always use the recommended ECS optimized linux 2 base image; used to obtain its AMI ID
-data "aws_ssm_parameter" "ecs_optimized_ami_1" {
+# remove after migration
+data "aws_ssm_parameter" "ecs_optimized_ami_al2" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended"
 }
 
+# always use the recommended ECS optimized linux 2023 base image; used to obtain its AMI ID
+data "aws_ssm_parameter" "ecs_optimized_ami_al2023" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
+}
+
+# remove after migration
+output "ami_id_al2" {
+  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
+  sensitive = true
+}
+
 # if the AMI is used elsewhere it can be obtained here
-output "ami_id" {
-  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_1.value)["image_id"]
+output "ami_id_al2023" {
+  value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   sensitive = true
 }
 
@@ -155,12 +228,13 @@ output "ami_id" {
 # Note - when updating this you will need to manually terminate the EC2s
 # so that the autoscaling group creates new ones using the new launch template
 
+# remove after migration
 #tfsec:ignore:AVD-AWS-0130:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
 resource "aws_launch_template" "ec2-launch-template" {
   #checkov:skip=CKV_AWS_79:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
   #checkov:skip=CKV_AWS_341:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
   name_prefix            = "${var.app_name}-ec2-launch-template"
-  image_id               = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_1.value)["image_id"]
+  image_id               = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
   instance_type          = var.instance_type
   key_name               = var.key_name
   ebs_optimized          = true
@@ -197,6 +271,68 @@ resource "aws_launch_template" "ec2-launch-template" {
   }
 
   user_data = var.user_data
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(tomap({
+      "Name" = "${var.app_name}-ecs-cluster"
+    }), var.tags_common)
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(tomap({
+      "Name" = "${var.app_name}-ecs-cluster"
+    }), var.tags_common)
+  }
+
+  tags = merge(tomap({
+    "Name" = "${var.app_name}-ecs-cluster-template"
+  }), var.tags_common)
+}
+
+#tfsec:ignore:AVD-AWS-0130:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
+resource "aws_launch_template" "ec2-launch-template-al2023" {
+  #checkov:skip=CKV_AWS_79:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
+  #checkov:skip=CKV_AWS_341:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
+  name_prefix            = "${var.app_name}-ec2-launch-template-al2023"
+  image_id               = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  ebs_optimized          = true
+  update_default_version = true
+
+  monitoring {
+    enabled = true
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "optional"
+    http_put_response_hop_limit = "2"
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2_instance_profile.name
+  }
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.cluster_ec2.id]
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      volume_size           = 30
+      volume_type           = "gp2"
+      iops                  = 0
+    }
+  }
+
+  user_data = var.user_data_al2023
 
   tag_specifications {
     resource_type = "instance"
@@ -400,6 +536,12 @@ resource "aws_ecs_service" "ecs_service" {
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.mlra.name
     weight            = 1
+  }
+
+  # increase weight gradually during migration
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.mlra-al2023.name
+    weight            = 0
   }
 
   health_check_grace_period_seconds = 300
@@ -652,6 +794,7 @@ resource "aws_appautoscaling_policy" "ecs_target_memory" {
   }
 }
 
+# remove after migration
 resource "aws_ecs_capacity_provider" "mlra" {
   name = "${var.app_name}-${var.environment}-capacity-provider"
 
@@ -668,9 +811,28 @@ resource "aws_ecs_capacity_provider" "mlra" {
   }
 }
 
+resource "aws_ecs_capacity_provider" "mlra-al2023" {
+  name = "${var.app_name}-${var.environment}-capacity-provider-al2023"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.cluster-scaling-group-al2023.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      # maximum_scaling_step_size = 1000
+      # minimum_scaling_step_size = 1
+      status          = "ENABLED"
+      target_capacity = var.ecs_target_capacity
+    }
+  }
+}
+
 resource "aws_ecs_cluster_capacity_providers" "mlra" {
   cluster_name = aws_ecs_cluster.ecs_cluster.name
 
-  capacity_providers = [aws_ecs_capacity_provider.mlra.name]
+  capacity_providers = [
+    aws_ecs_capacity_provider.mlra.name,
+    aws_ecs_capacity_provider.mlra-al2023.name
+  ]
 }
 

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -84,7 +84,7 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 
 resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
   vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
-  name                  = "${var.app_name}-cluster-scaling-group-al2023"
+  name_prefix                  = "${var.app_name}-ec2-al2023-"
   # New ASG, set capacity to 0 - will be scaled manually during migration.
   # Follow-up Terraform PR will update to desired final capacity.
   desired_capacity      = 0
@@ -122,7 +122,7 @@ resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
 
   tag {
     key                 = "Name"
-    value               = "${var.app_name}-cluster-scaling-group"
+    value               = "${var.app_name}-cluster-scaling-group-al2023"
     propagate_at_launch = true
   }
 
@@ -212,13 +212,14 @@ data "aws_ssm_parameter" "ecs_optimized_ami_al2023" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
 }
 
-# remove after migration
-output "ami_id_al2" {
+# update to reference AL2023 ID after migration
+# if the AMI is used elsewhere it can be obtained here
+output "ami_id" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
   sensitive = true
 }
 
-# if the AMI is used elsewhere it can be obtained here
+# move to ami_id after migration
 output "ami_id_al2023" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   sensitive = true
@@ -295,7 +296,7 @@ resource "aws_launch_template" "ec2-launch-template" {
 resource "aws_launch_template" "ec2-launch-template-al2023" {
   #checkov:skip=CKV_AWS_79:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
   #checkov:skip=CKV_AWS_341:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
-  name_prefix            = "${var.app_name}-ec2-launch-template-al2023"
+  name_prefix            = "${var.app_name}-ec2-al2023-"
   image_id               = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   instance_type          = var.instance_type
   key_name               = var.key_name

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -84,7 +84,7 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 
 resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
   vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
-  name_prefix                  = "${var.app_name}-ec2-al2023-"
+  name                  = "${var.app_name}-cluster-scaling-group-al2023"
   # New ASG, set capacity to 0 - will be scaled manually during migration.
   # Follow-up Terraform PR will update to desired final capacity.
   desired_capacity      = 0
@@ -832,8 +832,7 @@ resource "aws_ecs_cluster_capacity_providers" "mlra" {
   cluster_name = aws_ecs_cluster.ecs_cluster.name
 
   capacity_providers = [
-    aws_ecs_capacity_provider.mlra.name,
-    aws_ecs_capacity_provider.mlra-al2023.name
+    aws_ecs_capacity_provider.mlra.name
   ]
 }
 

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -84,7 +84,7 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 
 resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
   vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
-  name                  = "${var.app_name}-cluster-scaling-group-al2023"
+  name_prefix           = "${var.app_name}-ec2-al2023-"
   # New ASG, set capacity to 0 - will be scaled manually during migration.
   # Follow-up Terraform PR will update to desired final capacity.
   desired_capacity      = 0

--- a/terraform/environments/mlra/modules/ecs/variables.tf
+++ b/terraform/environments/mlra/modules/ecs/variables.tf
@@ -119,9 +119,15 @@ variable "appscaling_max_capacity" {
   default     = 6
 }
 
+# replace with AL2023 user data after migration
 variable "user_data" {
   type        = string
   description = "The configuration used when creating EC2s used for the ECS cluster"
+}
+
+variable "user_data_al2023" {
+  type        = string
+  description = "The configuration used when creating AL2023 EC2s used for the ECS cluster"
 }
 
 variable "vpc_all" {

--- a/terraform/environments/mlra/user_data_al2023.sh
+++ b/terraform/environments/mlra/user_data_al2023.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -xe
 echo ECS_CLUSTER=${app_name} >> /etc/ecs/ecs.config
+echo ECS_IMAGE_PULL_BEHAVIOR=always >> /etc/ecs/ecs.config
 # Install CloudWatch Agent
-yum install -y aws-cfn-bootstrap amazon-cloudwatch-agent
+yum install -y amazon-cloudwatch-agent
 # Write CloudWatch Agent config (provided via Terraform)
 cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<-EOF
 ${cw_agent_config}
@@ -35,7 +36,7 @@ else
   AGENT_PATH="pre-prod/cortex-agent.tar.gz"
 fi
 
-aws s3 cp $${XDR_AGENT_BUCKET}$${AGENT_PATH} ${xdr_tar}
+aws s3 cp "$${XDR_AGENT_BUCKET}$${AGENT_PATH}" ${xdr_tar}
 
 if [[ -f ${xdr_tar} ]]; then
   mkdir -p ${xdr_dir}

--- a/terraform/environments/mlra/user_data_al2023.sh
+++ b/terraform/environments/mlra/user_data_al2023.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -xe
+echo ECS_CLUSTER=${app_name} >> /etc/ecs/ecs.config
+# Install CloudWatch Agent
+yum install -y aws-cfn-bootstrap amazon-cloudwatch-agent
+# Write CloudWatch Agent config (provided via Terraform)
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<-EOF
+${cw_agent_config}
+EOF
+
+chmod 644 /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# Start rsyslog
+sudo yum install -y rsyslog
+sudo systemctl enable rsyslog
+sudo systemctl start rsyslog
+
+# Start CloudWatch Agent
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+sudo systemctl enable amazon-cloudwatch-agent
+sudo systemctl start amazon-cloudwatch-agent
+
+
+# Install prerequisites for Cortex agent
+sudo yum install -y selinux-policy-devel
+
+# Install XDR agent stored in S3 bucket
+XDR_AGENT_BUCKET="s3://modernisation-platform-laa-shared20250605080758955300000001/laa-platform/xdr-agent/"
+if [[ "production" = "${environment}" ]]; then
+  AGENT_PATH="prod/cortex-agent.tar.gz"
+else
+  AGENT_PATH="pre-prod/cortex-agent.tar.gz"
+fi
+
+aws s3 cp $${XDR_AGENT_BUCKET}$${AGENT_PATH} ${xdr_tar}
+
+if [[ -f ${xdr_tar} ]]; then
+  mkdir -p ${xdr_dir}
+  tar -xzf ${xdr_tar} -C ${xdr_dir}
+
+  if [[ -f ${xdr_dir}/cortex.conf ]]; then
+    sudo mkdir -p /etc/panw
+    sudo cp ${xdr_dir}/cortex.conf /etc/panw/
+  else
+    echo "Missing cortex.conf in extracted archive" >&2
+    exit 1
+  fi
+
+  sudo yum install -y ${xdr_dir}/*.rpm
+  sudo /opt/traps/bin/cytool endpoint_tags add "${xdr_tags}"
+
+else
+  echo "XDR agent download failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LASB-5060)

This PR introduces support for Amazon Linux 2023 (AL2023) for ECS on EC2 capacity used by MLRA, in preparation for the Amazon Linux 2 end-of-life (30 June 2026).
A blue/green capacity approach is used to allow a controlled and reversible migration, with no impact to existing workloads until explicitly triggered.

- Introduce AL2023 ECS‑optimised AMI via SSM parameter
- Add new launch template for AL2023 with updated user data
- Create new Auto Scaling Group for AL2023 with desired capacity set to 0 for controlled rollout
- Update user data script to install/configure CloudWatch Agent and remove awslogs dependencies
- Replace deprecated awslogs with Amazon CloudWatch Agent 
- Add CloudWatch Agent JSON configuration equivalent to existing awslogs setup 
- Maintain existing AL2 infrastructure for blue/green migration
- Add new Terraform output for AL2023 AMI ID
- Add new capacity manager for AL2023 ASG