### PR TITLE
fix: restrict Aurora ingress to EKS cluster security group

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/aurora.tf
+++ b/terraform/environments/data-platform/ai-gateway/aurora.tf
@@ -24,8 +24,8 @@ module "ai_gateway_aurora" {
 
   security_group_ingress_rules = {
     eks_ingress = {
-      cidr_ipv4   = data.aws_vpc.eks.cidr_block
-      description = "Allow PostgreSQL access from EKS pods"
+      referenced_security_group_id = data.aws_eks_cluster.cluster.vpc_config[0].cluster_security_group_id
+      description                  = "Allow PostgreSQL access from EKS pods"
     }
   }
 

--- a/terraform/environments/data-platform/ai-gateway/elasticache.tf
+++ b/terraform/environments/data-platform/ai-gateway/elasticache.tf
@@ -28,8 +28,8 @@ module "ai_gateway_elasticache" {
   security_group_description     = "Security group for AI Gateway Valkey"
   security_group_rules = {
     ingress_valkey = {
-      description = "Allow Valkey access from EKS pods"
-      cidr_ipv4   = data.aws_vpc.eks.cidr_block
+      description                  = "Allow Valkey access from EKS pods"
+      referenced_security_group_id = data.aws_eks_cluster.cluster.vpc_config[0].cluster_security_group_id
     }
   }
 


### PR DESCRIPTION
This PR remediates an ITHC finding relating to restrict access to RDS and ElastiCache.
PR is part of [this](https://github.com/ministryofjustice/data-platform-security/issues/60) ticket.