### PR TITLE
Long running initial batch jobs need dedicate resource

### DIFF
--- a/terraform/environments/electronic-monitoring-data/gdpr_batch_jobs.tf
+++ b/terraform/environments/electronic-monitoring-data/gdpr_batch_jobs.tf
@@ -115,11 +115,11 @@ resource "aws_batch_job_queue" "shred_unstructured_from_zip_batch_queue" {
   state    = "ENABLED"
   priority = 1
   compute_environment_order {
-    order               = 1
+    order               = 2
     compute_environment = aws_batch_compute_environment.shred_unstructured_from_zip_batch_compute_env[count.index].arn
   }
   compute_environment_order {
-    order               = 2
+    order               = 1
     compute_environment = aws_batch_compute_environment.shred_unstructured_from_zip_batch_on_demand_compute_env[count.index].arn
   }
   tags = merge(local.tags, { Batch_Job_Name = local.shred_unstructured_image_name })


### PR DESCRIPTION
We have noticed that some of the batch jobs are trying to shred over 9000 patterns (with multiple documents underneath each), probably because the volume of uncompliant data is initially higher on a first run.
This is taking much longer than anticipated, and AWS Spot Fleet resource is being reclaimed by other paying AWS customers for on-demand resource allocation causing a `"StatusReason": "Host EC2 (instance i-08784105ffff56b4f) terminated."` error. Examining the logs of each batch job terminated this way just shows that the container was sent a shut down signal so terminates on the line it was on.

This fix is our fallback incase of spot market issues, which is to default to an on-demand instance type which can easily be switched around to try to save MOJ costs when batch jobs become smaller in the future.