### PR TITLE
fix: coat terraform warnings fix + adjust chatbot lambda to only deploy on change

### DIFF
--- a/terraform/environments/coat/athena.tf
+++ b/terraform/environments/coat/athena.tf
@@ -176,7 +176,7 @@ aws athena start-query-execution \
   --work-group ${aws_athena_workgroup.ctas_athena_workgroup.name} \
   --result-configuration OutputLocation=s3://coat-${local.environment}-cur-v2-hourly/ctas/fct-daily-cost/ \
   --query-execution-context Database=${aws_glue_catalog_database.cur_v2_database.name} \
-  --region ${data.aws_region.current.name}
+  --region ${data.aws_region.current.region}
 EOF
   }
 

--- a/terraform/environments/coat/chatbot-api-gw.tf
+++ b/terraform/environments/coat/chatbot-api-gw.tf
@@ -32,7 +32,7 @@ resource "aws_api_gateway_integration" "send_request_post_integration" {
   resource_id             = aws_api_gateway_resource.send_request.id
   rest_api_id             = aws_api_gateway_rest_api.chatbot_api.id
   type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.rag_lambda.invoke_arn
+  uri                     = module.rag_lambda.lambda_function_invoke_arn
   integration_http_method = "POST"
 }
 
@@ -50,11 +50,10 @@ resource "aws_api_gateway_method" "send_request_options" {
 }
 
 resource "aws_api_gateway_integration" "send_request_options_integration" {
-  rest_api_id             = aws_api_gateway_rest_api.chatbot_api.id
-  resource_id             = aws_api_gateway_resource.send_request.id
-  http_method             = aws_api_gateway_method.send_request_options.http_method
-  type                    = "MOCK"
-  integration_http_method = "OPTIONS"
+  rest_api_id = aws_api_gateway_rest_api.chatbot_api.id
+  resource_id = aws_api_gateway_resource.send_request.id
+  http_method = aws_api_gateway_method.send_request_options.http_method
+  type        = "MOCK"
 
   request_templates = {
     "application/json" = "{\"statusCode\": 200}"
@@ -139,7 +138,7 @@ resource "aws_lambda_permission" "chatbot_api_lambda_permission" {
 
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.rag_lambda.function_name
+  function_name = module.rag_lambda.lambda_function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.chatbot_api.execution_arn}/*/*"
 }

--- a/terraform/environments/coat/chatbot-lambda.tf
+++ b/terraform/environments/coat/chatbot-lambda.tf
@@ -1,28 +1,5 @@
 # Lambda
 
-resource "null_resource" "build_lambda_zip" {
-
-  triggers = {
-    always_run = timestamp()
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      cd ${path.module}/lambdas/rag-lambda
-	    
-	    pip3 install -r requirements.txt -t .
-
-      zip -r rag-lambda.zip .
-    EOT
-  }
-}
-
-data "archive_file" "rag_lambda" {
-  type        = "zip"
-  source_dir  = "${path.module}/lambdas/rag-lambda/"
-  output_path = "${path.module}/lambdas/rag-lambda/rag-lambda.zip"
-}
-
 resource "aws_security_group" "rag_lambda" {
   name        = "${local.application_name}-${local.environment}-rag-lambda-security-group"
   description = "RAG Lambda Security Group"
@@ -37,54 +14,6 @@ resource "aws_security_group" "rag_lambda" {
   }
 }
 
-resource "aws_lambda_function" "rag_lambda" {
-  #checkov:skip=CKV_AWS_173:No sensitive information stored in Lambda environment variables
-  #checkov:skip=CKV_AWS_116:Queue it self has DLQ so Lambda fail should redrive to DLQ
-  #checkov:skip=CKV_AWS_272:Doesn't need code signing
-
-  function_name = "RAGLambdaFunction"
-  description   = "Recieve NL request from user, use Bedrock to create SQL from NL, and use query to extract data from Athena"
-
-  role    = aws_iam_role.rag_lambda_role.arn
-  runtime = "python3.12"
-  timeout = 30
-
-  handler          = "rag-lambda.lambda_handler"
-  package_type     = "Zip"
-  filename         = "${path.module}/lambdas/rag-lambda/rag-lambda.zip"
-  source_code_hash = data.archive_file.rag_lambda.output_base64sha256
-
-  reserved_concurrent_executions = 10
-
-  vpc_config {
-    security_group_ids = [aws_security_group.rag_lambda.id]
-    subnet_ids         = [data.aws_subnet.private_subnets_a.id]
-  }
-
-  tracing_config {
-    mode = "PassThrough"
-  }
-
-  environment {
-    variables = {
-      ENVIRONMENT = local.environment
-    }
-  }
-
-  tags = {
-    "service-area" = "Hosting"
-  }
-
-  depends_on = [null_resource.build_lambda_zip]
-}
-
-# Logs
-
-resource "aws_cloudwatch_log_group" "rag_lambda_log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.rag_lambda.function_name}"
-  retention_in_days = 120
-}
-
 # IAM role
 
 resource "aws_iam_role" "rag_lambda_role" {
@@ -93,14 +22,15 @@ resource "aws_iam_role" "rag_lambda_role" {
 
   assume_role_policy = data.aws_iam_policy_document.rag_lambda_function_assume_role.json
 
-  inline_policy {
-    name   = "rag_lambda_policy"
-    policy = data.aws_iam_policy_document.rag_lambda_function_role.json
-  }
-
   tags = {
     "service-area" = "Hosting"
   }
+}
+
+resource "aws_iam_role_policy" "rag_lambda_policy" {
+  name   = "rag_lambda_policy"
+  role   = aws_iam_role.rag_lambda_role.id
+  policy = data.aws_iam_policy_document.rag_lambda_function_role.json
 }
 
 data "aws_iam_policy_document" "rag_lambda_function_assume_role" {
@@ -126,7 +56,7 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
       "logs:PutLogEvents"
     ]
 
-    resources = ["arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/RAGLambdaFunction:*"]
+    resources = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/RAGLambdaFunction:*"]
   }
 
   statement {
@@ -183,8 +113,8 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
     actions = ["secretsmanager:GetSecretValue"]
 
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:secret:llm_gateway_key-USBFqg",
-      "arn:aws:secretsmanager:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:secret:llm_gateway_key-1biv4G"
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:llm_gateway_key-USBFqg",
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:llm_gateway_key-1biv4G"
     ]
   }
 
@@ -201,7 +131,7 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
     ]
 
     resources = [
-      "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/ef7e1dc9-dc2b-4733-9278-46885b7040c7"
+      "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/ef7e1dc9-dc2b-4733-9278-46885b7040c7"
     ]
   }
 }
@@ -209,6 +139,61 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
 resource "aws_iam_role_policy_attachment" "rag_lambda_vpc_access" {
   role       = aws_iam_role.rag_lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+module "rag_lambda" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_AWS_173:No sensitive information stored in Lambda environment variables
+  #checkov:skip=CKV_AWS_116:Queue it self has DLQ so Lambda fail should redrive to DLQ
+  #checkov:skip=CKV_AWS_272:Doesn't need code signing
+
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name = "RAGLambdaFunction"
+  description   = "Recieve NL request from user, use Bedrock to create SQL from NL, and use query to extract data from Athena"
+  handler       = "rag-lambda.lambda_handler"
+  runtime       = "python3.12"
+  timeout       = 30
+
+  source_path = [{
+    path = "${path.module}/lambdas/rag-lambda"
+    commands = [
+      "pip3 install -r requirements.txt -t .",
+      ":zip",
+    ]
+  }]
+  trigger_on_package_timestamp = false
+
+  reserved_concurrent_executions = 10
+
+  vpc_subnet_ids         = [data.aws_subnet.private_subnets_a.id]
+  vpc_security_group_ids = [aws_security_group.rag_lambda.id]
+
+  tracing_mode = "PassThrough"
+
+  environment_variables = {
+    ENVIRONMENT = local.environment
+  }
+
+  create_role = false
+  lambda_role = aws_iam_role.rag_lambda_role.arn
+
+  cloudwatch_logs_retention_in_days = 120
+
+  tags = {
+    "service-area" = "Hosting"
+  }
+}
+
+moved {
+  from = aws_lambda_function.rag_lambda
+  to   = module.rag_lambda.aws_lambda_function.this[0]
+}
+
+moved {
+  from = aws_cloudwatch_log_group.rag_lambda_log_group
+  to   = module.rag_lambda.aws_cloudwatch_log_group.lambda[0]
 }
 
 # Secrets

--- a/terraform/environments/coat/platform_providers.tf
+++ b/terraform/environments/coat/platform_providers.tf
@@ -8,8 +8,11 @@ provider "aws" {
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
 provider "aws" {
   region = "eu-west-2"
-  assume_role {
-    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+  dynamic "assume_role" {
+    for_each = can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? [1] : []
+    content {
+      role_arn = can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+    }
   }
   default_tags { tags = local.tags }
 }
@@ -48,8 +51,11 @@ provider "aws" {
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
-  assume_role {
-    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+  dynamic "assume_role" {
+    for_each = can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? [1] : []
+    content {
+      role_arn = can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+    }
   }
   default_tags { tags = local.tags }
 }

--- a/terraform/environments/coat/s3.tf
+++ b/terraform/environments/coat/s3.tf
@@ -4,7 +4,7 @@ module "cur_v2_hourly" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.0.0"
+  version = "5.14.0"
 
   bucket = "coat-${local.environment}-cur-v2-hourly"
 
@@ -27,16 +27,6 @@ module "cur_v2_hourly" {
   versioning = {
     status = "Enabled"
   }
-
-  lifecycle_rule = [
-    {
-      id      = "DeleteOldVersions"
-      enabled = true
-      noncurrent_version_expiration = {
-        days = 1
-      }
-    }
-  ]
 }
 
 data "aws_iam_policy_document" "coat_cur_v2_hourly_dev_bucket_policy" {
@@ -346,7 +336,7 @@ module "focus_reports" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.0.0"
+  version = "5.14.0"
 
   bucket           = "coat-${local.environment}-focus-reports"
   object_ownership = "BucketOwnerEnforced"
@@ -368,16 +358,6 @@ module "focus_reports" {
   versioning = {
     status = "Enabled"
   }
-
-  lifecycle_rule = [
-    {
-      id      = "DeleteOldVersions"
-      enabled = true
-      noncurrent_version_expiration = {
-        days = 1
-      }
-    }
-  ]
 }
 
 # COAT Reports 
@@ -419,7 +399,7 @@ module "coat_reports" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.0.0"
+  version = "5.14.0"
 
   bucket           = "coat-reports-${local.environment}"
   object_ownership = "BucketOwnerEnforced"
@@ -440,16 +420,6 @@ module "coat_reports" {
   versioning = {
     status = "Enabled"
   }
-
-  lifecycle_rule = [
-    {
-      id      = "DeleteOldVersions"
-      enabled = true
-      noncurrent_version_expiration = {
-        days = 1
-      }
-    }
-  ]
 }
 
 resource "aws_s3_object" "ebs_waste_reports" {
@@ -470,6 +440,87 @@ resource "aws_s3_object" "pod_waste_reports" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly" {
+  bucket = module.cur_v2_hourly.s3_bucket_id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "focus_reports" {
+  bucket = module.focus_reports.s3_bucket_id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "coat_reports" {
+  bucket = module.coat_reports.s3_bucket_id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly_enriched" {
+  count  = local.is-development ? 0 : 1
+  bucket = module.cur_v2_hourly_enriched[0].s3_bucket_id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+}
+
+moved {
+  from = module.cur_v2_hourly.aws_s3_bucket_lifecycle_configuration.this[0]
+  to   = aws_s3_bucket_lifecycle_configuration.cur_v2_hourly
+}
+
+moved {
+  from = module.focus_reports.aws_s3_bucket_lifecycle_configuration.this[0]
+  to   = aws_s3_bucket_lifecycle_configuration.focus_reports
+}
+
+moved {
+  from = module.coat_reports.aws_s3_bucket_lifecycle_configuration.this[0]
+  to   = aws_s3_bucket_lifecycle_configuration.coat_reports
+}
+
+moved {
+  from = module.cur_v2_hourly_enriched[0].aws_s3_bucket_lifecycle_configuration.this[0]
+  to   = aws_s3_bucket_lifecycle_configuration.cur_v2_hourly_enriched[0]
+}
+
 moved {
   from = module.cur_v2_hourly_enriched
   to   = module.cur_v2_hourly_enriched[0]
@@ -482,7 +533,7 @@ module "cur_v2_hourly_enriched" {
   count = local.is-development ? 0 : 1
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.0.0"
+  version = "5.14.0"
 
   bucket = "coat-${local.environment}-cur-v2-hourly-enriched"
 
@@ -507,16 +558,6 @@ module "cur_v2_hourly_enriched" {
   versioning = {
     status = "Enabled"
   }
-
-  lifecycle_rule = [
-    {
-      id      = "DeleteOldVersions"
-      enabled = true
-      noncurrent_version_expiration = {
-        days = 1
-      }
-    }
-  ]
 
   replication_configuration = {
     role = module.cur_v2_hourly_enriched_replication_role[0].iam_role_arn

--- a/terraform/environments/coat/versions.tf
+++ b/terraform/environments/coat/versions.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/835

Problem: COAT Terraform plans/applies were slow and noisy. The RAG chatbot Lambda was repackaged on every run, API Gateway kept replacing resources, and several AWS provider deprecation warnings appeared.

1. Chatbot Lambda — stop unnecessary repackaging

Before: Custom build with null_resource using timestamp() as a trigger, plus archive_file and aws_lambda_function — forced pip install + zip + Lambda update every apply.
After: Refactored to terraform-aws-modules/lambda/aws 
Added external provider (required by the lambda module)

2. API Gateway — stop OPTIONS integration replacement loop
Removed integration_http_method = "OPTIONS" from the MOCK CORS integration. API Gateway ignores this for MOCK integrations, causing Terraform to see drift and force replacement every plan.

3. fix deprecation warnings 
* Upgraded S3 bucket modules to 5.14.0
    * Moved lifecycle config to standalone aws_s3_bucket_lifecycle_configuration resources with explicit filter {} for:
    * cur_v2_hourly
    * focus_reports
    * coat_reports
    * cur_v2_hourly_enriched (prod only)
    
    athena.tf - data.aws_region.current.name → .region
    
    chatbot-lambda.tf - 
    data.aws_region.current.id → .region in IAM ARNs
    inline_policy on IAM role → separate aws_iam_role_policy
    
    platform_providers.tf - Static assume_role { role_arn = null } → dynamic "assume_role" (only when role assumption is needed)
    