### PR TITLE
TM-2168: nomis: allow ssh from DBs 

### DIFF
--- a/terraform/environments/nomis/locals_security_groups.tf
+++ b/terraform/environments/nomis/locals_security_groups.tf
@@ -114,6 +114,15 @@ locals {
             protocol    = -1
             self        = true
           }
+          ssh = {
+            description = "Allow SSH ingress"
+            from_port   = 22
+            to_port     = 22
+            protocol    = "tcp"
+            security_groups = [
+              "data-db",
+            ]
+          }
           http7001 = {
             description = "Allow http7001 ingress"
             from_port   = 7001


### PR DESCRIPTION
Since SSM connectivity will stop working on RHEL6