### PR TITLE
swagger-ui

### DIFF
--- a/scripts/bootstrap-api-credentials.sh
+++ b/scripts/bootstrap-api-credentials.sh
@@ -7,6 +7,7 @@ usage() {
 Usage:
   scripts/bootstrap-api-credentials.sh user --secret-id <secret-id> [--username <username>] [--role-name <role-name>] [--profile <aws-profile>] [--region <aws-region>]
   scripts/bootstrap-api-credentials.sh system --secret-id <secret-id> [--token-id <token-id>] [--role-name <role-name>] [--profile <aws-profile>] [--region <aws-region>]
+  scripts/bootstrap-api-credentials.sh docs --secret-id <secret-id> [--username <username>] [--profile <aws-profile>] [--region <aws-region>]
 
 Description:
   Generates a strong API credential outside Terraform state, writes it to the
@@ -24,6 +25,11 @@ Modes:
       {"tokenId":"...","bearerToken":"...","roleName":"..."}
     Prints only the bearer token value to hand over to the client in this form:
       <tokenId>.<bearerToken>
+
+  docs
+    Writes JSON in this shape:
+      {"username":"...","password":"..."}
+    Prints only the generated password to stdout.
 
 Notes:
   - If username, token-id, or role-name are omitted, the script will try to
@@ -96,8 +102,8 @@ if [ -z "$SECRET_ID" ]; then
   exit 1
 fi
 
-if [ "$MODE" != "user" ] && [ "$MODE" != "system" ]; then
-  echo "Mode must be 'user' or 'system'" >&2
+if [ "$MODE" != "user" ] && [ "$MODE" != "system" ] && [ "$MODE" != "docs" ]; then
+  echo "Mode must be 'user', 'system', or 'docs'" >&2
   exit 1
 fi
 
@@ -213,6 +219,35 @@ if [ "$MODE" = "user" ]; then
 
   echo "Username: $USERNAME" >&2
   echo "Role name: $ROLE_NAME" >&2
+  printf '%s\n' "$PASSWORD"
+  exit 0
+fi
+
+if [ "$MODE" = "docs" ]; then
+  USERNAME="${USERNAME:-$(read_secret_field "$CURRENT_SECRET_JSON" "username")}"
+
+  if [ -z "$USERNAME" ]; then
+    echo "Username is missing. Pass --username or store it in the current secret JSON." >&2
+    exit 1
+  fi
+
+  PASSWORD="$(generate_secret_value 40)"
+  SECRET_STRING="$(python3 - "$USERNAME" "$PASSWORD" <<'PY'
+import json
+import sys
+
+username, password = sys.argv[1:]
+print(json.dumps({"username": username, "password": password}, separators=(",", ":")), end="")
+PY
+)"
+
+  echo "Writing generated docs password to $SECRET_ID" >&2
+  "${AWS_CMD[@]}" secretsmanager put-secret-value \
+    --secret-id "$SECRET_ID" \
+    --secret-string "$SECRET_STRING" \
+    >/dev/null
+
+  echo "Username: $USERNAME" >&2
   printf '%s\n' "$PASSWORD"
   exit 0
 fi

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -281,4 +281,33 @@ curl -X DELETE "https://<api-endpoint>/transfer-tickets/<transfer-ticket>" \
 
 ## OpenAPI
 
-The API contract is documented in [`openapi.yaml`](openapi.yaml).
+The source contract is documented in [`openapi.yaml`](openapi.yaml).
+
+After deployment, the same API publishes a protected Swagger UI and the raw OpenAPI document:
+
+- `terraform output transfer_ticket_api_docs_url`
+- `terraform output transfer_ticket_openapi_url`
+- `terraform output transfer_ticket_api_docs_basic_auth_secret_name`
+
+The docs page and raw OpenAPI URL are protected with browser-friendly HTTP Basic auth backed by Secrets Manager. Bootstrap the live password outside Terraform state with:
+
+```bash
+terraform output transfer_ticket_api_docs_basic_auth_secret_name
+scripts/bootstrap-api-credentials.sh docs --secret-id <docs-secret-name>
+```
+
+Inside Swagger UI, callers should still use the API's own security schemes for actual operations:
+
+- Basic auth credentials backed by Secrets Manager, or
+- a Bearer token in the form `<tokenId>.<bearerToken>`
+
+## Recommended sharing pattern
+
+The standard pattern for sharing a Swagger contract with internal and external consumers is:
+
+1. Host the human-friendly UI close to the API itself so the contract and runtime stay in sync.
+2. Protect the UI with SSO or browser-friendly basic auth if broader internet reach is required.
+3. Publish the raw OpenAPI document as a separate protected URL for code generation, Postman imports, and client automation.
+4. Treat the OpenAPI file as versioned source alongside the implementation so contract changes are reviewed with code changes.
+
+This stack now follows that pattern by serving `/docs` and `/openapi.yaml` from the same HTTP API, protecting the docs URLs with dedicated basic auth, and keeping the upload operations on their existing Basic and Bearer authentication controls.

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -33,6 +33,14 @@ resource "aws_apigatewayv2_integration" "upload_ticket" {
   payload_format_version = "2.0"
 }
 
+resource "aws_apigatewayv2_integration" "api_docs" {
+  api_id                 = aws_apigatewayv2_api.upload_ticket.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = module.lambda_api_docs.lambda_function_invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
 resource "aws_apigatewayv2_authorizer" "mft_request" {
   api_id                            = aws_apigatewayv2_api.upload_ticket.id
   authorizer_type                   = "REQUEST"
@@ -75,6 +83,24 @@ resource "aws_apigatewayv2_route" "transfer_ticket_abort" {
   authorizer_id      = aws_apigatewayv2_authorizer.mft_request.id
 }
 
+resource "aws_apigatewayv2_route" "api_docs" {
+  api_id    = aws_apigatewayv2_api.upload_ticket.id
+  route_key = "GET /docs"
+  target    = "integrations/${aws_apigatewayv2_integration.api_docs.id}"
+}
+
+resource "aws_apigatewayv2_route" "api_docs_slash" {
+  api_id    = aws_apigatewayv2_api.upload_ticket.id
+  route_key = "GET /docs/"
+  target    = "integrations/${aws_apigatewayv2_integration.api_docs.id}"
+}
+
+resource "aws_apigatewayv2_route" "api_openapi_contract" {
+  api_id    = aws_apigatewayv2_api.upload_ticket.id
+  route_key = "GET /openapi.yaml"
+  target    = "integrations/${aws_apigatewayv2_integration.api_docs.id}"
+}
+
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.upload_ticket.id
   name        = "$default"
@@ -111,4 +137,12 @@ resource "aws_lambda_permission" "allow_api_gateway_authorizer" {
   function_name = module.lambda_api_authorizer.lambda_function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.upload_ticket.execution_arn}/authorizers/${aws_apigatewayv2_authorizer.mft_request.id}"
+}
+
+resource "aws_lambda_permission" "allow_api_gateway_api_docs" {
+  statement_id  = "AllowExecutionFromApiGatewayApiDocs"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_api_docs.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.upload_ticket.execution_arn}/*/*"
 }

--- a/terraform/environments/integration-hub/api-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-platform/api-gateway.tf
@@ -89,12 +89,6 @@ resource "aws_apigatewayv2_route" "api_docs" {
   target    = "integrations/${aws_apigatewayv2_integration.api_docs.id}"
 }
 
-resource "aws_apigatewayv2_route" "api_docs_slash" {
-  api_id    = aws_apigatewayv2_api.upload_ticket.id
-  route_key = "GET /docs/"
-  target    = "integrations/${aws_apigatewayv2_integration.api_docs.id}"
-}
-
 resource "aws_apigatewayv2_route" "api_openapi_contract" {
   api_id    = aws_apigatewayv2_api.upload_ticket.id
   route_key = "GET /openapi.yaml"

--- a/terraform/environments/integration-hub/api-platform/auth.tf
+++ b/terraform/environments/integration-hub/api-platform/auth.tf
@@ -45,3 +45,24 @@ module "api_system_bearer_token_secret" {
 
   tags = local.tags
 }
+
+module "api_docs_basic_auth_secret" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-${local.component_name}-${local.environment}-docs-basic-auth"
+  description             = "Basic auth credentials for the protected Swagger UI"
+  recovery_window_in_days = 7
+  create_policy           = false
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  # This value is a placeholder. Populate the real password directly in AWS
+  # Secrets Manager and Terraform will ignore later secret value changes.
+  secret_string = jsonencode({
+    username = local.api_docs_configuration.basic_auth_username
+    password = "replace-me"
+  })
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -141,3 +141,44 @@ module "lambda_api_authorizer" {
 
   tags = local.tags
 }
+
+module "lambda_api_docs" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-${local.component_name}-docs"
+  description                  = "Serves the protected Swagger UI and OpenAPI contract for the MFT API"
+  handler                      = "lambda_function.lambda_handler"
+  runtime                      = "python3.12"
+  trigger_on_package_timestamp = false
+  environment_variables = {
+    DOCS_BASIC_AUTH_SECRET_ID = module.api_docs_basic_auth_secret.secret_name
+  }
+  source_path = [
+    {
+      path     = "${path.module}/lambda/request-docs"
+      patterns = ["*.py"]
+    },
+    {
+      path     = "${path.module}"
+      patterns = ["openapi.yaml"]
+    },
+  ]
+
+  attach_policy_statements = true
+  policy_statements = {
+    docs_auth_secret_read = {
+      effect = "Allow"
+      actions = [
+        "secretsmanager:GetSecretValue",
+      ]
+      resources = [
+        module.api_docs_basic_auth_secret.secret_arn,
+      ]
+    }
+  }
+
+  cloudwatch_logs_retention_in_days = 30
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -150,7 +150,8 @@ module "lambda_api_docs" {
   description                  = "Serves the protected Swagger UI and OpenAPI contract for the MFT API"
   handler                      = "lambda_function.lambda_handler"
   runtime                      = "python3.12"
-  trigger_on_package_timestamp = false
+  # Rebuild the package on clean CI runners when the local zip is absent.
+  trigger_on_package_timestamp = true
   environment_variables = {
     DOCS_BASIC_AUTH_SECRET_ID = module.api_docs_basic_auth_secret.secret_name
   }

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -157,11 +157,11 @@ module "lambda_api_docs" {
   source_path = [
     {
       path     = "${path.module}/lambda/request-docs"
-      patterns = ["*.py"]
+      patterns = [".*\\.py$"]
     },
     {
       path     = "${path.module}"
-      patterns = ["openapi.yaml"]
+      patterns = ["openapi\\.yaml$"]
     },
   ]
 

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -155,14 +155,8 @@ module "lambda_api_docs" {
     DOCS_BASIC_AUTH_SECRET_ID = module.api_docs_basic_auth_secret.secret_name
   }
   source_path = [
-    {
-      path     = "${path.module}/lambda/request-docs"
-      patterns = [".*\\.py$"]
-    },
-    {
-      path     = "${path.module}"
-      patterns = ["openapi\\.yaml$"]
-    },
+    "${path.module}/lambda/request-docs",
+    "${path.module}/openapi.yaml",
   ]
 
   attach_policy_statements = true

--- a/terraform/environments/integration-hub/api-platform/lambda/request-docs/lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-docs/lambda_function.py
@@ -1,0 +1,302 @@
+import base64
+import binascii
+import hmac
+import json
+import os
+from pathlib import Path
+
+import boto3
+
+
+def _resolve_openapi_path():
+    candidate_paths = [
+        Path(__file__).with_name("openapi.yaml"),
+        Path(__file__).resolve().parents[2] / "openapi.yaml",
+    ]
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+    return candidate_paths[0]
+
+
+OPENAPI_PATH = _resolve_openapi_path()
+SECRETS_MANAGER = boto3.client("secretsmanager")
+DOCS_BASIC_AUTH_SECRET_ID = os.environ["DOCS_BASIC_AUTH_SECRET_ID"]
+
+
+def _response(status_code, body, content_type, extra_headers=None):
+    headers = {
+        "cache-control": "no-store",
+        "content-type": content_type,
+        "x-content-type-options": "nosniff",
+    }
+    headers.update(extra_headers or {})
+    return {
+        "statusCode": status_code,
+        "headers": headers,
+        "body": body,
+    }
+
+
+def _unauthorized():
+    return _response(
+        401,
+        "Authentication required",
+        "text/plain; charset=utf-8",
+        {"www-authenticate": 'Basic realm="Integration Hub API Docs", charset="UTF-8"'},
+    )
+
+
+def _get_header(event, header_name):
+    headers = (event or {}).get("headers") or {}
+    for key, value in headers.items():
+        if key.lower() == header_name.lower():
+            return value
+    return None
+
+
+def _load_secret_json(secret_id):
+    try:
+        response = SECRETS_MANAGER.get_secret_value(SecretId=secret_id)
+        secret_string = response.get("SecretString") or ""
+        return json.loads(secret_string) if secret_string else {}
+    except Exception:
+        return {}
+
+
+def _is_authorized(event):
+    authorization = _get_header(event, "authorization")
+    if not authorization:
+        return False
+
+    try:
+        scheme, token = authorization.split(" ", 1)
+    except ValueError:
+        return False
+
+    if scheme.lower() != "basic":
+        return False
+
+    try:
+        username, password = base64.b64decode(token.strip()).decode("utf-8").split(":", 1)
+    except (ValueError, UnicodeDecodeError, binascii.Error):
+        return False
+
+    secret = _load_secret_json(DOCS_BASIC_AUTH_SECRET_ID)
+    expected_username = str(secret.get("username", ""))
+    expected_password = str(secret.get("password", ""))
+
+    if not expected_username or not expected_password or expected_password == "replace-me":
+        return False
+
+    return hmac.compare_digest(username, expected_username) and hmac.compare_digest(password, expected_password)
+
+
+def _swagger_html(spec_url):
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Integration Hub API Contract</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+    <style>
+      :root {{
+        color-scheme: light;
+        --page-bg: linear-gradient(135deg, #f6f9fc 0%, #eef4f8 42%, #dde8f4 100%);
+        --panel-bg: rgba(255, 255, 255, 0.92);
+        --panel-border: rgba(22, 56, 89, 0.14);
+        --ink: #15324d;
+        --ink-soft: #49657d;
+        --accent: #0066cc;
+        --accent-soft: #dcecff;
+        --shadow: 0 24px 60px rgba(17, 39, 60, 0.12);
+      }}
+
+      body {{
+        margin: 0;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        background: var(--page-bg);
+        color: var(--ink);
+      }}
+
+      .page-shell {{
+        min-height: 100vh;
+        padding: 32px 20px 40px;
+      }}
+
+      .hero {{
+        max-width: 1180px;
+        margin: 0 auto 24px;
+        background: var(--panel-bg);
+        border: 1px solid var(--panel-border);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }}
+
+      .hero-inner {{
+        padding: 28px 28px 22px;
+        background:
+          radial-gradient(circle at top right, rgba(0, 102, 204, 0.15), transparent 32%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(250, 252, 255, 0.92));
+      }}
+
+      .eyebrow {{
+        display: inline-block;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }}
+
+      h1 {{
+        margin: 14px 0 10px;
+        font-size: clamp(2rem, 5vw, 3.25rem);
+        line-height: 1;
+      }}
+
+      .hero p {{
+        margin: 0;
+        max-width: 760px;
+        color: var(--ink-soft);
+        font-size: 1rem;
+        line-height: 1.65;
+      }}
+
+      .hero-meta {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+        margin-top: 22px;
+      }}
+
+      .meta-card {{
+        padding: 16px 18px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.82);
+        border: 1px solid rgba(22, 56, 89, 0.1);
+      }}
+
+      .meta-card strong {{
+        display: block;
+        margin-bottom: 6px;
+        font-size: 0.95rem;
+      }}
+
+      .meta-card span {{
+        color: var(--ink-soft);
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }}
+
+      #swagger-ui {{
+        max-width: 1180px;
+        margin: 0 auto;
+        background: rgba(255, 255, 255, 0.96);
+        border: 1px solid var(--panel-border);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }}
+
+      .swagger-ui .topbar {{
+        display: none;
+      }}
+
+      .swagger-ui .information-container {{
+        padding-bottom: 0;
+      }}
+
+      .swagger-ui .scheme-container {{
+        box-shadow: none;
+        border-top: 1px solid rgba(22, 56, 89, 0.08);
+        border-bottom: 1px solid rgba(22, 56, 89, 0.08);
+      }}
+
+      .swagger-ui .opblock-tag {{
+        border-bottom-color: rgba(22, 56, 89, 0.08);
+      }}
+
+      @media (max-width: 720px) {{
+        .page-shell {{
+          padding: 18px 12px 28px;
+        }}
+
+        .hero-inner {{
+          padding: 20px 18px 18px;
+        }}
+      }}
+    </style>
+  </head>
+  <body>
+    <div class="page-shell">
+      <section class="hero">
+        <div class="hero-inner">
+          <span class="eyebrow">API Contract</span>
+          <h1>Integration Hub Managed File Transfer API</h1>
+          <p>
+            Interactive Swagger UI for the single-upload and multipart upload contract.
+            Access to this page is protected by dedicated HTTP Basic auth, while API
+            operations inside the UI continue to use the API's own Basic and Bearer schemes.
+          </p>
+          <div class="hero-meta">
+            <div class="meta-card">
+              <strong>Authentication</strong>
+              <span>Use the Authorize button for Basic credentials or a Bearer token before trying requests.</span>
+            </div>
+            <div class="meta-card">
+              <strong>Sharing Pattern</strong>
+              <span>Host the docs on the same API domain and restrict visibility with basic auth or SSO.</span>
+            </div>
+            <div class="meta-card">
+              <strong>Contract Source</strong>
+              <span>The UI loads the bundled OpenAPI definition from <code>{spec_url}</code>.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div id="swagger-ui"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({{
+        url: "{spec_url}",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        displayRequestDuration: true,
+        docExpansion: "list",
+        filter: true,
+        persistAuthorization: true,
+        tryItOutEnabled: true,
+        defaultModelsExpandDepth: 1,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout"
+      }});
+    </script>
+  </body>
+</html>
+"""
+
+
+def lambda_handler(event, _context):
+    path = (event or {}).get("rawPath") or "/docs"
+
+    if not _is_authorized(event):
+        return _unauthorized()
+
+    if path in ("/docs", "/docs/"):
+        return _response(200, _swagger_html("/openapi.yaml"), "text/html; charset=utf-8")
+
+    if path == "/openapi.yaml":
+        return _response(200, OPENAPI_PATH.read_text(encoding="utf-8"), "application/yaml; charset=utf-8")
+
+    return _response(404, "Not found", "text/plain; charset=utf-8")

--- a/terraform/environments/integration-hub/api-platform/lambda/request-docs/test_lambda_function.py
+++ b/terraform/environments/integration-hub/api-platform/lambda/request-docs/test_lambda_function.py
@@ -1,0 +1,72 @@
+import base64
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+os.environ.setdefault("DOCS_BASIC_AUTH_SECRET_ID", "docs-secret")
+
+sys.modules.setdefault(
+    "boto3",
+    SimpleNamespace(
+        client=lambda _service_name: SimpleNamespace(),
+    ),
+)
+
+import lambda_function as handler
+
+
+class FakeSecretsManager:
+    def get_secret_value(self, SecretId):
+        assert SecretId == handler.DOCS_BASIC_AUTH_SECRET_ID
+        return {
+            "SecretString": json.dumps(
+                {
+                    "username": "docs-user",
+                    "password": "docs-password",
+                }
+            )
+        }
+
+
+class DocsLambdaTests(unittest.TestCase):
+    def _event(self, raw_path, authorization=None):
+        headers = {}
+        if authorization:
+            headers["authorization"] = authorization
+        return {
+            "rawPath": raw_path,
+            "headers": headers,
+        }
+
+    @patch.object(handler, "SECRETS_MANAGER", new=FakeSecretsManager())
+    def test_docs_html_is_returned(self):
+        token = base64.b64encode(b"docs-user:docs-password").decode("ascii")
+        response = handler.lambda_handler(self._event("/docs", f"Basic {token}"), None)
+
+        self.assertEqual(200, response["statusCode"])
+        self.assertIn("SwaggerUIBundle", response["body"])
+        self.assertTrue(response["headers"]["content-type"].startswith("text/html"))
+
+    @patch.object(handler, "SECRETS_MANAGER", new=FakeSecretsManager())
+    def test_openapi_yaml_is_returned(self):
+        token = base64.b64encode(b"docs-user:docs-password").decode("ascii")
+        response = handler.lambda_handler(self._event("/openapi.yaml", f"Basic {token}"), None)
+
+        self.assertEqual(200, response["statusCode"])
+        self.assertIn("openapi: 3.0.3", response["body"])
+        self.assertTrue(response["headers"]["content-type"].startswith("application/yaml"))
+
+    @patch.object(handler, "SECRETS_MANAGER", new=FakeSecretsManager())
+    def test_missing_authorization_is_rejected(self):
+        response = handler.lambda_handler(self._event("/docs"), None)
+
+        self.assertEqual(401, response["statusCode"])
+        self.assertIn("www-authenticate", response["headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/environments/integration-hub/api-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-platform/locals.tf
@@ -1,5 +1,11 @@
 locals {
-  api_configuration      = try(local.application_data.accounts[local.environment].api_configuration, {})
+  api_configuration = try(local.application_data.accounts[local.environment].api_configuration, {})
+  api_docs_configuration = merge(
+    {
+      basic_auth_username = "api-docs"
+    },
+    try(local.api_configuration.docs, {})
+  )
   auth_configuration     = try(local.application_data.accounts[local.environment].auth_configuration, {})
   auth_roles             = try(local.auth_configuration.roles, {})
   auth_users             = try(local.auth_configuration.users, {})

--- a/terraform/environments/integration-hub/api-platform/openapi.yaml
+++ b/terraform/environments/integration-hub/api-platform/openapi.yaml
@@ -9,16 +9,21 @@ info:
     Large files automatically switch to a multipart upload flow so the client
     ingress path can support uploads larger than 5 GB.
 servers:
-  - url: https://{apiHost}
-    variables:
-      apiHost:
-        default: example.execute-api.eu-west-2.amazonaws.com
+  - url: /
+    description: Same origin as the deployed Swagger UI or API hostname.
 security:
   - basicAuth: []
   - bearerAuth: []
+tags:
+  - name: Transfer Tickets
+    description: Create upload sessions for small and large files.
+  - name: Multipart Uploads
+    description: Continue, complete, or abort multipart transfers.
 paths:
   /transfer-tickets:
     post:
+      tags:
+        - Transfer Tickets
       summary: Create an upload transfer ticket
       description: |
         Creates either:
@@ -55,6 +60,8 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
   /transfer-tickets/{transferTicket}/parts:
     post:
+      tags:
+        - Multipart Uploads
       summary: Generate pre-signed multipart part URLs
       operationId: presignMultipartParts
       security:
@@ -87,6 +94,8 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
   /transfer-tickets/{transferTicket}/complete:
     post:
+      tags:
+        - Multipart Uploads
       summary: Complete a multipart upload
       operationId: completeMultipartUpload
       security:
@@ -119,6 +128,8 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
   /transfer-tickets/{transferTicket}:
     delete:
+      tags:
+        - Multipart Uploads
       summary: Abort a multipart upload
       operationId: abortMultipartUpload
       security:

--- a/terraform/environments/integration-hub/api-platform/outputs.tf
+++ b/terraform/environments/integration-hub/api-platform/outputs.tf
@@ -3,6 +3,21 @@ output "transfer_ticket_api_endpoint" {
   value       = aws_apigatewayv2_api.upload_ticket.api_endpoint
 }
 
+output "transfer_ticket_api_docs_url" {
+  description = "Protected Swagger UI for the managed file transfer API"
+  value       = "${aws_apigatewayv2_api.upload_ticket.api_endpoint}/docs"
+}
+
+output "transfer_ticket_openapi_url" {
+  description = "Protected OpenAPI contract URL for the managed file transfer API"
+  value       = "${aws_apigatewayv2_api.upload_ticket.api_endpoint}/openapi.yaml"
+}
+
+output "transfer_ticket_api_docs_basic_auth_secret_name" {
+  description = "Secrets Manager secret name for the Swagger UI basic auth credentials"
+  value       = module.api_docs_basic_auth_secret.secret_name
+}
+
 output "transfer_clients_table_name" {
   description = "DynamoDB table containing upload client configuration"
   value       = module.dynamodb_transfer_clients.dynamodb_table_id

--- a/terraform/environments/integration-hub/api-platform/swagger_ui_imports.tf
+++ b/terraform/environments/integration-hub/api-platform/swagger_ui_imports.tf
@@ -1,0 +1,43 @@
+locals {
+  swagger_ui_partial_apply_resources = {
+    secret_arn        = "arn:aws:secretsmanager:eu-west-2:508564776517:secret:integration-hub-api-platform-development-docs-basic-auth-cEanY5"
+    secret_version_id = "terraform-20260623151830736200000002"
+  }
+}
+
+# Adopt resources created during the partial Swagger UI apply in development.
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.api_docs_basic_auth_secret.aws_secretsmanager_secret.this[0]
+  id       = local.swagger_ui_partial_apply_resources.secret_arn
+}
+
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.api_docs_basic_auth_secret.aws_secretsmanager_secret_version.ignore_changes[0]
+  id       = "${local.swagger_ui_partial_apply_resources.secret_arn}|${local.swagger_ui_partial_apply_resources.secret_version_id}"
+}
+
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.lambda_api_docs.aws_iam_role.lambda[0]
+  id       = "${local.application_name}-${local.component_name}-docs"
+}
+
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.lambda_api_docs.aws_iam_role_policy.additional_inline[0]
+  id       = "${local.application_name}-${local.component_name}-docs:${local.application_name}-${local.component_name}-docs-inline"
+}
+
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.lambda_api_docs.aws_iam_role_policy.logs[0]
+  id       = "${local.application_name}-${local.component_name}-docs:${local.application_name}-${local.component_name}-docs-logs"
+}
+
+import {
+  for_each = local.environment == "development" ? { docs = true } : {}
+  to       = module.lambda_api_docs.aws_cloudwatch_log_group.lambda[0]
+  id       = "/aws/lambda/${local.application_name}-${local.component_name}-docs"
+}


### PR DESCRIPTION
Adds protected Swagger UI documentation for the integration-hub API platform.

This change introduces:
- `GET /docs` to serve a browser-based Swagger UI
- `GET /openapi.yaml` to serve the raw OpenAPI contract

Both endpoints are served from the existing API Gateway HTTP API and backed by a dedicated Lambda function. Access to the docs endpoints is protected with browser-friendly HTTP Basic auth, using a separate Secrets Manager secret so the docs credentials are managed independently from the existing API client authentication.

The intention is to make the contract easier to review and share with consumers while keeping it restricted behind simple credentials.

Implementation overview:
- adds a new Lambda (`lambda_api_docs`) that serves both the Swagger UI HTML and the bundled `openapi.yaml`
- adds API Gateway routes for `GET /docs` and `GET /openapi.yaml`
- adds a dedicated Secrets Manager secret for docs Basic auth credentials
- passes the secret name to the docs Lambda through an environment variable
- gives the docs Lambda permission to read that secret from Secrets Manager
- protects both docs endpoints in the Lambda by validating the incoming Basic auth header against the stored secret value