### PR TITLE
Add custom hostnames for SFTP servers

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/data.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/data.tf
@@ -1,3 +1,9 @@
 data "aws_availability_zones" "available" {
   state = "available"
 }
+
+data "aws_route53_zone" "service" {
+  provider     = aws.core-network-services
+  name         = local.is-production == false ? "${local.environment}.managed-file-transfer.service.justice.gov.uk" : "managed-file-transfer.service.justice.gov.uk"
+  private_zone = false
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/transfer-server.tf
@@ -20,6 +20,11 @@ resource "aws_transfer_server" "this" {
       aws_security_group.transfer.id
     ]
   }
+
+  tags = {
+    "transfer:customHostname"      = local.is-production == false ? "sftp.${local.environment}.managed-file-transfer.service.justice.gov.uk" : "sftp.managed-file-transfer.service.justice.gov.uk"
+    "transfer:route53HostedZoneId" = "/hostedzone/${data.aws_route53_zone.service.zone_id}"
+  }
 }
 
 resource "aws_eip" "this" {


### PR DESCRIPTION
Noticed that I was getting a curl error about security when using the new Route53 record to reach the transfer endpoint. 

Added configuration for custom hostname following the guidance in these AWS documents: https://docs.aws.amazon.com/transfer/latest/userguide/requirements-dns.html