### PR TITLE
Deploy shared VPC to other environments

### DIFF
--- a/.github/workflows/cloud-platform.yml
+++ b/.github/workflows/cloud-platform.yml
@@ -55,9 +55,6 @@ jobs:
             environment: preproduction
             action: "plan"
           - application: cloud-platform
-            environment: nonlive
-            action: "plan"
-          - application: cloud-platform
             environment: live
             action: "plan"
     uses: ./.github/workflows/cloud-platform-reusable.yml
@@ -77,9 +74,6 @@ jobs:
         include:
           - application: cloud-platform
             environment: preproduction
-            action: "plan_apply"
-          - application: cloud-platform
-            environment: nonlive
             action: "plan_apply"
           - application: cloud-platform
             environment: live

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -2,7 +2,6 @@ locals {
   mp_environments = [
     "cloud-platform-development",
     "cloud-platform-preproduction",
-    "cloud-platform-nonlive",
     "cloud-platform-live",
   ]
   enabled_workspaces  = ["development_cluster"]
@@ -10,16 +9,13 @@ locals {
   cp_vpc_name         = terraform.workspace
   cp_vpc_cidr = {
     development_cluster = "10.0.0.0/16"
-    development         = "10.1.0.0/16"
     preproduction       = "10.2.0.0/16"
-    nonlive             = "10.195.0.0/16"
     live                = "10.41.0.0/16"
   }
 
   vpc_cidr = {
     cloud-platform-development   = "10.195.32.0/20"
     cloud-platform-preproduction = "10.195.16.0/20"
-    cloud-platform-nonlive       = "10.0.0.0/20"
     cloud-platform-live          = "10.195.0.0/20"
   }
 

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -28,45 +28,4 @@ locals {
   vpc_flow_log_cloudwatch_log_group_retention_in_days = 400
   vpc_flow_log_max_aggregation_interval               = 60
 
-  # VPC endpoint service names
-  # Reference: https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html
-  vpc_interface_endpoint_service_names = [
-    "apigateway",       # API Gateway
-    "athena",           # Athena
-    "backup",           # AWS Backup
-    "cloudtrail",       # CloudTrail
-    "config",           # AWS Config
-    "detective",        # AWS Detective
-    "dms",              # AWS Database Migration Service
-    "ec2",              # EC2
-    "ecr.api",          # ECR (API)
-    "ecr.dkr",          # ECR (Docker)
-    "eks",              # EKS
-    "eks-auth",         # EKS Auth
-    "elasticache",      # ElastiCache
-    "email",            # SES (API)
-    "email-smtp",       # SES (SMTP)
-    "events",           # CloudWatch Events
-    "guardduty-data",   # GuardDuty
-    "inspector2",       # Inspector
-    "kinesis-firehose", # Kinesis Firehose
-    "kms",              # KMS
-    "lambda",           # Lambda
-    "logs",             # CloudWatch Logs
-    "rds",              # RDS
-    "rds-data",         # RDS Data
-    "secretsmanager",   # Secrets Manager
-    "securityhub",      # Security Hub
-    "sns",              # SNS
-    "sqs",              # SQS
-    "ssm",              # AWS Systems Manager
-    "sts",              # STS
-    "transcribe",       # AWS Transcribe
-    "wafv2"             # WAF
-  ]
-
-  vpc_gateway_endpoint_service_names = [
-    "s3",      # S3
-    "dynamodb" # DynamoDB
-  ]
 }

--- a/terraform/environments/cloud-platform/network/shared-vpc.tf
+++ b/terraform/environments/cloud-platform/network/shared-vpc.tf
@@ -1,7 +1,7 @@
 module "cluster_vpc" {
   version = "6.5.1"
   source  = "terraform-aws-modules/vpc/aws"
-  count   = terraform.workspace == "cloud-platform-development" ? 1 : 0
+  count   = contains(["cloud-platform-development", "cloud-platform-preproduction", "cloud-platform-live"], terraform.workspace) ? 1 : 0
 
   name = local.cp_vpc_name
   cidr = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? lookup(local.vpc_cidr, local.cp_vpc_name) : null
@@ -42,7 +42,7 @@ module "cluster_vpc" {
 }
 
 resource "aws_subnet" "tgw_private" {
-  count = terraform.workspace == "cloud-platform-development" ? 3 : 0
+  count = contains(["cloud-platform-development", "cloud-platform-preproduction", "cloud-platform-live"], terraform.workspace) ? 3 : 0
 
   vpc_id                  = module.cluster_vpc[0].vpc_id
   cidr_block              = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 8, count.index + 4) : null
@@ -59,7 +59,7 @@ resource "aws_subnet" "tgw_private" {
 }
 
 resource "aws_route_table_association" "tgw_private" {
-  count = terraform.workspace == "cloud-platform-development" ? 3 : 0
+  count = contains(["cloud-platform-development", "cloud-platform-preproduction", "cloud-platform-live"], terraform.workspace) ? 3 : 0
 
   subnet_id      = aws_subnet.tgw_private[count.index].id
   route_table_id = module.cluster_vpc[0].private_route_table_ids[count.index]

--- a/terraform/environments/cloud-platform/network/vpc.tf
+++ b/terraform/environments/cloud-platform/network/vpc.tf
@@ -3,7 +3,7 @@ module "vpc" {
   version = "6.5.1"
   source  = "terraform-aws-modules/vpc/aws"
 
-  name = local.cp_vpc_name
+  name = "${local.cp_vpc_name}-old"
   cidr = lookup(local.cp_vpc_cidr, local.cluster_environment)
   azs  = slice(data.aws_availability_zones.available.names, 0, 3)
   private_subnets = [

--- a/terraform/environments/cloud-platform/network/vpc.tf
+++ b/terraform/environments/cloud-platform/network/vpc.tf
@@ -3,7 +3,7 @@ module "vpc" {
   version = "6.5.1"
   source  = "terraform-aws-modules/vpc/aws"
 
-  name = "${local.cp_vpc_name}-old"
+  name = local.cluster_environment == "development_cluster" ? local.cp_vpc_name : "${local.cp_vpc_name}-old"
   cidr = lookup(local.cp_vpc_cidr, local.cluster_environment)
   azs  = slice(data.aws_availability_zones.available.names, 0, 3)
   private_subnets = [


### PR DESCRIPTION
Expands the shared VPC tested in dev to the other cloud platform environments
(Excluding non live as this will go)