### PR TITLE
TM-2138: Move qa12c-nomis-web into its own config

### DIFF
--- a/terraform/environments/nomis/locals_development.tf
+++ b/terraform/environments/nomis/locals_development.tf
@@ -227,6 +227,28 @@ locals {
           oracle-db-hostname-b = "none"
         })
       })
+
+      qa12c-nomis-web = merge(local.ec2_autoscaling_groups.qa12c-nomis-web, {
+        autoscaling_schedules = {}
+        config = merge(local.ec2_autoscaling_groups.qa12c-nomis-web.config, {
+          instance_profile_policies = concat(local.ec2_instances.db.config.instance_profile_policies, [
+            "Ec2Qa11GWeblogicPolicy",
+            "Ec2Qa11G2WeblogicPolicy",
+            "Ec2Qa19CWeblogicPolicy",
+          ])
+        })
+        user_data_cloud_init = merge(local.ec2_autoscaling_groups.qa12c-nomis-web.user_data_cloud_init, {
+          args = merge(local.ec2_autoscaling_groups.qa12c-nomis-web.user_data_cloud_init.args, {
+            branch = "TM-2138-NOMIS-Weblogic-12-Update-Ansible-role-to-be-compliant-with-Oracle-Licenses"
+          })
+        })
+        tags = merge(local.ec2_autoscaling_groups.qa12c-nomis-web.tags, {
+          nomis-environment    = "qa19c"
+          oracle-db-name       = "qa19c"
+          oracle-db-hostname-a = "dev-nomis-db19c-1-b"
+          oracle-db-hostname-b = "none"
+        })
+      })
     }
 
     ec2_instances = {

--- a/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
+++ b/terraform/environments/nomis/locals_ec2_autoscaling_groups.tf
@@ -483,6 +483,89 @@ locals {
       }
     }
 
+    qa12c-nomis-web = {
+      autoscaling_group = {
+        desired_capacity          = 1
+        force_delete              = true
+        max_size                  = 1
+        termination_policies      = ["NewestInstance"]
+        vpc_zone_identifier       = module.environment.subnets["private"].ids
+        wait_for_capacity_timeout = 0
+        warm_pool = {
+          min_size          = 0
+          reuse_on_scale_in = true
+        }
+      }
+      autoscaling_schedules = {
+        "scale_up"   = { recurrence = "0 6 * * Mon-Fri" }
+        "scale_down" = { desired_capacity = 0, recurrence = "0 19 * * Mon-Fri" }
+      }
+      config = {
+        ami_name                  = "base_ol_8_5*"
+        iam_resource_names_prefix = "ec2-instance"
+        instance_profile_policies = [
+          # "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", # now included automatically by module
+          "EC2Default",
+          "EC2S3BucketWriteAndDeleteAccessPolicy",
+          "ImageBuilderS3BucketWriteAndDeleteAccessPolicy"
+        ]
+        subnet_name = "private"
+      }
+      ebs_volumes = {
+        "/dev/sdb" = { label = "app", type = "gp3", size = 100 }
+      }
+      instance = {
+        disable_api_termination      = false
+        instance_type                = "t3.large"
+        key_name                     = "ec2-user"
+        vpc_security_group_ids       = ["private-web"]
+        metadata_options_http_tokens = "required"
+      }
+      lb_target_groups = {
+        http-7777 = {
+          deregistration_delay = 30
+          port                 = 7777
+          protocol             = "HTTP"
+
+          health_check = {
+            enabled             = true
+            healthy_threshold   = 3
+            interval            = 10
+            matcher             = "200-399"
+            path                = "/"
+            port                = 7777
+            protocol            = "HTTP"
+            timeout             = 5
+            unhealthy_threshold = 2
+          }
+          stickiness = {
+            enabled = true
+            type    = "lb_cookie"
+          }
+        }
+      }
+      user_data_cloud_init = {
+        args = {
+          branch       = "TM-2138-NOMIS-Weblogic-12-Update-Ansible-role-to-be-compliant-with-Oracle-Licenses"
+          ansible_args = "--tags ec2provision"
+        }
+        scripts = [ # paths are relative to templates/ dir
+          "../../../modules/baseline_presets/ec2-user-data/install-ssm-agent.sh",
+          "../../../modules/baseline_presets/ec2-user-data/ansible-ec2provision.sh.tftpl",
+          "../../../modules/baseline_presets/ec2-user-data/post-ec2provision.sh",
+        ]
+      }
+      tags = {
+        # ami                 = "base_ol_8_5" # commented out to ensure harden role does not re-run
+        backup           = "false"
+        component        = "web"
+        description      = "For testing nomis weblogic 12 image"
+        os-type          = "Linux"
+        server-type      = "nomis-web12"
+        update-ssm-agent = "patchgroup1"
+      }
+    }
+
     web19c = {
       autoscaling_group = {
         desired_capacity          = 1


### PR DESCRIPTION
This PR exists to create unique configuration for qa12c-nomis-web

We will be performing a review with DBAs + Syscon to agree which of the other 12c related EC2s can be removed in due course