### PR TITLE
chore(devcontainer): add apm feature

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,6 +10,11 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
+    "ghcr.io/ministryofjustice/devcontainer-feature/apm:": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/apm@sha256:b562e126312767cf69b772bce79ae551a82f97c2eda7cce400fe068530261f71",
+      "integrity": "sha256:b562e126312767cf69b772bce79ae551a82f97c2eda7cce400fe068530261f71"
+    },
     "ghcr.io/ministryofjustice/devcontainer-feature/astral:": {
       "version": "1.0.1",
       "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/astral@sha256:8ee1cd600c19e2c6ac841dccdebd135a628680ca4aeca70f1ff74b1afe153645",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:": {},
     "ghcr.io/devcontainers/features/github-cli:": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/apm:": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/astral:": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/aws:": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {},


### PR DESCRIPTION
Adds the [`ministryofjustice/devcontainer-feature/apm`](https://github.com/ministryofjustice/devcontainer-feature/tree/main/src/apm) feature to the [devcontainer configuration](../blob/agents/add-apm-feature-to-devcontainer/.devcontainer/devcontainer.json) so contributors have consistent APM tooling available out of the box.

This is optional, no user impact to users other than those that want to use `apm`.

## Changes

- Added `ghcr.io/ministryofjustice/devcontainer-feature/apm` to the `features` block in [`.devcontainer/devcontainer.json`](../blob/agents/add-apm-feature-to-devcontainer/.devcontainer/devcontainer.json).
- Updated [`.devcontainer/devcontainer-lock.json`](../blob/agents/add-apm-feature-to-devcontainer/.devcontainer/devcontainer-lock.json) with the pinned digest for version `1.0.0`.