### PR TITLE
add HTTP to HTTPS redirect routes

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "ai_gateway_configuration" {
   name      = "${local.component_name}-configuration"
   chart     = "${path.module}/src/helm/charts/${local.component_name}-configuration"
-  version   = "1.4.0"
+  version   = "1.4.1"
   namespace = module.ai_gateway_namespace.name
 
   values = [

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/Chart.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: ai-gateway-configuration
 description: A Helm chart to deploy Gateway API configuration for ai-gateway
 type: application
-version: 1.4.0
+version: 1.4.1

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/gateway.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/gateway.yaml
@@ -12,6 +12,14 @@ spec:
       kind: LoadBalancerConfiguration
       name: ai-gateway
   listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: {{ .Values.hostname }}
+    - name: http-admin
+      protocol: HTTP
+      port: 80
+      hostname: {{ .Values.adminHostname }}
     - name: https
       protocol: HTTPS
       port: 443

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/httproute-admin.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/httproute-admin.yaml
@@ -25,3 +25,23 @@ spec:
     - backendRefs:
         - name: litellm-admin
           port: 4000
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ai-gateway-admin-http-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  hostnames:
+    - {{ .Values.adminHostname }}
+  parentRefs:
+    - name: ai-gateway
+      sectionName: http-admin
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: 443
+            statusCode: 301

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/httproute.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/httproute.yaml
@@ -14,3 +14,23 @@ spec:
     - backendRefs:
         - name: litellm
           port: 4000
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ai-gateway-http-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  hostnames:
+    - {{ .Values.hostname }}
+  parentRefs:
+    - name: ai-gateway
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: 443
+            statusCode: 301


### PR DESCRIPTION
This PR remediates an ITHC finding relating to strict transport and security not enforced

- Add HTTP listeners for main and admin hostnames on port `80`
- Create HTTPRoute redirect resources for gateway and admin endpoints
- Redirect all HTTP traffic to HTTPS with `301` status code
- Bump ai-gateway-configuration chart version to `1.4.1`

PR is part of [this](https://github.com/ministryofjustice/data-platform-security/issues/54) ticket.