### PR TITLE
Update_240626_2

### DIFF
--- a/terraform/environments/ppud/s3_replication.tf
+++ b/terraform/environments/ppud/s3_replication.tf
@@ -1,3 +1,4 @@
+/*
 ##########################################################################################
 # S3 Replication Buckets (database-source & report-source) for DEV, UAT, PROD
 # Optimised replacement for s3.tf lines 282-443, 447-604, 1017-1174, 1178-1336, 1559-1716, 1720-1877
@@ -291,3 +292,4 @@ resource "aws_iam_role_policy_attachment" "s3_replication" {
   role       = aws_iam_role.s3_replication[each.key].name
   policy_arn = aws_iam_policy.s3_replication[each.key].arn
 }
+*/


### PR DESCRIPTION
Deleting S3 replication buckets (to be recreated shortly with renamed keys for destination IAM policy matching reasons).