### PR TITLE
Api platform -  mft flow for uploading files via presigned url

### DIFF
--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -1,0 +1,88 @@
+# Integration Hub API Platform
+
+This component provides a thin API layer for Managed File Transfer uploads.
+
+## What it does
+
+1. A client calls `POST /transfer-tickets` on API Gateway.
+2. API Gateway invokes a Lambda function.
+3. The Lambda function reads client upload configuration from DynamoDB.
+4. The Lambda function generates a short-lived S3 pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
+5. The client uploads the file directly to S3 with the returned URL and headers.
+
+## Sample request payload
+
+```json
+{
+  "clientId": "products-poc",
+  "fileName": "example-upload.csv",
+  "contentType": "text/csv",
+  "sizeBytes": 12345,
+  "requestedExpirySeconds": 900,
+  "contentMd5": "CY9rzUYh03PK3k6DJie09g=="
+}
+```
+
+## Example response shape
+
+```json
+{
+  "transferTicket": "f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61",
+  "clientId": "products-poc",
+  "upload": {
+    "method": "PUT",
+    "url": "https://...",
+    "headers": {
+      "Content-Type": "text/csv",
+      "Content-MD5": "CY9rzUYh03PK3k6DJie09g==",
+      "x-amz-meta-client-id": "products-poc",
+      "x-amz-meta-original-file-name": "example-upload.csv",
+      "x-amz-meta-transfer-ticket": "f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61",
+      "x-amz-server-side-encryption": "aws:kms",
+      "x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:eu-west-2:123456789012:key/..."
+    },
+    "expiresInSeconds": 900
+  },
+  "object": {
+    "bucket": "integration-hub-unscanned-...",
+    "key": "products-poc/uploads/2026/06/09/uuid.csv"
+  }
+}
+```
+
+## Terraform commands
+
+Apply the Managed File Transfer stack first so its remote state exposes the upload bucket output:
+
+```bash
+cd /Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/managed-file-transfer
+terraform init -reconfigure
+terraform workspace select integration-hub-development
+terraform plan
+```
+
+Then initialise and plan the API platform stack:
+
+```bash
+cd /Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/api-platform
+terraform init -reconfigure
+terraform workspace select integration-hub-development
+terraform plan
+```
+
+## Example API call
+
+Replace `<api-endpoint>` with the `transfer_ticket_api_endpoint` Terraform output after apply.
+
+```bash
+curl -X POST "https://<api-endpoint>/transfer-tickets" \
+  -H "content-type: application/json" \
+  -d '{
+    "clientId": "products-poc",
+    "fileName": "example-upload.csv",
+    "contentType": "text/csv",
+    "sizeBytes": 12345,
+    "requestedExpirySeconds": 900,
+    "contentMd5": "CY9rzUYh03PK3k6DJie09g=="
+  }'
+```

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -52,7 +52,7 @@ This component provides a thin API layer for Managed File Transfer uploads.
 
 ## Terraform commands
 
-Apply the Managed File Transfer stack first so its remote state exposes the upload bucket output:
+Apply the Managed File Transfer stack first so it creates the SSM parameters for the upload bucket (consumed by this stack):
 
 ```bash
 cd terraform/environments/integration-hub/managed-file-transfer

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -55,7 +55,7 @@ This component provides a thin API layer for Managed File Transfer uploads.
 Apply the Managed File Transfer stack first so its remote state exposes the upload bucket output:
 
 ```bash
-cd /Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/managed-file-transfer
+cd terraform/environments/integration-hub/managed-file-transfer
 terraform init -reconfigure
 terraform workspace select integration-hub-development
 terraform plan

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -64,7 +64,7 @@ terraform plan
 Then initialise and plan the API platform stack:
 
 ```bash
-cd /Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/api-platform
+cd terraform/environments/integration-hub/api-platform
 terraform init -reconfigure
 terraform workspace select integration-hub-development
 terraform plan

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -1,0 +1,66 @@
+resource "aws_cloudwatch_log_group" "api_access" {
+  name              = "/aws/apigateway/${local.application_name}-${local.component_name}"
+  retention_in_days = 30
+  tags              = local.tags
+}
+
+resource "aws_apigatewayv2_api" "upload_ticket" {
+  name          = "${local.application_name}-${local.component_name}"
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers = ["content-md5", "content-type"]
+    allow_methods = ["OPTIONS", "POST"]
+    allow_origins = ["*"]
+    expose_headers = [
+      "content-type",
+    ]
+    max_age = 300
+  }
+
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_integration" "upload_ticket" {
+  api_id                 = aws_apigatewayv2_api.upload_ticket.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = module.lambda_upload_ticket.lambda_function_invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "transfer_tickets" {
+  api_id    = aws_apigatewayv2_api.upload_ticket.id
+  route_key = "POST /transfer-tickets"
+  target    = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.upload_ticket.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      sourceIp       = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
+  tags = local.tags
+}
+
+resource "aws_lambda_permission" "allow_api_gateway_upload_ticket" {
+  statement_id  = "AllowExecutionFromApiGatewayUploadTicket"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_upload_ticket.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.upload_ticket.execution_arn}/*/*"
+}

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -8,14 +8,18 @@ resource "aws_apigatewayv2_api" "upload_ticket" {
   name          = "${local.application_name}-${local.component_name}"
   protocol_type = "HTTP"
 
-  cors_configuration {
-    allow_headers = ["content-md5", "content-type"]
-    allow_methods = ["OPTIONS", "POST"]
-    allow_origins = ["*"]
-    expose_headers = [
-      "content-type",
-    ]
-    max_age = 300
+  dynamic "cors_configuration" {
+    for_each = length(local.cors_allowed_origins) > 0 ? [1] : []
+
+    content {
+      allow_headers = ["content-md5", "content-type"]
+      allow_methods = ["OPTIONS", "POST"]
+      allow_origins = local.cors_allowed_origins
+      expose_headers = [
+        "content-type",
+      ]
+      max_age = 300
+    }
   }
 
   tags = local.tags

--- a/terraform/environments/integration-hub/api-platform/application_variables.json
+++ b/terraform/environments/integration-hub/api-platform/application_variables.json
@@ -1,0 +1,43 @@
+{
+  "accounts": {
+    "development": {
+      "api_configuration": {
+        "max_presigned_url_expiry_seconds": 3600,
+        "presigned_url_expiry_seconds": 900
+      },
+      "transfer_clients": {
+        "products-poc": {
+          "enabled": true,
+          "key_prefix": "products-poc/uploads",
+          "max_upload_size_bytes": 52428800,
+          "allowed_content_types": [
+            "text/csv",
+            "application/json",
+            "application/zip"
+          ]
+        }
+      }
+    },
+    "test": {
+      "api_configuration": {
+        "max_presigned_url_expiry_seconds": 3600,
+        "presigned_url_expiry_seconds": 900
+      },
+      "transfer_clients": {}
+    },
+    "preproduction": {
+      "api_configuration": {
+        "max_presigned_url_expiry_seconds": 3600,
+        "presigned_url_expiry_seconds": 900
+      },
+      "transfer_clients": {}
+    },
+    "production": {
+      "api_configuration": {
+        "max_presigned_url_expiry_seconds": 3600,
+        "presigned_url_expiry_seconds": 900
+      },
+      "transfer_clients": {}
+    }
+  }
+}

--- a/terraform/environments/integration-hub/api-platform/application_variables.json
+++ b/terraform/environments/integration-hub/api-platform/application_variables.json
@@ -2,6 +2,7 @@
   "accounts": {
     "development": {
       "api_configuration": {
+        "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
@@ -20,6 +21,7 @@
     },
     "test": {
       "api_configuration": {
+        "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
@@ -27,6 +29,7 @@
     },
     "preproduction": {
       "api_configuration": {
+        "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
@@ -34,6 +37,7 @@
     },
     "production": {
       "api_configuration": {
+        "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },

--- a/terraform/environments/integration-hub/api-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-platform/dynamo-db.tf
@@ -1,0 +1,53 @@
+module "dynamodb_transfer_clients" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-transfer-clients"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "client_id"
+
+  attributes = [
+    {
+      name = "client_id"
+      type = "S"
+    }
+  ]
+
+  table_class = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_dynamodb_table_item" "transfer_client" {
+  for_each = local.transfer_clients
+
+  table_name = module.dynamodb_transfer_clients.dynamodb_table_id
+  hash_key   = "client_id"
+
+  item = jsonencode({
+    client_id = {
+      S = each.key
+    }
+    enabled = {
+      BOOL = try(each.value.enabled, true)
+    }
+    key_prefix = {
+      S = try(each.value.key_prefix, each.key)
+    }
+    max_upload_size_bytes = {
+      N = tostring(try(each.value.max_upload_size_bytes, 52428800))
+    }
+    allowed_content_types = {
+      L = [
+        for value in try(each.value.allowed_content_types, []) : {
+          S = value
+        }
+      ]
+    }
+  })
+}

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -13,8 +13,8 @@ module "lambda_upload_ticket" {
     MAX_PRESIGNED_URL_EXPIRY_SECONDS = tostring(try(local.api_configuration.max_presigned_url_expiry_seconds, 3600))
     PRESIGNED_URL_EXPIRY_SECONDS     = tostring(try(local.api_configuration.presigned_url_expiry_seconds, 900))
     TRANSFER_CLIENTS_TABLE           = module.dynamodb_transfer_clients.dynamodb_table_id
-    UPLOAD_BUCKET_KMS_KEY_ARN        = data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.kms_key_arn
-    UPLOAD_BUCKET_NAME               = data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.id
+    UPLOAD_BUCKET_KMS_KEY_ARN        = data.aws_ssm_parameter.mft_upload_bucket_kms_key_arn.value
+    UPLOAD_BUCKET_NAME               = data.aws_ssm_parameter.mft_upload_bucket_name.value
   }
 
   attach_policy_statements = true
@@ -34,7 +34,7 @@ module "lambda_upload_ticket" {
         "s3:PutObject",
       ]
       resources = [
-        "${data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.arn}/*",
+        "${data.aws_ssm_parameter.mft_upload_bucket_arn.value}/*",
       ]
     }
     upload_bucket_kms_access = {
@@ -45,7 +45,7 @@ module "lambda_upload_ticket" {
         "kms:GenerateDataKey*",
       ]
       resources = [
-        data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.kms_key_arn,
+        data.aws_ssm_parameter.mft_upload_bucket_kms_key_arn.value,
       ]
     }
   }

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -1,0 +1,56 @@
+module "lambda_upload_ticket" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-${local.component_name}-upload-ticket"
+  description                  = "Generates presigned S3 upload URLs for managed file transfer clients"
+  handler                      = "lambda_function.lambda_handler"
+  runtime                      = "python3.12"
+  source_path                  = "${path.module}/lambda/request-upload-ticket"
+  trigger_on_package_timestamp = false
+
+  environment_variables = {
+    MAX_PRESIGNED_URL_EXPIRY_SECONDS = tostring(try(local.api_configuration.max_presigned_url_expiry_seconds, 3600))
+    PRESIGNED_URL_EXPIRY_SECONDS     = tostring(try(local.api_configuration.presigned_url_expiry_seconds, 900))
+    TRANSFER_CLIENTS_TABLE           = module.dynamodb_transfer_clients.dynamodb_table_id
+    UPLOAD_BUCKET_KMS_KEY_ARN        = data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.kms_key_arn
+    UPLOAD_BUCKET_NAME               = data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.id
+  }
+
+  attach_policy_statements = true
+  policy_statements = {
+    transfer_client_table_read = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:GetItem",
+      ]
+      resources = [
+        module.dynamodb_transfer_clients.dynamodb_table_arn,
+      ]
+    }
+    upload_bucket_write = {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+      ]
+      resources = [
+        "${data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.arn}/*",
+      ]
+    }
+    upload_bucket_kms_access = {
+      effect = "Allow"
+      actions = [
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+      ]
+      resources = [
+        data.terraform_remote_state.managed_file_transfer.outputs.upload_bucket.kms_key_arn,
+      ]
+    }
+  }
+
+  cloudwatch_logs_retention_in_days = 30
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -25,6 +25,7 @@ def _response(status_code, body):
         "statusCode": status_code,
         "headers": {
             "content-type": "application/json",
+            "cache-control": "no-store",
         },
         "body": json.dumps(body),
     }

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -90,8 +90,13 @@ def lambda_handler(event, _context):
         )
 
     size_bytes = request.get("sizeBytes")
+    try:
+        size_bytes_int = int(size_bytes) if size_bytes is not None else None
+    except (TypeError, ValueError):
+        return _response(400, {"message": "sizeBytes must be an integer"})
+
     max_upload_size_bytes = int(record.get("max_upload_size_bytes", 0))
-    if size_bytes is not None and max_upload_size_bytes and int(size_bytes) > max_upload_size_bytes:
+    if size_bytes_int is not None and max_upload_size_bytes and size_bytes_int > max_upload_size_bytes:
         return _response(
             400,
             {
@@ -100,9 +105,13 @@ def lambda_handler(event, _context):
             },
         )
 
-    requested_expiry_seconds = int(request.get("requestedExpirySeconds", DEFAULT_EXPIRY_SECONDS))
+    try:
+        requested_expiry_seconds = int(
+            request.get("requestedExpirySeconds", DEFAULT_EXPIRY_SECONDS)
+        )
+    except (TypeError, ValueError):
+        return _response(400, {"message": "requestedExpirySeconds must be an integer"})
     expiry_seconds = max(1, min(requested_expiry_seconds, MAX_EXPIRY_SECONDS))
-
     transfer_ticket = str(uuid.uuid4())
     object_key = _build_object_key(record["key_prefix"], file_name)
     content_md5 = request.get("contentMd5")

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -1,0 +1,160 @@
+import base64
+import json
+import os
+import posixpath
+import re
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import boto3
+
+
+S3_CLIENT = boto3.client("s3")
+DYNAMODB = boto3.resource("dynamodb")
+
+TRANSFER_CLIENTS_TABLE = os.environ["TRANSFER_CLIENTS_TABLE"]
+UPLOAD_BUCKET_NAME = os.environ["UPLOAD_BUCKET_NAME"]
+UPLOAD_BUCKET_KMS_KEY_ARN = os.environ["UPLOAD_BUCKET_KMS_KEY_ARN"]
+DEFAULT_EXPIRY_SECONDS = int(os.environ["PRESIGNED_URL_EXPIRY_SECONDS"])
+MAX_EXPIRY_SECONDS = int(os.environ["MAX_PRESIGNED_URL_EXPIRY_SECONDS"])
+
+
+def _response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "content-type": "application/json",
+        },
+        "body": json.dumps(body),
+    }
+
+
+def _load_body(event):
+    body = event.get("body")
+    if body is None:
+        return {}
+
+    if event.get("isBase64Encoded"):
+        body = json.loads(base64.b64decode(body).decode("utf-8"))
+    elif isinstance(body, str):
+        body = json.loads(body)
+
+    if not isinstance(body, dict):
+        raise ValueError("Request body must be a JSON object")
+
+    return body
+
+
+def _normalise_extension(file_name):
+    suffix = Path(file_name).suffix.lower()
+    return suffix if re.fullmatch(r"\.[a-z0-9]{1,10}", suffix) else ""
+
+
+def _build_object_key(prefix, file_name):
+    today_prefix = datetime.now(UTC).strftime("%Y/%m/%d")
+    generated_name = f"{uuid.uuid4()}{_normalise_extension(file_name)}"
+    return posixpath.join(prefix.strip("/"), today_prefix, generated_name)
+
+
+def lambda_handler(event, _context):
+    try:
+        request = _load_body(event)
+    except (ValueError, json.JSONDecodeError) as exc:
+        return _response(400, {"message": str(exc)})
+
+    client_id = request.get("clientId")
+    file_name = request.get("fileName")
+
+    if not client_id or not file_name:
+        return _response(400, {"message": "clientId and fileName are required"})
+
+    table = DYNAMODB.Table(TRANSFER_CLIENTS_TABLE)
+    record = table.get_item(Key={"client_id": client_id}).get("Item")
+
+    if record is None:
+        return _response(404, {"message": f"Unknown clientId '{client_id}'"})
+
+    if not record.get("enabled", True):
+        return _response(403, {"message": f"Client '{client_id}' is disabled"})
+
+    content_type = request.get("contentType")
+    allowed_content_types = record.get("allowed_content_types", [])
+    if allowed_content_types and content_type not in allowed_content_types:
+        return _response(
+            400,
+            {
+                "message": "contentType is not allowed for this client",
+                "allowedContentTypes": allowed_content_types,
+            },
+        )
+
+    size_bytes = request.get("sizeBytes")
+    max_upload_size_bytes = int(record.get("max_upload_size_bytes", 0))
+    if size_bytes is not None and max_upload_size_bytes and int(size_bytes) > max_upload_size_bytes:
+        return _response(
+            400,
+            {
+                "message": "Requested file size exceeds the configured limit",
+                "maxUploadSizeBytes": max_upload_size_bytes,
+            },
+        )
+
+    requested_expiry_seconds = int(request.get("requestedExpirySeconds", DEFAULT_EXPIRY_SECONDS))
+    expiry_seconds = max(1, min(requested_expiry_seconds, MAX_EXPIRY_SECONDS))
+
+    transfer_ticket = str(uuid.uuid4())
+    object_key = _build_object_key(record["key_prefix"], file_name)
+    content_md5 = request.get("contentMd5")
+
+    put_object_params = {
+        "Bucket": UPLOAD_BUCKET_NAME,
+        "Key": object_key,
+        "Metadata": {
+            "client-id": client_id,
+            "original-file-name": Path(file_name).name,
+            "transfer-ticket": transfer_ticket,
+        },
+        "ServerSideEncryption": "aws:kms",
+        "SSEKMSKeyId": UPLOAD_BUCKET_KMS_KEY_ARN,
+    }
+    required_headers = {
+        "x-amz-server-side-encryption": "aws:kms",
+        "x-amz-server-side-encryption-aws-kms-key-id": UPLOAD_BUCKET_KMS_KEY_ARN,
+        "x-amz-meta-client-id": client_id,
+        "x-amz-meta-original-file-name": Path(file_name).name,
+        "x-amz-meta-transfer-ticket": transfer_ticket,
+    }
+
+    if content_type:
+        put_object_params["ContentType"] = content_type
+        required_headers["Content-Type"] = content_type
+
+    if content_md5:
+        put_object_params["ContentMD5"] = content_md5
+        required_headers["Content-MD5"] = content_md5
+
+    presigned_url = S3_CLIENT.generate_presigned_url(
+        ClientMethod="put_object",
+        Params=put_object_params,
+        ExpiresIn=expiry_seconds,
+        HttpMethod="PUT",
+    )
+
+    return _response(
+        200,
+        {
+            "transferTicket": transfer_ticket,
+            "clientId": client_id,
+            "upload": {
+                "method": "PUT",
+                "url": presigned_url,
+                "headers": required_headers,
+                "expiresInSeconds": expiry_seconds,
+            },
+            "object": {
+                "bucket": UPLOAD_BUCKET_NAME,
+                "key": object_key,
+            },
+        },
+    )

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  api_configuration = try(local.application_data.accounts[local.environment].api_configuration, {})
-  transfer_clients  = try(local.application_data.accounts[local.environment].transfer_clients, {})
+  api_configuration    = try(local.application_data.accounts[local.environment].api_configuration, {})
+  cors_allowed_origins = try(local.api_configuration.cors_allowed_origins, [])
+  transfer_clients     = try(local.application_data.accounts[local.environment].transfer_clients, {})
 }

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -2,4 +2,6 @@ locals {
   api_configuration    = try(local.application_data.accounts[local.environment].api_configuration, {})
   cors_allowed_origins = try(local.api_configuration.cors_allowed_origins, [])
   transfer_clients     = try(local.application_data.accounts[local.environment].transfer_clients, {})
+
+  mft_upload_bucket_parameter_prefix = "/${local.application_name}/managed-file-transfer/${local.environment}/upload-bucket"
 }

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  api_configuration = try(local.application_data.accounts[local.environment].api_configuration, {})
+  transfer_clients  = try(local.application_data.accounts[local.environment].transfer_clients, {})
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/bruno.json
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "mft-upload-test",
+  "type": "collection"
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/example-upload.csv
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/example-upload.csv
@@ -1,0 +1,2 @@
+id,name
+1,test-file

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: https://9zb4pskede.execute-api.eu-west-2.amazonaws.com/transfer-tickets
+  url: {{api_endpoint}}/transfer-tickets
   body: json
   auth: none
 }

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Get Transfer Ticket
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://9zb4pskede.execute-api.eu-west-2.amazonaws.com/transfer-tickets
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "clientId": "products-poc",
+    "fileName": "example-upload.csv",
+    "contentType": "text/csv",
+    "sizeBytes": 20,
+    "requestedExpirySeconds": 3600,
+    "contentMd5": "MpUHEEJHYMGcKUQ+bkiJug=="
+  }
+}
+
+script:post-response {
+  const ticket = res.getBody();
+  
+  bru.setVar("upload_url", ticket["upload"]["url"]);
+  bru.setVar("sse", ticket["upload"]["headers"]["x-amz-server-side-encryption"]);
+  bru.setVar("kms_key", ticket["upload"]["headers"]["x-amz-server-side-encryption-aws-kms-key-id"]);
+  bru.setVar("client_id", ticket["upload"]["headers"]["x-amz-meta-client-id"]);
+  bru.setVar("original_file_name", ticket["upload"]["headers"]["x-amz-meta-original-file-name"]);
+  bru.setVar("transfer_ticket", ticket["upload"]["headers"]["x-amz-meta-transfer-ticket"]);
+  bru.setVar("content_type", ticket["upload"]["headers"]["Content-Type"]);
+  bru.setVar("content_md5", ticket["upload"]["headers"]["Content-MD5"]);
+  bru.setVar("upload_bucket", ticket["object"]["bucket"]);
+  bru.setVar("upload_key", ticket["object"]["key"]);
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/upload-file-to-s3.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/upload-file-to-s3.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Upload File To S3
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{upload_url}}
+  body: file
+  auth: none
+}
+
+headers {
+  x-amz-server-side-encryption: {{sse}}
+  x-amz-server-side-encryption-aws-kms-key-id: {{kms_key}}
+  x-amz-meta-client-id: {{client_id}}
+  x-amz-meta-original-file-name: {{original_file_name}}
+  x-amz-meta-transfer-ticket: {{transfer_ticket}}
+  Content-Type: {{content_type}}
+  Content-MD5: {{content_md5}}
+}
+
+body:file {
+  file: @file(example-upload.csv) @contentType(text/csv)
+}

--- a/terraform/environments/integration-hub/api-platform/outputs.tf
+++ b/terraform/environments/integration-hub/api-platform/outputs.tf
@@ -1,0 +1,9 @@
+output "transfer_ticket_api_endpoint" {
+  description = "HTTP API endpoint for issuing managed file transfer upload tickets"
+  value       = aws_apigatewayv2_api.upload_ticket.api_endpoint
+}
+
+output "transfer_clients_table_name" {
+  description = "DynamoDB table containing upload client configuration"
+  value       = module.dynamodb_transfer_clients.dynamodb_table_id
+}

--- a/terraform/environments/integration-hub/api-platform/platform_data.tf
+++ b/terraform/environments/integration-hub/api-platform/platform_data.tf
@@ -150,6 +150,18 @@ data "terraform_remote_state" "core_network_services" {
   }
 }
 
+data "terraform_remote_state" "managed_file_transfer" {
+  backend = "s3"
+  config = {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    workspace_key_prefix = "environments/members/integration-hub/managed-file-transfer"
+  }
+}
+
 data "aws_organizations_organization" "root_account" {}
 
 # Retrieve information about the modernisation platform account

--- a/terraform/environments/integration-hub/api-platform/platform_data.tf
+++ b/terraform/environments/integration-hub/api-platform/platform_data.tf
@@ -152,6 +152,8 @@ data "terraform_remote_state" "core_network_services" {
 
 data "terraform_remote_state" "managed_file_transfer" {
   backend = "s3"
+  workspace = terraform.workspace
+
   config = {
     acl                  = "bucket-owner-full-control"
     bucket               = "modernisation-platform-terraform-state"

--- a/terraform/environments/integration-hub/api-platform/platform_data.tf
+++ b/terraform/environments/integration-hub/api-platform/platform_data.tf
@@ -150,18 +150,16 @@ data "terraform_remote_state" "core_network_services" {
   }
 }
 
-data "terraform_remote_state" "managed_file_transfer" {
-  backend   = "s3"
-  workspace = terraform.workspace
+data "aws_ssm_parameter" "mft_upload_bucket_name" {
+  name = "${local.mft_upload_bucket_parameter_prefix}/name"
+}
 
-  config = {
-    acl                  = "bucket-owner-full-control"
-    bucket               = "modernisation-platform-terraform-state"
-    encrypt              = true
-    key                  = "terraform.tfstate"
-    region               = "eu-west-2"
-    workspace_key_prefix = "environments/members/integration-hub/managed-file-transfer"
-  }
+data "aws_ssm_parameter" "mft_upload_bucket_arn" {
+  name = "${local.mft_upload_bucket_parameter_prefix}/arn"
+}
+
+data "aws_ssm_parameter" "mft_upload_bucket_kms_key_arn" {
+  name = "${local.mft_upload_bucket_parameter_prefix}/kms-key-arn"
 }
 
 data "aws_organizations_organization" "root_account" {}

--- a/terraform/environments/integration-hub/api-platform/platform_data.tf
+++ b/terraform/environments/integration-hub/api-platform/platform_data.tf
@@ -151,7 +151,7 @@ data "terraform_remote_state" "core_network_services" {
 }
 
 data "terraform_remote_state" "managed_file_transfer" {
-  backend = "s3"
+  backend   = "s3"
   workspace = terraform.workspace
 
   config = {

--- a/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
@@ -1,9 +1,0 @@
-output "upload_bucket" {
-  description = "Upload bucket details for API-driven managed file transfer ingestion"
-
-  value = {
-    arn         = module.s3_bucket["unscanned"].s3_bucket_arn
-    id          = module.s3_bucket["unscanned"].s3_bucket_id
-    kms_key_arn = module.kms_s3_bucket["unscanned"].key_arn
-  }
-}

--- a/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
@@ -1,0 +1,9 @@
+output "upload_bucket" {
+  description = "Upload bucket details for API-driven managed file transfer ingestion"
+
+  value = {
+    arn         = module.s3_bucket["unscanned"].s3_bucket_arn
+    id          = module.s3_bucket["unscanned"].s3_bucket_id
+    kms_key_arn = module.kms_s3_bucket["unscanned"].key_arn
+  }
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/platform_locals.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/platform_locals.tf
@@ -36,4 +36,6 @@ locals {
   # example usage:
   # example_data = local.application_data.accounts[local.environment].example_var
   application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : null
+
+  upload_bucket_parameter_prefix = "/${local.application_name}/${local.component_name}/${local.environment}/upload-bucket"
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/ssm.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/ssm.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "upload_bucket_name" {
+  name  = "${local.upload_bucket_parameter_prefix}/name"
+  type  = "String"
+  value = module.s3_bucket["unscanned"].s3_bucket_id
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "upload_bucket_arn" {
+  name  = "${local.upload_bucket_parameter_prefix}/arn"
+  type  = "String"
+  value = module.s3_bucket["unscanned"].s3_bucket_arn
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "upload_bucket_kms_key_arn" {
+  name  = "${local.upload_bucket_parameter_prefix}/kms-key-arn"
+  type  = "String"
+  value = module.kms_s3_bucket["unscanned"].key_arn
+
+  tags = local.tags
+}


### PR DESCRIPTION
It introduces a /transfer-tickets endpoint that allows a client to request the parameters needed for a file upload. The API returns a short-lived pre-signed S3 upload URL together with the required headers and transfer metadata. The client then uses those values to upload the file directly to the existing MFT unscanned bucket.

This keeps the implementation as a lightweight two-stage flow:

Client calls /transfer-tickets
Client uploads the file directly to S3 using the returned parameters

The PR includes the API Gateway, Lambda, DynamoDB client configuration table, and the wiring needed to reference the existing Managed File Transfer upload bucket. The aim is to provide a thin API layer in front of the current MFT solution without introducing a separate application service at this stage.