### PR TITLE
Add secondary CIDR and fix BU accounts not being added

### DIFF
--- a/terraform/environments/cloud-platform/cluster-components/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-components/locals.tf
@@ -1,11 +1,14 @@
 locals {
-  mp_environments = [
-    "cloud-platform-preproduction",
-    "cloud-platform-nonlive",
-    "cloud-platform-live",
-    "container-platform-octo-nonlive",
-    "container-platform-octo-live"
-  ]
+  bu_accounts = jsondecode(file("${path.module}/../accounts.json"))
+
+  mp_environments = concat(
+    [
+      "cloud-platform-preproduction",
+      "cloud-platform-nonlive",
+      "cloud-platform-live"
+    ],
+    local.bu_accounts.accounts
+  )
 
   cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace

--- a/terraform/environments/cloud-platform/cluster-components/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-components/locals.tf
@@ -3,7 +3,10 @@ locals {
     "cloud-platform-preproduction",
     "cloud-platform-nonlive",
     "cloud-platform-live",
+    "container-platform-octo-nonlive",
+    "container-platform-octo-live"
   ]
+
   cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -1,11 +1,14 @@
 locals {
-  mp_environments = [
-    "cloud-platform-preproduction",
-    "cloud-platform-nonlive",
-    "cloud-platform-live",
-    "container-platform-octo-nonlive",
-    "container-platform-octo-live"
-  ]
+  bu_accounts = jsondecode(file("${path.module}/../accounts.json"))
+
+  mp_environments = concat(
+    [
+      "cloud-platform-preproduction",
+      "cloud-platform-nonlive",
+      "cloud-platform-live"
+    ],
+    local.bu_accounts.accounts
+  )
 
   cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -3,7 +3,10 @@ locals {
     "cloud-platform-preproduction",
     "cloud-platform-nonlive",
     "cloud-platform-live",
+    "container-platform-octo-nonlive",
+    "container-platform-octo-live"
   ]
+
   cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -1,11 +1,14 @@
 locals {
-  mp_environments = [
-    "cloud-platform-preproduction",
-    "cloud-platform-nonlive",
-    "cloud-platform-live",
-    "container-platform-octo-nonlive",
-    "container-platform-octo-live"
-  ]
+  bu_accounts = jsondecode(file("${path.module}/../accounts.json"))
+
+  mp_environments = concat(
+    [
+      "cloud-platform-preproduction",
+      "cloud-platform-nonlive",
+      "cloud-platform-live"
+    ],
+    local.bu_accounts.accounts
+  )
 
   environment_configuration = local.environment_configurations[local.cluster_environment]
   cp_vpc_name               = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -3,7 +3,10 @@ locals {
     "cloud-platform-preproduction",
     "cloud-platform-nonlive",
     "cloud-platform-live",
+    "container-platform-octo-nonlive",
+    "container-platform-octo-live"
   ]
+
   environment_configuration = local.environment_configurations[local.cluster_environment]
   cp_vpc_name               = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
   cluster_name              = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -8,12 +8,26 @@ locals {
   cp_vpc_name         = terraform.workspace
 
   vpc_cidr = {
-    cloud-platform-development      = "10.195.32.0/20"
-    cloud-platform-preproduction    = "10.195.16.0/20"
-    cloud-platform-live             = "10.195.0.0/20"
-    container-platform-octo-nonlive = "10.195.48.0/20"
-    container-platform-octo-live    = "10.41.0.0/20"
-  }
+    cloud-platform-development = {
+      primary   = "10.195.32.0/20"
+      secondary = "100.66.0.0/16"
+    }
+    cloud-platform-preproduction = {
+      primary   = "10.195.16.0/20"
+      secondary = "100.65.0.0/16"
+    }
+    cloud-platform-live = {
+      primary   = "10.195.0.0/20"
+      secondary = "100.64.0.0/16"
+    }
+    container-platform-octo-nonlive = {
+      primary   = "10.195.48.0/20"
+      secondary = "100.68.0.0/16"
+    }
+    container-platform-octo-live = {
+      primary   = "10.41.0.0/20"
+      secondary = "100.80.0.0/16"
+    }
 
   vpc_flow_log_cloudwatch_log_group_name_prefix       = "/aws/vpc-flow-log/"
   vpc_flow_log_cloudwatch_log_group_name_suffix       = local.cp_vpc_name

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -1,11 +1,14 @@
 locals {
-  mp_environments = [
-    "cloud-platform-development",
-    "cloud-platform-preproduction",
-    "cloud-platform-live",
-    "container-platform-octo-nonlive",
-    "container-platform-octo-live"
-  ]
+  bu_accounts = jsondecode(file("${path.module}/../accounts.json"))
+
+  mp_environments = concat(
+    [
+      "cloud-platform-development",
+      "cloud-platform-preproduction",
+      "cloud-platform-live"
+    ],
+    local.bu_accounts.accounts
+  )
 
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
   cp_vpc_name         = terraform.workspace

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -3,7 +3,10 @@ locals {
     "cloud-platform-development",
     "cloud-platform-preproduction",
     "cloud-platform-live",
+    "container-platform-octo-nonlive",
+    "container-platform-octo-live"
   ]
+
   cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
   cp_vpc_name         = terraform.workspace
 
@@ -28,6 +31,7 @@ locals {
       primary   = "10.41.0.0/20"
       secondary = "100.80.0.0/16"
     }
+  }
 
   vpc_flow_log_cloudwatch_log_group_name_prefix       = "/aws/vpc-flow-log/"
   vpc_flow_log_cloudwatch_log_group_name_suffix       = local.cp_vpc_name

--- a/terraform/environments/cloud-platform/network/vpc.tf
+++ b/terraform/environments/cloud-platform/network/vpc.tf
@@ -65,6 +65,6 @@ resource "aws_route_table_association" "tgw_private" {
 
 # Secondary CIDR for pods
 resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
-  vpc_id     = aws_vpc.this.id
+  vpc_id     = module.cluster_vpc.vpc_id
   cidr_block = local.vpc_cidr[local.cp_vpc_name].secondary
 }

--- a/terraform/environments/cloud-platform/network/vpc.tf
+++ b/terraform/environments/cloud-platform/network/vpc.tf
@@ -3,18 +3,18 @@ module "cluster_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
 
   name = local.cp_vpc_name
-  cidr = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? lookup(local.vpc_cidr, local.cp_vpc_name) : null
+  cidr = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? local.vpc_cidr[local.cp_vpc_name].primary : null
   azs  = slice(data.aws_availability_zones.available.names, 0, 3)
   private_subnets = [
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 3, 1) : null,
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 3, 2) : null,
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 3, 3) : null
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 3, 1) : null,
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 3, 2) : null,
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 3, 3) : null
   ]
 
   public_subnets = [
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 7, 4) : null,
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 7, 5) : null,
-    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 7, 6) : null
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 7, 4) : null,
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 7, 5) : null,
+    contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 7, 6) : null
   ]
 
   manage_default_network_acl    = false
@@ -44,7 +44,7 @@ resource "aws_subnet" "tgw_private" {
   count = 3
 
   vpc_id                  = module.cluster_vpc.vpc_id
-  cidr_block              = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(lookup(local.vpc_cidr, local.cp_vpc_name), 8, count.index + 4) : null
+  cidr_block              = contains(keys(local.vpc_cidr), local.cp_vpc_name) ? cidrsubnet(local.vpc_cidr[local.cp_vpc_name].primary, 8, count.index + 4) : null
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
 
@@ -61,4 +61,10 @@ resource "aws_route_table_association" "tgw_private" {
   count          = 3
   subnet_id      = aws_subnet.tgw_private[count.index].id
   route_table_id = module.cluster_vpc.private_route_table_ids[count.index]
+}
+
+# Secondary CIDR for pods
+resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
+  vpc_id     = aws_vpc.this.id
+  cidr_block = local.vpc_cidr[local.cp_vpc_name].secondary
 }


### PR DESCRIPTION
Add in secondary CIDR range, refactor the local to included primary and secondary ranges.

Add the business unit accounts into the mp_environments local so that they don't get built as "development_cluster" clusters.