### PR TITLE
remove enhance-scp-error.sh

### DIFF
--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -359,4 +359,4 @@
               set -o pipefail
               tf_args="${{ inputs.plan_apply_tfargs }} x.tfplan"
               echo "terraform apply ${tf_args}"
-              terraform apply ${tf_args} 2>&1 | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh | bash ${GITHUB_WORKSPACE}/scripts/enhance-scp-error.sh
+              terraform apply ${tf_args} 2>&1 | bash ${GITHUB_WORKSPACE}/scripts/redact-output.sh

--- a/scripts/enhance-scp-error.sh
+++ b/scripts/enhance-scp-error.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sed -E 's|p-w8ht8v1x|p-w8ht8v1x (Enforce mandatory tags), please see our tagging policy https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/finops-and-greenops-at-moj/standards/tagging.html|g'


### PR DESCRIPTION
* Removed scripts/enhance-scp-error.sh, which was used to mask/enhance tagging SCP error output.

* Removed the workflow reference to that script from reusable_terraform_components_plan_apply.yml.

https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/806