### PR TITLE
feat(data-factory-laa): bump fabric module ref to 9f5634c

### DIFF
--- a/terraform/environments/data-factory-laa/fabric.tf
+++ b/terraform/environments/data-factory-laa/fabric.tf
@@ -3,7 +3,7 @@
 
 module "fabric_oidc_provider" {
   count  = local.fabric_oidc_enabled ? 1 : 0
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-oidc-provider?ref=9f5634c0d1d450ed2ee9614ffc4e9613a492bc31"
 
   tenant_id          = local.fabric_tenant_id
   oidc_provider_name = "fabric-s3-access"
@@ -31,7 +31,7 @@ module "fabric_curated_bucket" {
 
 module "fabric_iam_role" {
   count  = local.fabric_oidc_enabled ? 1 : 0
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=c770ed02f420a0c66744189ad9818a9cf03e92a4"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/fabric-iam-role?ref=9f5634c0d1d450ed2ee9614ffc4e9613a492bc31"
 
   object_id                          = local.fabric_enterprise_app_object_id
   oidc_provider_arn                  = module.fabric_oidc_provider[0].arn


### PR DESCRIPTION

The upstream module updates the `fabric-iam-role` inline policy to grant `s3:*` and `s3-object-lambda:*` on all resources, replacing the previously scoped permissions. This resolves a Microsoft Fabric shortcut creation failure:

> InsufficientPermissions: Shortcut cannot be created as client permissions
> insufficient to check Object MetadataProperties.

The narrowly scoped policy did not cover all the metadata/object operations Fabric performs when validating and creating a shortcut.

## Notes
- `fabric_curated_bucket` is intentionally left untouched — it pins a  different module (`modernisation-platform-terraform-s3-bucket`) and is  still required. The IAM role continues to pass `bucket_arn`, which the  upstream module still validates.
- This is a deliberate broadening of permissions to the whole account.   Least-privilege scoping should be addressed in a follow-up, in line with the upstream PR's own note.

## Plan expectations
- In-place update to the `fabric_iam_role` inline policy.
- No changes to `fabric_curated_bucket`.
- Applies to the `development` environment only (`fabric_oidc_enabled_environments`).