### PR TITLE
fix: filter suffix removed from s3 bucket

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-file-transfer/ccms-xfer-s3.tf
+++ b/terraform/environments/ccms-ebs/ccms-file-transfer/ccms-xfer-s3.tf
@@ -118,7 +118,6 @@ resource "aws_s3_bucket_notification" "sftp_bucket_notification" {
     lambda_function_arn = aws_lambda_function.process_file_from_bucket_lambda_function.arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "ccms-transfer-bc-${local.environment}/inbound/"
-    filter_suffix       = ".csv"
   }
 
   depends_on = [module.s3-bucket-sftp-bc]

--- a/terraform/environments/ccms-ebs/ccms-file-transfer/waf.tf
+++ b/terraform/environments/ccms-ebs/ccms-file-transfer/waf.tf
@@ -75,7 +75,7 @@ resource "aws_wafv2_web_acl" "sftp_web_acl" {
 
     statement {
       rate_based_statement {
-        limit                 = 1
+        limit                 = 10
         aggregate_key_type    = "IP"
         evaluation_window_sec = 600
 

--- a/terraform/environments/ccms-ebs/ccms-file-transfer/waf.tf
+++ b/terraform/environments/ccms-ebs/ccms-file-transfer/waf.tf
@@ -75,9 +75,9 @@ resource "aws_wafv2_web_acl" "sftp_web_acl" {
 
     statement {
       rate_based_statement {
-        limit                 = 30
+        limit                 = 1
         aggregate_key_type    = "IP"
-        evaluation_window_sec = 60
+        evaluation_window_sec = 600
 
         # scope_down_statement {
         #   byte_match_statement {


### PR DESCRIPTION
filter suffix of csv removed from s3 bucket