### PR TITLE
adding tag for public subnet so cluster know where to provision LBs

### DIFF
--- a/terraform/environments/cloud-platform/network/vpc.tf
+++ b/terraform/environments/cloud-platform/network/vpc.tf
@@ -28,7 +28,8 @@ module "cluster_vpc" {
   create_multiple_public_route_tables = true
 
   public_subnet_tags = {
-    SubnetType = "Public"
+    SubnetType                        = "Public"
+    "kubernetes.io/role/elb"          = "1"
   }
 
   private_subnet_tags = {


### PR DESCRIPTION
Following AWS guidance: https://docs.aws.amazon.com/eks/latest/userguide/tag-subnets-auto.html