### PR TITLE
PDHD-88: Give assessment view service a shorter name.

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -68,6 +68,10 @@
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": true
+        },
+        "pr-assess-view": {
+          "share_with_cloud_platform": true,
+          "create_glue_connection": true
         }
       },
       "dps_domains": [
@@ -303,6 +307,10 @@
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": true
+        },
+        "pr-assess-view": {
+          "share_with_cloud_platform": true,
+          "create_glue_connection": true
         }
       },
       "dps_domains": [
@@ -517,6 +525,10 @@
       "scheduled_dataset_lambda_version": "vLatest",
       "probation_domains": {
         "pr-assessment-view": {
+          "share_with_cloud_platform": true,
+          "create_glue_connection": true
+        },
+        "pr-assess-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": true
         }
@@ -748,6 +760,10 @@
         "pr-assessment-view": {
           "share_with_cloud_platform": true,
           "create_glue_connection": false
+        },
+        "pr-assess-view": {
+          "share_with_cloud_platform": true,
+          "create_glue_connection": true
         }
       },
       "dps_domains": [

--- a/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
+++ b/terraform/environments/digital-prison-reporting/modules/data_source_secret/main.tf
@@ -80,4 +80,8 @@ resource "aws_secretsmanager_secret_version" "this" {
 
 data "aws_secretsmanager_secret_version" "this" {
   secret_id = aws_secretsmanager_secret.this.id
+
+  depends_on = [
+    aws_secretsmanager_secret_version.this
+  ]
 }


### PR DESCRIPTION
This is to work around the length restrictions on IAM names. The old name `pr-assessment-view` will be removed at a later date once the ARNS Sentence Plan team have migrated their secrets update process to the new secrets