### PR TITLE
add Aurora reader endpoint support for LiteLLM

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/aurora.tf
+++ b/terraform/environments/data-platform/ai-gateway/aurora.tf
@@ -48,11 +48,16 @@ module "ai_gateway_aurora_secret" {
 
   name = "${local.component_name}/aurora"
 
-  secret_string = jsonencode({
-    username = module.ai_gateway_aurora.cluster_master_username
-    password = random_password.aurora.result
-    host     = module.ai_gateway_aurora.cluster_endpoint
-    port     = tostring(module.ai_gateway_aurora.cluster_port)
-    dbname   = module.ai_gateway_aurora.cluster_database_name
-  })
+  secret_string = jsonencode(merge(
+    {
+      username = module.ai_gateway_aurora.cluster_master_username
+      password = random_password.aurora.result
+      host     = module.ai_gateway_aurora.cluster_endpoint
+      port     = tostring(module.ai_gateway_aurora.cluster_port)
+      dbname   = module.ai_gateway_aurora.cluster_database_name
+    },
+    local.has_reader ? {
+      read-url = "postgresql://${module.ai_gateway_aurora.cluster_master_username}:${random_password.aurora.result}@${module.ai_gateway_aurora.cluster_reader_endpoint}/${module.ai_gateway_aurora.cluster_database_name}"
+    } : {}
+  ))
 }

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,6 +1,7 @@
 locals {
   environment_configuration = local.environment_configurations[local.environment]
   ai_gateway_models         = yamldecode(file("${path.module}/configuration/models.yml"))
+  has_reader                = contains(keys(local.environment_configuration.aurora_instances), "reader")
   environment_configurations = {
     proxy_admin_emails = [
       "Muhammad.Ahmad@justice.gov.uk",

--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -35,11 +35,12 @@ resource "helm_release" "litellm" {
         ingressHostname    = local.environment_configuration.ai_gateway_hostname
 
         # Database
-        databaseSecret      = "aurora"
-        databaseUserNameKey = "username"
-        databasePasswordKey = "password"
-        databaseEndpointKey = "host"
-        databaseName        = module.ai_gateway_aurora.cluster_database_name
+        databaseSecret            = "aurora"
+        databaseUserNameKey       = "username"
+        databasePasswordKey       = "password"
+        databaseEndpointKey       = "host"
+        databaseReaderEndpointKey = local.has_reader ? "read-url" : ""
+        databaseName              = module.ai_gateway_aurora.cluster_database_name
 
         # LiteLLM
         masterkeySecretName = kubernetes_secret_v1.litellm_master_key.metadata[0].name
@@ -99,11 +100,12 @@ resource "helm_release" "litellm_admin" {
         proxyHostname      = local.environment_configuration.ai_gateway_hostname
 
         # Database
-        databaseSecret      = "aurora"
-        databaseUserNameKey = "username"
-        databasePasswordKey = "password"
-        databaseEndpointKey = "host"
-        databaseName        = module.ai_gateway_aurora.cluster_database_name
+        databaseSecret            = "aurora"
+        databaseUserNameKey       = "username"
+        databasePasswordKey       = "password"
+        databaseEndpointKey       = "host"
+        databaseReaderEndpointKey = local.has_reader ? "read-url" : ""
+        databaseName              = module.ai_gateway_aurora.cluster_database_name
 
         # LiteLLM
         masterkeySecretName = kubernetes_secret_v1.litellm_master_key.metadata[0].name

--- a/terraform/environments/data-platform/ai-gateway/kubernetes-external-secrets.tf
+++ b/terraform/environments/data-platform/ai-gateway/kubernetes-external-secrets.tf
@@ -133,43 +133,54 @@ resource "kubernetes_manifest" "external_secret_aurora" {
       target = {
         name = "aurora"
       }
-      data = [
-        {
-          secretKey = "username"
-          remoteRef = {
-            key      = tostring(module.ai_gateway_aurora_secret.secret_id)
-            property = "username"
+      data = concat(
+        [
+          {
+            secretKey = "username"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "username"
+            }
+          },
+          {
+            secretKey = "password"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "password"
+            }
+          },
+          {
+            secretKey = "host"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "host"
+            }
+          },
+          {
+            secretKey = "port"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "port"
+            }
+          },
+          {
+            secretKey = "dbname"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "dbname"
+            }
           }
-        },
-        {
-          secretKey = "password"
-          remoteRef = {
-            key      = tostring(module.ai_gateway_aurora_secret.secret_id)
-            property = "password"
+        ],
+        local.has_reader ? [
+          {
+            secretKey = "read-url"
+            remoteRef = {
+              key      = tostring(module.ai_gateway_aurora_secret.secret_id)
+              property = "read-url"
+            }
           }
-        },
-        {
-          secretKey = "host"
-          remoteRef = {
-            key      = tostring(module.ai_gateway_aurora_secret.secret_id)
-            property = "host"
-          }
-        },
-        {
-          secretKey = "port"
-          remoteRef = {
-            key      = tostring(module.ai_gateway_aurora_secret.secret_id)
-            property = "port"
-          }
-        },
-        {
-          secretKey = "dbname"
-          remoteRef = {
-            key      = tostring(module.ai_gateway_aurora_secret.secret_id)
-            property = "dbname"
-          }
-        }
-      ]
+        ] : []
+      )
     }
   }
 }

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -32,7 +32,7 @@ db:
     usernameKey: ${databaseUserNameKey}
     passwordKey: ${databasePasswordKey}
     endpointKey: ${databaseEndpointKey}
-
+${databaseReaderEndpointKey != "" ? "    readReplicaUrlKey: ${databaseReaderEndpointKey}" : ""}
 masterkeySecretName: ${masterkeySecretName}
 masterkeySecretKey: ${masterkeySecretKey}
 

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -36,7 +36,7 @@ db:
     usernameKey: ${databaseUserNameKey}
     passwordKey: ${databasePasswordKey}
     endpointKey: ${databaseEndpointKey}
-
+${databaseReaderEndpointKey != "" ? "    readReplicaUrlKey: ${databaseReaderEndpointKey}" : ""}
 masterkeySecretName: ${masterkeySecretName}
 masterkeySecretKey: ${masterkeySecretKey}
 


### PR DESCRIPTION
This PR allows the LiteLLM proxy to route all read-only queries to a separate Aurora reader endpoint while writes continue to go to the primary. The reader URL is stored in the existing `aurora` Kubernetes secret and referenced by key, so credentials are never exposed in the pod spec. Once applied, LiteLLM will automatically have the `DATABASE_URL_READ_REPLICA` environment variable set with the replica connection details.

**Changes:**
- Adds `has_reader` local to detect reader instances from environment config
- Conditionally writes a `read-url` key into the Aurora secret
- Conditionally syncs `read-url` into the Kubernetes secret via External Secrets
- Passes `readReplicaUrlKey` to both Helm releases and conditionally renders it under `db.secret` in the values templates



PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/304) ticket.