### PR TITLE
Protect GuardDuty scan-status tags on MFT buckets

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/iam.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/iam.tf
@@ -1,6 +1,6 @@
 module "guardduty_s3_plan_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name        = local.iam_configuration.guardduty_policy_name
   description = "GuardDuty S3 malware protection plan policy"
@@ -13,7 +13,7 @@ module "guardduty_s3_plan_policy" {
 
 module "guardduty_s3_plan_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   create          = true
   use_name_prefix = false
@@ -123,7 +123,7 @@ data "aws_iam_policy_document" "guardduty_s3_plan_permission_policy" {
 
 module "iam_for_transfer" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   create          = true
   use_name_prefix = true

--- a/terraform/environments/integration-hub/managed-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/kms.tf
@@ -20,7 +20,7 @@ module "kms_s3_bucket" {
 
 module "kms_secrets" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "~> 4.1.0"
+  version = "4.2.0"
 
   aliases                 = ["transfer/secrets"]
   description             = "KMS CMK for Secrets Manager encryption"

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
@@ -102,7 +102,7 @@ resource "aws_s3_bucket_notification" "clean_bucket_events" {
 
 module "sqs_clean_file_notifications" {
   source  = "terraform-aws-modules/sqs/aws"
-  version = "5.2.1"
+  version = "5.2.2"
 
   name            = "${local.resource_name_prefix}-clean-file-notifications"
   use_name_prefix = false

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -6,6 +6,9 @@ module "s3_bucket" {
   version = "5.13.0"
 
   allowed_kms_key_arn = module.kms_s3_bucket[each.key].key_arn
+  attach_deny_incorrect_encryption_headers = true
+  attach_deny_insecure_transport_policy    = true
+  attach_deny_unencrypted_object_uploads   = true
   bucket_prefix       = each.value.bucket_prefix
   cors_rule = each.key == "unscanned" ? [
     {

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -103,7 +103,7 @@ module "s3_bucket" {
     for key, value in local.bucket_configuration : key => value
   }
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.13.0"
+  version = "5.14.0"
 
   allowed_kms_key_arn                   = module.kms_s3_bucket[each.key].key_arn
   attach_policy                         = contains(["processing", "unscanned"], each.key)

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -107,9 +107,7 @@ module "s3_bucket" {
 
   allowed_kms_key_arn                      = module.kms_s3_bucket[each.key].key_arn
   attach_policy                            = contains(["processing", "unscanned"], each.key)
-  attach_deny_incorrect_encryption_headers = true
   attach_deny_insecure_transport_policy    = true
-  attach_deny_unencrypted_object_uploads   = true
   bucket_prefix                            = each.value.bucket_prefix
   policy                                   = each.key == "unscanned" ? data.aws_iam_policy_document.unscanned_guardduty_tag_protection.json : each.key == "processing" ? data.aws_iam_policy_document.processing_guardduty_tag_protection.json : null
   cors_rule = each.key == "unscanned" ? [

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "unscanned_guardduty_tag_protection" {
+data "aws_iam_policy_document" "unscanned" {
   statement {
     sid    = "DenyGuardDutyTagWrites"
     effect = "Deny"
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "unscanned_guardduty_tag_protection" {
   }
 }
 
-data "aws_iam_policy_document" "processing_guardduty_tag_protection" {
+data "aws_iam_policy_document" "processing" {
   statement {
     sid    = "DenyGuardDutyTagWritesFromNonGuardDutyPrincipals"
     effect = "Deny"
@@ -105,11 +105,18 @@ module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "5.13.0"
 
-  allowed_kms_key_arn                      = module.kms_s3_bucket[each.key].key_arn
-  attach_policy                            = contains(["processing", "unscanned"], each.key)
-  attach_deny_insecure_transport_policy    = true
-  bucket_prefix                            = each.value.bucket_prefix
-  policy                                   = each.key == "unscanned" ? data.aws_iam_policy_document.unscanned_guardduty_tag_protection.json : each.key == "processing" ? data.aws_iam_policy_document.processing_guardduty_tag_protection.json : null
+  allowed_kms_key_arn                   = module.kms_s3_bucket[each.key].key_arn
+  attach_policy                         = contains(["processing", "unscanned"], each.key)
+  attach_deny_insecure_transport_policy = true
+  bucket_prefix                         = each.value.bucket_prefix
+  policy = lookup(
+    {
+      unscanned  = data.aws_iam_policy_document.unscanned.json
+      processing = data.aws_iam_policy_document.processing.json
+    },
+    each.key,
+    null
+  )
   cors_rule = each.key == "unscanned" ? [
     {
       allowed_headers = ["*"]

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -1,3 +1,103 @@
+data "aws_iam_policy_document" "unscanned_guardduty_tag_protection" {
+  statement {
+    sid    = "DenyGuardDutyTagWrites"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    # The S3 bucket module replaces the bucket placeholders with the created bucket ARN.
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "processing_guardduty_tag_protection" {
+  statement {
+    sid    = "DenyGuardDutyTagWritesFromNonGuardDutyPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+
+  statement {
+    sid    = "DenyGuardDutyTagMutationFromNonGuardDutyPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
+      ]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["false"]
+    }
+  }
+}
+
 module "s3_bucket" {
   for_each = {
     for key, value in local.bucket_configuration : key => value
@@ -5,11 +105,13 @@ module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "5.13.0"
 
-  allowed_kms_key_arn = module.kms_s3_bucket[each.key].key_arn
+  allowed_kms_key_arn                      = module.kms_s3_bucket[each.key].key_arn
+  attach_policy                            = contains(["processing", "unscanned"], each.key)
   attach_deny_incorrect_encryption_headers = true
   attach_deny_insecure_transport_policy    = true
   attach_deny_unencrypted_object_uploads   = true
-  bucket_prefix       = each.value.bucket_prefix
+  bucket_prefix                            = each.value.bucket_prefix
+  policy                                   = each.key == "unscanned" ? data.aws_iam_policy_document.unscanned_guardduty_tag_protection.json : each.key == "processing" ? data.aws_iam_policy_document.processing_guardduty_tag_protection.json : null
   cors_rule = each.key == "unscanned" ? [
     {
       allowed_headers = ["*"]

--- a/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/sqs.tf
@@ -1,6 +1,6 @@
 module "sqs_unscanned_s3_notifications" {
   source  = "terraform-aws-modules/sqs/aws"
-  version = "5.2.1"
+  version = "5.2.2"
 
   name            = "${local.application_name}-unscanned-s3-notifications"
   use_name_prefix = false
@@ -50,7 +50,7 @@ module "sqs_unscanned_s3_notifications" {
 
 module "sqs_guard_duty_malware_protection_for_s3_events" {
   source  = "terraform-aws-modules/sqs/aws"
-  version = "5.2.1"
+  version = "5.2.2"
 
   name            = "${local.application_name}-guard-duty-malware-protection-for-s3-events"
   use_name_prefix = false

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "transfer_user_session" {
 
 module "transfer_user_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name        = "${local.application_name}-transfer-user-policy"
   description = "AWS Transfer User policy"
@@ -92,7 +92,7 @@ module "transfer_user_policy" {
 
 module "transfer_user_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name            = "${local.application_name}-transfer-user"
   description     = "AWS Transfer User role"

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-web-app.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "transfer_web_app" {
 
 module "transfer_web_app_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name        = "${local.application_name}-transfer-web-app-policy"
   description = "AWS Transfer web app access grants policy"
@@ -49,7 +49,7 @@ module "transfer_web_app_policy" {
 
 module "transfer_web_app_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   create          = true
   use_name_prefix = false
@@ -198,7 +198,7 @@ data "aws_iam_policy_document" "s3_access_grants_location" {
 
 module "s3_access_grants_location_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name        = "${local.application_name}-s3-access-grants-location-policy"
   description = "AWS S3 Access Grants read/write access to the unscanned bucket"
@@ -209,7 +209,7 @@ module "s3_access_grants_location_policy" {
 
 module "s3_access_grants_location_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name            = "transfer-s3-access-grants-location"
   use_name_prefix = false

--- a/terraform/environments/integration-hub/managed-file-transfer/vpc.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/vpc.tf
@@ -2,7 +2,7 @@ module "isolated_vpc" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name            = "${local.application_name}-${local.environment}-isolated"
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed ✨

This tightens the S3 bucket policies for managed file transfer so the `GuardDutyMalwareScanStatus` tag behaves itself 🪣

- `unscanned` now denies requests that try to introduce `GuardDutyMalwareScanStatus`
- `processing` now allows only GuardDuty Malware Protection for S3 to set, change, or remove that tag
- the existing Lambda flow stays untouched, so metadata and the rest of the tag set keep flowing through the pipeline as they do today 🚚
- also bumped a bunch of terraform modules for freshness 🥦 

## Why this shape? 🛡️

This is the smallest TBAC change that protects the ingress path without changing the copy pipeline.

- it blocks accidental (or intentional) upload-time introduction of the GuardDuty tag in `unscanned`
- it preserves GuardDuty ownership of the scan-status tag in `processing`
- it avoids Lambda changes for now, keeping behaviour predictable and boring in the best possible way 😌

## A small Terraform trick worth calling out 🎩

The policy documents use `_S3_BUCKET_ARN_` in the resource list.

That placeholder is handled by the `terraform-aws-modules/s3-bucket/aws` module itself. The module builds a combined bucket policy, then replaces `_S3_BUCKET_ARN_` and its sibling placeholders with the real bucket ARN, bucket ID, and account ID before creating the final `aws_s3_bucket_policy` resource.

That means we can define reusable `data.aws_iam_policy_document` statements up front, feed them into the module conditionally, and still have the final policy point at the correct bucket resources without creating a dependency knot 🎯

## Testing ✅

- `terraform fmt s3.tf`
- `terraform validate`

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>
