### PR TITLE
RST-8242: Fixing Wardship WAF upload blocking

### DIFF
--- a/terraform/environments/wardship/waf.tf
+++ b/terraform/environments/wardship/waf.tf
@@ -18,6 +18,13 @@ resource "aws_wafv2_web_acl" "wardship_web_acl" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Wardship WAF config current blocks file uploads over around 8kb. A fix to just monitor and not block is being added.