### PR TITLE
Update architecture for lambdas

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -12,7 +12,6 @@ module "lambda_unscanned_to_processing" {
   source_path                    = "lambda/s3-file-mover"
   timeout                        = 30
   tracing_mode                   = "Active"
-  trigger_on_package_timestamp   = false
 
   event_source_mapping = {
     sqs = {
@@ -111,7 +110,6 @@ module "lambda_processing_to_post_scan" {
   source_path                    = "lambda/guard-duty-file-mover"
   timeout                        = 30
   tracing_mode                   = "Active"
-  trigger_on_package_timestamp   = false
 
   event_source_mapping = {
     sqs = {

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -12,6 +12,7 @@ module "lambda_unscanned_to_processing" {
   source_path                    = "lambda/s3-file-mover"
   timeout                        = 30
   tracing_mode                   = "Active"
+  trigger_on_package_timestamp   = false
 
   event_source_mapping = {
     sqs = {
@@ -110,6 +111,7 @@ module "lambda_processing_to_post_scan" {
   source_path                    = "lambda/guard-duty-file-mover"
   timeout                        = 30
   tracing_mode                   = "Active"
+  trigger_on_package_timestamp   = false
 
   event_source_mapping = {
     sqs = {

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda.tf
@@ -3,6 +3,7 @@ module "lambda_unscanned_to_processing" {
   version = "8.8.0"
 
   function_name                  = "${local.application_name}-unscanned-to-processing"
+  architectures                  = ["arm64"]
   description                    = "Moves uploaded files from the unscanned bucket to the processing bucket"
   handler                        = "lambda_function.lambda_handler"
   memory_size                    = 256
@@ -101,6 +102,7 @@ module "lambda_processing_to_post_scan" {
   version = "8.8.0"
 
   function_name                  = "${local.application_name}-processing-to-post-scan"
+  architectures                  = ["arm64"]
   description                    = "Moves scanned files from the processing bucket to the post-scan destination bucket"
   handler                        = "lambda_function.lambda_handler"
   memory_size                    = 256


### PR DESCRIPTION
Use `ARM64` for speed and cost saving.