### PR TITLE
authentication and client authorisation for API platform

### DIFF
--- a/scripts/bootstrap-api-credentials.sh
+++ b/scripts/bootstrap-api-credentials.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/bootstrap-api-credentials.sh user --secret-id <secret-id> [--username <username>] [--role-name <role-name>] [--profile <aws-profile>] [--region <aws-region>]
+  scripts/bootstrap-api-credentials.sh system --secret-id <secret-id> [--token-id <token-id>] [--role-name <role-name>] [--profile <aws-profile>] [--region <aws-region>]
+
+Description:
+  Generates a strong API credential outside Terraform state, writes it to the
+  target AWS Secrets Manager secret, and prints only the sensitive handover
+  value to stdout.
+
+Modes:
+  user
+    Writes JSON in this shape:
+      {"username":"...","password":"...","roleName":"..."}
+    Prints only the generated password to stdout.
+
+  system
+    Writes JSON in this shape:
+      {"tokenId":"...","bearerToken":"...","roleName":"..."}
+    Prints only the bearer token value to hand over to the client in this form:
+      <tokenId>.<bearerToken>
+
+Notes:
+  - If username, token-id, or role-name are omitted, the script will try to
+    read them from the current secret value first.
+  - Progress messages are sent to stderr so stdout stays safe for one-time
+    capture of the handover value.
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+MODE="$1"
+shift
+
+SECRET_ID=""
+USERNAME=""
+TOKEN_ID=""
+ROLE_NAME=""
+AWS_PROFILE=""
+AWS_REGION=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --secret-id|--secret-name)
+      SECRET_ID="$2"
+      shift 2
+      ;;
+    --username)
+      USERNAME="$2"
+      shift 2
+      ;;
+    --token-id)
+      TOKEN_ID="$2"
+      shift 2
+      ;;
+    --role-name)
+      ROLE_NAME="$2"
+      shift 2
+      ;;
+    --profile)
+      AWS_PROFILE="$2"
+      shift 2
+      ;;
+    --region)
+      AWS_REGION="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$SECRET_ID" ]; then
+  echo "--secret-id is required" >&2
+  exit 1
+fi
+
+if [ "$MODE" != "user" ] && [ "$MODE" != "system" ]; then
+  echo "Mode must be 'user' or 'system'" >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required" >&2
+  exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+AWS_CMD=(aws)
+if [ -n "$AWS_PROFILE" ]; then
+  AWS_CMD+=(--profile "$AWS_PROFILE")
+fi
+if [ -n "$AWS_REGION" ]; then
+  AWS_CMD+=(--region "$AWS_REGION")
+fi
+
+generate_secret_value() {
+  local length="$1"
+  openssl rand -base64 64 | tr -d '\n=' | tr '/+' '_-' | cut -c1-"$length"
+}
+
+read_secret_field() {
+  local secret_json="$1"
+  local field_name="$2"
+
+  SECRET_JSON="$secret_json" python3 - "$field_name" <<'PY'
+import json
+import os
+import sys
+
+field_name = sys.argv[1]
+secret_json = os.environ.get("SECRET_JSON", "")
+if not secret_json:
+    sys.exit(0)
+
+try:
+    data = json.loads(secret_json)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"SecretString is not valid JSON: {exc}")
+
+value = data.get(field_name, "")
+if value is None:
+    value = ""
+
+print(value, end="")
+PY
+}
+
+build_secret_json() {
+  local mode="$1"
+  local identifier="$2"
+  local role_name="$3"
+  local secret_value="$4"
+
+  python3 - "$mode" "$identifier" "$role_name" "$secret_value" <<'PY'
+import json
+import sys
+
+mode, identifier, role_name, secret_value = sys.argv[1:]
+if mode == "user":
+    payload = {
+        "username": identifier,
+        "password": secret_value,
+        "roleName": role_name,
+    }
+else:
+    payload = {
+        "tokenId": identifier,
+        "bearerToken": secret_value,
+        "roleName": role_name,
+    }
+
+print(json.dumps(payload, separators=(",", ":")), end="")
+PY
+}
+
+echo "Reading secret container metadata from Secrets Manager" >&2
+CURRENT_SECRET_JSON="$("${AWS_CMD[@]}" secretsmanager get-secret-value --secret-id "$SECRET_ID" --query SecretString --output text)"
+
+if [ "$MODE" = "user" ]; then
+  USERNAME="${USERNAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "username")}"
+  ROLE_NAME="${ROLE_NAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "roleName")}"
+
+  if [ -z "$USERNAME" ]; then
+    echo "Username is missing. Pass --username or store it in the current secret JSON." >&2
+    exit 1
+  fi
+  if [ -z "$ROLE_NAME" ]; then
+    echo "Role name is missing. Pass --role-name or store it in the current secret JSON." >&2
+    exit 1
+  fi
+
+  PASSWORD="$(generate_secret_value 40)"
+  SECRET_STRING="$(build_secret_json user "$USERNAME" "$ROLE_NAME" "$PASSWORD")"
+
+  echo "Writing generated user password to $SECRET_ID" >&2
+  "${AWS_CMD[@]}" secretsmanager put-secret-value \
+    --secret-id "$SECRET_ID" \
+    --secret-string "$SECRET_STRING" \
+    >/dev/null
+
+  echo "Username: $USERNAME" >&2
+  echo "Role name: $ROLE_NAME" >&2
+  printf '%s\n' "$PASSWORD"
+  exit 0
+fi
+
+TOKEN_ID="${TOKEN_ID:-$(read_secret_field "$CURRENT_SECRET_JSON" "tokenId")}"
+ROLE_NAME="${ROLE_NAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "roleName")}"
+
+if [ -z "$TOKEN_ID" ]; then
+  echo "Token ID is missing. Pass --token-id or store it in the current secret JSON." >&2
+  exit 1
+fi
+if [ -z "$ROLE_NAME" ]; then
+  echo "Role name is missing. Pass --role-name or store it in the current secret JSON." >&2
+  exit 1
+fi
+
+BEARER_TOKEN="$(generate_secret_value 48)"
+SECRET_STRING="$(build_secret_json system "$TOKEN_ID" "$ROLE_NAME" "$BEARER_TOKEN")"
+
+echo "Writing generated system bearer token to $SECRET_ID" >&2
+"${AWS_CMD[@]}" secretsmanager put-secret-value \
+  --secret-id "$SECRET_ID" \
+  --secret-string "$SECRET_STRING" \
+  >/dev/null
+
+echo "Token ID: $TOKEN_ID" >&2
+echo "Role name: $ROLE_NAME" >&2
+printf '%s.%s\n' "$TOKEN_ID" "$BEARER_TOKEN"

--- a/scripts/bootstrap-api-credentials.sh
+++ b/scripts/bootstrap-api-credentials.sh
@@ -186,7 +186,9 @@ PY
 
 echo "Reading secret container metadata from Secrets Manager" >&2
 CURRENT_SECRET_JSON="$("${AWS_CMD[@]}" secretsmanager get-secret-value --secret-id "$SECRET_ID" --query SecretString --output text)"
-
+if [ "$CURRENT_SECRET_JSON" = "None" ] || [ "$CURRENT_SECRET_JSON" = "null" ]; then
+  CURRENT_SECRET_JSON=""
+fi
 if [ "$MODE" = "user" ]; then
   USERNAME="${USERNAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "username")}"
   ROLE_NAME="${ROLE_NAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "roleName")}"

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -200,4 +200,4 @@ curl -X POST "https://<api-endpoint>/transfer-tickets" \
 
 ## OpenAPI
 
-The API contract is documented in [`openapi.yaml`](</Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/api-platform/openapi.yaml>).
+The API contract is documented in [`openapi.yaml`](openapi.yaml).

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -2,13 +2,21 @@
 
 This component provides a thin API layer for Managed File Transfer uploads.
 
+It now protects the API with:
+
+1. Basic authentication for user-driven HTTPS uploads using Secrets Manager-held credentials.
+2. Bearer token authentication for system-to-system API integrations using Secrets Manager-held tokens.
+3. Role-based authorisation that maps callers to one or more permitted `clientId` values.
+
 ## What it does
 
-1. A client calls `POST /transfer-tickets` on API Gateway.
-2. API Gateway invokes a Lambda function.
-3. The Lambda function reads client upload configuration from DynamoDB.
-4. The Lambda function generates a short-lived S3 pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
-5. The client uploads the file directly to S3 with the returned URL and headers.
+1. A caller sends `POST /transfer-tickets` to API Gateway with either a Basic auth header or a Bearer token.
+2. API Gateway invokes a Lambda request authorizer.
+3. The authorizer validates the caller against Secrets Manager credentials or bearer tokens and resolves the caller's role mapping from DynamoDB.
+4. The upload-ticket Lambda reads client upload configuration from DynamoDB.
+5. The upload-ticket Lambda verifies that the authenticated caller is allowed to request a ticket for the requested `clientId`.
+6. The Lambda generates a short-lived S3 pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
+7. The client uploads the file directly to S3 with the returned URL and headers.
 
 ## Sample request payload
 
@@ -70,12 +78,99 @@ terraform workspace select integration-hub-development
 terraform plan
 ```
 
-## Example API call
+## Authentication configuration
+
+`application_variables.json` now supports an `auth_configuration` block per environment:
+
+```json
+{
+  "auth_configuration": {
+    "roles": {
+      "products-poc-upload": {
+        "allowed_client_ids": ["products-poc"]
+      }
+    },
+    "users": {
+      "products-poc-user": {
+        "enabled": true,
+        "role_name": "products-poc-upload"
+      }
+    },
+    "system_principals": {
+      "products-poc-api": {
+        "enabled": true,
+        "role_name": "products-poc-upload"
+      }
+    }
+  }
+}
+```
+
+After apply, retrieve the created secret names from the Terraform outputs:
+
+```bash
+terraform output user_auth_secret_names
+terraform output system_auth_secret_names
+```
+
+Terraform creates the secret containers, but the live secret values are managed operationally in AWS Secrets Manager and ignored by Terraform after creation.
+
+For repeatable credential bootstrapping outside Terraform state, use:
+
+```bash
+scripts/bootstrap-api-credentials.sh user --secret-id <user-secret-name>
+scripts/bootstrap-api-credentials.sh system --secret-id <system-secret-name>
+```
+
+The script generates the live credential locally, writes it to Secrets Manager, and prints only the one-time handover value to stdout.
+
+Populate a user secret with JSON in this shape:
+
+```json
+{
+  "username": "products-poc-user",
+  "password": "replace-with-password",
+  "roleName": "products-poc-upload"
+}
+```
+
+Populate a system principal secret with JSON in this shape:
+
+```json
+{
+  "tokenId": "products-poc-api",
+  "bearerToken": "replace-with-token",
+  "roleName": "products-poc-upload"
+}
+```
+
+The bearer token supplied to the API is:
+
+```text
+<tokenId>.<bearerToken>
+```
+
+Example bootstrap flow for a user secret:
+
+```bash
+terraform output user_auth_secret_names
+scripts/bootstrap-api-credentials.sh user --secret-id integration-hub-api-platform-development-user-products-poc-user
+```
+
+Example bootstrap flow for a system principal:
+
+```bash
+terraform output system_auth_secret_names
+scripts/bootstrap-api-credentials.sh system --secret-id integration-hub-api-platform-development-system-products-poc-api
+```
+
+## Example API call with Basic auth
 
 Replace `<api-endpoint>` with the `transfer_ticket_api_endpoint` Terraform output after apply.
 
 ```bash
 curl -X POST "https://<api-endpoint>/transfer-tickets" \
+  -u "<username>:<password>" \
   -H "content-type: application/json" \
   -d '{
     "clientId": "products-poc",
@@ -86,3 +181,23 @@ curl -X POST "https://<api-endpoint>/transfer-tickets" \
     "contentMd5": "CY9rzUYh03PK3k6DJie09g=="
   }'
 ```
+
+## Example API call with Bearer auth
+
+```bash
+curl -X POST "https://<api-endpoint>/transfer-tickets" \
+  -H "authorization: Bearer <tokenId>.<token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "clientId": "products-poc",
+    "fileName": "example-upload.csv",
+    "contentType": "text/csv",
+    "sizeBytes": 12345,
+    "requestedExpirySeconds": 900,
+    "contentMd5": "CY9rzUYh03PK3k6DJie09g=="
+  }'
+```
+
+## OpenAPI
+
+The API contract is documented in [`openapi.yaml`](</Users/harsh.vasudev/IdeaProjects/modernisation-platform-environments/terraform/environments/integration-hub/api-platform/openapi.yaml>).

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -113,7 +113,7 @@ terraform output user_auth_secret_names
 terraform output system_auth_secret_names
 ```
 
-Terraform creates the secret containers, but the live secret values are managed operationally in AWS Secrets Manager and ignored by Terraform after creation.
+Terraform creates the secret containers, but the live secret values are managed operationally in AWS Secrets Manager and ignored by Terraform after creation. The authorizer resolves the current secret value from Secrets Manager at request time using the stored secret name.
 
 For repeatable credential bootstrapping outside Terraform state, use:
 

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -12,7 +12,7 @@ resource "aws_apigatewayv2_api" "upload_ticket" {
     for_each = length(local.cors_allowed_origins) > 0 ? [1] : []
 
     content {
-      allow_headers = ["content-md5", "content-type"]
+      allow_headers = ["authorization", "content-md5", "content-type"]
       allow_methods = ["OPTIONS", "POST"]
       allow_origins = local.cors_allowed_origins
       expose_headers = [
@@ -33,10 +33,22 @@ resource "aws_apigatewayv2_integration" "upload_ticket" {
   payload_format_version = "2.0"
 }
 
+resource "aws_apigatewayv2_authorizer" "mft_request" {
+  api_id                            = aws_apigatewayv2_api.upload_ticket.id
+  authorizer_type                   = "REQUEST"
+  name                              = "${local.application_name}-${local.component_name}-authorizer"
+  authorizer_uri                    = module.lambda_api_authorizer.lambda_function_invoke_arn
+  authorizer_payload_format_version = "2.0"
+  enable_simple_responses           = true
+  identity_sources                  = ["$request.header.Authorization"]
+}
+
 resource "aws_apigatewayv2_route" "transfer_tickets" {
-  api_id    = aws_apigatewayv2_api.upload_ticket.id
-  route_key = "POST /transfer-tickets"
-  target    = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+  api_id             = aws_apigatewayv2_api.upload_ticket.id
+  route_key          = "POST /transfer-tickets"
+  target             = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id
 }
 
 resource "aws_apigatewayv2_stage" "default" {
@@ -67,4 +79,12 @@ resource "aws_lambda_permission" "allow_api_gateway_upload_ticket" {
   function_name = module.lambda_upload_ticket.lambda_function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.upload_ticket.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "allow_api_gateway_authorizer" {
+  statement_id  = "AllowExecutionFromApiGatewayAuthorizer"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_api_authorizer.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.upload_ticket.execution_arn}/authorizers/${aws_apigatewayv2_authorizer.mft_request.id}"
 }

--- a/terraform/environments/integration-hub/api-platform/application_variables.json
+++ b/terraform/environments/integration-hub/api-platform/application_variables.json
@@ -6,6 +6,27 @@
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
+      "auth_configuration": {
+        "roles": {
+          "products-poc-upload": {
+            "allowed_client_ids": [
+              "products-poc"
+            ]
+          }
+        },
+        "users": {
+          "products-poc-user": {
+            "enabled": true,
+            "role_name": "products-poc-upload"
+          }
+        },
+        "system_principals": {
+          "products-poc-api": {
+            "enabled": true,
+            "role_name": "products-poc-upload"
+          }
+        }
+      },
       "transfer_clients": {
         "products-poc": {
           "enabled": true,
@@ -20,6 +41,11 @@
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
+      "auth_configuration": {
+        "roles": {},
+        "users": {},
+        "system_principals": {}
+      },
       "transfer_clients": {}
     },
     "preproduction": {
@@ -28,6 +54,11 @@
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
       },
+      "auth_configuration": {
+        "roles": {},
+        "users": {},
+        "system_principals": {}
+      },
       "transfer_clients": {}
     },
     "production": {
@@ -35,6 +66,11 @@
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900
+      },
+      "auth_configuration": {
+        "roles": {},
+        "users": {},
+        "system_principals": {}
       },
       "transfer_clients": {}
     }

--- a/terraform/environments/integration-hub/api-platform/auth.tf
+++ b/terraform/environments/integration-hub/api-platform/auth.tf
@@ -1,0 +1,47 @@
+module "api_user_credentials_secret" {
+  for_each = local.auth_users
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-${local.component_name}-${local.environment}-user-${each.key}"
+  description             = "HTTPS upload credentials for ${each.key}"
+  recovery_window_in_days = 7
+  create_policy           = false
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  # This value is a placeholder. Populate the real password directly in AWS
+  # Secrets Manager and Terraform will ignore later secret value changes.
+  secret_string = jsonencode({
+    username = each.key
+    password = "replace-me"
+    roleName = each.value.role_name
+  })
+
+  tags = local.tags
+}
+
+module "api_system_bearer_token_secret" {
+  for_each = local.auth_system_principals
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-${local.component_name}-${local.environment}-system-${each.key}"
+  description             = "Bearer token secret for ${each.key}"
+  recovery_window_in_days = 7
+  create_policy           = false
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  # This value is a placeholder. Populate the real token directly in AWS
+  # Secrets Manager and Terraform will ignore later secret value changes.
+  secret_string = jsonencode({
+    tokenId     = each.key
+    bearerToken = "replace-me"
+    roleName    = each.value.role_name
+  })
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-platform/dynamo-db.tf
@@ -144,8 +144,8 @@ resource "aws_dynamodb_table_item" "auth_user_principal" {
     role_name = {
       S = each.value.role_name
     }
-    secret_arn = {
-      S = module.api_user_credentials_secret[each.key].secret_arn
+    secret_name = {
+      S = module.api_user_credentials_secret[each.key].secret_name
     }
   })
 }
@@ -172,8 +172,8 @@ resource "aws_dynamodb_table_item" "auth_system_principal" {
     role_name = {
       S = each.value.role_name
     }
-    secret_arn = {
-      S = module.api_system_bearer_token_secret[each.key].secret_arn
+    secret_name = {
+      S = module.api_system_bearer_token_secret[each.key].secret_name
     }
   })
 }

--- a/terraform/environments/integration-hub/api-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-platform/dynamo-db.tf
@@ -23,6 +23,56 @@ module "dynamodb_transfer_clients" {
   tags = local.tags
 }
 
+module "dynamodb_auth_roles" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-auth-roles"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "role_name"
+
+  attributes = [
+    {
+      name = "role_name"
+      type = "S"
+    }
+  ]
+
+  table_class = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  tags = local.tags
+}
+
+module "dynamodb_auth_principals" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-auth-principals"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "auth_lookup_key"
+
+  attributes = [
+    {
+      name = "auth_lookup_key"
+      type = "S"
+    }
+  ]
+
+  table_class = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  tags = local.tags
+}
+
 resource "aws_dynamodb_table_item" "transfer_client" {
   for_each = local.transfer_clients
 
@@ -48,6 +98,82 @@ resource "aws_dynamodb_table_item" "transfer_client" {
           S = value
         }
       ]
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "auth_role" {
+  for_each = local.auth_roles
+
+  table_name = module.dynamodb_auth_roles.dynamodb_table_id
+  hash_key   = "role_name"
+
+  item = jsonencode({
+    role_name = {
+      S = each.key
+    }
+    allowed_client_ids = {
+      L = [
+        for client_id in try(each.value.allowed_client_ids, []) : {
+          S = client_id
+        }
+      ]
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "auth_user_principal" {
+  for_each = local.auth_users
+
+  table_name = module.dynamodb_auth_principals.dynamodb_table_id
+  hash_key   = "auth_lookup_key"
+
+  item = jsonencode({
+    auth_lookup_key = {
+      S = "basic#${each.key}"
+    }
+    principal_id = {
+      S = each.key
+    }
+    auth_type = {
+      S = "basic"
+    }
+    enabled = {
+      BOOL = try(each.value.enabled, true)
+    }
+    role_name = {
+      S = each.value.role_name
+    }
+    secret_arn = {
+      S = module.api_user_credentials_secret[each.key].secret_arn
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "auth_system_principal" {
+  for_each = local.auth_system_principals
+
+  table_name = module.dynamodb_auth_principals.dynamodb_table_id
+  hash_key   = "auth_lookup_key"
+
+  item = jsonencode({
+    auth_lookup_key = {
+      S = "bearer#${each.key}"
+    }
+    principal_id = {
+      S = each.key
+    }
+    auth_type = {
+      S = "bearer"
+    }
+    enabled = {
+      BOOL = try(each.value.enabled, true)
+    }
+    role_name = {
+      S = each.value.role_name
+    }
+    secret_arn = {
+      S = module.api_system_bearer_token_secret[each.key].secret_arn
     }
   })
 }

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -54,3 +54,70 @@ module "lambda_upload_ticket" {
 
   tags = local.tags
 }
+
+module "lambda_api_authorizer" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-${local.component_name}-authorizer"
+  description                  = "Authenticates and authorises MFT API callers"
+  handler                      = "lambda_function.lambda_handler"
+  runtime                      = "python3.12"
+  source_path                  = "${path.module}/lambda/request-authorizer"
+  trigger_on_package_timestamp = false
+
+  environment_variables = {
+    AUTH_PRINCIPALS_TABLE = module.dynamodb_auth_principals.dynamodb_table_id
+    AUTH_ROLES_TABLE      = module.dynamodb_auth_roles.dynamodb_table_id
+  }
+
+  attach_policy_statements = true
+  policy_statements = merge(
+    {
+      auth_principals_table_read = {
+        effect = "Allow"
+        actions = [
+          "dynamodb:GetItem",
+        ]
+        resources = [
+          module.dynamodb_auth_principals.dynamodb_table_arn,
+        ]
+      }
+      auth_roles_table_read = {
+        effect = "Allow"
+        actions = [
+          "dynamodb:GetItem",
+        ]
+        resources = [
+          module.dynamodb_auth_roles.dynamodb_table_arn,
+        ]
+      }
+    },
+    length(local.auth_users) > 0 ? {
+      auth_user_secret_read = {
+        effect = "Allow"
+        actions = [
+          "secretsmanager:GetSecretValue",
+        ]
+        resources = [
+          for secret in values(module.api_user_credentials_secret) : secret.secret_arn
+        ]
+      }
+    } : {},
+    length(local.auth_system_principals) > 0 ? {
+      auth_system_secret_read = {
+        effect = "Allow"
+        actions = [
+          "secretsmanager:GetSecretValue",
+        ]
+        resources = [
+          for secret in values(module.api_system_bearer_token_secret) : secret.secret_arn
+        ]
+      }
+    } : {}
+  )
+
+  cloudwatch_logs_retention_in_days = 30
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -37,9 +37,12 @@ def _get_role(role_name):
 
 
 def _load_secret_json(secret_arn):
-    secret_value = SECRETS_MANAGER.get_secret_value(SecretId=secret_arn)["SecretString"]
-    return json.loads(secret_value)
-
+    try:
+        response = SECRETS_MANAGER.get_secret_value(SecretId=secret_arn)
+        secret_string = response.get("SecretString") or ""
+        return json.loads(secret_string) if secret_string else {}
+    except Exception:
+        return {}
 
 def _authenticate_basic(token):
     try:

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -1,0 +1,116 @@
+import base64
+import binascii
+import hmac
+import json
+import os
+
+import boto3
+
+
+DYNAMODB = boto3.resource("dynamodb")
+SECRETS_MANAGER = boto3.client("secretsmanager")
+
+AUTH_PRINCIPALS_TABLE = os.environ["AUTH_PRINCIPALS_TABLE"]
+AUTH_ROLES_TABLE = os.environ["AUTH_ROLES_TABLE"]
+
+
+def _deny():
+    return {"isAuthorized": False, "context": {}}
+
+
+def _get_header(event, header_name):
+    headers = event.get("headers") or {}
+    for key, value in headers.items():
+        if key.lower() == header_name.lower():
+            return value
+    return None
+
+
+def _get_principal(lookup_key):
+    table = DYNAMODB.Table(AUTH_PRINCIPALS_TABLE)
+    return table.get_item(Key={"auth_lookup_key": lookup_key}).get("Item")
+
+
+def _get_role(role_name):
+    table = DYNAMODB.Table(AUTH_ROLES_TABLE)
+    return table.get_item(Key={"role_name": role_name}).get("Item")
+
+
+def _load_secret_json(secret_arn):
+    secret_value = SECRETS_MANAGER.get_secret_value(SecretId=secret_arn)["SecretString"]
+    return json.loads(secret_value)
+
+
+def _authenticate_basic(token):
+    try:
+        username, password = base64.b64decode(token).decode("utf-8").split(":", 1)
+    except (ValueError, UnicodeDecodeError, binascii.Error):
+        return None
+
+    principal = _get_principal(f"basic#{username}")
+    if principal is None or not principal.get("enabled", True):
+        return None
+
+    secret = _load_secret_json(principal["secret_arn"])
+    if not hmac.compare_digest(password, secret["password"]):
+        return None
+
+    return principal
+
+
+def _authenticate_bearer(token):
+    token_id, separator, token_secret = token.partition(".")
+    if not separator or not token_id or not token_secret:
+        return None
+
+    principal = _get_principal(f"bearer#{token_id}")
+    if principal is None or not principal.get("enabled", True):
+        return None
+
+    secret = _load_secret_json(principal["secret_arn"])
+    expected_token = secret.get("bearerToken")
+    if not expected_token or not hmac.compare_digest(str(expected_token), token_secret):
+        return None
+
+    return principal
+
+
+def _build_context(principal, role):
+    allowed_client_ids = role.get("allowed_client_ids", [])
+    return {
+        "isAuthorized": True,
+        "context": {
+            "principalId": principal["principal_id"],
+            "roleName": principal["role_name"],
+            "authType": principal["auth_type"],
+            "allowedClientIds": ",".join(allowed_client_ids),
+        },
+    }
+
+
+def lambda_handler(event, _context):
+    authorization = _get_header(event, "authorization")
+    if not authorization:
+        return _deny()
+
+    try:
+        scheme, token = authorization.split(" ", 1)
+    except ValueError:
+        return _deny()
+    token = token.strip()
+
+    if scheme.lower() == "basic":
+        principal = _authenticate_basic(token)
+    elif scheme.lower() == "bearer":
+        principal = _authenticate_bearer(token)
+    else:
+        principal = None
+
+    if principal is None:
+        return _deny()
+
+    role = _get_role(principal["role_name"])
+    if role is None:
+        return _deny()
+
+    return _build_context(principal, role)

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -54,8 +54,9 @@ def _authenticate_basic(token):
     if principal is None or not principal.get("enabled", True):
         return None
 
-    secret = _load_secret_json(principal["secret_arn"])
-    if not hmac.compare_digest(password, secret["password"]):
+    secret = _load_secret_json(principal.get("secret_arn", ""))
+    expected_password = secret.get("password")
+    if not expected_password or expected_password == "replace-me" or not hmac.compare_digest(password, str(expected_password)):
         return None
 
     return principal

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -71,9 +71,9 @@ def _authenticate_bearer(token):
     if principal is None or not principal.get("enabled", True):
         return None
 
-    secret = _load_secret_json(principal["secret_arn"])
+    secret = _load_secret_json(principal.get("secret_arn", ""))
     expected_token = secret.get("bearerToken")
-    if not expected_token or not hmac.compare_digest(str(expected_token), token_secret):
+    if not expected_token or expected_token == "replace-me" or not hmac.compare_digest(str(expected_token), token_secret):
         return None
 
     return principal

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -80,14 +80,15 @@ def _authenticate_bearer(token):
 
 
 def _build_context(principal, role):
-    allowed_client_ids = role.get("allowed_client_ids", [])
+    allowed_client_ids = role.get("allowed_client_ids") or []
+    allowed_client_ids_csv = ",".join(str(value) for value in allowed_client_ids if value is not None)
     return {
         "isAuthorized": True,
         "context": {
             "principalId": principal["principal_id"],
             "roleName": principal["role_name"],
             "authType": principal["auth_type"],
-            "allowedClientIds": ",".join(allowed_client_ids),
+            "allowedClientIds": allowed_client_ids_csv,
         },
     }
 

--- a/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py
@@ -36,9 +36,9 @@ def _get_role(role_name):
     return table.get_item(Key={"role_name": role_name}).get("Item")
 
 
-def _load_secret_json(secret_arn):
+def _load_secret_json(secret_id):
     try:
-        response = SECRETS_MANAGER.get_secret_value(SecretId=secret_arn)
+        response = SECRETS_MANAGER.get_secret_value(SecretId=secret_id)
         secret_string = response.get("SecretString") or ""
         return json.loads(secret_string) if secret_string else {}
     except Exception:
@@ -54,7 +54,7 @@ def _authenticate_basic(token):
     if principal is None or not principal.get("enabled", True):
         return None
 
-    secret = _load_secret_json(principal.get("secret_arn", ""))
+    secret = _load_secret_json(principal.get("secret_name", ""))
     expected_password = secret.get("password")
     if not expected_password or expected_password == "replace-me" or not hmac.compare_digest(password, str(expected_password)):
         return None
@@ -71,7 +71,7 @@ def _authenticate_bearer(token):
     if principal is None or not principal.get("enabled", True):
         return None
 
-    secret = _load_secret_json(principal.get("secret_arn", ""))
+    secret = _load_secret_json(principal.get("secret_name", ""))
     expected_token = secret.get("bearerToken")
     if not expected_token or expected_token == "replace-me" or not hmac.compare_digest(str(expected_token), token_secret):
         return None

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -58,6 +58,21 @@ def _build_object_key(prefix, file_name):
     return posixpath.join(prefix.strip("/"), today_prefix, generated_name)
 
 
+def _authorizer_context(event):
+    authorizer = event.get("requestContext", {}).get("authorizer", {})
+    if isinstance(authorizer.get("lambda"), dict):
+        return authorizer["lambda"]
+    return authorizer
+
+
+def _allowed_client_ids(event):
+    context = _authorizer_context(event)
+    raw_value = context.get("allowedClientIds", "")
+    if not raw_value:
+        return set()
+    return {value for value in raw_value.split(",") if value}
+
+
 def lambda_handler(event, _context):
     try:
         request = _load_body(event)
@@ -69,6 +84,10 @@ def lambda_handler(event, _context):
 
     if not client_id or not file_name:
         return _response(400, {"message": "clientId and fileName are required"})
+
+    allowed_client_ids = _allowed_client_ids(event)
+    if not allowed_client_ids or ("*" not in allowed_client_ids and client_id not in allowed_client_ids):
+        return _response(403, {"message": f"Not authorised to request tickets for clientId '{client_id}'"})
 
     table = DYNAMODB.Table(TRANSFER_CLIENTS_TABLE)
     record = table.get_item(Key={"client_id": client_id}).get("Item")

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -1,7 +1,11 @@
 locals {
-  api_configuration    = try(local.application_data.accounts[local.environment].api_configuration, {})
-  cors_allowed_origins = try(local.api_configuration.cors_allowed_origins, [])
-  transfer_clients     = try(local.application_data.accounts[local.environment].transfer_clients, {})
+  api_configuration      = try(local.application_data.accounts[local.environment].api_configuration, {})
+  auth_configuration     = try(local.application_data.accounts[local.environment].auth_configuration, {})
+  auth_roles             = try(local.auth_configuration.roles, {})
+  auth_users             = try(local.auth_configuration.users, {})
+  auth_system_principals = try(local.auth_configuration.system_principals, {})
+  cors_allowed_origins   = try(local.api_configuration.cors_allowed_origins, [])
+  transfer_clients       = try(local.application_data.accounts[local.environment].transfer_clients, {})
 
   mft_upload_bucket_parameter_prefix = "/${local.application_name}/managed-file-transfer/${local.environment}/upload-bucket"
 }

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket-basic.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/get-transfer-ticket-basic.bru
@@ -1,21 +1,22 @@
 meta {
-  name: Get Transfer Ticket (Bearer)
+  name: Get Transfer Ticket (Basic)
   type: http
-  seq: 1
+  seq: 3
 }
 
 post {
   url: {{api_endpoint}}/transfer-tickets
   body: json
-  auth: bearer
+  auth: basic
 }
 
 headers {
   Content-Type: application/json
 }
 
-auth:bearer {
-  token: {{bearer_token}}
+auth:basic {
+  username: {{api_username}}
+  password: {{api_password}}
 }
 
 body:json {
@@ -31,7 +32,7 @@ body:json {
 
 script:post-response {
   const ticket = res.getBody();
-  
+
   bru.setVar("upload_url", ticket["upload"]["url"]);
   bru.setVar("sse", ticket["upload"]["headers"]["x-amz-server-side-encryption"]);
   bru.setVar("kms_key", ticket["upload"]["headers"]["x-amz-server-side-encryption-aws-kms-key-id"]);

--- a/terraform/environments/integration-hub/api-platform/openapi.yaml
+++ b/terraform/environments/integration-hub/api-platform/openapi.yaml
@@ -1,0 +1,167 @@
+openapi: 3.0.3
+info:
+  title: Integration Hub Managed File Transfer API
+  version: 1.0.0
+  description: |
+    Thin API layer for Managed File Transfer uploads.
+
+    The API supports:
+    - Basic authentication for user-driven HTTPS upload flows
+    - Bearer token authentication for system-to-system integrations
+
+    Authorisation is role-based. Each authenticated principal is mapped to one
+    or more permitted `clientId` values.
+servers:
+  - url: https://{apiHost}
+    variables:
+      apiHost:
+        default: example.execute-api.eu-west-2.amazonaws.com
+security:
+  - basicAuth: []
+  - bearerAuth: []
+paths:
+  /transfer-tickets:
+    post:
+      summary: Create an upload transfer ticket
+      description: |
+        Issues a short-lived pre-signed S3 PUT URL for an authorised transfer client.
+
+        For Basic authentication, provide the configured username and password.
+
+        For Bearer authentication, provide a token in the form:
+        `<tokenId>.<bearerToken>`
+      operationId: createTransferTicket
+      security:
+        - basicAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferTicketRequest'
+            examples:
+              csvUpload:
+                value:
+                  clientId: products-poc
+                  fileName: example-upload.csv
+                  contentType: text/csv
+                  sizeBytes: 12345
+                  requestedExpirySeconds: 900
+                  contentMd5: CY9rzUYh03PK3k6DJie09g==
+      responses:
+        '200':
+          description: Transfer ticket created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferTicketResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed
+        '403':
+          description: Authenticated caller is not authorised for the requested client
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown transfer client
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: Basic auth using a Secrets Manager-managed username/password.
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque token in the form tokenId.bearerToken
+      description: Bearer token using a Secrets Manager-managed token pair.
+  schemas:
+    TransferTicketRequest:
+      type: object
+      required:
+        - clientId
+        - fileName
+      properties:
+        clientId:
+          type: string
+          example: products-poc
+        fileName:
+          type: string
+          example: example-upload.csv
+        contentType:
+          type: string
+          example: text/csv
+        sizeBytes:
+          type: integer
+          format: int64
+          example: 12345
+        requestedExpirySeconds:
+          type: integer
+          example: 900
+        contentMd5:
+          type: string
+          description: Base64-encoded MD5 digest of the upload content
+          example: CY9rzUYh03PK3k6DJie09g==
+    TransferTicketResponse:
+      type: object
+      required:
+        - transferTicket
+        - clientId
+        - upload
+        - object
+      properties:
+        transferTicket:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        upload:
+          type: object
+          required:
+            - method
+            - url
+            - headers
+            - expiresInSeconds
+          properties:
+            method:
+              type: string
+              example: PUT
+            url:
+              type: string
+              format: uri
+            headers:
+              type: object
+              additionalProperties:
+                type: string
+            expiresInSeconds:
+              type: integer
+              example: 900
+        object:
+          type: object
+          required:
+            - bucket
+            - key
+          properties:
+            bucket:
+              type: string
+            key:
+              type: string
+    ErrorResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string

--- a/terraform/environments/integration-hub/api-platform/outputs.tf
+++ b/terraform/environments/integration-hub/api-platform/outputs.tf
@@ -7,3 +7,27 @@ output "transfer_clients_table_name" {
   description = "DynamoDB table containing upload client configuration"
   value       = module.dynamodb_transfer_clients.dynamodb_table_id
 }
+
+output "auth_roles_table_name" {
+  description = "DynamoDB table containing API authorisation roles"
+  value       = module.dynamodb_auth_roles.dynamodb_table_id
+}
+
+output "auth_principals_table_name" {
+  description = "DynamoDB table containing API authentication principals"
+  value       = module.dynamodb_auth_principals.dynamodb_table_id
+}
+
+output "user_auth_secret_names" {
+  description = "HTTPS upload credential secret names keyed by username"
+  value = {
+    for username, secret in module.api_user_credentials_secret : username => secret.secret_name
+  }
+}
+
+output "system_auth_secret_names" {
+  description = "Bearer token secret names keyed by system principal"
+  value = {
+    for principal, secret in module.api_system_bearer_token_secret : principal => secret.secret_name
+  }
+}


### PR DESCRIPTION

**Title**
Add authentication and authorisation for MFT API upload flow

**Description**
This PR protects the Integration Hub Managed File Transfer API by adding authentication and authorisation for both user-driven HTTPS uploads and system-to-system API integrations.

It builds on the existing `POST /transfer-tickets` flow and introduces a request authorizer in front of the API so only authenticated and authorised callers can obtain upload tickets.

**What changed**
- Added API Gateway custom request authorizer for `POST /transfer-tickets`
- Added Lambda authorizer to support:
  - Basic authentication for user-driven HTTPS upload flows
  - Bearer token authentication for system-to-system integrations
- Added role-based authorisation so authenticated principals are restricted to permitted `clientId` values
- Added DynamoDB tables/items for:
  - auth principals
  - auth roles
- Added Secrets Manager-backed credential/token model for API auth
- Added OpenAPI/Swagger documentation for the protected API
- Added Bruno examples for both Basic and Bearer authenticated requests
- Added operational bootstrap script to generate live credentials outside Terraform state and write them to Secrets Manager

**Auth model**
API auth model aligns with auth pattern MFT approach:
- Terraform manages infrastructure, principal metadata, role mapping, and secret containers
- Live passwords and bearer token values are not generated in Terraform
- Live secret values are stored in AWS Secrets Manager
- Lambda validates credentials/tokens at runtime
- Terraform ignores later secret value changes to avoid making Terraform state the source of truth for live credentials

**Bootstrap / operations**
A new script is included:
- `scripts/bootstrap-api-credentials.sh`

This script:
- generates a strong password or bearer token outside Terraform state
- writes it to the correct Secrets Manager secret
- prints only the one-time handover value for the operator to share securely with the client

**Why**
This implements the story requirement to add authentication and authorisation to MFT:
- user authentication through a locally managed credential and role mapping for HTTPS upload
- system authentication and authorisation through bearer token for API integration

**Consumer impact**
Clients must now authenticate before calling `POST /transfer-tickets`:
- User flow:
  - `Authorization: Basic ...`
- System flow:
  - `Authorization: Bearer <tokenId>.<bearerToken>`

Authenticated callers are only allowed to request tickets for `clientId` values mapped to their role.

**Files of interest**
- `terraform/environments/integration-hub/api-platform/api-gateway.tf`
- `terraform/environments/integration-hub/api-platform/lambda.tf`
- `terraform/environments/integration-hub/api-platform/dynamo-db.tf`
- `terraform/environments/integration-hub/api-platform/auth.tf`
- `terraform/environments/integration-hub/api-platform/lambda/request-authorizer/lambda_function.py`
- `terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py`
- `terraform/environments/integration-hub/api-platform/openapi.yaml`
- `scripts/bootstrap-api-credentials.sh`
