### PR TITLE
Trimmed lambda memory use after observing live behaviour

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -5,7 +5,7 @@ module "lambda_unscanned_to_processing" {
   function_name                  = "${local.application_name}-unscanned-to-processing"
   description                    = "Moves uploaded files from the unscanned bucket to the processing bucket"
   handler                        = "lambda_function.lambda_handler"
-  memory_size                    = 512
+  memory_size                    = 256
   reserved_concurrent_executions = 10
   runtime                        = "python3.12"
   source_path                    = "lambda/s3-file-mover"
@@ -103,7 +103,7 @@ module "lambda_processing_to_post_scan" {
   function_name                  = "${local.application_name}-processing-to-post-scan"
   description                    = "Moves scanned files from the processing bucket to the post-scan destination bucket"
   handler                        = "lambda_function.lambda_handler"
-  memory_size                    = 512
+  memory_size                    = 256
   reserved_concurrent_executions = 10
   runtime                        = "python3.12"
   source_path                    = "lambda/guard-duty-file-mover"


### PR DESCRIPTION
From observing the logs and traces of the object movement lambdas they use approximately 115MB of memory; this gives them some scaling headroom while keeping costs down.

We might be OK with 192MB, but at this point I feel like that's splitting hairs given our use.