### PR TITLE
multi part uploads when file size is greater than 5GB

### DIFF
--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -73,7 +73,7 @@ It now protects the API with:
   "multipart": {
     "uploadId": "abc123...",
     "partSizeBytes": 67108864,
-    "totalParts": 1600,
+    "totalParts": 160,
     "maxParts": 10000,
     "expiresInSeconds": 900,
     "initialParts": [

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -15,8 +15,9 @@ It now protects the API with:
 3. The authorizer validates the caller against Secrets Manager credentials or bearer tokens and resolves the caller's role mapping from DynamoDB.
 4. The upload-ticket Lambda reads client upload configuration from DynamoDB.
 5. The upload-ticket Lambda verifies that the authenticated caller is allowed to request a ticket for the requested `clientId`.
-6. The Lambda generates a short-lived S3 pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
-7. The client uploads the file directly to S3 with the returned URL and headers.
+6. For files at or below the single PUT limit, the Lambda generates a short-lived pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
+7. For larger files, the Lambda initiates an S3 multipart upload, persists the upload session, and returns the first batch of pre-signed part URLs plus follow-up API operations for the remaining parts, completion, and abort.
+8. The client uploads directly to S3 and, for multipart flows, completes the upload through the API once all parts have been transferred.
 
 ## Sample request payload
 
@@ -31,7 +32,7 @@ It now protects the API with:
 }
 ```
 
-## Example response shape
+## Example single-upload response shape
 
 ```json
 {
@@ -44,6 +45,7 @@ It now protects the API with:
       "Content-Type": "text/csv",
       "Content-MD5": "CY9rzUYh03PK3k6DJie09g==",
       "x-amz-meta-client-id": "products-poc",
+      "x-amz-meta-declared-size-bytes": "12345",
       "x-amz-meta-original-file-name": "example-upload.csv",
       "x-amz-meta-transfer-ticket": "f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61",
       "x-amz-server-side-encryption": "aws:kms",
@@ -54,6 +56,40 @@ It now protects the API with:
   "object": {
     "bucket": "integration-hub-unscanned-...",
     "key": "products-poc/uploads/2026/06/09/uuid.csv"
+  }
+}
+```
+
+## Example multipart response shape
+
+```json
+{
+  "transferTicket": "f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61",
+  "clientId": "products-poc",
+  "object": {
+    "bucket": "integration-hub-unscanned-...",
+    "key": "products-poc/uploads/2026/06/09/uuid.csv"
+  },
+  "multipart": {
+    "uploadId": "abc123...",
+    "partSizeBytes": 67108864,
+    "totalParts": 1600,
+    "maxParts": 10000,
+    "expiresInSeconds": 900,
+    "initialParts": [
+      {
+        "partNumber": 1,
+        "method": "PUT",
+        "url": "https://...",
+        "headers": {},
+        "expiresInSeconds": 900
+      }
+    ],
+    "operations": {
+      "presignPartsPath": "/transfer-tickets/f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61/parts",
+      "completePath": "/transfer-tickets/f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61/complete",
+      "abortPath": "/transfer-tickets/f2e7fd50-f0c5-4f8c-b0ad-f27c0c4d2b61"
+    }
   }
 }
 ```
@@ -164,6 +200,16 @@ terraform output system_auth_secret_names
 scripts/bootstrap-api-credentials.sh system --secret-id integration-hub-api-platform-development-system-products-poc-api
 ```
 
+## Upload selection
+
+The client always provides `sizeBytes`. The API uses that declared size to:
+
+- reject requests above the configured 100 GB maximum for the client
+- return a single pre-signed `PUT` upload for files up to the S3 single-request limit
+- return a multipart upload session for files above the single-request limit
+
+The declared size is stored as multipart session state and written into the uploaded object's S3 metadata for traceability.
+
 ## Example API call with Basic auth
 
 Replace `<api-endpoint>` with the `transfer_ticket_api_endpoint` Terraform output after apply.
@@ -196,6 +242,41 @@ curl -X POST "https://<api-endpoint>/transfer-tickets" \
     "requestedExpirySeconds": 900,
     "contentMd5": "CY9rzUYh03PK3k6DJie09g=="
   }'
+```
+
+## Multipart follow-up calls
+
+Request more part URLs:
+
+```bash
+curl -X POST "https://<api-endpoint>/transfer-tickets/<transfer-ticket>/parts" \
+  -H "authorization: Bearer <tokenId>.<token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "partNumberStart": 11,
+    "partNumberEnd": 20
+  }'
+```
+
+Complete the multipart upload after collecting the `ETag` response header from each uploaded part:
+
+```bash
+curl -X POST "https://<api-endpoint>/transfer-tickets/<transfer-ticket>/complete" \
+  -H "authorization: Bearer <tokenId>.<token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "parts": [
+      { "partNumber": 1, "eTag": "\"etag-for-part-1\"" },
+      { "partNumber": 2, "eTag": "\"etag-for-part-2\"" }
+    ]
+  }'
+```
+
+Abort a multipart upload if the transfer is abandoned:
+
+```bash
+curl -X DELETE "https://<api-endpoint>/transfer-tickets/<transfer-ticket>" \
+  -H "authorization: Bearer <tokenId>.<token>"
 ```
 
 ## OpenAPI

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -13,7 +13,7 @@ resource "aws_apigatewayv2_api" "upload_ticket" {
 
     content {
       allow_headers = ["authorization", "content-md5", "content-type"]
-      allow_methods = ["OPTIONS", "POST"]
+      allow_methods = ["DELETE", "OPTIONS", "POST"]
       allow_origins = local.cors_allowed_origins
       expose_headers = [
         "content-type",
@@ -46,6 +46,30 @@ resource "aws_apigatewayv2_authorizer" "mft_request" {
 resource "aws_apigatewayv2_route" "transfer_tickets" {
   api_id             = aws_apigatewayv2_api.upload_ticket.id
   route_key          = "POST /transfer-tickets"
+  target             = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id
+}
+
+resource "aws_apigatewayv2_route" "transfer_ticket_parts" {
+  api_id             = aws_apigatewayv2_api.upload_ticket.id
+  route_key          = "POST /transfer-tickets/{transferTicket}/parts"
+  target             = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id
+}
+
+resource "aws_apigatewayv2_route" "transfer_ticket_complete" {
+  api_id             = aws_apigatewayv2_api.upload_ticket.id
+  route_key          = "POST /transfer-tickets/{transferTicket}/complete"
+  target             = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id
+}
+
+resource "aws_apigatewayv2_route" "transfer_ticket_abort" {
+  api_id             = aws_apigatewayv2_api.upload_ticket.id
+  route_key          = "DELETE /transfer-tickets/{transferTicket}"
   target             = "integrations/${aws_apigatewayv2_integration.upload_ticket.id}"
   authorization_type = "CUSTOM"
   authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id

--- a/terraform/environments/integration-hub/api-platform/application_variables.json
+++ b/terraform/environments/integration-hub/api-platform/application_variables.json
@@ -4,7 +4,13 @@
       "api_configuration": {
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
-        "presigned_url_expiry_seconds": 900
+        "presigned_url_expiry_seconds": 900,
+        "multipart_upload": {
+          "single_put_limit_bytes": 5368709120,
+          "multipart_default_part_size_bytes": 67108864,
+          "multipart_max_parts": 10000,
+          "multipart_initial_presign_parts": 10
+        }
       },
       "auth_configuration": {
         "roles": {
@@ -39,7 +45,13 @@
       "api_configuration": {
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
-        "presigned_url_expiry_seconds": 900
+        "presigned_url_expiry_seconds": 900,
+        "multipart_upload": {
+          "single_put_limit_bytes": 5368709120,
+          "multipart_default_part_size_bytes": 67108864,
+          "multipart_max_parts": 10000,
+          "multipart_initial_presign_parts": 10
+        }
       },
       "auth_configuration": {
         "roles": {},
@@ -52,7 +64,13 @@
       "api_configuration": {
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
-        "presigned_url_expiry_seconds": 900
+        "presigned_url_expiry_seconds": 900,
+        "multipart_upload": {
+          "single_put_limit_bytes": 5368709120,
+          "multipart_default_part_size_bytes": 67108864,
+          "multipart_max_parts": 10000,
+          "multipart_initial_presign_parts": 10
+        }
       },
       "auth_configuration": {
         "roles": {},
@@ -65,7 +83,13 @@
       "api_configuration": {
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
-        "presigned_url_expiry_seconds": 900
+        "presigned_url_expiry_seconds": 900,
+        "multipart_upload": {
+          "single_put_limit_bytes": 5368709120,
+          "multipart_default_part_size_bytes": 67108864,
+          "multipart_max_parts": 10000,
+          "multipart_initial_presign_parts": 10
+        }
       },
       "auth_configuration": {
         "roles": {},

--- a/terraform/environments/integration-hub/api-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-platform/dynamo-db.tf
@@ -73,6 +73,34 @@ module "dynamodb_auth_principals" {
   tags = local.tags
 }
 
+module "dynamodb_multipart_uploads" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-multipart-uploads"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "transfer_ticket"
+
+  attributes = [
+    {
+      name = "transfer_ticket"
+      type = "S"
+    }
+  ]
+
+  table_class = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  ttl_enabled        = true
+  ttl_attribute_name = "expires_at_epoch"
+
+  tags = local.tags
+}
+
 resource "aws_dynamodb_table_item" "transfer_client" {
   for_each = local.transfer_clients
 

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -10,11 +10,16 @@ module "lambda_upload_ticket" {
   trigger_on_package_timestamp = false
 
   environment_variables = {
-    MAX_PRESIGNED_URL_EXPIRY_SECONDS = tostring(try(local.api_configuration.max_presigned_url_expiry_seconds, 3600))
-    PRESIGNED_URL_EXPIRY_SECONDS     = tostring(try(local.api_configuration.presigned_url_expiry_seconds, 900))
-    TRANSFER_CLIENTS_TABLE           = module.dynamodb_transfer_clients.dynamodb_table_id
-    UPLOAD_BUCKET_KMS_KEY_ARN        = data.aws_ssm_parameter.mft_upload_bucket_kms_key_arn.value
-    UPLOAD_BUCKET_NAME               = data.aws_ssm_parameter.mft_upload_bucket_name.value
+    MAX_PRESIGNED_URL_EXPIRY_SECONDS  = tostring(try(local.api_configuration.max_presigned_url_expiry_seconds, 3600))
+    MULTIPART_DEFAULT_PART_SIZE_BYTES = tostring(local.multipart_configuration.multipart_default_part_size_bytes)
+    MULTIPART_INITIAL_PRESIGN_PARTS   = tostring(local.multipart_configuration.multipart_initial_presign_parts)
+    MULTIPART_MAX_PARTS               = tostring(local.multipart_configuration.multipart_max_parts)
+    MULTIPART_SESSIONS_TABLE          = module.dynamodb_multipart_uploads.dynamodb_table_id
+    PRESIGNED_URL_EXPIRY_SECONDS      = tostring(try(local.api_configuration.presigned_url_expiry_seconds, 900))
+    SINGLE_PUT_LIMIT_BYTES            = tostring(local.multipart_configuration.single_put_limit_bytes)
+    TRANSFER_CLIENTS_TABLE            = module.dynamodb_transfer_clients.dynamodb_table_id
+    UPLOAD_BUCKET_KMS_KEY_ARN         = data.aws_ssm_parameter.mft_upload_bucket_kms_key_arn.value
+    UPLOAD_BUCKET_NAME                = data.aws_ssm_parameter.mft_upload_bucket_name.value
   }
 
   attach_policy_statements = true
@@ -28,9 +33,23 @@ module "lambda_upload_ticket" {
         module.dynamodb_transfer_clients.dynamodb_table_arn,
       ]
     }
+    multipart_session_table_access = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+      ]
+      resources = [
+        module.dynamodb_multipart_uploads.dynamodb_table_arn,
+      ]
+    }
     upload_bucket_write = {
       effect = "Allow"
       actions = [
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts",
         "s3:PutObject",
       ]
       resources = [

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -59,6 +59,7 @@ module "lambda_upload_ticket" {
     upload_bucket_kms_access = {
       effect = "Allow"
       actions = [
+        "kms:Decrypt",
         "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey*",

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -493,6 +493,10 @@ def _load_active_session(transfer_ticket, allowed_client_ids):
     if session is None:
         return None, _response(404, {"message": f"Unknown transfer ticket '{transfer_ticket}'"})
 
+    expires_at_epoch = session.get("expires_at_epoch")
+    if expires_at_epoch is not None and int(expires_at_epoch) <= int(datetime.now(timezone.utc).timestamp()):
+        return None, _response(409, {"message": f"Transfer ticket '{transfer_ticket}' has expired"})
+
     access_error = _validate_client_access(session["client_id"], allowed_client_ids)
     if access_error:
         return None, access_error

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -1,10 +1,11 @@
 import base64
 import json
+import math
 import os
 import posixpath
 import re
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import boto3
@@ -14,10 +15,18 @@ S3_CLIENT = boto3.client("s3")
 DYNAMODB = boto3.resource("dynamodb")
 
 TRANSFER_CLIENTS_TABLE = os.environ["TRANSFER_CLIENTS_TABLE"]
+MULTIPART_SESSIONS_TABLE = os.environ["MULTIPART_SESSIONS_TABLE"]
 UPLOAD_BUCKET_NAME = os.environ["UPLOAD_BUCKET_NAME"]
 UPLOAD_BUCKET_KMS_KEY_ARN = os.environ["UPLOAD_BUCKET_KMS_KEY_ARN"]
 DEFAULT_EXPIRY_SECONDS = int(os.environ["PRESIGNED_URL_EXPIRY_SECONDS"])
 MAX_EXPIRY_SECONDS = int(os.environ["MAX_PRESIGNED_URL_EXPIRY_SECONDS"])
+SINGLE_PUT_LIMIT_BYTES = int(os.environ["SINGLE_PUT_LIMIT_BYTES"])
+MULTIPART_DEFAULT_PART_SIZE_BYTES = int(os.environ["MULTIPART_DEFAULT_PART_SIZE_BYTES"])
+MULTIPART_INITIAL_PRESIGN_PARTS = int(os.environ["MULTIPART_INITIAL_PRESIGN_PARTS"])
+MULTIPART_MAX_PARTS = int(os.environ["MULTIPART_MAX_PARTS"])
+
+MIN_MULTIPART_PART_SIZE_BYTES = 5 * 1024 * 1024
+MULTIPART_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
 def _response(status_code, body):
@@ -53,7 +62,7 @@ def _normalise_extension(file_name):
 
 
 def _build_object_key(prefix, file_name):
-    today_prefix = datetime.now(UTC).strftime("%Y/%m/%d")
+    today_prefix = datetime.now(timezone.utc).strftime("%Y/%m/%d")
     generated_name = f"{uuid.uuid4()}{_normalise_extension(file_name)}"
     return posixpath.join(prefix.strip("/"), today_prefix, generated_name)
 
@@ -65,6 +74,15 @@ def _authorizer_context(event):
     return authorizer
 
 
+def _principal_context(event):
+    context = _authorizer_context(event)
+    return {
+        "principal_id": context.get("principalId", ""),
+        "role_name": context.get("roleName", ""),
+        "auth_type": context.get("authType", ""),
+    }
+
+
 def _allowed_client_ids(event):
     context = _authorizer_context(event)
     raw_value = context.get("allowedClientIds", "")
@@ -73,32 +91,84 @@ def _allowed_client_ids(event):
     return {value for value in raw_value.split(",") if value}
 
 
-def lambda_handler(event, _context):
-    try:
-        request = _load_body(event)
-    except (ValueError, json.JSONDecodeError) as exc:
-        return _response(400, {"message": str(exc)})
-
-    client_id = request.get("clientId")
-    file_name = request.get("fileName")
-
-    if not client_id or not file_name:
-        return _response(400, {"message": "clientId and fileName are required"})
-
-    allowed_client_ids = _allowed_client_ids(event)
-    if not allowed_client_ids or ("*" not in allowed_client_ids and client_id not in allowed_client_ids):
-        return _response(403, {"message": f"Not authorised to request tickets for clientId '{client_id}'"})
-
+def _get_transfer_client(client_id):
     table = DYNAMODB.Table(TRANSFER_CLIENTS_TABLE)
-    record = table.get_item(Key={"client_id": client_id}).get("Item")
+    return table.get_item(Key={"client_id": client_id}).get("Item")
 
+
+def _get_multipart_session(transfer_ticket):
+    table = DYNAMODB.Table(MULTIPART_SESSIONS_TABLE)
+    return table.get_item(Key={"transfer_ticket": transfer_ticket}).get("Item")
+
+
+def _update_multipart_session(transfer_ticket, status, extra_attributes=None):
+    table = DYNAMODB.Table(MULTIPART_SESSIONS_TABLE)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    extra_attributes = extra_attributes or {}
+    expression_names = {"#status": "status", "#updated_at": "updated_at"}
+    expression_values = {
+        ":status": status,
+        ":updated_at": now_iso,
+    }
+    update_terms = ["#status = :status", "#updated_at = :updated_at"]
+
+    for key, value in extra_attributes.items():
+        name_key = f"#attr_{key}"
+        value_key = f":attr_{key}"
+        expression_names[name_key] = key
+        expression_values[value_key] = value
+        update_terms.append(f"{name_key} = {value_key}")
+
+    table.update_item(
+        Key={"transfer_ticket": transfer_ticket},
+        UpdateExpression="SET " + ", ".join(update_terms),
+        ExpressionAttributeNames=expression_names,
+        ExpressionAttributeValues=expression_values,
+    )
+
+
+def _validate_client_access(client_id, allowed_client_ids):
+    if not allowed_client_ids or ("*" not in allowed_client_ids and client_id not in allowed_client_ids):
+        return _response(403, {"message": f"Not authorised to access clientId '{client_id}'"})
+    return None
+
+
+def _load_and_validate_client(client_id, allowed_client_ids):
+    access_error = _validate_client_access(client_id, allowed_client_ids)
+    if access_error:
+        return None, access_error
+
+    record = _get_transfer_client(client_id)
     if record is None:
-        return _response(404, {"message": f"Unknown clientId '{client_id}'"})
+        return None, _response(404, {"message": f"Unknown clientId '{client_id}'"})
 
     if not record.get("enabled", True):
-        return _response(403, {"message": f"Client '{client_id}' is disabled"})
+        return None, _response(403, {"message": f"Client '{client_id}' is disabled"})
 
-    content_type = request.get("contentType")
+    return record, None
+
+
+def _parse_optional_int(request, field_name):
+    value = request.get(field_name)
+    if value is None:
+        return None, None
+
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, _response(400, {"message": f"{field_name} must be an integer"})
+
+
+def _resolve_expiry_seconds(request):
+    try:
+        requested_expiry_seconds = int(request.get("requestedExpirySeconds", DEFAULT_EXPIRY_SECONDS))
+    except (TypeError, ValueError):
+        return None, _response(400, {"message": "requestedExpirySeconds must be an integer"})
+
+    return max(1, min(requested_expiry_seconds, MAX_EXPIRY_SECONDS)), None
+
+
+def _validate_content_type(content_type, record):
     allowed_content_types = record.get("allowed_content_types", [])
     if allowed_content_types and content_type not in allowed_content_types:
         return _response(
@@ -108,15 +178,17 @@ def lambda_handler(event, _context):
                 "allowedContentTypes": allowed_content_types,
             },
         )
+    return None
 
-    size_bytes = request.get("sizeBytes")
-    try:
-        size_bytes_int = int(size_bytes) if size_bytes is not None else None
-    except (TypeError, ValueError):
-        return _response(400, {"message": "sizeBytes must be an integer"})
 
-    max_upload_size_bytes = int(record.get("max_upload_size_bytes", 0))
-    if size_bytes_int is not None and max_upload_size_bytes and size_bytes_int > max_upload_size_bytes:
+def _validate_file_size(size_bytes, max_upload_size_bytes):
+    if size_bytes is None:
+        return _response(400, {"message": "sizeBytes is required"})
+
+    if size_bytes < 0:
+        return _response(400, {"message": "sizeBytes must be greater than or equal to 0"})
+
+    if max_upload_size_bytes and size_bytes > max_upload_size_bytes:
         return _response(
             400,
             {
@@ -124,16 +196,44 @@ def lambda_handler(event, _context):
                 "maxUploadSizeBytes": max_upload_size_bytes,
             },
         )
+    return None
 
-    try:
-        requested_expiry_seconds = int(
-            request.get("requestedExpirySeconds", DEFAULT_EXPIRY_SECONDS)
+
+def _select_upload_mode(size_bytes):
+    return "multipart" if size_bytes > SINGLE_PUT_LIMIT_BYTES else "single"
+
+
+def _round_up(value, increment):
+    return int(math.ceil(value / increment) * increment)
+
+
+def _resolve_part_size_bytes(size_bytes):
+    required_part_size = max(
+        MULTIPART_DEFAULT_PART_SIZE_BYTES,
+        MIN_MULTIPART_PART_SIZE_BYTES,
+        int(math.ceil(size_bytes / MULTIPART_MAX_PARTS)),
+    )
+    part_size_bytes = _round_up(required_part_size, MIN_MULTIPART_PART_SIZE_BYTES)
+    total_parts = int(math.ceil(size_bytes / part_size_bytes))
+
+    if total_parts > MULTIPART_MAX_PARTS:
+        return None, _response(
+            400,
+            {
+                "message": "Requested file size exceeds multipart part limits",
+                "multipartMaxParts": MULTIPART_MAX_PARTS,
+            },
         )
-    except (TypeError, ValueError):
-        return _response(400, {"message": "requestedExpirySeconds must be an integer"})
-    expiry_seconds = max(1, min(requested_expiry_seconds, MAX_EXPIRY_SECONDS))
+
+    return part_size_bytes, None
+
+
+def _generate_single_upload(record, request, expiry_seconds):
+    file_name = request["fileName"]
+    client_id = request["clientId"]
     transfer_ticket = str(uuid.uuid4())
     object_key = _build_object_key(record["key_prefix"], file_name)
+    content_type = request.get("contentType")
     content_md5 = request.get("contentMd5")
 
     put_object_params = {
@@ -141,6 +241,7 @@ def lambda_handler(event, _context):
         "Key": object_key,
         "Metadata": {
             "client-id": client_id,
+            "declared-size-bytes": str(request["sizeBytes"]),
             "original-file-name": Path(file_name).name,
             "transfer-ticket": transfer_ticket,
         },
@@ -151,6 +252,7 @@ def lambda_handler(event, _context):
         "x-amz-server-side-encryption": "aws:kms",
         "x-amz-server-side-encryption-aws-kms-key-id": UPLOAD_BUCKET_KMS_KEY_ARN,
         "x-amz-meta-client-id": client_id,
+        "x-amz-meta-declared-size-bytes": str(request["sizeBytes"]),
         "x-amz-meta-original-file-name": Path(file_name).name,
         "x-amz-meta-transfer-ticket": transfer_ticket,
     }
@@ -187,3 +289,426 @@ def lambda_handler(event, _context):
             },
         },
     )
+
+
+def _build_session_item(request, principal, transfer_ticket, upload_id, object_key, expiry_seconds, part_size_bytes, total_parts):
+    now = datetime.now(timezone.utc)
+    item = {
+        "transfer_ticket": transfer_ticket,
+        "status": "initiated",
+        "client_id": request["clientId"],
+        "file_name": Path(request["fileName"]).name,
+        "bucket": UPLOAD_BUCKET_NAME,
+        "object_key": object_key,
+        "upload_id": upload_id,
+        "principal_id": principal["principal_id"],
+        "role_name": principal["role_name"],
+        "auth_type": principal["auth_type"],
+        "declared_size_bytes": request["sizeBytes"],
+        "expires_in_seconds": expiry_seconds,
+        "part_size_bytes": part_size_bytes,
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+        "expires_at_epoch": int(now.timestamp()) + MULTIPART_SESSION_TTL_SECONDS,
+    }
+
+    if request.get("contentType"):
+        item["content_type"] = request["contentType"]
+    if total_parts is not None:
+        item["total_parts"] = total_parts
+    return item
+
+
+def _build_multipart_part_presign(transfer_ticket, upload_id, object_key, part_number, expiry_seconds):
+    presigned_url = S3_CLIENT.generate_presigned_url(
+        ClientMethod="upload_part",
+        Params={
+            "Bucket": UPLOAD_BUCKET_NAME,
+            "Key": object_key,
+            "PartNumber": part_number,
+            "UploadId": upload_id,
+        },
+        ExpiresIn=expiry_seconds,
+        HttpMethod="PUT",
+    )
+    return {
+        "partNumber": part_number,
+        "method": "PUT",
+        "url": presigned_url,
+        "headers": {},
+        "expiresInSeconds": expiry_seconds,
+    }
+
+
+def _persist_multipart_session(item):
+    table = DYNAMODB.Table(MULTIPART_SESSIONS_TABLE)
+    table.put_item(Item=item)
+
+
+def _generate_initial_parts(transfer_ticket, upload_id, object_key, expiry_seconds, total_parts):
+    if MULTIPART_INITIAL_PRESIGN_PARTS <= 0:
+        return []
+
+    if total_parts is None:
+        upper_bound = MULTIPART_INITIAL_PRESIGN_PARTS
+    else:
+        upper_bound = min(total_parts, MULTIPART_INITIAL_PRESIGN_PARTS)
+
+    return [
+        _build_multipart_part_presign(transfer_ticket, upload_id, object_key, part_number, expiry_seconds)
+        for part_number in range(1, upper_bound + 1)
+    ]
+
+
+def _generate_multipart_upload(record, request, principal, expiry_seconds, size_bytes):
+    if request.get("contentMd5"):
+        return _response(
+            400,
+            {"message": "contentMd5 is only supported for single-part uploads"},
+        )
+
+    part_size_bytes, error_response = _resolve_part_size_bytes(size_bytes)
+    if error_response:
+        return error_response
+
+    total_parts = int(math.ceil(size_bytes / part_size_bytes)) if size_bytes else None
+    transfer_ticket = str(uuid.uuid4())
+    object_key = _build_object_key(record["key_prefix"], request["fileName"])
+
+    create_request = {
+        "Bucket": UPLOAD_BUCKET_NAME,
+        "Key": object_key,
+        "Metadata": {
+            "client-id": request["clientId"],
+            "declared-size-bytes": str(request["sizeBytes"]),
+            "original-file-name": Path(request["fileName"]).name,
+            "transfer-ticket": transfer_ticket,
+        },
+        "ServerSideEncryption": "aws:kms",
+        "SSEKMSKeyId": UPLOAD_BUCKET_KMS_KEY_ARN,
+    }
+    if request.get("contentType"):
+        create_request["ContentType"] = request["contentType"]
+
+    multipart_response = S3_CLIENT.create_multipart_upload(**create_request)
+    upload_id = multipart_response["UploadId"]
+
+    session_item = _build_session_item(
+        request=request,
+        principal=principal,
+        transfer_ticket=transfer_ticket,
+        upload_id=upload_id,
+        object_key=object_key,
+        expiry_seconds=expiry_seconds,
+        part_size_bytes=part_size_bytes,
+        total_parts=total_parts,
+    )
+    _persist_multipart_session(session_item)
+
+    return _response(
+        200,
+        {
+            "transferTicket": transfer_ticket,
+            "clientId": request["clientId"],
+            "object": {
+                "bucket": UPLOAD_BUCKET_NAME,
+                "key": object_key,
+            },
+            "multipart": {
+                "uploadId": upload_id,
+                "partSizeBytes": part_size_bytes,
+                "totalParts": total_parts,
+                "maxParts": MULTIPART_MAX_PARTS,
+                "expiresInSeconds": expiry_seconds,
+                "initialParts": _generate_initial_parts(
+                    transfer_ticket=transfer_ticket,
+                    upload_id=upload_id,
+                    object_key=object_key,
+                    expiry_seconds=expiry_seconds,
+                    total_parts=total_parts,
+                ),
+                "operations": {
+                    "presignPartsPath": f"/transfer-tickets/{transfer_ticket}/parts",
+                    "completePath": f"/transfer-tickets/{transfer_ticket}/complete",
+                    "abortPath": f"/transfer-tickets/{transfer_ticket}",
+                },
+            },
+        },
+    )
+
+
+def _normalise_part_numbers(request, session):
+    part_numbers = request.get("partNumbers")
+    part_number_start = request.get("partNumberStart")
+    part_number_end = request.get("partNumberEnd")
+
+    if part_numbers is not None and (part_number_start is not None or part_number_end is not None):
+        return None, _response(400, {"message": "Use either partNumbers or partNumberStart/partNumberEnd"})
+
+    if part_numbers is not None:
+        if not isinstance(part_numbers, list) or not part_numbers:
+            return None, _response(400, {"message": "partNumbers must be a non-empty array"})
+        values = part_numbers
+    else:
+        if part_number_start is None or part_number_end is None:
+            return None, _response(400, {"message": "Provide partNumbers or both partNumberStart and partNumberEnd"})
+        try:
+            start_value = int(part_number_start)
+            end_value = int(part_number_end)
+        except (TypeError, ValueError):
+            return None, _response(400, {"message": "partNumberStart and partNumberEnd must be integers"})
+        if start_value > end_value:
+            return None, _response(400, {"message": "partNumberStart must be less than or equal to partNumberEnd"})
+        values = list(range(start_value, end_value + 1))
+
+    try:
+        normalised = sorted({int(value) for value in values})
+    except (TypeError, ValueError):
+        return None, _response(400, {"message": "Part numbers must be integers"})
+
+    if not normalised:
+        return None, _response(400, {"message": "At least one part number is required"})
+
+    if any(part_number < 1 or part_number > MULTIPART_MAX_PARTS for part_number in normalised):
+        return None, _response(
+            400,
+            {"message": f"Part numbers must be between 1 and {MULTIPART_MAX_PARTS}"},
+        )
+
+    total_parts = session.get("total_parts")
+    if total_parts is not None and any(part_number > int(total_parts) for part_number in normalised):
+        return None, _response(
+            400,
+            {
+                "message": "Requested part number exceeds the number of parts for this upload",
+                "totalParts": int(total_parts),
+            },
+        )
+
+    return normalised, None
+
+
+def _load_active_session(transfer_ticket, allowed_client_ids):
+    session = _get_multipart_session(transfer_ticket)
+    if session is None:
+        return None, _response(404, {"message": f"Unknown transfer ticket '{transfer_ticket}'"})
+
+    access_error = _validate_client_access(session["client_id"], allowed_client_ids)
+    if access_error:
+        return None, access_error
+
+    if session.get("status") != "initiated":
+        return None, _response(
+            409,
+            {
+                "message": f"Transfer ticket '{transfer_ticket}' is not active",
+                "status": session.get("status"),
+            },
+        )
+
+    return session, None
+
+
+def _handle_create_transfer_ticket(event):
+    try:
+        request = _load_body(event)
+    except (ValueError, json.JSONDecodeError) as exc:
+        return _response(400, {"message": str(exc)})
+
+    client_id = request.get("clientId")
+    file_name = request.get("fileName")
+    if not client_id or not file_name:
+        return _response(400, {"message": "clientId and fileName are required"})
+
+    allowed_client_ids = _allowed_client_ids(event)
+    record, error_response = _load_and_validate_client(client_id, allowed_client_ids)
+    if error_response:
+        return error_response
+
+    content_type = request.get("contentType")
+    error_response = _validate_content_type(content_type, record)
+    if error_response:
+        return error_response
+
+    size_bytes, error_response = _parse_optional_int(request, "sizeBytes")
+    if error_response:
+        return error_response
+
+    max_upload_size_bytes = int(record.get("max_upload_size_bytes", 0))
+    error_response = _validate_file_size(size_bytes, max_upload_size_bytes)
+    if error_response:
+        return error_response
+
+    upload_mode = _select_upload_mode(size_bytes)
+
+    expiry_seconds, error_response = _resolve_expiry_seconds(request)
+    if error_response:
+        return error_response
+
+    if upload_mode == "multipart":
+        return _generate_multipart_upload(
+            record=record,
+            request=request,
+            principal=_principal_context(event),
+            expiry_seconds=expiry_seconds,
+            size_bytes=size_bytes,
+        )
+
+    return _generate_single_upload(record=record, request=request, expiry_seconds=expiry_seconds)
+
+
+def _handle_presign_parts(event):
+    transfer_ticket = (event.get("pathParameters") or {}).get("transferTicket")
+    if not transfer_ticket:
+        return _response(400, {"message": "transferTicket path parameter is required"})
+
+    try:
+        request = _load_body(event)
+    except (ValueError, json.JSONDecodeError) as exc:
+        return _response(400, {"message": str(exc)})
+
+    session, error_response = _load_active_session(transfer_ticket, _allowed_client_ids(event))
+    if error_response:
+        return error_response
+
+    part_numbers, error_response = _normalise_part_numbers(request, session)
+    if error_response:
+        return error_response
+
+    parts = [
+        _build_multipart_part_presign(
+            transfer_ticket=transfer_ticket,
+            upload_id=session["upload_id"],
+            object_key=session["object_key"],
+            part_number=part_number,
+            expiry_seconds=int(session["expires_in_seconds"]),
+        )
+        for part_number in part_numbers
+    ]
+
+    return _response(
+        200,
+        {
+            "transferTicket": transfer_ticket,
+            "clientId": session["client_id"],
+            "uploadId": session["upload_id"],
+            "parts": parts,
+        },
+    )
+
+
+def _handle_complete_multipart(event):
+    transfer_ticket = (event.get("pathParameters") or {}).get("transferTicket")
+    if not transfer_ticket:
+        return _response(400, {"message": "transferTicket path parameter is required"})
+
+    try:
+        request = _load_body(event)
+    except (ValueError, json.JSONDecodeError) as exc:
+        return _response(400, {"message": str(exc)})
+
+    session, error_response = _load_active_session(transfer_ticket, _allowed_client_ids(event))
+    if error_response:
+        return error_response
+
+    parts = request.get("parts")
+    if not isinstance(parts, list) or not parts:
+        return _response(400, {"message": "parts must be a non-empty array"})
+
+    normalised_parts = []
+    try:
+        for entry in parts:
+            part_number = int(entry["partNumber"])
+            etag = str(entry["eTag"]).strip()
+            if not etag:
+                raise ValueError("ETag must not be empty")
+            normalised_parts.append({"PartNumber": part_number, "ETag": etag})
+    except (KeyError, TypeError, ValueError) as exc:
+        return _response(400, {"message": f"Invalid multipart completion payload: {exc}"})
+
+    normalised_parts.sort(key=lambda item: item["PartNumber"])
+    if len({item["PartNumber"] for item in normalised_parts}) != len(normalised_parts):
+        return _response(400, {"message": "Duplicate partNumber values are not allowed"})
+
+    if any(item["PartNumber"] < 1 or item["PartNumber"] > MULTIPART_MAX_PARTS for item in normalised_parts):
+        return _response(400, {"message": f"partNumber must be between 1 and {MULTIPART_MAX_PARTS}"})
+
+    complete_response = S3_CLIENT.complete_multipart_upload(
+        Bucket=session["bucket"],
+        Key=session["object_key"],
+        UploadId=session["upload_id"],
+        MultipartUpload={"Parts": normalised_parts},
+    )
+
+    _update_multipart_session(
+        transfer_ticket,
+        "completed",
+        {
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "completed_etag": complete_response.get("ETag", ""),
+        },
+    )
+
+    return _response(
+        200,
+        {
+            "transferTicket": transfer_ticket,
+            "clientId": session["client_id"],
+            "status": "completed",
+            "object": {
+                "bucket": session["bucket"],
+                "key": session["object_key"],
+            },
+            "result": {
+                "eTag": complete_response.get("ETag"),
+                "location": complete_response.get("Location"),
+                "partCount": len(normalised_parts),
+            },
+        },
+    )
+
+
+def _handle_abort_multipart(event):
+    transfer_ticket = (event.get("pathParameters") or {}).get("transferTicket")
+    if not transfer_ticket:
+        return _response(400, {"message": "transferTicket path parameter is required"})
+
+    session, error_response = _load_active_session(transfer_ticket, _allowed_client_ids(event))
+    if error_response:
+        return error_response
+
+    S3_CLIENT.abort_multipart_upload(
+        Bucket=session["bucket"],
+        Key=session["object_key"],
+        UploadId=session["upload_id"],
+    )
+
+    _update_multipart_session(
+        transfer_ticket,
+        "aborted",
+        {"aborted_at": datetime.now(timezone.utc).isoformat()},
+    )
+
+    return _response(
+        200,
+        {
+            "transferTicket": transfer_ticket,
+            "clientId": session["client_id"],
+            "status": "aborted",
+        },
+    )
+
+
+def lambda_handler(event, _context):
+    route_key = event.get("routeKey")
+
+    if route_key == "POST /transfer-tickets":
+        return _handle_create_transfer_ticket(event)
+    if route_key == "POST /transfer-tickets/{transferTicket}/parts":
+        return _handle_presign_parts(event)
+    if route_key == "POST /transfer-tickets/{transferTicket}/complete":
+        return _handle_complete_multipart(event)
+    if route_key == "DELETE /transfer-tickets/{transferTicket}":
+        return _handle_abort_multipart(event)
+
+    return _response(404, {"message": f"Unsupported route '{route_key}'"})

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -9,9 +9,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import boto3
+from botocore.config import Config
 
 
-S3_CLIENT = boto3.client("s3")
+AWS_REGION = os.environ.get("AWS_REGION", "eu-west-2")
+
+S3_CLIENT = boto3.client(
+    "s3",
+    region_name=AWS_REGION,
+    endpoint_url=f"https://s3.{AWS_REGION}.amazonaws.com",
+    config=Config(signature_version="s3v4", s3={"addressing_style": "virtual"}),
+)
 DYNAMODB = boto3.resource("dynamodb")
 
 TRANSFER_CLIENTS_TABLE = os.environ["TRANSFER_CLIENTS_TABLE"]

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -635,9 +635,15 @@ def _handle_complete_multipart(event):
     if len({item["PartNumber"] for item in normalised_parts}) != len(normalised_parts):
         return _response(400, {"message": "Duplicate partNumber values are not allowed"})
 
+    total_parts = session.get("total_parts")
+    if total_parts is not None and any(item["PartNumber"] > int(total_parts) for item in normalised_parts):
+        return _response(
+            400,
+            {"message": "Requested part number exceeds the number of parts for this upload", "totalParts": int(total_parts)},
+        )
+
     if any(item["PartNumber"] < 1 or item["PartNumber"] > MULTIPART_MAX_PARTS for item in normalised_parts):
         return _response(400, {"message": f"partNumber must be between 1 and {MULTIPART_MAX_PARTS}"})
-
     complete_response = S3_CLIENT.complete_multipart_upload(
         Bucket=session["bucket"],
         Key=session["object_key"],

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/lambda_function.py
@@ -124,6 +124,7 @@ def _update_multipart_session(transfer_ticket, status, extra_attributes=None):
         UpdateExpression="SET " + ", ".join(update_terms),
         ExpressionAttributeNames=expression_names,
         ExpressionAttributeValues=expression_values,
+        ConditionExpression="attribute_exists(transfer_ticket)",
     )
 
 

--- a/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/test_lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-upload-ticket/test_lambda_function.py
@@ -1,0 +1,203 @@
+import os
+import json
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("TRANSFER_CLIENTS_TABLE", "transfer-clients")
+os.environ.setdefault("MULTIPART_SESSIONS_TABLE", "multipart-sessions")
+os.environ.setdefault("UPLOAD_BUCKET_NAME", "upload-bucket")
+os.environ.setdefault("UPLOAD_BUCKET_KMS_KEY_ARN", "arn:aws:kms:eu-west-2:111122223333:key/example")
+os.environ.setdefault("PRESIGNED_URL_EXPIRY_SECONDS", "900")
+os.environ.setdefault("MAX_PRESIGNED_URL_EXPIRY_SECONDS", "3600")
+os.environ.setdefault("SINGLE_PUT_LIMIT_BYTES", "5368709120")
+os.environ.setdefault("MULTIPART_DEFAULT_PART_SIZE_BYTES", "67108864")
+os.environ.setdefault("MULTIPART_INITIAL_PRESIGN_PARTS", "10")
+os.environ.setdefault("MULTIPART_MAX_PARTS", "10000")
+
+sys.modules.setdefault(
+    "boto3",
+    SimpleNamespace(
+        client=lambda _service_name: SimpleNamespace(),
+        resource=lambda _service_name: SimpleNamespace(),
+    ),
+)
+
+import lambda_function as handler
+
+
+class FakeTable:
+    def __init__(self, items=None):
+        self.items = items or {}
+
+    def get_item(self, Key):
+        key_name, key_value = next(iter(Key.items()))
+        item = self.items.get(key_value)
+        return {"Item": item} if item is not None else {}
+
+    def put_item(self, Item):
+        self.items[Item["transfer_ticket"]] = Item
+
+    def update_item(self, Key, **_kwargs):
+        transfer_ticket = Key["transfer_ticket"]
+        if transfer_ticket not in self.items:
+            raise KeyError(transfer_ticket)
+
+
+class FakeDynamoResource:
+    def __init__(self, tables):
+        self.tables = tables
+
+    def Table(self, name):
+        return self.tables[name]
+
+
+class FakeS3Client:
+    def __init__(self):
+        self.create_calls = []
+        self.presign_calls = []
+
+    def generate_presigned_url(self, ClientMethod, Params, ExpiresIn, HttpMethod):
+        self.presign_calls.append(
+            {
+                "ClientMethod": ClientMethod,
+                "Params": Params,
+                "ExpiresIn": ExpiresIn,
+                "HttpMethod": HttpMethod,
+            }
+        )
+        if ClientMethod == "upload_part":
+            return f"https://example.test/upload-part/{Params['PartNumber']}"
+        return "https://example.test/upload"
+
+    def create_multipart_upload(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return {"UploadId": "upload-123"}
+
+
+class UploadLambdaTests(unittest.TestCase):
+    def setUp(self):
+        self.transfer_clients = FakeTable(
+            {
+                "products-poc": {
+                    "client_id": "products-poc",
+                    "enabled": True,
+                    "key_prefix": "products-poc/uploads",
+                    "max_upload_size_bytes": 107374182400,
+                    "allowed_content_types": ["text/csv"],
+                }
+            }
+        )
+        self.multipart_sessions = FakeTable()
+        self.fake_dynamo = FakeDynamoResource(
+            {
+                handler.TRANSFER_CLIENTS_TABLE: self.transfer_clients,
+                handler.MULTIPART_SESSIONS_TABLE: self.multipart_sessions,
+            }
+        )
+        self.fake_s3 = FakeS3Client()
+
+    def _event(self, route_key, body, path_parameters=None):
+        return {
+            "routeKey": route_key,
+            "body": json.dumps(body) if body is not None else None,
+            "pathParameters": path_parameters or {},
+            "requestContext": {
+                "authorizer": {
+                    "lambda": {
+                        "allowedClientIds": "products-poc",
+                        "principalId": "test-user",
+                        "roleName": "products-poc-upload",
+                        "authType": "basic",
+                    }
+                }
+            },
+        }
+
+    @patch.object(handler, "DYNAMODB")
+    @patch.object(handler, "S3_CLIENT")
+    @patch.object(handler.uuid, "uuid4", side_effect=["ticket-1", "object-1"])
+    def test_small_file_uses_single_upload(self, _uuid4, patched_s3, patched_dynamo):
+        patched_s3.generate_presigned_url = self.fake_s3.generate_presigned_url
+        patched_dynamo.Table = self.fake_dynamo.Table
+
+        response = handler.lambda_handler(
+            self._event(
+                "POST /transfer-tickets",
+                {
+                    "clientId": "products-poc",
+                    "fileName": "example.csv",
+                    "contentType": "text/csv",
+                    "sizeBytes": 1024,
+                },
+            ),
+            None,
+        )
+
+        body = json.loads(response["body"])
+        self.assertEqual(200, response["statusCode"])
+        self.assertEqual("https://example.test/upload", body["upload"]["url"])
+        self.assertEqual("1024", body["upload"]["headers"]["x-amz-meta-declared-size-bytes"])
+
+    @patch.object(handler, "DYNAMODB")
+    @patch.object(handler, "S3_CLIENT")
+    @patch.object(handler.uuid, "uuid4", side_effect=["ticket-2", "object-2"])
+    def test_large_file_uses_multipart_upload(self, _uuid4, patched_s3, patched_dynamo):
+        patched_s3.generate_presigned_url = self.fake_s3.generate_presigned_url
+        patched_s3.create_multipart_upload = self.fake_s3.create_multipart_upload
+        patched_dynamo.Table = self.fake_dynamo.Table
+
+        response = handler.lambda_handler(
+            self._event(
+                "POST /transfer-tickets",
+                {
+                    "clientId": "products-poc",
+                    "fileName": "example.csv",
+                    "contentType": "text/csv",
+                    "sizeBytes": handler.SINGLE_PUT_LIMIT_BYTES + 1,
+                },
+            ),
+            None,
+        )
+
+        body = json.loads(response["body"])
+        self.assertEqual(200, response["statusCode"])
+        self.assertEqual("upload-123", body["multipart"]["uploadId"])
+        self.assertTrue(body["multipart"]["initialParts"])
+        self.assertIn("ticket-2", self.multipart_sessions.items)
+        self.assertEqual(handler.SINGLE_PUT_LIMIT_BYTES + 1, self.multipart_sessions.items["ticket-2"]["declared_size_bytes"])
+
+    @patch.object(handler, "DYNAMODB")
+    @patch.object(handler, "S3_CLIENT")
+    def test_part_presign_returns_requested_parts(self, patched_s3, patched_dynamo):
+        patched_s3.generate_presigned_url = self.fake_s3.generate_presigned_url
+        patched_dynamo.Table = self.fake_dynamo.Table
+        self.multipart_sessions.items["ticket-3"] = {
+            "transfer_ticket": "ticket-3",
+            "status": "initiated",
+            "client_id": "products-poc",
+            "bucket": "bucket-name",
+            "object_key": "products-poc/uploads/object.csv",
+            "upload_id": "upload-456",
+            "expires_in_seconds": 900,
+            "part_size_bytes": 67108864,
+            "total_parts": 3,
+        }
+
+        response = handler.lambda_handler(
+            self._event(
+                "POST /transfer-tickets/{transferTicket}/parts",
+                {"partNumbers": [1, 3]},
+                {"transferTicket": "ticket-3"},
+            ),
+            None,
+        )
+
+        body = json.loads(response["body"])
+        self.assertEqual(200, response["statusCode"])
+        self.assertEqual([1, 3], [part["partNumber"] for part in body["parts"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -6,6 +6,15 @@ locals {
   auth_system_principals = try(local.auth_configuration.system_principals, {})
   cors_allowed_origins   = try(local.api_configuration.cors_allowed_origins, [])
   transfer_clients       = try(local.application_data.accounts[local.environment].transfer_clients, {})
+  multipart_configuration = merge(
+    {
+      single_put_limit_bytes            = 5368709120
+      multipart_default_part_size_bytes = 67108864
+      multipart_max_parts               = 10000
+      multipart_initial_presign_parts   = 10
+    },
+    try(local.api_configuration.multipart_upload, {})
+  )
 
   mft_upload_bucket_parameter_prefix = "/${local.application_name}/managed-file-transfer/${local.environment}/upload-bucket"
 }

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/abort-multipart-upload.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/abort-multipart-upload.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Abort Multipart Upload
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{api_endpoint}}/transfer-tickets/{{transfer_ticket}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/complete-multipart-upload.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/complete-multipart-upload.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Complete Multipart Upload
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{api_endpoint}}/transfer-tickets/{{transfer_ticket}}/complete
+  body: json
+  auth: bearer
+}
+
+headers {
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+body:json {
+  {
+    "parts": [
+      {
+        "partNumber": 1,
+        "eTag": "\"replace-with-uploaded-part-etag\""
+      }
+    ]
+  }
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/create-multipart-upload.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/create-multipart-upload.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Create Multipart Upload
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{api_endpoint}}/transfer-tickets
+  body: json
+  auth: bearer
+}
+
+headers {
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+body:json {
+  {
+    "clientId": "products-poc",
+    "fileName": "large-example-upload.csv",
+    "contentType": "text/csv",
+    "sizeBytes": 10737418240,
+    "requestedExpirySeconds": 3600
+  }
+}
+
+script:post-response {
+  const ticket = res.getBody();
+  const firstPart = ticket["multipart"]["initialParts"][0];
+
+  bru.setVar("transfer_ticket", ticket["transferTicket"]);
+  bru.setVar("multipart_upload_id", ticket["multipart"]["uploadId"]);
+  bru.setVar("part_size_bytes", ticket["multipart"]["partSizeBytes"]);
+  bru.setVar("upload_bucket", ticket["object"]["bucket"]);
+  bru.setVar("upload_key", ticket["object"]["key"]);
+  bru.setVar("part_1_url", firstPart["url"]);
+}

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/get-multipart-part-urls.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/get-multipart-part-urls.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Get Multipart Part URLs
+  name: Presign Multipart Part URLs
   type: http
   seq: 5
 }

--- a/terraform/environments/integration-hub/api-platform/mft-upload-test/get-multipart-part-urls.bru
+++ b/terraform/environments/integration-hub/api-platform/mft-upload-test/get-multipart-part-urls.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Multipart Part URLs
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{api_endpoint}}/transfer-tickets/{{transfer_ticket}}/parts
+  body: json
+  auth: bearer
+}
+
+headers {
+  Content-Type: application/json
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+body:json {
+  {
+    "partNumberStart": 2,
+    "partNumberEnd": 3
+  }
+}

--- a/terraform/environments/integration-hub/api-platform/openapi.yaml
+++ b/terraform/environments/integration-hub/api-platform/openapi.yaml
@@ -1,16 +1,13 @@
 openapi: 3.0.3
 info:
   title: Integration Hub Managed File Transfer API
-  version: 1.0.0
+  version: 2.0.0
   description: |
     Thin API layer for Managed File Transfer uploads.
 
-    The API supports:
-    - Basic authentication for user-driven HTTPS upload flows
-    - Bearer token authentication for system-to-system integrations
-
-    Authorisation is role-based. Each authenticated principal is mapped to one
-    or more permitted `clientId` values.
+    Small files can use a single pre-signed S3 PUT.
+    Large files automatically switch to a multipart upload flow so the client
+    ingress path can support uploads larger than 5 GB.
 servers:
   - url: https://{apiHost}
     variables:
@@ -24,12 +21,11 @@ paths:
     post:
       summary: Create an upload transfer ticket
       description: |
-        Issues a short-lived pre-signed S3 PUT URL for an authorised transfer client.
+        Creates either:
+        - a single PUT upload ticket for smaller files, or
+        - a multipart upload session for larger files.
 
-        For Basic authentication, provide the configured username and password.
-
-        For Bearer authentication, provide a token in the form:
-        `<tokenId>.<bearerToken>`
+        The client supplies `sizeBytes` and the API decides which upload path to use.
       operationId: createTransferTicket
       security:
         - basicAuth: []
@@ -40,43 +36,127 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TransferTicketRequest'
-            examples:
-              csvUpload:
-                value:
-                  clientId: products-poc
-                  fileName: example-upload.csv
-                  contentType: text/csv
-                  sizeBytes: 12345
-                  requestedExpirySeconds: 900
-                  contentMd5: CY9rzUYh03PK3k6DJie09g==
       responses:
         '200':
-          description: Transfer ticket created
+          description: Upload session created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TransferTicketResponse'
+                oneOf:
+                  - $ref: '#/components/schemas/SingleUploadTicketResponse'
+                  - $ref: '#/components/schemas/MultipartUploadTicketResponse'
         '400':
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '401':
           description: Authentication failed
         '403':
-          description: Authenticated caller is not authorised for the requested client
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '404':
-          description: Unknown transfer client
+          $ref: '#/components/responses/ErrorResponse'
+  /transfer-tickets/{transferTicket}/parts:
+    post:
+      summary: Generate pre-signed multipart part URLs
+      operationId: presignMultipartParts
+      security:
+        - basicAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TransferTicket'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultipartPartRequest'
+      responses:
+        '200':
+          description: Pre-signed part URLs generated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/MultipartPartResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          description: Authentication failed
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/ErrorResponse'
+  /transfer-tickets/{transferTicket}/complete:
+    post:
+      summary: Complete a multipart upload
+      operationId: completeMultipartUpload
+      security:
+        - basicAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TransferTicket'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultipartCompleteRequest'
+      responses:
+        '200':
+          description: Multipart upload completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipartCompleteResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          description: Authentication failed
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/ErrorResponse'
+  /transfer-tickets/{transferTicket}:
+    delete:
+      summary: Abort a multipart upload
+      operationId: abortMultipartUpload
+      security:
+        - basicAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TransferTicket'
+      responses:
+        '200':
+          description: Multipart upload aborted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipartAbortResponse'
+        '401':
+          description: Authentication failed
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/ErrorResponse'
 components:
+  parameters:
+    TransferTicket:
+      name: transferTicket
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    ErrorResponse:
+      description: Request failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
   securitySchemes:
     basicAuth:
       type: http
@@ -93,6 +173,7 @@ components:
       required:
         - clientId
         - fileName
+        - sizeBytes
       properties:
         clientId:
           type: string
@@ -112,9 +193,39 @@ components:
           example: 900
         contentMd5:
           type: string
-          description: Base64-encoded MD5 digest of the upload content
+          description: Base64-encoded MD5 digest for single PUT uploads only
           example: CY9rzUYh03PK3k6DJie09g==
-    TransferTicketResponse:
+    ObjectReference:
+      type: object
+      required:
+        - bucket
+        - key
+      properties:
+        bucket:
+          type: string
+        key:
+          type: string
+    PresignedSingleUpload:
+      type: object
+      required:
+        - method
+        - url
+        - headers
+        - expiresInSeconds
+      properties:
+        method:
+          type: string
+          example: PUT
+        url:
+          type: string
+          format: uri
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        expiresInSeconds:
+          type: integer
+    SingleUploadTicketResponse:
       type: object
       required:
         - transferTicket
@@ -128,36 +239,183 @@ components:
         clientId:
           type: string
         upload:
-          type: object
-          required:
-            - method
-            - url
-            - headers
-            - expiresInSeconds
-          properties:
-            method:
-              type: string
-              example: PUT
-            url:
-              type: string
-              format: uri
-            headers:
-              type: object
-              additionalProperties:
-                type: string
-            expiresInSeconds:
-              type: integer
-              example: 900
+          $ref: '#/components/schemas/PresignedSingleUpload'
         object:
+          $ref: '#/components/schemas/ObjectReference'
+    MultipartOperationPaths:
+      type: object
+      required:
+        - presignPartsPath
+        - completePath
+        - abortPath
+      properties:
+        presignPartsPath:
+          type: string
+        completePath:
+          type: string
+        abortPath:
+          type: string
+    MultipartPart:
+      type: object
+      required:
+        - partNumber
+        - method
+        - url
+        - headers
+        - expiresInSeconds
+      properties:
+        partNumber:
+          type: integer
+        method:
+          type: string
+          example: PUT
+        url:
+          type: string
+          format: uri
+        headers:
           type: object
-          required:
-            - bucket
-            - key
+          additionalProperties:
+            type: string
+        expiresInSeconds:
+          type: integer
+    MultipartUploadSession:
+      type: object
+      required:
+        - uploadId
+        - partSizeBytes
+        - maxParts
+        - expiresInSeconds
+        - initialParts
+        - operations
+      properties:
+        uploadId:
+          type: string
+        partSizeBytes:
+          type: integer
+          format: int64
+        totalParts:
+          type: integer
+          nullable: true
+        maxParts:
+          type: integer
+        expiresInSeconds:
+          type: integer
+        initialParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultipartPart'
+        operations:
+          $ref: '#/components/schemas/MultipartOperationPaths'
+    MultipartUploadTicketResponse:
+      type: object
+      required:
+        - transferTicket
+        - clientId
+        - object
+        - multipart
+      properties:
+        transferTicket:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        object:
+          $ref: '#/components/schemas/ObjectReference'
+        multipart:
+          $ref: '#/components/schemas/MultipartUploadSession'
+    MultipartPartRequest:
+      type: object
+      description: Provide either `partNumbers` or `partNumberStart` and `partNumberEnd`.
+      properties:
+        partNumbers:
+          type: array
+          items:
+            type: integer
+        partNumberStart:
+          type: integer
+        partNumberEnd:
+          type: integer
+    MultipartPartResponse:
+      type: object
+      required:
+        - transferTicket
+        - clientId
+        - uploadId
+        - parts
+      properties:
+        transferTicket:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        uploadId:
+          type: string
+        parts:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultipartPart'
+    MultipartCompletedPart:
+      type: object
+      required:
+        - partNumber
+        - eTag
+      properties:
+        partNumber:
+          type: integer
+        eTag:
+          type: string
+    MultipartCompleteRequest:
+      type: object
+      required:
+        - parts
+      properties:
+        parts:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultipartCompletedPart'
+    MultipartCompleteResponse:
+      type: object
+      required:
+        - transferTicket
+        - clientId
+        - status
+        - object
+        - result
+      properties:
+        transferTicket:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        status:
+          type: string
+          enum: [completed]
+        object:
+          $ref: '#/components/schemas/ObjectReference'
+        result:
+          type: object
           properties:
-            bucket:
+            eTag:
               type: string
-            key:
+            location:
               type: string
+            partCount:
+              type: integer
+    MultipartAbortResponse:
+      type: object
+      required:
+        - transferTicket
+        - clientId
+        - status
+      properties:
+        transferTicket:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        status:
+          type: string
+          enum: [aborted]
     ErrorResponse:
       type: object
       required:

--- a/terraform/environments/integration-hub/api-platform/outputs.tf
+++ b/terraform/environments/integration-hub/api-platform/outputs.tf
@@ -18,6 +18,11 @@ output "auth_principals_table_name" {
   value       = module.dynamodb_auth_principals.dynamodb_table_id
 }
 
+output "multipart_uploads_table_name" {
+  description = "DynamoDB table containing multipart upload sessions"
+  value       = module.dynamodb_multipart_uploads.dynamodb_table_id
+}
+
 output "user_auth_secret_names" {
   description = "HTTPS upload credential secret names keyed by username"
   value = {


### PR DESCRIPTION
## Summary

This PR redesigns the Integration Hub upload ticket API so it can support files larger than the S3 single `PUT` limit of 5 GB.

Previously, the API always returned a single presigned `put_object` URL, which meant the first hop into S3 was capped at 5 GB even though our intended file-size limit is up to 100 GB. This change introduces an automatic multipart upload flow for larger files while keeping the existing single-upload path for smaller files.

## What changed

- The upload API now chooses the upload strategy automatically based on `sizeBytes`
- Files up to the single-request S3 limit use the existing single presigned `PUT` flow
- Files above that limit use an S3 multipart upload flow
- Requests above the configured per-client max size are rejected up front
- The declared `sizeBytes` is stored for traceability in multipart session state and written into S3 object metadata

## API behaviour

The public contract is intentionally kept simple:

- Clients always send `sizeBytes`
- Clients do not choose single vs multipart
- The API decides whether to return:
  - a single-upload response, or
  - a multipart upload session with:
    - initial presigned part URLs
    - a route to request more part URLs
    - a route to complete the multipart upload
    - a route to abort the multipart upload

## Infrastructure changes

- Added a DynamoDB table to persist multipart upload session state
- Extended the upload Lambda IAM permissions for multipart session handling and multipart S3 operations
- Added API Gateway routes for:
  - `POST /transfer-tickets/{transferTicket}/parts`
  - `POST /transfer-tickets/{transferTicket}/complete`
  - `DELETE /transfer-tickets/{transferTicket}`

## Documentation and tests

- Updated the OpenAPI contract
- Updated the README to document the new automatic upload selection behaviour
- Added Bruno examples for multipart create/presign/complete/abort flows
- Added unit tests covering single-upload and multipart-upload routing

## Why

This keeps the public API simple while removing the 5 GB first-hop limitation and aligning the ingress design with the real upper limit we want to support, which is currently 100 GB per file.