### PR TITLE
Fix local.environment not being correct

### DIFF
--- a/terraform/environments/cloud-platform/cluster-components/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-components/locals.tf
@@ -10,7 +10,8 @@ locals {
     local.bu_accounts.accounts
   )
 
-  cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
-  cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
-  cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
+  cp_vpc_name           = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
+  workspace_environment = element(reverse(split("-", terraform.workspace)), 0)
+  cluster_name          = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : terraform.workspace
+  cluster_environment   = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 }

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -10,7 +10,8 @@ locals {
     local.bu_accounts.accounts
   )
 
-  cp_vpc_name         = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
-  cluster_name        = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
-  cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
+  cp_vpc_name           = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
+  workspace_environment = element(reverse(split("-", terraform.workspace)), 0)
+  cluster_name          = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : terraform.workspace
+  cluster_environment   = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 }

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -40,7 +40,7 @@ locals {
           Terraform                                      = "true"
           "cloud-platform.justice.gov.uk/default-ng"     = "true"
           "container-platform.justice.gov.uk/default-ng" = "true"
-          Cluster                                        = local.environment
+          Cluster                                        = local.cluster_environment
         }
       }
 
@@ -77,7 +77,7 @@ locals {
           Terraform                                         = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng"     = "true"
           "container-platform.justice.gov.uk/monitoring-ng" = "true"
-          Cluster                                           = local.environment
+          Cluster                                           = local.cluster_environment
         }
       }
       system_ng = {
@@ -113,7 +113,7 @@ locals {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/system-ng"     = "true"
           "container-platform.justice.gov.uk/system-ng" = "true"
-          Cluster                                       = local.environment
+          Cluster                                       = local.cluster_environment
         }
       }
     }
@@ -157,7 +157,7 @@ locals {
           Terraform                                      = "true"
           "cloud-platform.justice.gov.uk/default-ng"     = "true"
           "container-platform.justice.gov.uk/default-ng" = "true"
-          Cluster                                        = local.environment
+          Cluster                                        = local.cluster_environment
         }
       }
 
@@ -194,7 +194,7 @@ locals {
           Terraform                                         = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng"     = "true"
           "container-platform.justice.gov.uk/monitoring-ng" = "true"
-          Cluster                                           = local.environment
+          Cluster                                           = local.cluster_environment
         }
       }
       system_ng = {
@@ -230,7 +230,7 @@ locals {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/system-ng"     = "true"
           "container-platform.justice.gov.uk/system-ng" = "true"
-          Cluster                                       = local.environment
+          Cluster                                       = local.cluster_environment
         }
       }
     }
@@ -274,7 +274,7 @@ locals {
           Terraform                                      = "true"
           "cloud-platform.justice.gov.uk/default-ng"     = "true"
           "container-platform.justice.gov.uk/default-ng" = "true"
-          Cluster                                        = local.environment
+          Cluster                                        = local.cluster_environment
         }
       }
 
@@ -311,7 +311,7 @@ locals {
           Terraform                                         = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng"     = "true"
           "container-platform.justice.gov.uk/monitoring-ng" = "true"
-          Cluster                                           = local.environment
+          Cluster                                           = local.cluster_environment
         }
       }
       system_ng = {
@@ -347,7 +347,7 @@ locals {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/system-ng"     = "true"
           "container-platform.justice.gov.uk/system-ng" = "true"
-          Cluster                                       = local.environment
+          Cluster                                       = local.cluster_environment
         }
       }
     }
@@ -391,7 +391,7 @@ locals {
           Terraform                                      = "true"
           "cloud-platform.justice.gov.uk/default-ng"     = "true"
           "container-platform.justice.gov.uk/default-ng" = "true"
-          Cluster                                        = local.environment
+          Cluster                                        = local.cluster_environment
         }
       }
 
@@ -428,7 +428,7 @@ locals {
           Terraform                                         = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng"     = "true"
           "container-platform.justice.gov.uk/monitoring-ng" = "true"
-          Cluster                                           = local.environment
+          Cluster                                           = local.cluster_environment
         }
       }
       system_ng = {
@@ -464,7 +464,7 @@ locals {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/system-ng"     = "true"
           "container-platform.justice.gov.uk/system-ng" = "true"
-          Cluster                                       = local.environment
+          Cluster                                       = local.cluster_environment
         }
       }
     }
@@ -508,7 +508,7 @@ locals {
           Terraform                                      = "true"
           "cloud-platform.justice.gov.uk/default-ng"     = "true"
           "container-platform.justice.gov.uk/default-ng" = "true"
-          Cluster                                        = local.environment
+          Cluster                                        = local.cluster_environment
         }
       }
 
@@ -545,7 +545,7 @@ locals {
           Terraform                                         = "true"
           "cloud-platform.justice.gov.uk/monitoring-ng"     = "true"
           "container-platform.justice.gov.uk/monitoring-ng" = "true"
-          Cluster                                           = local.environment
+          Cluster                                           = local.cluster_environment
         }
       }
       system_ng = {
@@ -581,7 +581,7 @@ locals {
           Terraform                                     = "true"
           "cloud-platform.justice.gov.uk/system-ng"     = "true"
           "container-platform.justice.gov.uk/system-ng" = "true"
-          Cluster                                       = local.environment
+          Cluster                                       = local.cluster_environment
         }
       }
     }

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -12,6 +12,7 @@ locals {
 
   environment_configuration = local.environment_configurations[local.cluster_environment]
   cp_vpc_name               = local.cluster_environment == "development_cluster" ? "cloud-platform-development" : terraform.workspace
-  cluster_name              = contains(local.mp_environments, terraform.workspace) ? local.environment : terraform.workspace
-  cluster_environment       = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
+  workspace_environment     = element(reverse(split("-", terraform.workspace)), 0)
+  cluster_name              = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : terraform.workspace
+  cluster_environment       = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 }

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -10,8 +10,9 @@ locals {
     local.bu_accounts.accounts
   )
 
-  cluster_environment = contains(local.mp_environments, terraform.workspace) ? local.environment : "development_cluster"
-  cp_vpc_name         = terraform.workspace
+  workspace_environment = element(reverse(split("-", terraform.workspace)), 0)
+  cluster_environment   = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
+  cp_vpc_name           = terraform.workspace
 
   vpc_cidr = {
     cloud-platform-development = {


### PR DESCRIPTION
Because we are using a different account to deploy to for container-platform-bus, the local.environment provided in platform_locals doesn't work any more as it uses the application-name which is cloud-platform.  Changing to using cluster_environment and amending that so that it gets the correct environment (eg nonlive or live)