### PR TITLE
chore(data-platform): update efs csi driver addon to latest version

### DIFF
--- a/terraform/environments/data-platform/cluster/configuration/cluster.yml
+++ b/terraform/environments/data-platform/cluster/configuration/cluster.yml
@@ -4,7 +4,7 @@ environment:
     bottlerocket_version: "1.62.0-49f1c7d2"
     addon_versions:
       aws_ebs_csi_driver: "v1.62.0-eksbuild.1"
-      aws_efs_csi_driver: "v3.2.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.3.0-eksbuild.1"
       aws_guardduty_agent: "v1.15.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.4-eksbuild.1"
       eks_node_monitoring_agent: "v1.6.6-eksbuild.1"
@@ -38,7 +38,7 @@ environment:
     bottlerocket_version: "1.62.0-49f1c7d2"
     addon_versions:
       aws_ebs_csi_driver: "v1.62.0-eksbuild.1"
-      aws_efs_csi_driver: "v3.2.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.3.0-eksbuild.1"
       aws_guardduty_agent: "v1.15.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.4-eksbuild.1"
       eks_node_monitoring_agent: "v1.6.6-eksbuild.1"
@@ -72,7 +72,7 @@ environment:
     bottlerocket_version: "1.62.0-49f1c7d2"
     addon_versions:
       aws_ebs_csi_driver: "v1.62.0-eksbuild.1"
-      aws_efs_csi_driver: "v3.2.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.3.0-eksbuild.1"
       aws_guardduty_agent: "v1.15.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.4-eksbuild.1"
       eks_node_monitoring_agent: "v1.6.6-eksbuild.1"
@@ -106,7 +106,7 @@ environment:
     bottlerocket_version: "1.62.0-49f1c7d2"
     addon_versions:
       aws_ebs_csi_driver: "v1.62.0-eksbuild.1"
-      aws_efs_csi_driver: "v3.2.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.3.0-eksbuild.1"
       aws_guardduty_agent: "v1.15.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.4-eksbuild.1"
       eks_node_monitoring_agent: "v1.6.6-eksbuild.1"


### PR DESCRIPTION
Bump the aws-efs-csi-driver managed add-on across all environments:

- v3.2.0-eksbuild.1 -> v3.3.0-eksbuild.1