### PR TITLE
Adds laa-workspaces-development to the plan evaluator skip

### DIFF
--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -51,7 +51,7 @@
     env:
       ACCOUNT_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
       WORKSPACE_NAME: "${{ inputs.application }}-${{ inputs.environment }}"
-      SKIP_PLAN_EVALUATOR: '["cloud-platform-development", "cloud-platform-preproduction", "cloud-platform-nonlive", "cloud-platform-live", "data-platform-development", "data-platform-test", "data-platform-preproduction", "data-platform-production"]'
+      SKIP_PLAN_EVALUATOR: '["cloud-platform-development", "cloud-platform-preproduction", "cloud-platform-nonlive", "cloud-platform-live", "data-platform-development", "data-platform-test", "data-platform-preproduction", "data-platform-production", "laa-workspaces-development"]'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
As above. 

This is a short-term measure to allow the migrations team to work on their testing without the need for our input.