### PR TITLE
LASB-5060: Move MLRA config to AL2023

### DIFF
--- a/terraform/environments/mlra/ecs.tf
+++ b/terraform/environments/mlra/ecs.tf
@@ -6,12 +6,12 @@ module "mlra-ecs" {
 
   source = "./modules/ecs"
 
-  subnet_set_name         = local.subnet_set_name
-  vpc_all                 = local.vpc_all
-  app_name                = local.application_name
-  container_instance_type = local.application_data.accounts[local.environment].container_instance_type
-  instance_type           = local.application_data.accounts[local.environment].instance_type
-  # replace with AL2023 user data after migration
+  subnet_set_name                = local.subnet_set_name
+  vpc_all                        = local.vpc_all
+  app_name                       = local.application_name
+  container_instance_type        = local.application_data.accounts[local.environment].container_instance_type
+  instance_type                  = local.application_data.accounts[local.environment].instance_type
+  # TODO LASB-5089 Replace with AL2023 user data
   user_data                      = local.user_data
   user_data_al2023               = local.user_data_al2023
   key_name                       = local.application_data.accounts[local.environment].key_name

--- a/terraform/environments/mlra/locals.tf
+++ b/terraform/environments/mlra/locals.tf
@@ -12,7 +12,7 @@ locals {
 
   alb_security_group_id = module.alb.security_group.id
 
-  # remove after migration
+  # TODO LASB-5089 Remove
   user_data = base64encode(templatefile("user_data.sh", {
     app_name    = local.application_name,
     environment = local.environment,
@@ -21,6 +21,7 @@ locals {
     xdr_tags    = local.xdr_tags
   }))
 
+  # TODO LASB-5089 (Optional) rename to user_data
   user_data_al2023 = base64encode(templatefile("user_data_al2023.sh", {
     app_name    = local.application_name,
     environment = local.environment,

--- a/terraform/environments/mlra/modules/ecs/main.tf
+++ b/terraform/environments/mlra/modules/ecs/main.tf
@@ -22,13 +22,13 @@ data "aws_subnets" "shared-private" {
   }
 }
 
-# remove after migration
+# TODO LASB-5089 Remove
 resource "aws_autoscaling_group" "cluster-scaling-group" {
   vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
   name                  = "${var.app_name}-cluster-scaling-group"
-  desired_capacity      = var.ec2_desired_capacity
+  desired_capacity      = 0
   max_size              = var.ec2_max_size
-  min_size              = var.ec2_min_size
+  min_size              = 0
   protect_from_scale_in = true
   metrics_granularity   = "1Minute"
   enabled_metrics = [
@@ -83,13 +83,11 @@ resource "aws_autoscaling_group" "cluster-scaling-group" {
 }
 
 resource "aws_autoscaling_group" "cluster-scaling-group-al2023" {
-  vpc_zone_identifier = sort(data.aws_subnets.shared-private.ids)
-  name_prefix         = "${var.app_name}-ec2-al2023-"
-  # New ASG, set capacity to 0 - will be scaled manually during migration.
-  # Follow-up Terraform PR will update to desired final capacity.
-  desired_capacity      = 0
+  vpc_zone_identifier   = sort(data.aws_subnets.shared-private.ids)
+  name_prefix           = "${var.app_name}-ec2-al2023-"
+  desired_capacity      = var.ec2_desired_capacity
   max_size              = var.ec2_max_size
-  min_size              = 0
+  min_size              = var.ec2_min_size
   protect_from_scale_in = true
   metrics_granularity   = "1Minute"
   enabled_metrics = [
@@ -202,7 +200,7 @@ resource "aws_security_group_rule" "mlra_to_maatdb_sg_rule_outbound" {
   source_security_group_id = var.maatdb_rds_sec_group_id
 }
 
-# remove after migration
+# TODO LASB-5089 Remove
 data "aws_ssm_parameter" "ecs_optimized_ami_al2" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended"
 }
@@ -212,14 +210,14 @@ data "aws_ssm_parameter" "ecs_optimized_ami_al2023" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
 }
 
-# update to reference AL2023 ID after migration
+# TODO LASB-5089 update to reference AL2023 ID after migration
 # if the AMI is used elsewhere it can be obtained here
 output "ami_id" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2.value)["image_id"]
   sensitive = true
 }
 
-# move to ami_id after migration
+# TODO LASB-5089 rename to ami_id after migration
 output "ami_id_al2023" {
   value     = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami_al2023.value)["image_id"]
   sensitive = true
@@ -229,7 +227,7 @@ output "ami_id_al2023" {
 # Note - when updating this you will need to manually terminate the EC2s
 # so that the autoscaling group creates new ones using the new launch template
 
-# remove after migration
+# TODO LASB-5089 Remove
 #tfsec:ignore:AVD-AWS-0130:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
 resource "aws_launch_template" "ec2-launch-template" {
   #checkov:skip=CKV_AWS_79:TODO Will be addressed as part of https://dsdmoj.atlassian.net/browse/LASB-3390
@@ -536,13 +534,12 @@ resource "aws_ecs_service" "ecs_service" {
 
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.mlra.name
-    weight            = 1
+    weight            = 0
   }
 
-  # increase weight gradually during migration
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.mlra-al2023.name
-    weight            = 0
+    weight            = 1
   }
 
   health_check_grace_period_seconds = 300
@@ -795,7 +792,7 @@ resource "aws_appautoscaling_policy" "ecs_target_memory" {
   }
 }
 
-# remove after migration
+# TODO LASB-5089 Remove
 resource "aws_ecs_capacity_provider" "mlra" {
   name = "${var.app_name}-${var.environment}-capacity-provider"
 

--- a/terraform/environments/mlra/modules/ecs/variables.tf
+++ b/terraform/environments/mlra/modules/ecs/variables.tf
@@ -119,7 +119,7 @@ variable "appscaling_max_capacity" {
   default     = 6
 }
 
-# replace with AL2023 user data after migration
+# TODO LASB-5089 Replace with AL2023 user data
 variable "user_data" {
   type        = string
   description = "The configuration used when creating EC2s used for the ECS cluster"

--- a/terraform/environments/mlra/user_data.sh
+++ b/terraform/environments/mlra/user_data.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+# TODO LASB-5089 Remove
 echo ECS_CLUSTER=${app_name} >> /etc/ecs/ecs.config
 echo ECS_IMAGE_PULL_BEHAVIOR=always >> /etc/ecs/ecs.config
 yum install -y awslogs


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LASB-5060)

- Use AL2023 for new MLRA instances rather than AL2
  - Scale down AL2 ASG
  - Set weight of AL2 capacity provider to 0
  - Scale up AL2023 ASG
  - Set weight of Al2023 capacity provider to 1
- Add TODOs to cleanup unused resources post-migration