### PR TITLE
Deploy monitoring module

### DIFF
--- a/terraform/environments/data-platform/iam-roles.tf
+++ b/terraform/environments/data-platform/iam-roles.tf
@@ -1,6 +1,5 @@
 module "monitoring" {
   source = "./modules/monitoring"
-  # count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
 }
 
 # Import blocks for moving resources from monitoring workspace to data-platform workspace

--- a/terraform/environments/data-platform/iam-roles.tf
+++ b/terraform/environments/data-platform/iam-roles.tf
@@ -1,0 +1,25 @@
+module "monitoring" {
+  source = "./modules/monitoring"
+  # count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+}
+
+# Import blocks for moving resources from monitoring workspace to data-platform workspace
+import {
+  to = module.monitoring.module.iam_role.aws_iam_role.this[0]
+  id = "data-platform-monitoring"
+}
+
+import {
+  to = module.monitoring.aws_iam_role_policy_attachment.cloudwatch_read_only_access
+  id = "data-platform-monitoring/arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+import {
+  to = module.monitoring.aws_iam_role_policy_attachment.amazon_prometheus_query_access
+  id = "data-platform-monitoring/arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
+}
+
+import {
+  to = module.monitoring.aws_iam_role_policy_attachment.aws_xray_read_only_access
+  id = "data-platform-monitoring/arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
+}

--- a/terraform/environments/data-platform/iam-roles.tf
+++ b/terraform/environments/data-platform/iam-roles.tf
@@ -1,24 +1,3 @@
 module "monitoring" {
   source = "./modules/monitoring"
 }
-
-# Import blocks for moving resources from monitoring workspace to data-platform workspace
-import {
-  to = module.monitoring.module.iam_role.aws_iam_role.this[0]
-  id = "data-platform-monitoring"
-}
-
-import {
-  to = module.monitoring.aws_iam_role_policy_attachment.cloudwatch_read_only_access
-  id = "data-platform-monitoring/arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
-}
-
-import {
-  to = module.monitoring.aws_iam_role_policy_attachment.amazon_prometheus_query_access
-  id = "data-platform-monitoring/arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
-}
-
-import {
-  to = module.monitoring.aws_iam_role_policy_attachment.aws_xray_read_only_access
-  id = "data-platform-monitoring/arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
-}

--- a/terraform/environments/data-platform/monitoring/iam-roles.tf
+++ b/terraform/environments/data-platform/monitoring/iam-roles.tf
@@ -1,4 +1,0 @@
-module "monitoring" {
-  source = "../modules/monitoring"
-  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
-}


### PR DESCRIPTION
Tracked in this ticket [Task: Deploy Monitoring module](https://github.com/ministryofjustice/data-platform/issues/387)
- ♻️ Move initial deployment from monitoring component to root component
- ✨ Create monitoring roles in test and pre-prod, as well as dev and prod

Notes: removed dev and prod deploys from data-platform/monitoring and imported to data-platform prior to PR merge.