### PR TITLE
wire SNS alerts into GDPR Step Function

### DIFF
--- a/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
+++ b/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
@@ -105,12 +105,13 @@
 
       "PublishUnstructuredSuccessMessage": {
          "Type": "Task",
+         "QueryLanguage": "JSONata",
          "Resource": "arn:aws:states:::sns:publish",
-         "Parameters": {
+         "Arguments": {
             "TopicArn": "${sns_topic_arn}",
-            "Message.$": "States.JsonToString($.notification)"
+            "Message": "{% $string($states.input.notification) %}"
          },
-         "ResultPath": null,
+         "Output": "{% $states.input %}",
          "Next": "RunContainerTask"
       },
 
@@ -147,12 +148,13 @@
 
       "PublishUnstructuredControlFailureMessage": {
          "Type": "Task",
+         "QueryLanguage": "JSONata",
          "Resource": "arn:aws:states:::sns:publish",
-         "Parameters": {
+         "Arguments": {
             "TopicArn": "${sns_topic_arn}",
-            "Message.$": "States.JsonToString($.notification)"
+            "Message": "{% $string($states.input.notification) %}"
          },
-         "ResultPath": null,
+         "Output": "{% $states.input %}",
          "Next": "FailUnstructuredControl"
       },
 
@@ -196,12 +198,13 @@
 
       "PublishUnstructuredBatchFailureMessage": {
          "Type": "Task",
+         "QueryLanguage": "JSONata",
          "Resource": "arn:aws:states:::sns:publish",
-         "Parameters": {
+         "Arguments": {
             "TopicArn": "${sns_topic_arn}",
-            "Message.$": "States.JsonToString($.notification)"
+            "Message": "{% $string($states.input.notification) %}"
          },
-         "ResultPath": null,
+         "Output": "{% $states.input %}",
          "Next": "FailUnstructuredBatch"
       },
 

--- a/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
+++ b/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
@@ -1,17 +1,36 @@
-{  
+{
    "StartAt": "ControlLambda",
-   "States": {  
+   "States": {
 
       "ControlLambda": {
          "Type": "Task",
          "Resource": "${control_lambda_arn}",
-         "Next": "TriggerBatchDeletionJobs"
+         "Next": "TriggerBatchDeletionJobs",
+         "Catch": [
+            {
+               "ErrorEquals": [
+                  "States.ALL"
+               ],
+               "ResultPath": "$.unstructured_error",
+               "Next": "BuildUnstructuredControlFailureMessage"
+            }
+         ]
       },
 
       "TriggerBatchDeletionJobs": {
          "Type": "Map",
          "ItemsPath": "$.jobs_to_run",
-         "Next": "RunContainerTask",
+         "ResultPath": "$.batch_results",
+         "Next": "BuildUnstructuredSuccessMessage",
+         "Catch": [
+            {
+               "ErrorEquals": [
+                  "States.ALL"
+               ],
+               "ResultPath": "$.unstructured_error",
+               "Next": "BuildUnstructuredBatchFailureMessage"
+            }
+         ],
          "ItemProcessor": {
             "ProcessorConfig": {
                "Mode": "INLINE"
@@ -56,10 +75,146 @@
          }
       },
 
-      "RunContainerTask": {  
+      "BuildUnstructuredSuccessMessage": {
+         "Type": "Pass",
+         "ResultPath": "$.notification",
+         "Parameters": {
+            "version": "1.0",
+            "source": "custom",
+            "id.$": "States.Format('gdpr-unstructured-deletion-{}', $$.Execution.Name)",
+            "content": {
+               "textType": "client-markdown",
+               "title": ":white_check_mark: GDPR unstructured deletion succeeded in ${environment_name}",
+               "description.$": "States.Format('*Environment*: {}\\n*Jobs run*: {}\\n*Atrium records selected*: {}\\n*Blob records selected*: {}\\n*XDrive records selected*: {}\\n*Audit bucket*: `{}`', $.summary.environment, $.summary.jobs_to_run, $.summary.atrium_records_selected, $.summary.blob_records_selected, $.summary.xdrive_records_selected, $.summary.audit_bucket)",
+               "nextSteps": [],
+               "keywords": [
+                  "GDPR",
+                  "Unstructured Deletion",
+                  "SUCCEEDED"
+               ]
+            },
+            "metadata": {
+               "additionalContext": {
+                  "environment": "${environment_name}"
+               },
+               "enableCustomActions": false
+            }
+         },
+         "Next": "PublishUnstructuredSuccessMessage"
+      },
+
+      "PublishUnstructuredSuccessMessage": {
+         "Type": "Task",
+         "Resource": "arn:aws:states:::sns:publish",
+         "Parameters": {
+            "TopicArn": "${sns_topic_arn}",
+            "Message.$": "States.JsonToString($.notification)"
+         },
+         "ResultPath": null,
+         "Next": "RunContainerTask"
+      },
+
+      "BuildUnstructuredControlFailureMessage": {
+         "Type": "Pass",
+         "ResultPath": "$.notification",
+         "Parameters": {
+            "version": "1.0",
+            "source": "custom",
+            "id.$": "States.Format('gdpr-unstructured-control-failure-{}', $$.Execution.Name)",
+            "content": {
+               "textType": "client-markdown",
+               "title": ":x: GDPR unstructured control failed in ${environment_name}",
+               "description.$": "States.Format('*Environment*: ${environment_name}\\n*Failed state*: ControlLambda\\n*Error*: {}\\n*Cause*: {}', $.unstructured_error.Error, $.unstructured_error.Cause)",
+               "nextSteps": [
+                  "Review the Step Function execution history.",
+                  "Review the unstructured control Lambda logs."
+               ],
+               "keywords": [
+                  "GDPR",
+                  "Unstructured Deletion",
+                  "FAILED"
+               ]
+            },
+            "metadata": {
+               "additionalContext": {
+                  "environment": "${environment_name}"
+               },
+               "enableCustomActions": false
+            }
+         },
+         "Next": "PublishUnstructuredControlFailureMessage"
+      },
+
+      "PublishUnstructuredControlFailureMessage": {
+         "Type": "Task",
+         "Resource": "arn:aws:states:::sns:publish",
+         "Parameters": {
+            "TopicArn": "${sns_topic_arn}",
+            "Message.$": "States.JsonToString($.notification)"
+         },
+         "ResultPath": null,
+         "Next": "FailUnstructuredControl"
+      },
+
+      "FailUnstructuredControl": {
+         "Type": "Fail",
+         "Error": "UnstructuredControlFailed",
+         "Cause": "The unstructured control Lambda failed."
+      },
+
+      "BuildUnstructuredBatchFailureMessage": {
+         "Type": "Pass",
+         "ResultPath": "$.notification",
+         "Parameters": {
+            "version": "1.0",
+            "source": "custom",
+            "id.$": "States.Format('gdpr-unstructured-batch-failure-{}', $$.Execution.Name)",
+            "content": {
+               "textType": "client-markdown",
+               "title": ":x: GDPR unstructured deletion failed in ${environment_name}",
+               "description.$": "States.Format('*Environment*: {}\\n*Failed state*: TriggerBatchDeletionJobs\\n*Jobs prepared*: {}\\n*Error*: {}\\n*Cause*: {}', $.summary.environment, $.summary.jobs_to_run, $.unstructured_error.Error, $.unstructured_error.Cause)",
+               "nextSteps": [
+                  "Review the Step Function execution history.",
+                  "Review the Batch job logs.",
+                  "Check the manifest and audit parquet outputs."
+               ],
+               "keywords": [
+                  "GDPR",
+                  "Unstructured Deletion",
+                  "FAILED"
+               ]
+            },
+            "metadata": {
+               "additionalContext": {
+                  "environment": "${environment_name}"
+               },
+               "enableCustomActions": false
+            }
+         },
+         "Next": "PublishUnstructuredBatchFailureMessage"
+      },
+
+      "PublishUnstructuredBatchFailureMessage": {
+         "Type": "Task",
+         "Resource": "arn:aws:states:::sns:publish",
+         "Parameters": {
+            "TopicArn": "${sns_topic_arn}",
+            "Message.$": "States.JsonToString($.notification)"
+         },
+         "ResultPath": null,
+         "Next": "FailUnstructuredBatch"
+      },
+
+      "FailUnstructuredBatch": {
+         "Type": "Fail",
+         "Error": "UnstructuredBatchFailed",
+         "Cause": "The unstructured Batch Map state failed."
+      },
+
+      "RunContainerTask": {
          "Type": "Task",
          "Resource": "arn:aws:states:::ecs:runTask.sync",
-         "Parameters": {  
+         "Parameters": {
             "LaunchType": "FARGATE",
             "Cluster": "${cluster_arn}",
             "TaskDefinition": "${task_definition_family}",
@@ -70,8 +225,8 @@
                   "AssignPublicIp": "DISABLED"
                }
             },
-            "Overrides": {  
-               "ContainerOverrides": [  
+            "Overrides": {
+               "ContainerOverrides": [
                   {
                      "Name": "${container_name}",
                      "Environment": [

--- a/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
+++ b/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
@@ -85,7 +85,7 @@
             "content": {
                "textType": "client-markdown",
                "title": ":white_check_mark: GDPR unstructured deletion succeeded in ${environment_name}",
-               "description.$": "States.Format('*Environment*: {}\\n*Jobs run*: {}\\n*Atrium records selected*: {}\\n*Blob records selected*: {}\\n*XDrive records selected*: {}\\n*Audit bucket*: `{}`', $.summary.environment, $.summary.jobs_to_run, $.summary.atrium_records_selected, $.summary.blob_records_selected, $.summary.xdrive_records_selected, $.summary.audit_bucket)",
+               "description.$": "States.Format('Environment: {}; Jobs run: {}; Atrium records selected: {}; Blob records selected: {}; XDrive records selected: {}; Audit bucket: {}', $.summary.environment, $.summary.jobs_to_run, $.summary.atrium_records_selected, $.summary.blob_records_selected, $.summary.xdrive_records_selected, $.summary.audit_bucket)",
                "nextSteps": [],
                "keywords": [
                   "GDPR",
@@ -124,7 +124,7 @@
             "content": {
                "textType": "client-markdown",
                "title": ":x: GDPR unstructured control failed in ${environment_name}",
-               "description.$": "States.Format('*Environment*: ${environment_name}\\n*Failed state*: ControlLambda\\n*Error*: {}\\n*Cause*: {}', $.unstructured_error.Error, $.unstructured_error.Cause)",
+               "description.$": "States.Format('Environment: ${environment_name}; Failed state: ControlLambda; Error: {}; Cause: {}', $.unstructured_error.Error, $.unstructured_error.Cause)",
                "nextSteps": [
                   "Review the Step Function execution history.",
                   "Review the unstructured control Lambda logs."
@@ -172,7 +172,7 @@
             "content": {
                "textType": "client-markdown",
                "title": ":x: GDPR unstructured deletion failed in ${environment_name}",
-               "description.$": "States.Format('*Environment*: {}\\n*Failed state*: TriggerBatchDeletionJobs\\n*Jobs prepared*: {}\\n*Error*: {}\\n*Cause*: {}', $.summary.environment, $.summary.jobs_to_run, $.unstructured_error.Error, $.unstructured_error.Cause)",
+               "description.$": "States.Format('Environment: {}; Failed state: TriggerBatchDeletionJobs; Jobs prepared: {}; Error: {}; Cause: {}', $.summary.environment, $.summary.jobs_to_run, $.unstructured_error.Error, $.unstructured_error.Cause)",
                "nextSteps": [
                   "Review the Step Function execution history.",
                   "Review the Batch job logs.",

--- a/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
+++ b/terraform/environments/electronic-monitoring-data/step_function_definitions/gdpr_deletion.json.tmpl
@@ -85,7 +85,7 @@
             "content": {
                "textType": "client-markdown",
                "title": ":white_check_mark: GDPR unstructured deletion succeeded in ${environment_name}",
-               "description.$": "States.Format('Environment: {}; Jobs run: {}; Atrium records selected: {}; Blob records selected: {}; XDrive records selected: {}; Audit bucket: {}', $.summary.environment, $.summary.jobs_to_run, $.summary.atrium_records_selected, $.summary.blob_records_selected, $.summary.xdrive_records_selected, $.summary.audit_bucket)",
+               "description.$": "States.Format('Environment: ${environment_name}; Jobs run: {}', States.ArrayLength($.jobs_to_run))",
                "nextSteps": [],
                "keywords": [
                   "GDPR",
@@ -174,7 +174,7 @@
             "content": {
                "textType": "client-markdown",
                "title": ":x: GDPR unstructured deletion failed in ${environment_name}",
-               "description.$": "States.Format('Environment: {}; Failed state: TriggerBatchDeletionJobs; Jobs prepared: {}; Error: {}; Cause: {}', $.summary.environment, $.summary.jobs_to_run, $.unstructured_error.Error, $.unstructured_error.Cause)",
+               "description.$": "States.Format('Environment: ${environment_name}; Failed state: TriggerBatchDeletionJobs; Jobs prepared: {}; Error: {}; Cause: {}', States.ArrayLength($.jobs_to_run), $.unstructured_error.Error, $.unstructured_error.Cause)",
                "nextSteps": [
                   "Review the Step Function execution history.",
                   "Review the Batch job logs.",

--- a/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
@@ -161,6 +161,28 @@ data "aws_iam_policy_document" "gdpr_delete_policy_document" {
       "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"
     ]
   }
+  statement {
+    sid    = "PublishGdprStepFunctionNotifications"
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+    resources = [
+      aws_sns_topic.emds_alerts.arn
+    ]
+  }
+
+  statement {
+    sid    = "UseEncryptedAlertsTopicForGdprStepFunction"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = [
+      aws_kms_key.emds_alerts.arn
+    ]
+  }  
 }
 
 resource "aws_iam_policy" "gdpr_delete_iam_policy" {

--- a/terraform/environments/electronic-monitoring-data/step_functions_main.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_main.tf
@@ -93,6 +93,8 @@ module "gdpr_deletion_step_function" {
       "control_lambda_arn"       = module.gdpr_unstructured_control_lambda[0].lambda_function_arn
       "batch_job_queue_arn"      = aws_batch_job_queue.shred_unstructured_from_zip_batch_queue[0].arn
       "batch_job_definition_arn" = aws_batch_job_definition.shred_unstructured_from_zip_job.arn
+      "sns_topic_arn"            = aws_sns_topic.emds_alerts.arn
+      "environment_name"         = local.environment_shorthand
     }
   )
   type = "STANDARD"


### PR DESCRIPTION
Permissions for this PR https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/894

Adds the TF wiring needed for GDPR Step Function SNS notifications.

Changes

Passes the shared alerts topic ARN and environment name into the GDPR deletion Step Function.
Grants the Step Function role permission to publish to the alerts topic.

Outcome
The GDPR Step Function has the required inputs and permissions for unstructured deletion notification PR above