### PR TITLE
feat: introduce FTPS connectivity via custom identity provider (managed file transfer)

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -1,0 +1,44 @@
+# Managed File Transfer
+
+This environment provides a proof-of-concept AWS Transfer Family endpoint for Integration Hub file uploads.
+
+## Custom IdP POC
+
+The Transfer server uses a Lambda custom identity provider backed by DynamoDB metadata and Secrets Manager credentials. The POC server exposes SFTP and FTPS on a single VPC-hosted endpoint with one Elastic IP address.
+
+The initial POC identity provider is Secrets Manager because it supports password authentication for FTPS and public key authentication for SFTP with a small migration from the previous service-managed SFTP user model. This is not the preferred long-term password strategy. Before production use, evaluate Argon2 password hashes for local users or an enterprise identity provider such as Entra ID or Active Directory.
+
+## Required Configuration
+
+Set `TF_VAR_transfer_ftps_certificate_arn` to an ACM certificate ARN in `eu-west-2` before planning or applying. AWS Transfer uses this certificate for FTPS.
+
+The POC user secret is named from `custom_idp_configuration.secret_prefix` plus the username. With the default configuration, the `dms1981` secret is `transfer/dms1981` and must contain JSON in this shape:
+
+```json
+{
+  "Password": "replace-with-ftps-password",
+  "PublicKeys": [
+    "ssh-ed25519 replace-with-public-key"
+  ]
+}
+```
+
+The secret value is ignored by Terraform after creation and should be populated directly in AWS Secrets Manager.
+
+## Network Ports
+
+The Transfer security group allows:
+
+- TCP 22 for SFTP
+- TCP 21 for FTPS control
+- TCP 8192-8200 for FTPS passive data channels
+
+The development POC currently allows these from `0.0.0.0/0`. Narrow `custom_idp_configuration.ingress_cidr_blocks` before using this with known client networks.
+
+## Operations
+
+Before applying, confirm no client is pinned to either of the two Elastic IP addresses that Terraform will remove. Changing the Transfer identity provider and protocol set may update or replace the server, so coordinate a short outage for the POC endpoint.
+
+After applying, test password authentication with the AWS Transfer console custom IdP tester using protocol `FTPS`, then test SFTP public key access and FTPS passive-mode uploads with a client such as FileZilla or `lftp`.
+
+Monitor the Transfer log group and the custom IdP Lambda log group. Keep `custom_idp_configuration.log_level` at `INFO` unless troubleshooting in a non-production environment, because debug logs can expose sensitive authentication context.

--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -17,7 +17,7 @@ _If you have any questions surrounding this page please post in the `#ask-integr
 
 <!-- A short (less than 50 word) description of what your service does, and who it’s for.-->
 
-A proof of concept managed file transfer service for the Integration Hub. It lets external partners upload files over SFTP and FTPS (or a browser-based web app), scans every file for malware with Amazon GuardDuty, and applies preset patterns clean files are ready to collect.
+A proof of concept managed file transfer service for the Integration Hub. It lets external partners upload files over SFTP and FTPS (or a browser-based web app), scans every file for malware with Amazon GuardDuty, and routes clean files onward so the team can collect them.
 
 ### **Service URLs:**
 
@@ -104,10 +104,6 @@ CloudWatch alarms are configured for the custom identity provider Lambda:
 <!-- A short description of the risks if your service is down for an extended period of time. -->
 
 If the identity provider Lambda or the Transfer server is unavailable, partners cannot authenticate or upload files. If the post-scan pipeline is down, files remain in the `unscanned`/`processing` buckets and are not delivered, but short bucket lifecycle rules mean undelivered files expire after one day. As a proof of concept the service carries no production data.
-
-### **Impact of an outage:**
-
-<!-- A short description of the risks if your service is down for an extended period of time. -->
 
 ### **Out of hours response types:**
 

--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -1,44 +1,134 @@
-# Managed File Transfer
+# Service Runbook
 
-This environment provides a proof-of-concept AWS Transfer Family endpoint for Integration Hub file uploads.
+<!-- This is a template that should be populated by the development team when moving to the modernisation platform, but also reviewed and kept up to date.
+To ensure that people looking at your runbook can get the information they need quickly, your runbook should be short but clear. Throughout, only use acronyms if you’re confident that someone who has just been woken up at 3am would understand them. -->
 
-## Custom IdP POC
+_If you have any questions surrounding this page please post in the `#ask-integration-hub` channel._
 
-The Transfer server uses a Lambda custom identity provider backed by DynamoDB metadata and Secrets Manager credentials. The POC server exposes SFTP and FTPS on a single VPC-hosted endpoint with one Elastic IP address.
+## Mandatory Information
 
-The initial POC identity provider is Secrets Manager because it supports password authentication for FTPS and public key authentication for SFTP with a small migration from the previous service-managed SFTP user model. This is not the preferred long-term password strategy. Before production use, evaluate Argon2 password hashes for local users or an enterprise identity provider such as Entra ID or Active Directory.
+### **Last review date:**
 
-## Required Configuration
+<!-- Adding the last date this page was reviewed, with any accompanying information -->
 
-Set `TF_VAR_transfer_ftps_certificate_arn` to an ACM certificate ARN in `eu-west-2` before planning or applying. AWS Transfer uses this certificate for FTPS.
+22 June 2026
 
-The POC user secret is named from `custom_idp_configuration.secret_prefix` plus the username. With the default configuration, the `dms1981` secret is `transfer/dms1981` and must contain JSON in this shape:
+### **Description:**
 
-```json
-{
-  "Password": "replace-with-ftps-password",
-  "PublicKeys": [
-    "ssh-ed25519 replace-with-public-key"
-  ]
-}
-```
+<!-- A short (less than 50 word) description of what your service does, and who it’s for.-->
 
-The secret value is ignored by Terraform after creation and should be populated directly in AWS Secrets Manager.
+A proof of concept managed file transfer service for the Integration Hub. It lets external partners upload files over SFTP and FTPS (or a browser-based web app), scans every file for malware with Amazon GuardDuty, and applies preset patterns clean files are ready to collect.
 
-## Network Ports
+### **Service URLs:**
 
-The Transfer security group allows:
+<!--  The URL(s) of the service’s production environment, and test environments if possible-->
 
-- TCP 22 for SFTP
-- TCP 21 for FTPS control
-- TCP 8192-8200 for FTPS passive data channels
+DNS follows the pattern `<endpoint>.<environment>.managed-file-transfer.service.justice.gov.uk` in non-production, and `<endpoint>.managed-file-transfer.service.justice.gov.uk` in production. The `<endpoint>` host names are:
 
-The development POC currently allows these from `0.0.0.0/0`. Narrow `custom_idp_configuration.ingress_cidr_blocks` before using this with known client networks.
+| Host | Purpose |
+| --- | --- |
+| `sftp.*` | AWS Transfer Family SFTP endpoint |
+| `ftps.*` | AWS Transfer Family FTPS endpoint |
+| `web.*` | AWS Transfer Family web app (browser uploads) |
+| `api.*` | Reserved for future API access (not yet provisioned) |
 
-## Operations
+For example, the development SFTP endpoint resolves at `sftp.development.managed-file-transfer.service.justice.gov.uk`.
 
-Before applying, confirm no client is pinned to either of the two Elastic IP addresses that Terraform will remove. Changing the Transfer identity provider and protocol set may update or replace the server, so coordinate a short outage for the POC endpoint.
+### **Incident response hours:**
 
-After applying, test password authentication with the AWS Transfer console custom IdP tester using protocol `FTPS`, then test SFTP public key access and FTPS passive-mode uploads with a client such as FileZilla or `lftp`.
+<!-- When your service receives support for urgent issues. This should be written in a clear, unambiguous way. For example: 24/7/365, Office hours, usually 9am-6pm on working days, or 7am-10pm, 365 days a year. -->
 
-Monitor the Transfer log group and the custom IdP Lambda log group. Keep `custom_idp_configuration.log_level` at `INFO` unless troubleshooting in a non-production environment, because debug logs can expose sensitive authentication context.
+Office hours, usually 9am–5pm on working days. As a proof of concept there is no out-of-hours support.
+
+### **Incident contact details:**
+
+<!-- How people can raise an urgent issue with your service. This must not be the email address or phone number of an individual on your team, it should be a shared email address, phone number, or website that allows someone with an urgent issue to raise it quickly. -->
+
+Raise urgent issues in the `#ask-integration-hub` Slack channel.
+
+### **Service team contact:**
+
+<!-- How people with non-urgent issues or questions can get in touch with your team. As with incident contact details, this must not be the email address or phone number of an individual on the team, it should be a shared email address or a ticket tracking system.-->
+
+For non-urgent questions, contact the team in the `#ask-integration-hub` Slack channel.
+
+### **Hosting environment:**
+
+Modernisation Platform
+
+<!-- If your service is hosted on another MOJ team’s infrastructure, link to their runbook. If your service has another arrangement or runs its own infrastructure, you should list the supplier of that infrastructure (ideally linking to your account’s login page) and describe, simply and briefly, how to raise an issue with them. -->
+
+## Architecture overview
+
+The service is built entirely from AWS managed services, provisioned with Terraform in this directory.
+
+1. **Ingress.** Partners connect to an AWS Transfer Family server over SFTP or FTPS (FTPS uses an ACM certificate), or upload through the AWS Transfer Family web app. The server runs on a VPC endpoint with a static Elastic IP.
+2. **Authentication.** The Transfer server delegates authentication to a custom identity provider (a Lambda function backed by DynamoDB and Secrets Manager). See [docs/custom-idp.md](docs/custom-idp.md) for full detail.
+3. **Landing.** Authenticated users can only write to their own logical home directory in the `unscanned` S3 bucket.
+4. **Move to scanning.** An S3 event notification puts a message on an SQS queue; the `unscanned-to-processing` Lambda moves the object into the `processing` bucket (idempotently, using a DynamoDB table).
+5. **Malware scanning.** GuardDuty Malware Protection for S3 scans every object in the `processing` bucket and tags it with the result.
+6. **Post-scan routing.** EventBridge rules react to the scan result and a Lambda moves the object to:
+   - `clean` — `NO_THREATS_FOUND`
+   - `quarantine` — `THREATS_FOUND`
+   - `investigation` — `UNSUPPORTED`, `ACCESS_DENIED` or `FAILED`
+7. **Notification.** When a clean object lands, the `send-presigned-url` module generates a time-limited presigned download URL and posts it to Slack.
+
+All buckets are KMS-encrypted, versioned, block public access, and have short (one day) lifecycle expiry as befits a transfer staging area.
+
+## Optional
+
+### **Other URLs:**
+
+<!--  If you can, provide links to the service’s monitoring dashboard(s), health checks, documentation (ideally describing how to run/work with the service), and main GitHub repository. -->
+
+- Main repository: [ministryofjustice/modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments) — this service lives under `terraform/environments/integration-hub/managed-file-transfer`.
+- Custom identity provider documentation: [docs/custom-idp.md](docs/custom-idp.md)
+- Monitoring: CloudWatch (structured Transfer logs, Lambda logs and alarms) in the Integration Hub AWS account.
+
+### **Expected speed and frequency of releases:**
+
+<!-- How often are you able to release changes to your service, and how long do those changes take? -->
+
+### **Automatic alerts:**
+
+<!-- List, briefly, problems (or types of problem) that will automatically alert your team when they occur. -->
+
+CloudWatch alarms are configured for the custom identity provider Lambda:
+
+- **Errors** — any function error.
+- **Throttles** — any throttled invocation (concurrency exhausted).
+- **Duration** — average runtime approaching the 30-second authentication timeout.
+
+### **Impact of an outage:**
+
+<!-- A short description of the risks if your service is down for an extended period of time. -->
+
+If the identity provider Lambda or the Transfer server is unavailable, partners cannot authenticate or upload files. If the post-scan pipeline is down, files remain in the `unscanned`/`processing` buckets and are not delivered, but short bucket lifecycle rules mean undelivered files expire after one day. As a proof of concept the service carries no production data.
+
+### **Impact of an outage:**
+
+<!-- A short description of the risks if your service is down for an extended period of time. -->
+
+### **Out of hours response types:**
+
+<!-- Describe how incidents that page a person on call are responded to. How long are out-of-hours responders expected to spend trying to resolve issues before they stop working, put the service into maintenance mode, and hand the issue to in-hours support? -->
+
+### **Consumers of this service:**
+
+<!-- List which other services (with links to their runbooks) rely on this service. If your service is considered a platform, these may be too numerous to reasonably list. -->
+
+### **Services consumed by this:**
+
+<!-- List which other services (with links to their runbooks) this service relies on. -->
+
+### **Restrictions on access:**
+
+<!-- Describe any conditions which restrict access to the service, such as if it’s IP-restricted or only accessible from a private network.-->
+
+- Each user is restricted to their own logical home directory and may only upload (not download or list other users' files) to the `unscanned` bucket.
+- The custom identity provider supports per-user and per-provider IPv4 allow lists (`ingress_cidr_blocks`). In development this currently defaults to `0.0.0.0/0` and will be tightened before any real use.
+- The web app is gated behind AWS IAM Identity Center and S3 Access Grants.
+
+### **How to resolve specific issues:**
+
+<!-- Describe the steps someone might take to resolve a specific issue or incident, often for use when on call. This may be a large amount of information, so may need to be split out into multiple pages, or link to other documents.-->

--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -97,6 +97,14 @@
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 1800
       },
+      "custom_idp_configuration": {
+        "ingress_cidr_blocks": [
+          "0.0.0.0/0"
+        ],
+        "log_level": "INFO",
+        "secret_prefix": "transfer/",
+        "user_name_delimiter": "@@"
+      },
       "vpc_configuration": {
         "isolated_vpc_cidr": "10.0.0.0/23",
         "isolated_vpc_private_subnet_cidrs": [

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-dynamodb.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-dynamodb.tf
@@ -1,0 +1,125 @@
+module "dynamodb_custom_idp_users" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-custom-idp-users"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "user"
+  range_key    = "identity_provider_key"
+
+  attributes = [
+    {
+      name = "user"
+      type = "S"
+    },
+    {
+      name = "identity_provider_key"
+      type = "S"
+    }
+  ]
+
+  point_in_time_recovery_enabled = true
+  table_class                    = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  tags = local.tags
+}
+
+module "dynamodb_custom_idp_identity_providers" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-custom-idp-identity-providers"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "provider"
+
+  attributes = [
+    {
+      name = "provider"
+      type = "S"
+    }
+  ]
+
+  point_in_time_recovery_enabled = true
+  table_class                    = "STANDARD"
+  timeouts = {
+    create = "60m"
+    delete = "60m"
+    update = "60m"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_dynamodb_table_item" "custom_idp_identity_provider_secrets" {
+  table_name = module.dynamodb_custom_idp_identity_providers.dynamodb_table_id
+  hash_key   = "provider"
+
+  item = jsonencode({
+    provider = {
+      S = "secrets"
+    }
+    module = {
+      S = "secrets_manager"
+    }
+    public_key_support = {
+      BOOL = true
+    }
+    config = {
+      M = {
+        secret_prefix = {
+          S = local.custom_idp_configuration.secret_prefix
+        }
+      }
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "custom_idp_user_dms1981" {
+  table_name = module.dynamodb_custom_idp_users.dynamodb_table_id
+  hash_key   = "user"
+  range_key  = "identity_provider_key"
+
+  item = jsonencode({
+    user = {
+      S = "dms1981"
+    }
+    identity_provider_key = {
+      S = "secrets"
+    }
+    ipv4_allow_list = {
+      SS = local.custom_idp_configuration.ingress_cidr_blocks
+    }
+    config = {
+      M = {
+        Role = {
+          S = module.transfer_user_role.arn
+        }
+        Policy = {
+          S = data.aws_iam_policy_document.transfer_user_session.json
+        }
+        HomeDirectoryType = {
+          S = "LOGICAL"
+        }
+        HomeDirectoryDetails = {
+          L = [
+            {
+              M = {
+                Entry = {
+                  S = "/"
+                }
+                Target = {
+                  S = "/${module.s3_bucket["unscanned"].s3_bucket_id}/dms1981"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  })
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-dynamodb.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-dynamodb.tf
@@ -79,20 +79,22 @@ resource "aws_dynamodb_table_item" "custom_idp_identity_provider_secrets" {
   })
 }
 
-resource "aws_dynamodb_table_item" "custom_idp_user_dms1981" {
+resource "aws_dynamodb_table_item" "custom_idp_user" {
+  for_each = local.custom_idp_users
+
   table_name = module.dynamodb_custom_idp_users.dynamodb_table_id
   hash_key   = "user"
   range_key  = "identity_provider_key"
 
   item = jsonencode({
     user = {
-      S = "dms1981"
+      S = each.key
     }
     identity_provider_key = {
-      S = "secrets"
+      S = try(each.value.identity_provider_key, "secrets")
     }
     ipv4_allow_list = {
-      SS = local.custom_idp_configuration.ingress_cidr_blocks
+      SS = try(each.value.ipv4_allow_list, local.custom_idp_configuration.ingress_cidr_blocks)
     }
     config = {
       M = {
@@ -113,7 +115,7 @@ resource "aws_dynamodb_table_item" "custom_idp_user_dms1981" {
                   S = "/"
                 }
                 Target = {
-                  S = "/${module.s3_bucket["unscanned"].s3_bucket_id}/dms1981"
+                  S = try(each.value.home_directory_target, "/${module.s3_bucket["unscanned"].s3_bucket_id}/${each.key}")
                 }
               }
             }

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-lambda.tf
@@ -94,6 +94,7 @@ resource "aws_lambda_permission" "transfer_custom_idp" {
   function_name  = module.lambda_custom_idp.lambda_function_name
   principal      = "transfer.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
+  source_arn     = aws_transfer_server.this.arn
 }
 
 resource "aws_cloudwatch_metric_alarm" "custom_idp_lambda_errors" {

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-lambda.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-lambda.tf
@@ -1,0 +1,154 @@
+module "lambda_custom_idp_layer" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  create_function = false
+  create_layer    = true
+
+  layer_name          = "${local.application_name}-${local.component_name}-custom-idp"
+  description         = "Shared code for the AWS Transfer custom identity provider"
+  compatible_runtimes = ["python3.12"]
+  source_path         = "lambda/custom-idp/layer"
+
+  trigger_on_package_timestamp = false
+
+  tags = local.tags
+}
+
+module "lambda_custom_idp" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                  = "${local.application_name}-${local.component_name}-custom-idp"
+  description                    = "Authenticates AWS Transfer users with DynamoDB metadata and Secrets Manager credentials"
+  handler                        = "app.lambda_handler"
+  layers                         = [module.lambda_custom_idp_layer.lambda_layer_arn]
+  memory_size                    = 256
+  reserved_concurrent_executions = 5
+  runtime                        = "python3.12"
+  source_path                    = "lambda/custom-idp/idp_handler"
+  timeout                        = 30
+  tracing_mode                   = "Active"
+  trigger_on_package_timestamp   = false
+
+  environment_variables = {
+    IDENTITY_PROVIDERS_TABLE = module.dynamodb_custom_idp_identity_providers.dynamodb_table_id
+    LOGLEVEL                 = local.custom_idp_configuration.log_level
+    USER_NAME_DELIMITER      = local.custom_idp_configuration.user_name_delimiter
+    USERS_TABLE              = module.dynamodb_custom_idp_users.dynamodb_table_id
+  }
+
+  attach_policy_statements = true
+  policy_statements = {
+    custom_idp_tables = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+      ]
+      resources = [
+        module.dynamodb_custom_idp_identity_providers.dynamodb_table_arn,
+        module.dynamodb_custom_idp_users.dynamodb_table_arn,
+      ]
+    }
+    custom_idp_secrets = {
+      effect = "Allow"
+      actions = [
+        "secretsmanager:GetSecretValue",
+      ]
+      resources = [
+        "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${local.custom_idp_configuration.secret_prefix}*",
+      ]
+    }
+    custom_idp_secrets_kms = {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+      ]
+      resources = [
+        module.kms_secrets.key_arn,
+      ]
+    }
+    describe_transfer_servers = {
+      effect = "Allow"
+      actions = [
+        "transfer:DescribeServer",
+      ]
+      resources = [
+        "arn:aws:transfer:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:server/*",
+      ]
+    }
+  }
+
+  attach_tracing_policy = true
+
+  cloudwatch_logs_kms_key_id        = module.kms_cloudwatch_logs.key_arn
+  cloudwatch_logs_retention_in_days = 30
+
+  tags = local.tags
+}
+
+resource "aws_lambda_permission" "transfer_custom_idp" {
+  action         = "lambda:InvokeFunction"
+  function_name  = module.lambda_custom_idp.lambda_function_name
+  principal      = "transfer.amazonaws.com"
+  source_account = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_cloudwatch_metric_alarm" "custom_idp_lambda_errors" {
+  alarm_name          = "${local.application_name}-${local.component_name}-custom-idp-errors"
+  alarm_description   = "AWS Transfer custom IdP Lambda errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = module.lambda_custom_idp.lambda_function_name
+  }
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "custom_idp_lambda_throttles" {
+  alarm_name          = "${local.application_name}-${local.component_name}-custom-idp-throttles"
+  alarm_description   = "AWS Transfer custom IdP Lambda throttles"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = module.lambda_custom_idp.lambda_function_name
+  }
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "custom_idp_lambda_duration" {
+  alarm_name          = "${local.application_name}-${local.component_name}-custom-idp-duration"
+  alarm_description   = "AWS Transfer custom IdP Lambda duration is nearing the authentication timeout"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 25000
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = module.lambda_custom_idp.lambda_function_name
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-users.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-users.tf
@@ -1,14 +1,31 @@
 locals {
-  # Custom IdP user records. Add a new user by appending a key to this map; every
-  # field is optional and falls back to a sensible default in the
-  # aws_dynamodb_table_item.custom_idp_user resource (see custom-idp-dynamodb.tf).
+  # Custom IdP user records. Add a new user by appending a key (the username) to
+  # this map. Every field is optional: an empty object (e.g. `dms1981 = {}`)
+  # creates a fully working user on all defaults. Each field is resolved with a
+  # try() fallback in aws_dynamodb_table_item.custom_idp_user (see
+  # custom-idp-dynamodb.tf).
   #
-  # Defaults applied when a field is omitted:
-  #   identity_provider_key = "secrets"
-  #   ipv4_allow_list       = local.custom_idp_configuration.ingress_cidr_blocks
-  #   home_directory_target = "/<unscanned-bucket>/<username>"
+  # Field reference and default applied when omitted:
   #
-  # Example of a fully specified user (uncomment and adapt as needed):
+  #   identity_provider_key (string)
+  #     Which identity provider record authenticates the user.
+  #     Default: "secrets" (authenticate against AWS Secrets Manager).
+  #
+  #   ipv4_allow_list (list(string))
+  #     Source CIDR blocks permitted to authenticate as this user.
+  #     Default: local.custom_idp_configuration.ingress_cidr_blocks
+  #     (the shared ingress allow-list for the transfer server).
+  #
+  #   home_directory_target (string)
+  #     The physical S3 path the user's logical "/" maps to. The transfer
+  #     server uses LOGICAL home directories, so this is an S3 location of the
+  #     form "/<bucket>/<prefix>", not a server-wide setting. Point it at the
+  #     bucket/prefix the user should land in (the unscanned bucket is the AV
+  #     scan landing zone).
+  #     Default: "/<unscanned-bucket>/<username>"
+  #
+  # Example of a fully specified user, overriding every default (uncomment and
+  # adapt as needed):
   #
   # alice = {
   #   identity_provider_key = "secrets"

--- a/terraform/environments/integration-hub/managed-file-transfer/custom-idp-users.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/custom-idp-users.tf
@@ -1,0 +1,21 @@
+locals {
+  # Custom IdP user records. Add a new user by appending a key to this map; every
+  # field is optional and falls back to a sensible default in the
+  # aws_dynamodb_table_item.custom_idp_user resource (see custom-idp-dynamodb.tf).
+  #
+  # Defaults applied when a field is omitted:
+  #   identity_provider_key = "secrets"
+  #   ipv4_allow_list       = local.custom_idp_configuration.ingress_cidr_blocks
+  #   home_directory_target = "/<unscanned-bucket>/<username>"
+  #
+  # Example of a fully specified user (uncomment and adapt as needed):
+  #
+  # alice = {
+  #   identity_provider_key = "secrets"
+  #   ipv4_allow_list       = ["203.0.113.0/24", "198.51.100.10/32"]
+  #   home_directory_target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/alice"
+  # }
+  custom_idp_users = {
+    dms1981 = {}
+  }
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/docs/custom-idp.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/docs/custom-idp.md
@@ -159,38 +159,39 @@ For the seeded `dms1981` user, the response pins the session to the shared `tran
 
 ## Managing users
 
-A user exists as **two** linked things: a record in the users DynamoDB table (who they are and what they can do) and a secret in Secrets Manager (their credentials). Both are managed in Terraform in this directory. Use the seeded `dms1981` resources as templates: `custom_idp_user_dms1981` in [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf) and `secrets_custom_idp_user_dms1981` in [`secrets.tf`](../secrets.tf).
+A user exists as **two** linked things: a record in the users DynamoDB table (who they are and what they can do) and a secret in Secrets Manager (their credentials). Both are driven from a single map, `local.custom_idp_users` in [`custom-idp-users.tf`](../custom-idp-users.tf). Each key in that map is a username; the `aws_dynamodb_table_item.custom_idp_user` resource in [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf) and the `module.secrets_custom_idp_user` block in [`secrets.tf`](../secrets.tf) both `for_each` over it, so adding a user is a one-line change.
 
 ### Add a user
 
-1. **Add the user record** to [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf). Set `identity_provider_key` to `secrets`, point the home directory at the user's own prefix in the `unscanned` bucket, and add `ipv4_allow_list`/`server_id_allow_list` restrictions as needed:
+1. **Add a key to `local.custom_idp_users`** in [`custom-idp-users.tf`](../custom-idp-users.tf). The simplest form uses all defaults:
 
    ```hcl
-   resource "aws_dynamodb_table_item" "custom_idp_user_alice" {
-     table_name = module.dynamodb_custom_idp_users.dynamodb_table_id
-     hash_key   = "user"
-     range_key  = "identity_provider_key"
-
-     item = jsonencode({
-       user                  = { S = "alice" }
-       identity_provider_key = { S = "secrets" }
-       ipv4_allow_list       = { SS = local.custom_idp_configuration.ingress_cidr_blocks }
-       config = { M = {
-         Role              = { S = module.transfer_user_role.arn }
-         Policy            = { S = data.aws_iam_policy_document.transfer_user_session.json }
-         HomeDirectoryType = { S = "LOGICAL" }
-         HomeDirectoryDetails = { L = [{ M = {
-           Entry  = { S = "/" }
-           Target = { S = "/${module.s3_bucket["unscanned"].s3_bucket_id}/alice" }
-         } }] }
-       } }
-     })
+   custom_idp_users = {
+     dms1981 = {}
+     alice   = {}
    }
    ```
 
-2. **Add the credential secret** to [`secrets.tf`](../secrets.tf), named `${local.custom_idp_configuration.secret_prefix}alice` (i.e. `transfer/alice`), mirroring `secrets_custom_idp_user_dms1981`.
-3. **Apply** the Terraform. This creates the record and a *placeholder* secret only — `ignore_secret_changes = true` means Terraform will never read or overwrite the real value.
-4. **Set the real credentials out of band.** Put the actual `Password` and/or `PublicKeys` into the secret in the AWS console or CLI, so they are never committed to source control:
+   Every field is optional. Omitting a field applies its default (resolved with `try()` in the resource):
+
+   - `identity_provider_key` → `secrets` (authenticate against Secrets Manager)
+   - `ipv4_allow_list` → `local.custom_idp_configuration.ingress_cidr_blocks` (the shared ingress allow-list)
+   - `home_directory_target` → `/<unscanned-bucket>/<username>` (the user's own prefix in the `unscanned` bucket)
+
+   To override any of them, give the user an object instead of `{}`:
+
+   ```hcl
+   custom_idp_users = {
+     alice = {
+       identity_provider_key = "secrets"
+       ipv4_allow_list       = ["203.0.113.0/24", "198.51.100.10/32"]
+       home_directory_target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/alice"
+     }
+   }
+   ```
+
+2. **Apply** the Terraform. For the new key this creates the DynamoDB user record and a *placeholder* credential secret named `${local.custom_idp_configuration.secret_prefix}<username>` (i.e. `transfer/alice`). `ignore_secret_changes = true` means Terraform will never read or overwrite the real value.
+3. **Set the real credentials out of band.** Put the actual `Password` and/or `PublicKeys` into the secret in the AWS console or CLI, so they are never committed to source control:
 
    ```bash
    aws secretsmanager put-secret-value \
@@ -204,8 +205,7 @@ The user can now authenticate as `alice` (or `alice@@secrets` to name the provid
 
 ### Remove a user
 
-1. **Delete the user record** by removing the `aws_dynamodb_table_item` block from [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf) and applying. As soon as the record is gone the user can no longer authenticate (the IdP denies any login with no matching record, unless a `$default$` record exists).
-2. **Delete the credential secret** by removing the secret block from [`secrets.tf`](../secrets.tf) and applying. The secret enters its recovery window (7 days) before final deletion; use `aws secretsmanager delete-secret --force-delete-without-recovery` only if immediate removal is required.
+1. **Remove the user's key** from `local.custom_idp_users` in [`custom-idp-users.tf`](../custom-idp-users.tf) and apply. This deletes both the DynamoDB user record and the credential secret in one step. As soon as the record is gone the user can no longer authenticate (the IdP denies any login with no matching record, unless a `$default$` record exists). The secret enters its recovery window (7 days) before final deletion; use `aws secretsmanager delete-secret --force-delete-without-recovery` only if immediate removal is required.
 
 To revoke access **immediately** without a Terraform run, blank the credentials in the secret (`put-secret-value` with empty `Password`/`PublicKeys`) — the next login attempt will fail. To revoke **everyone** at once, set `disabled = true` on the `secrets` provider record.
 

--- a/terraform/environments/integration-hub/managed-file-transfer/docs/custom-idp.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/docs/custom-idp.md
@@ -1,0 +1,248 @@
+# Custom Identity Provider
+
+This document describes the operation and function of the custom identity provider (IdP) that authenticates and authorises users of the Integration Hub managed file transfer proof of concept.
+
+It is written for a technically literate audience: engineers operating the service, reviewers, and anyone integrating a new partner. It complements the [service runbook](../README.md) and follows Ministry of Justice [technical guidance](https://developer-portal.service.justice.gov.uk/docs/ministry-of-justice-technical-guidance/).
+
+> **Proof of concept.** This identity provider is deliberately small and is intended to prove the pattern. Several defaults (open IPv4 allow lists, manually populated secrets, a single seeded user) are not production-ready and are called out in [Limitations and caveats](#limitations-and-caveats).
+
+## Contents
+
+- [Why a custom identity provider](#why-a-custom-identity-provider)
+- [Data model](#data-model)
+- [Authentication and authorisation flow](#authentication-and-authorisation-flow)
+- [Username and provider selection](#username-and-provider-selection)
+- [Credential validation](#credential-validation)
+- [Authorisation context](#authorisation-context)
+- [Building the Transfer response](#building-the-transfer-response)
+- [Managing users](#managing-users)
+- [Security considerations](#security-considerations)
+- [Observability](#observability)
+- [Limitations and caveats](#limitations-and-caveats)
+- [References](#references)
+
+## Why a custom identity provider
+
+[AWS Transfer Family](https://docs.aws.amazon.com/transfer/latest/userguide/what-is-aws-transfer-family.html) supports several identity provider types: a service-managed user store, AWS Directory Service, AWS IAM Identity Center, and a *custom* provider. A custom provider hands every authentication request to either an Amazon API Gateway endpoint or, as here, an AWS Lambda function. The Lambda decides whether the connection is allowed and, if so, returns the IAM role, scope-down policy and home directory the session should use.
+
+We use a custom Lambda provider because it lets us:
+
+- Hold user records and credentials in our own AWS account, under our own KMS keys.
+- Apply per-user authorisation (home directory, IAM scope-down policy, source-IP allow lists) without standing up a directory service.
+- Support both password and SSH public key authentication for SFTP, and password authentication for FTPS.
+- Evolve towards multiple back-end providers (for example LDAP or an external IdP) behind a single, stable interface.
+
+The Lambda is derived from the AWS open-source [Toolkit for AWS Transfer Family — custom IdP solution](https://github.com/aws-samples/toolkit-for-aws-transfer-family/tree/main/solutions/custom-idp), so its DynamoDB record shape and Secrets Manager conventions match that project's documentation.
+
+The Transfer server is wired to the Lambda in [`transfer-server.tf`](../transfer-server.tf):
+
+```hcl
+identity_provider_type = "AWS_LAMBDA"
+function               = module.lambda_custom_idp.lambda_function_arn
+```
+
+The secret prefix (`transfer/`) and the user name delimiter (`@@`) are set from `local.custom_idp_configuration` (see [`locals.tf`](../locals.tf) and `application_variables.json`); the prefix is stored on the identity provider record so different providers can use different prefixes.
+
+## Data model
+
+Authentication state is split across three stores.
+
+### Users table
+
+Hash key `user`, range key `identity_provider_key`. Each item describes one principal and how to authorise their session.
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `user` | String | Login name (lower-cased on lookup) |
+| `identity_provider_key` | String | The provider this record authenticates against (for example `secrets`) |
+| `idp_username` | String (optional) | Override used when looking up the credential, if it differs from `user` |
+| `ipv4_allow_list` | String set (optional) | CIDR ranges permitted for this user |
+| `server_id_allow_list` | String set (optional) | Transfer server IDs this user may use |
+| `config` | Map | Session attributes: `Role`, `Policy`, `HomeDirectoryType`, `HomeDirectoryDetails`/`HomeDirectory`, `PosixProfile`, `PublicKeys` |
+
+A record with `user = "$default$"` acts as a fallback that matches any otherwise-unknown user — useful when all credentials are validated by an external provider. The seeded proof-of-concept user is `dms1981`, mapped to the `secrets` provider with a logical home directory of `/<bucket>/dms1981` in the `unscanned` bucket.
+
+### Identity providers table
+
+Hash key `provider`. Each item describes a back-end that can validate credentials.
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `provider` | String | Provider name referenced by `identity_provider_key` |
+| `module` | String | Back-end type (currently `secrets_manager`) |
+| `public_key_support` | Boolean | Whether the provider returns SSH public keys |
+| `disabled` | Boolean (optional) | If true, authentication is refused |
+| `ipv4_allow_list` | String set (optional) | CIDR ranges permitted for this provider |
+| `server_id_allow_list` | String set (optional) | Transfer server IDs this provider may use |
+| `config` | Map | Provider settings, e.g. `secret_prefix`, and optional session defaults |
+
+The proof of concept seeds a single provider named `secrets` using the `secrets_manager` module with `public_key_support = true` and `secret_prefix = transfer/`.
+
+### Secrets Manager
+
+Credentials are **not** held in DynamoDB. For the `secrets_manager` provider, each user has a secret at `<secret_prefix><idp_username>` (for example `transfer/dms1981`). The secret JSON may contain:
+
+- `Password` — the expected password.
+- `PublicKeys` — a list (or JSON-encoded list) of authorised SSH public keys.
+
+Public keys may alternatively be stored in a separate secret at `<secret_prefix><idp_username>/keys`. Secrets are encrypted with the service KMS key and their values are managed manually (Terraform creates the secret with a placeholder and `ignore_secret_changes = true`).
+
+## Authentication and authorisation flow
+
+Every SFTP/FTPS authentication attempt invokes `lambda_handler` with an event containing `username`, `serverId`, `protocol`, `sourceIp`, and either `password` or (for SSH) no password. The handler proceeds as follows.
+
+```mermaid
+flowchart TD
+    A[Transfer server receives connection] --> B[Invoke custom IdP Lambda]
+    B --> C[Parse username and provider]
+    C --> D[Look up user record]
+    D --> E[Look up identity provider record]
+    E --> F{Provider disabled?}
+    F -- yes --> X[Return empty -> deny]
+    F -- no --> G[Validate server and source IP allow lists]
+    G -->|fails| X
+    G -->|passes| H[Build base response: Role, Policy, HomeDirectory]
+    H --> I{Password supplied?}
+    I -- yes --> J[Compare password from Secrets Manager]
+    I -- no --> K[Return PublicKeys from Secrets Manager]
+    J -->|mismatch| X
+    J -->|match| L[Normalise home directory and substitute variables]
+    K --> L
+    L --> M[Return session response -> allow]
+```
+
+A successful response is a JSON object describing the session (`Role`, optional `Policy`, `HomeDirectoryType`, `HomeDirectoryDetails`/`HomeDirectory`, and for SSH a `PublicKeys` array). **Any failure — at any stage — returns an empty object `{}`, which Transfer Family treats as access denied.** The function never reveals *why* authentication failed to the client; the reason is only logged in CloudWatch. Unexpected exceptions are caught, logged with a stack trace, and also denied.
+
+## Username and provider selection
+
+The submitted user name is lower-cased and split on the configured delimiter (`@@`):
+
+- `dms1981` → user `dms1981`, provider resolved from the user record.
+- `dms1981@@secrets` → user `dms1981`, provider `secrets` (explicit).
+
+The reserved values `$` and `$default$` are rejected outright as login names. Lookup order:
+
+1. If a provider was given explicitly, fetch the exact `(user, provider)` item.
+2. Otherwise query by `user` and take the first matching record.
+3. If nothing matches, fall back to the `$default$` record.
+4. If there is still no record, deny.
+
+This lets a single Transfer server front multiple back-end providers while keeping each user's authorisation explicit.
+
+## Credential validation
+
+The protocol determines which credential is checked:
+
+- **Password present** (FTPS, or SFTP with password): the handler reads the user's secret and compares the supplied password against the stored `Password` using `hmac.compare_digest`, a constant-time comparison that avoids leaking information through timing.
+- **No password** (SFTP with a key): the handler returns the user's authorised `PublicKeys`. Transfer Family then verifies the client's signature against those keys. Keys come from the provider's secret (`PublicKeys`), or a dedicated `…/keys` secret, or — if the provider does not support keys — from the user record's `config.PublicKeys`. If no keys are configured, authentication is denied.
+
+## Authorisation context
+
+Before credentials are even checked, the request context is validated against allow lists on **both** the user record and the provider record:
+
+- **Server allow list** (`server_id_allow_list`) — the connection's `serverId` must be permitted (an empty/absent list means "any").
+- **Source IP allow list** (`ipv4_allow_list`) — the connection's `sourceIp` must fall within one of the CIDR ranges (an empty/absent list means "any"). Matching is done with Python's `ipaddress` module.
+
+Both the user and the provider must pass; either can independently deny the request. This gives defence in depth: a provider-wide network restriction cannot be widened by an individual user record.
+
+## Building the Transfer response
+
+The session response is assembled from the provider `config` first and then the user `config`, so **user settings override provider defaults**. The fields copied through are `Role`, `Policy`, `HomeDirectoryDetails`, `HomeDirectory` and `PosixProfile`.
+
+- If `HomeDirectoryDetails` is present, `HomeDirectoryType` is set to `LOGICAL` (the user sees a virtual `/` mapped onto an S3 prefix). If only `HomeDirectory` is present, the type is `PATH`.
+- A `Role` is mandatory; without it the request is denied. The role is the IAM role Transfer assumes for the session, and `Policy` is an optional session (scope-down) policy that further restricts it.
+- `HomeDirectoryDetails`, if supplied as a list, is JSON-encoded as required by the Transfer API.
+
+Finally, template variables in the response are substituted: `{{USERNAME}}`, `{{AWS_REGION}}`, `{{AWS_ACCOUNT}}` and `{{SERVER_ID}}`. This lets a single provider-level template produce per-user home directories and policies without duplicating configuration.
+
+For the seeded `dms1981` user, the response pins the session to the shared `transfer-user` IAM role, attaches the upload-only session policy from [`transfer-user.tf`](../transfer-user.tf), and maps `/` to `/<unscanned-bucket>/dms1981` — so the user can only write into their own prefix.
+
+## Managing users
+
+A user exists as **two** linked things: a record in the users DynamoDB table (who they are and what they can do) and a secret in Secrets Manager (their credentials). Both are managed in Terraform in this directory. Use the seeded `dms1981` resources as templates: `custom_idp_user_dms1981` in [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf) and `secrets_custom_idp_user_dms1981` in [`secrets.tf`](../secrets.tf).
+
+### Add a user
+
+1. **Add the user record** to [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf). Set `identity_provider_key` to `secrets`, point the home directory at the user's own prefix in the `unscanned` bucket, and add `ipv4_allow_list`/`server_id_allow_list` restrictions as needed:
+
+   ```hcl
+   resource "aws_dynamodb_table_item" "custom_idp_user_alice" {
+     table_name = module.dynamodb_custom_idp_users.dynamodb_table_id
+     hash_key   = "user"
+     range_key  = "identity_provider_key"
+
+     item = jsonencode({
+       user                  = { S = "alice" }
+       identity_provider_key = { S = "secrets" }
+       ipv4_allow_list       = { SS = local.custom_idp_configuration.ingress_cidr_blocks }
+       config = { M = {
+         Role              = { S = module.transfer_user_role.arn }
+         Policy            = { S = data.aws_iam_policy_document.transfer_user_session.json }
+         HomeDirectoryType = { S = "LOGICAL" }
+         HomeDirectoryDetails = { L = [{ M = {
+           Entry  = { S = "/" }
+           Target = { S = "/${module.s3_bucket["unscanned"].s3_bucket_id}/alice" }
+         } }] }
+       } }
+     })
+   }
+   ```
+
+2. **Add the credential secret** to [`secrets.tf`](../secrets.tf), named `${local.custom_idp_configuration.secret_prefix}alice` (i.e. `transfer/alice`), mirroring `secrets_custom_idp_user_dms1981`.
+3. **Apply** the Terraform. This creates the record and a *placeholder* secret only — `ignore_secret_changes = true` means Terraform will never read or overwrite the real value.
+4. **Set the real credentials out of band.** Put the actual `Password` and/or `PublicKeys` into the secret in the AWS console or CLI, so they are never committed to source control:
+
+   ```bash
+   aws secretsmanager put-secret-value \
+     --secret-id transfer/alice \
+     --secret-string '{"Password":"…","PublicKeys":["ssh-ed25519 AAAA… alice"]}'
+   ```
+
+   For key-only (SSH) access, omit `Password`. For password-only (FTPS) access, omit `PublicKeys`.
+
+The user can now authenticate as `alice` (or `alice@@secrets` to name the provider explicitly).
+
+### Remove a user
+
+1. **Delete the user record** by removing the `aws_dynamodb_table_item` block from [`custom-idp-dynamodb.tf`](../custom-idp-dynamodb.tf) and applying. As soon as the record is gone the user can no longer authenticate (the IdP denies any login with no matching record, unless a `$default$` record exists).
+2. **Delete the credential secret** by removing the secret block from [`secrets.tf`](../secrets.tf) and applying. The secret enters its recovery window (7 days) before final deletion; use `aws secretsmanager delete-secret --force-delete-without-recovery` only if immediate removal is required.
+
+To revoke access **immediately** without a Terraform run, blank the credentials in the secret (`put-secret-value` with empty `Password`/`PublicKeys`) — the next login attempt will fail. To revoke **everyone** at once, set `disabled = true` on the `secrets` provider record.
+
+### Add a back-end provider
+
+To onboard a new credential back-end (for example LDAP or an external IdP), add a record to the identity providers table describing its `module` and `config`, then point user records at it via `identity_provider_key`.
+
+## Security considerations
+
+- **Least privilege.** The Lambda's IAM policy is scoped to the two tables, the `transfer/` secret prefix and the single KMS key. Each authenticated session is further constrained by its IAM role and scope-down policy to its own S3 prefix.
+- **No information leakage.** All failures return an identical empty response, so clients cannot distinguish "unknown user" from "wrong password" from "blocked IP".
+- **Constant-time comparison.** Passwords are compared with `hmac.compare_digest` to resist timing attacks.
+- **Encryption.** Credentials live in Secrets Manager under a customer-managed KMS key; DynamoDB tables have point-in-time recovery enabled.
+- **Network controls.** Per-user and per-provider IPv4 allow lists provide source-IP restriction independent of the network path.
+- **Secrets hygiene.** Secret values are excluded from Terraform state changes and must be set out of band.
+
+## Observability
+
+- **Logging.** The handler logs each request (user, server, protocol) and the outcome at `INFO`; denials log a warning with the reason and unexpected errors log a full stack trace. Verbosity is controlled by `LOGLEVEL`.
+- **Tracing.** AWS X-Ray active tracing is enabled, so DynamoDB and Secrets Manager calls are visible per invocation.
+- **Alarms.** CloudWatch alarms fire on Lambda **errors**, **throttles**, and **duration** approaching the 30-second authentication timeout (see [`custom-idp-lambda.tf`](../custom-idp-lambda.tf)). Transfer server activity is captured in structured CloudWatch logs.
+
+## Limitations and caveats
+
+This is a proof of concept. Before any real use, at minimum:
+
+- Replace the default `ingress_cidr_blocks` of `0.0.0.0/0` with specific partner CIDR ranges.
+- Replace the placeholder secret values for every user and rotate them on a schedule.
+- Review whether a `$default$` user is appropriate, and remove it if not.
+- Consider a managed way to provision user records and secrets rather than per-user Terraform plus manual secret population.
+- Confirm logging does not capture sensitive material at the configured `LOGLEVEL` before raising verbosity for debugging.
+
+## References
+
+- [AWS Transfer Family — custom identity providers](https://docs.aws.amazon.com/transfer/latest/userguide/custom-identity-provider-users.html)
+- [AWS Transfer Family — Lambda custom IdP events and responses](https://docs.aws.amazon.com/transfer/latest/userguide/custom-lambda-idp.html)
+- [Toolkit for AWS Transfer Family — custom IdP solution (AWS open source)](https://github.com/aws-samples/toolkit-for-aws-transfer-family/tree/main/solutions/custom-idp)
+- [Ministry of Justice technical guidance](https://developer-portal.service.justice.gov.uk/docs/ministry-of-justice-technical-guidance/)
+- [Modernisation Platform user guide](https://developer-portal.service.justice.gov.uk/docs/modernisation-platform/)
+- [Service runbook](../README.md)

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/custom-idp/idp_handler/app.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/custom-idp/idp_handler/app.py
@@ -1,0 +1,204 @@
+import hmac
+import json
+import logging
+import os
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from custom_idp_common import (
+    ip_in_cidr_list,
+    normalise_home_directory_details,
+    replace_response_variables,
+    server_id_in_allow_list,
+)
+
+
+LOG_LEVEL = os.environ.get("LOGLEVEL", "INFO")
+USER_NAME_DELIMITER = os.environ.get("USER_NAME_DELIMITER", "@@")
+USERS_TABLE_NAME = os.environ["USERS_TABLE"]
+IDENTITY_PROVIDERS_TABLE_NAME = os.environ["IDENTITY_PROVIDERS_TABLE"]
+
+logger = logging.getLogger()
+logger.setLevel(LOG_LEVEL)
+
+sts_client = boto3.client("sts")
+secretsmanager_client = boto3.client("secretsmanager")
+dynamodb_resource = boto3.resource("dynamodb")
+users_table = dynamodb_resource.Table(USERS_TABLE_NAME)
+identity_providers_table = dynamodb_resource.Table(IDENTITY_PROVIDERS_TABLE_NAME)
+account_id = sts_client.get_caller_identity()["Account"]
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+def lambda_handler(event, context):
+    try:
+        username, identity_provider_name = parse_username(event)
+        logger.info(
+            "Processing authentication request for user %s on server %s using protocol %s",
+            username,
+            event.get("serverId"),
+            event.get("protocol"),
+        )
+
+        user_record = get_user_record(username, identity_provider_name)
+        identity_provider_record = get_identity_provider_record(user_record["identity_provider_key"])
+        validate_request_context(event, username, user_record, identity_provider_record)
+
+        idp_username = user_record.get("idp_username") or username
+        response_data = build_transfer_response(user_record, identity_provider_record)
+
+        if event.get("password", "").strip():
+            authenticate_password(event["password"], idp_username, identity_provider_record)
+        else:
+            public_keys = get_public_keys(idp_username, user_record, identity_provider_record)
+            if not public_keys:
+                raise AuthenticationError("No public keys configured for user")
+            response_data["PublicKeys"] = public_keys
+
+        response_data = normalise_home_directory_details(response_data)
+        response_data = replace_response_variables(response_data, username, account_id, event["serverId"])
+        logger.info("Authentication succeeded for user %s", username)
+        return response_data
+    except AuthenticationError as error:
+        logger.warning("Authentication failed: %s", error)
+        return {}
+    except Exception:
+        logger.exception("Unexpected custom IdP error")
+        return {}
+
+
+def parse_username(event):
+    if "username" not in event or "serverId" not in event:
+        raise AuthenticationError("Incoming username or serverId is missing")
+
+    input_username = event["username"].lower()
+    if input_username in {"$", "$default$"}:
+        raise AuthenticationError("Reserved username cannot authenticate")
+
+    parsed_username = input_username.split(USER_NAME_DELIMITER)
+    if len(parsed_username) > 1:
+        return USER_NAME_DELIMITER.join(parsed_username[:-1]), parsed_username[-1]
+
+    return input_username, None
+
+
+def get_user_record(username, identity_provider_name):
+    if identity_provider_name:
+        user_record = users_table.get_item(
+            Key={"user": username, "identity_provider_key": identity_provider_name}
+        ).get("Item")
+    else:
+        user_records = users_table.query(KeyConditionExpression=Key("user").eq(username)).get("Items", [])
+        user_record = user_records[0] if user_records else None
+
+    if not user_record:
+        default_records = users_table.query(KeyConditionExpression=Key("user").eq("$default$")).get("Items", [])
+        user_record = default_records[0] if default_records else None
+
+    if not user_record:
+        raise AuthenticationError("No matching user record found")
+
+    return user_record
+
+
+def get_identity_provider_record(identity_provider_name):
+    identity_provider_record = identity_providers_table.get_item(
+        Key={"provider": identity_provider_name}
+    ).get("Item")
+
+    if not identity_provider_record:
+        raise AuthenticationError("Identity provider is not defined")
+
+    if identity_provider_record.get("disabled", False):
+        raise AuthenticationError("Identity provider is disabled")
+
+    return identity_provider_record
+
+
+def validate_request_context(event, username, user_record, identity_provider_record):
+    server_id = event["serverId"]
+    source_ip = event.get("sourceIp", "0.0.0.0")
+
+    if not server_id_in_allow_list(server_id, user_record.get("server_id_allow_list")):
+        raise AuthenticationError(f"User {username} is not allowed on this server")
+
+    if not server_id_in_allow_list(server_id, identity_provider_record.get("server_id_allow_list")):
+        raise AuthenticationError("Identity provider is not allowed on this server")
+
+    if not ip_in_cidr_list(source_ip, user_record.get("ipv4_allow_list")):
+        raise AuthenticationError("Source IP is not allowed for this user")
+
+    if not ip_in_cidr_list(source_ip, identity_provider_record.get("ipv4_allow_list")):
+        raise AuthenticationError("Source IP is not allowed for this identity provider")
+
+
+def build_transfer_response(user_record, identity_provider_record):
+    response_data = {}
+    identity_provider_config = identity_provider_record.get("config", {})
+    user_config = user_record.get("config", {})
+
+    for field_name in ["Role", "Policy", "HomeDirectoryDetails", "HomeDirectory", "PosixProfile"]:
+        if field_name in identity_provider_config:
+            response_data[field_name] = identity_provider_config[field_name]
+        if field_name in user_config:
+            response_data[field_name] = user_config[field_name]
+
+    if "HomeDirectoryDetails" in response_data:
+        response_data["HomeDirectoryType"] = "LOGICAL"
+    elif "HomeDirectory" in response_data:
+        response_data["HomeDirectoryType"] = "PATH"
+
+    if not response_data.get("Role"):
+        raise AuthenticationError("Transfer role is not configured")
+
+    return response_data
+
+
+def authenticate_password(input_password, username, identity_provider_record):
+    secret_value = get_user_secret(username, identity_provider_record)
+    expected_password = secret_value.get("Password")
+
+    if not expected_password:
+        raise AuthenticationError("Password is not configured for user")
+
+    if not hmac.compare_digest(str(expected_password), input_password):
+        raise AuthenticationError("Password does not match")
+
+
+def get_public_keys(username, user_record, identity_provider_record):
+    if not identity_provider_record.get("public_key_support", False):
+        return user_record.get("config", {}).get("PublicKeys", [])
+
+    secret_value = get_user_secret(username, identity_provider_record)
+    public_keys = secret_value.get("PublicKeys", [])
+    if isinstance(public_keys, str):
+        public_keys = json.loads(public_keys)
+
+    if public_keys:
+        return public_keys
+
+    key_secret_name = f"{get_secret_prefix(identity_provider_record)}{username}/keys"
+    try:
+        key_secret = secretsmanager_client.get_secret_value(SecretId=key_secret_name)
+        key_secret_value = json.loads(key_secret["SecretString"])
+        return key_secret_value.get("PublicKeys", [])
+    except secretsmanager_client.exceptions.ResourceNotFoundException:
+        return []
+
+
+def get_user_secret(username, identity_provider_record):
+    secret_name = f"{get_secret_prefix(identity_provider_record)}{username}"
+    try:
+        secret = secretsmanager_client.get_secret_value(SecretId=secret_name)
+    except secretsmanager_client.exceptions.ResourceNotFoundException as error:
+        raise AuthenticationError("User secret does not exist") from error
+
+    return json.loads(secret["SecretString"])
+
+
+def get_secret_prefix(identity_provider_record):
+    return identity_provider_record.get("config", {}).get("secret_prefix", "transfer/")

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/custom-idp/layer/python/custom_idp_common.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/custom-idp/layer/python/custom_idp_common.py
@@ -1,0 +1,46 @@
+import ipaddress
+import json
+import os
+import re
+
+
+AWS_REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
+
+
+def ip_in_cidr_list(ip_address, cidr_list):
+    if not cidr_list:
+        return True
+
+    source_ip = ipaddress.ip_address(ip_address)
+    return any(source_ip in ipaddress.ip_network(cidr) for cidr in cidr_list)
+
+
+def server_id_in_allow_list(server_id, allow_list):
+    if not allow_list:
+        return True
+
+    return server_id in allow_list
+
+
+def replace_response_variables(response_data, username, account_id, server_id):
+    response_variables = {
+        "USERNAME": username,
+        "AWS_REGION": AWS_REGION,
+        "AWS_ACCOUNT": account_id,
+        "SERVER_ID": server_id,
+    }
+
+    response_text = json.dumps(response_data)
+
+    def replace_match(match):
+        return response_variables.get(match.group(1), match.group(0))
+
+    return json.loads(re.sub(r"\{\{(\w+)\}\}", replace_match, response_text))
+
+
+def normalise_home_directory_details(response_data):
+    home_directory_details = response_data.get("HomeDirectoryDetails")
+    if isinstance(home_directory_details, list):
+        response_data["HomeDirectoryDetails"] = json.dumps(home_directory_details)
+
+    return response_data

--- a/terraform/environments/integration-hub/managed-file-transfer/locals.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/locals.tf
@@ -1,5 +1,14 @@
 locals {
   bucket_configuration = local.application_data.accounts[local.environment].bucket_configuration
-  iam_configuration    = local.application_data.accounts[local.environment].iam_configuration
-  vpc_configuration    = local.application_data.accounts[local.environment].vpc_configuration
+  custom_idp_configuration = merge(
+    {
+      log_level           = "INFO"
+      secret_prefix       = "transfer/"
+      user_name_delimiter = "@@"
+      ingress_cidr_blocks = ["0.0.0.0/0"]
+    },
+    try(local.application_data.accounts[local.environment].custom_idp_configuration, {})
+  )
+  iam_configuration = local.application_data.accounts[local.environment].iam_configuration
+  vpc_configuration = local.application_data.accounts[local.environment].vpc_configuration
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/platform_base_variables.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/platform_base_variables.tf
@@ -7,13 +7,3 @@ variable "collaborator_access" {
   default     = "developer"
   description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
 }
-
-variable "transfer_ftps_certificate_arn" {
-  type        = string
-  description = "ACM certificate ARN used by the AWS Transfer FTPS endpoint."
-
-  validation {
-    condition     = can(regex("^arn:aws:acm:eu-west-2:[0-9]{12}:certificate/[0-9a-f-]+$", var.transfer_ftps_certificate_arn))
-    error_message = "transfer_ftps_certificate_arn must be an ACM certificate ARN in eu-west-2."
-  }
-}

--- a/terraform/environments/integration-hub/managed-file-transfer/platform_base_variables.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/platform_base_variables.tf
@@ -7,3 +7,13 @@ variable "collaborator_access" {
   default     = "developer"
   description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
 }
+
+variable "transfer_ftps_certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN used by the AWS Transfer FTPS endpoint."
+
+  validation {
+    condition     = can(regex("^arn:aws:acm:eu-west-2:[0-9]{12}:certificate/[0-9a-f-]+$", var.transfer_ftps_certificate_arn))
+    error_message = "transfer_ftps_certificate_arn must be an ACM certificate ARN in eu-west-2."
+  }
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/route53.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/route53.tf
@@ -8,6 +8,12 @@ module "r53_managed_file_transfer" {
   create_zone = false
 
   records = {
+    ftps = {
+      name    = "ftps"
+      type    = "A"
+      ttl     = 300
+      records = [for key, value in aws_eip.this : value.public_ip]
+    }
     sftp = {
       name    = "sftp"
       type    = "A"

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -1,9 +1,15 @@
-module "secrets_custom_idp_user_dms1981" {
+module "secrets_custom_idp_user" {
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "2.1.0"
 
-  name                    = "${local.custom_idp_configuration.secret_prefix}dms1981"
-  description             = "${local.application_name} custom IdP POC credentials for dms1981"
+  for_each = local.custom_idp_users
+
+  # The custom IdP Lambda looks up each user's credentials at
+  # "<secret_prefix><username>" (see lambda/custom-idp/idp_handler/app.py), so
+  # every user must have their own secret. One secret per user also keeps the
+  # blast radius small and makes per-user access auditing and rotation simpler.
+  name                    = "${local.custom_idp_configuration.secret_prefix}${each.key}"
+  description             = "${local.application_name} custom IdP POC credentials for ${each.key}"
   recovery_window_in_days = 7
   kms_key_id              = module.kms_secrets.key_arn
   create_policy           = true

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -29,7 +29,34 @@ module "secrets_transfer_user_ssh" {
   })
 }
 
-data "aws_secretsmanager_secret_version" "secrets_transfer_user_ssh" {
-  depends_on = [module.secrets_transfer_user_ssh]
-  secret_id  = module.secrets_transfer_user_ssh.secret_id
+module "secrets_custom_idp_user_dms1981" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.custom_idp_configuration.secret_prefix}dms1981"
+  description             = "${local.application_name} custom IdP POC credentials for dms1981"
+  recovery_window_in_days = 7
+  kms_key_id              = module.kms_secrets.key_arn
+  create_policy           = true
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  policy_statements = {
+    read = {
+      sid = "AllowCIRolesToRead"
+      principals = [{
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+        ]
+      }]
+      actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      resources = ["*"]
+    }
+  }
+
+  secret_string = jsonencode({
+    Password   = "replace-me"
+    PublicKeys = ["replace-me"]
+  })
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -1,34 +1,3 @@
-module "secrets_transfer_user_ssh" {
-  source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.1.0"
-
-  name                    = "${local.application_name}-transfer-user-ssh-keys"
-  description             = "${local.application_name} Transfer User SSH Keys"
-  recovery_window_in_days = 7
-  kms_key_id              = module.kms_secrets.key_arn
-  create_policy           = true
-  block_public_policy     = true
-  ignore_secret_changes   = true
-
-  policy_statements = {
-    read = {
-      sid = "AllowCIRolesToRead"
-      principals = [{
-        type = "AWS"
-        identifiers = [
-          "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
-        ]
-      }]
-      actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
-      resources = ["*"]
-    }
-  }
-  # This value will be manually populated in AWS and will be ignored due to ignore_secret_changes = true
-  secret_string = jsonencode({
-    username = "123456789012"
-  })
-}
-
 module "secrets_custom_idp_user_dms1981" {
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "2.1.0"

--- a/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/secrets.tf
@@ -31,7 +31,7 @@ module "secrets_custom_idp_user" {
   }
 
   secret_string = jsonencode({
-    Password   = "replace-me"
-    PublicKeys = ["replace-me"]
+    Password   = null
+    PublicKeys = []
   })
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
@@ -4,7 +4,6 @@ resource "aws_security_group" "transfer" {
   vpc_id      = module.isolated_vpc.vpc_id
 }
 
-/*
 resource "aws_security_group_rule" "transfer_inbound_sftp" {
   description       = "Inbound rule for SFTP protocol on port 22"
   type              = "ingress"
@@ -12,16 +11,25 @@ resource "aws_security_group_rule" "transfer_inbound_sftp" {
   to_port           = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.transfer.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
 }
 
-resource "aws_security_group_rule" "transfer_inbound_ftps" {
-  description       = "Inbound rule for FTPS protocol on port 443"
+resource "aws_security_group_rule" "transfer_inbound_ftps_control" {
+  description       = "Inbound rule for FTPS control channel on port 21"
   type              = "ingress"
-  from_port         = 443
-  to_port           = 443
+  from_port         = 21
+  to_port           = 21
   protocol          = "tcp"
   security_group_id = aws_security_group.transfer.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
 }
-*/
+
+resource "aws_security_group_rule" "transfer_inbound_ftps_passive" {
+  description       = "Inbound rule for FTPS passive data channel ports"
+  type              = "ingress"
+  from_port         = 8192
+  to_port           = 8200
+  protocol          = "tcp"
+  security_group_id = aws_security_group.transfer.id
+  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/security-groups.tf
@@ -4,6 +4,7 @@ resource "aws_security_group" "transfer" {
   vpc_id      = module.isolated_vpc.vpc_id
 }
 
+/*
 resource "aws_security_group_rule" "transfer_inbound_sftp" {
   description       = "Inbound rule for SFTP protocol on port 22"
   type              = "ingress"
@@ -11,25 +12,16 @@ resource "aws_security_group_rule" "transfer_inbound_sftp" {
   to_port           = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.transfer.id
-  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "transfer_inbound_ftps_control" {
-  description       = "Inbound rule for FTPS control channel on port 21"
+resource "aws_security_group_rule" "transfer_inbound_ftps" {
+  description       = "Inbound rule for FTPS protocol on port 21"
   type              = "ingress"
   from_port         = 21
   to_port           = 21
   protocol          = "tcp"
   security_group_id = aws_security_group.transfer.id
-  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
+  cidr_blocks       = ["0.0.0.0/0"]
 }
-
-resource "aws_security_group_rule" "transfer_inbound_ftps_passive" {
-  description       = "Inbound rule for FTPS passive data channel ports"
-  type              = "ingress"
-  from_port         = 8192
-  to_port           = 8200
-  protocol          = "tcp"
-  security_group_id = aws_security_group.transfer.id
-  cidr_blocks       = local.custom_idp_configuration.ingress_cidr_blocks
-}
+*/

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
@@ -1,20 +1,25 @@
 resource "aws_transfer_server" "this" {
+  certificate            = var.transfer_ftps_certificate_arn
   domain                 = "S3"
   endpoint_type          = "VPC"
-  identity_provider_type = "SERVICE_MANAGED"
+  function               = module.lambda_custom_idp.lambda_function_arn
+  identity_provider_type = "AWS_LAMBDA"
   logging_role           = module.iam_for_transfer.arn
-  protocols              = ["SFTP"]
+  protocols              = ["SFTP", "FTPS"]
   security_policy_name   = "TransferSecurityPolicy-2025-03"
   structured_log_destinations = [
     "${module.cloudwatch_transfer.cloudwatch_log_group_arn}:*"
   ]
+
+  protocol_details {
+    passive_ip = aws_eip.this[0].public_ip
+  }
+
   endpoint_details {
     vpc_id     = module.isolated_vpc.vpc_id
-    subnet_ids = module.isolated_vpc.public_subnets
+    subnet_ids = slice(module.isolated_vpc.public_subnets, 0, 1)
     address_allocation_ids = [
       aws_eip.this[0].id,
-      aws_eip.this[1].id,
-      aws_eip.this[2].id,
     ]
     security_group_ids = [
       aws_security_group.transfer.id
@@ -28,6 +33,6 @@ resource "aws_transfer_server" "this" {
 }
 
 resource "aws_eip" "this" {
-  count  = length(module.isolated_vpc.public_subnets)
+  count  = 1
   domain = "vpc"
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
@@ -1,5 +1,5 @@
 resource "aws_transfer_server" "this" {
-  certificate            = var.transfer_ftps_certificate_arn
+  certificate            = aws_acm_certificate.ftps.arn
   domain                 = "S3"
   endpoint_type          = "VPC"
   function               = module.lambda_custom_idp.lambda_function_arn
@@ -11,28 +11,32 @@ resource "aws_transfer_server" "this" {
     "${module.cloudwatch_transfer.cloudwatch_log_group_arn}:*"
   ]
 
-  protocol_details {
-    passive_ip = aws_eip.this[0].public_ip
-  }
-
   endpoint_details {
     vpc_id     = module.isolated_vpc.vpc_id
     subnet_ids = slice(module.isolated_vpc.public_subnets, 0, 1)
     address_allocation_ids = [
-      aws_eip.this[0].id,
+      aws_eip.this[0].id
     ]
     security_group_ids = [
       aws_security_group.transfer.id
     ]
+  }
+  
+  protocol_details {
+    passive_ip = aws_eip.this[0].public_ip
   }
 
   tags = {
     "transfer:customHostname"      = local.is-production == false ? "sftp.${local.environment}.managed-file-transfer.service.justice.gov.uk" : "sftp.managed-file-transfer.service.justice.gov.uk"
     "transfer:route53HostedZoneId" = "/hostedzone/${data.aws_route53_zone.service.zone_id}"
   }
+
+  depends_on = [aws_acm_certificate.ftps]
 }
 
 resource "aws_eip" "this" {
   count  = 1
   domain = "vpc"
+
+  depends_on = [aws_acm_certificate.ftps]
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
@@ -21,7 +21,7 @@ resource "aws_transfer_server" "this" {
       aws_security_group.transfer.id
     ]
   }
-  
+
   protocol_details {
     passive_ip = aws_eip.this[0].public_ip
   }

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-user.tf
@@ -113,25 +113,3 @@ module "transfer_user_role" {
     transfer_user_policy = module.transfer_user_policy.arn
   }
 }
-
-# POC user based on my GitHub username
-resource "aws_transfer_user" "this" {
-  for_each            = toset(["dms1981"])
-  role                = module.transfer_user_role.arn
-  server_id           = aws_transfer_server.this.id
-  user_name           = "dms1981"
-  home_directory_type = "LOGICAL"
-  home_directory      = "/"
-  home_directory_mappings {
-    entry  = "/"
-    target = "/${module.s3_bucket["unscanned"].s3_bucket_id}/${each.key}"
-  }
-  policy = data.aws_iam_policy_document.transfer_user_session.json
-}
-
-resource "aws_transfer_ssh_key" "this" {
-  for_each  = toset(["dms1981"])
-  body      = data.aws_secretsmanager_secret_version.secrets_transfer_user_ssh.secret_string
-  server_id = aws_transfer_server.this.id
-  user_name = aws_transfer_user.this[each.key].user_name
-}


### PR DESCRIPTION
<!-- :copilot: _This pull request body was generated by GitHub Copilot_ -->

## 🚀 What's this?

Adds **FTPS** connectivity to the Integration Hub managed file transfer proof of concept, fronted by a **custom Lambda identity provider** so users can be authenticated and authorised from our own AWS account. 🔐

## 📦 What's in the box

- 🔑 **Custom identity provider** — a Python 3.12 Lambda (`custom-idp-lambda.tf`, `lambda/custom-idp/`) that authenticates AWS Transfer users against DynamoDB metadata and Secrets Manager credentials, derived from the AWS [Toolkit for AWS Transfer Family custom IdP solution](https://github.com/aws-samples/toolkit-for-aws-transfer-family/tree/main/solutions/custom-idp).
- 🗃️ **Two DynamoDB tables** (`custom-idp-dynamodb.tf`) — one for users, one for identity providers, plus the seeded proof-of-concept user.
- 🛡️ **Secrets Manager** wiring (`secrets.tf`) for per-user credentials, with values populated out of band (`ignore_secret_changes = true`).
- 🌐 **Transfer server** now offers both `SFTP` and `FTPS` and delegates auth to the Lambda (`transfer-server.tf`).
- 📊 **Observability** — CloudWatch alarms for Lambda errors, throttles and duration, plus X-Ray tracing.
- 📖 **Docs** — fleshed-out [service runbook](terraform/environments/integration-hub/managed-file-transfer/README.md) and a new [custom IdP guide](terraform/environments/integration-hub/managed-file-transfer/docs/custom-idp.md) covering how it works and how to add/remove users.

## 🧪 Validation

- ✅ `terraform fmt`
- ✅ `terraform validate`

## ⚠️ Proof-of-concept caveats

This is deliberately a PoC. A few defaults are **not** production-ready and are flagged in the docs — notably the open `0.0.0.0/0` IPv4 allow list and placeholder secret values. These should be tightened before any real use. 🚧

---

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>