### PR TITLE
Switch dev clusters to use shared vpc

### DIFF
--- a/terraform/environments/cloud-platform/cluster-components/data.tf
+++ b/terraform/environments/cloud-platform/cluster-components/data.tf
@@ -6,17 +6,6 @@ data "aws_vpc" "selected" {
   }
 }
 
-data "aws_subnets" "eks_private" {
-
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected.id]
-  }
-  tags = {
-    SubnetType = "EKS-Private"
-  }
-}
-
 data "aws_subnets" "private" {
 
   filter {

--- a/terraform/environments/cloud-platform/cluster-components/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-components/locals.tf
@@ -4,7 +4,7 @@ locals {
     "cloud-platform-nonlive",
     "cloud-platform-live",
   ]
-  cp_vpc_name         = terraform.workspace
+  cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
 }

--- a/terraform/environments/cloud-platform/cluster-core/data.tf
+++ b/terraform/environments/cloud-platform/cluster-core/data.tf
@@ -6,17 +6,6 @@ data "aws_vpc" "selected" {
   }
 }
 
-data "aws_subnets" "eks_private" {
-
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected.id]
-  }
-  tags = {
-    SubnetType = "EKS-Private"
-  }
-}
-
 data "aws_subnets" "private" {
 
   filter {

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -4,7 +4,7 @@ locals {
     "cloud-platform-nonlive",
     "cloud-platform-live",
   ]
-  cp_vpc_name         = terraform.workspace
+  cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
 }

--- a/terraform/environments/cloud-platform/cluster/data.tf
+++ b/terraform/environments/cloud-platform/cluster/data.tf
@@ -6,17 +6,6 @@ data "aws_vpc" "selected" {
   }
 }
 
-data "aws_subnets" "eks_private" {
-
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected.id]
-  }
-  tags = {
-    SubnetType = "EKS-Private"
-  }
-}
-
 data "aws_subnets" "private" {
 
   filter {

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -6,7 +6,7 @@ module "eks" {
   name               = local.cluster_name
   kubernetes_version = local.environment_configuration.eks_cluster_version
   vpc_id             = data.aws_vpc.selected.id
-  subnet_ids         = data.aws_subnets.eks_private.ids
+  subnet_ids         = data.aws_subnets.private.ids
   enable_irsa        = true
 
   endpoint_private_access = true

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -5,7 +5,7 @@ locals {
     "cloud-platform-live",
   ]
   environment_configuration = local.environment_configurations[local.cluster_environment]
-  cp_vpc_name               = terraform.workspace
+  cp_vpc_name               = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name              = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
   cluster_environment       = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
 }


### PR DESCRIPTION
Moving dev clusters to use the new cloud-platform-development shared vpc.

Should be merged at the same time as - https://github.com/ministryofjustice/cloud-platform-github-workflows/pull/60

(Preprod and live failing as old vpc needs to be rebuilt - will be done after merge)