### PR TITLE
Add tag based protections to protect against misuse of threat objects

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
@@ -100,6 +100,31 @@ data "aws_iam_policy_document" "processing" {
 
 data "aws_iam_policy_document" "clean" {
   statement {
+    sid    = "DenyAccessToObjectsWithoutCleanGuardDutyStatus"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["NO_THREATS_FOUND"]
+    }
+  }
+
+  statement {
     sid    = "DenyGuardDutyTagWritesFromNonFileMoverPrincipals"
     effect = "Deny"
 
@@ -170,6 +195,31 @@ data "aws_iam_policy_document" "clean" {
 }
 
 data "aws_iam_policy_document" "quarantine" {
+  statement {
+    sid    = "DenyAccessToObjectsWithoutCleanGuardDutyStatus"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["NO_THREATS_FOUND"]
+    }
+  }
+
   statement {
     sid    = "DenyGuardDutyTagWritesFromNonFileMoverPrincipals"
     effect = "Deny"

--- a/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "processing" {
 
 data "aws_iam_policy_document" "clean" {
   statement {
-    sid    = "DenyAccessToObjectsWithoutCleanGuardDutyStatus"
+    sid    = "DenyAccessToObjectsWithoutNoThreatsFoundGuardDutyStatus"
     effect = "Deny"
 
     principals {
@@ -196,7 +196,7 @@ data "aws_iam_policy_document" "clean" {
 
 data "aws_iam_policy_document" "quarantine" {
   statement {
-    sid    = "DenyAccessToObjectsWithoutCleanGuardDutyStatus"
+    sid    = "DenyAccessToObjectsWithoutNoThreatsFoundGuardDutyStatus"
     effect = "Deny"
 
     principals {

--- a/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3-policies.tf
@@ -1,0 +1,242 @@
+data "aws_iam_policy_document" "unscanned" {
+  statement {
+    sid    = "DenyGuardDutyTagWrites"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    # The S3 bucket module replaces the bucket placeholders with the created bucket ARN.
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "processing" {
+  statement {
+    sid    = "DenyGuardDutyTagWritesFromNonGuardDutyPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+
+  statement {
+    sid    = "DenyGuardDutyTagMutationFromNonGuardDutyPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
+      ]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["false"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "clean" {
+  statement {
+    sid    = "DenyGuardDutyTagWritesFromNonFileMoverPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        module.lambda_processing_to_post_scan.lambda_role_arn,
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+
+  statement {
+    sid    = "DenyGuardDutyTagMutationFromNonFileMoverPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        module.lambda_processing_to_post_scan.lambda_role_arn,
+      ]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["false"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "quarantine" {
+  statement {
+    sid    = "DenyGuardDutyTagWritesFromNonFileMoverPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        module.lambda_processing_to_post_scan.lambda_role_arn,
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:RequestObjectTagKeys"
+      values   = ["GuardDutyMalwareScanStatus"]
+    }
+  }
+
+  statement {
+    sid    = "DenyGuardDutyTagMutationFromNonFileMoverPrincipals"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersionTagging",
+    ]
+
+    resources = [
+      "_S3_BUCKET_ARN_/*",
+    ]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "aws:PrincipalArn"
+      values = [
+        module.lambda_processing_to_post_scan.lambda_role_arn,
+      ]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+      values   = ["false"]
+    }
+  }
+}
+

--- a/terraform/environments/integration-hub/managed-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/s3.tf
@@ -1,103 +1,3 @@
-data "aws_iam_policy_document" "unscanned" {
-  statement {
-    sid    = "DenyGuardDutyTagWrites"
-    effect = "Deny"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:PutObject",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
-    ]
-
-    # The S3 bucket module replaces the bucket placeholders with the created bucket ARN.
-    resources = [
-      "_S3_BUCKET_ARN_/*",
-    ]
-
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "s3:RequestObjectTagKeys"
-      values   = ["GuardDutyMalwareScanStatus"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "processing" {
-  statement {
-    sid    = "DenyGuardDutyTagWritesFromNonGuardDutyPrincipals"
-    effect = "Deny"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:PutObject",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
-    ]
-
-    resources = [
-      "_S3_BUCKET_ARN_/*",
-    ]
-
-    condition {
-      test     = "ArnNotEquals"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
-      ]
-    }
-
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "s3:RequestObjectTagKeys"
-      values   = ["GuardDutyMalwareScanStatus"]
-    }
-  }
-
-  statement {
-    sid    = "DenyGuardDutyTagMutationFromNonGuardDutyPrincipals"
-    effect = "Deny"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
-      "s3:DeleteObjectTagging",
-      "s3:DeleteObjectVersionTagging",
-    ]
-
-    resources = [
-      "_S3_BUCKET_ARN_/*",
-    ]
-
-    condition {
-      test     = "ArnNotEquals"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.iam_configuration.guardduty_role_name}",
-      ]
-    }
-
-    condition {
-      test     = "Null"
-      variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
-      values   = ["false"]
-    }
-  }
-}
-
 module "s3_bucket" {
   for_each = {
     for key, value in local.bucket_configuration : key => value
@@ -106,13 +6,15 @@ module "s3_bucket" {
   version = "5.14.0"
 
   allowed_kms_key_arn                   = module.kms_s3_bucket[each.key].key_arn
-  attach_policy                         = contains(["processing", "unscanned"], each.key)
+  attach_policy                         = contains(["clean", "processing", "quarantine", "unscanned"], each.key)
   attach_deny_insecure_transport_policy = true
   bucket_prefix                         = each.value.bucket_prefix
   policy = lookup(
     {
+      clean      = data.aws_iam_policy_document.clean.json
       unscanned  = data.aws_iam_policy_document.unscanned.json
       processing = data.aws_iam_policy_document.processing.json
+      quarantine = data.aws_iam_policy_document.quarantine.json
     },
     each.key,
     null


### PR DESCRIPTION
Ensures that the file mover lambda can write GuardDuty status tags to the destination bucket, while also preventing access to files that are not tagged as "NO_THREATS_FOUND".