### PR TITLE
Use dynamic KMS key lookup for Terraform backend init

### DIFF
--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -147,7 +147,7 @@
                 exit 1
               fi
 
-              echo "terraform init with dynamically resolved state bucket KMS backend config"
+              echo "terraform init with state bucket KMS backend config"
               terraform init -backend-config="kms_key_id=${state_kms_key_id}"
 
           #
@@ -359,7 +359,7 @@
                 exit 1
               fi
 
-              echo "terraform init with dynamically resolved state bucket KMS backend config"
+              echo "terraform init with state bucket KMS backend config"
               terraform init -backend-config="kms_key_id=${state_kms_key_id}"
 
           - name: Terraform Workspace Select

--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -136,8 +136,19 @@
             working-directory: "${{ inputs.component != 'root' && format('terraform/environments/{0}/{1}', inputs.application, inputs.component) || format('terraform/environments/{0}', inputs.application) }}"
             run: |
               terraform --version
-              echo "terraform init"
-              terraform init
+              state_kms_key_id=$(aws s3api get-bucket-encryption \
+                --bucket modernisation-platform-terraform-state \
+                --region eu-west-2 \
+                --query 'ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.KMSMasterKeyID' \
+                --output text)
+
+              if [[ -z "${state_kms_key_id}" || "${state_kms_key_id}" == "None" ]]; then
+                echo "Unable to resolve state bucket KMS key ARN from bucket encryption config." >&2
+                exit 1
+              fi
+
+              echo "terraform init with dynamically resolved state bucket KMS backend config"
+              terraform init -backend-config="kms_key_id=${state_kms_key_id}"
 
           #
           # Terraform Workspace Select
@@ -337,8 +348,19 @@
             working-directory: "${{ inputs.component != 'root' && format('terraform/environments/{0}/{1}', inputs.application, inputs.component) || format('terraform/environments/{0}', inputs.application) }}"
             run: |
               terraform --version
-              echo "terraform init"
-              terraform init
+              state_kms_key_id=$(aws s3api get-bucket-encryption \
+                --bucket modernisation-platform-terraform-state \
+                --region eu-west-2 \
+                --query 'ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.KMSMasterKeyID' \
+                --output text)
+
+              if [[ -z "${state_kms_key_id}" || "${state_kms_key_id}" == "None" ]]; then
+                echo "Unable to resolve state bucket KMS key ARN from bucket encryption config." >&2
+                exit 1
+              fi
+
+              echo "terraform init with dynamically resolved state bucket KMS backend config"
+              terraform init -backend-config="kms_key_id=${state_kms_key_id}"
 
           - name: Terraform Workspace Select
             working-directory: "${{ inputs.component != 'root' && format('terraform/environments/{0}/{1}', inputs.application, inputs.component) || format('terraform/environments/{0}', inputs.application) }}"


### PR DESCRIPTION

## A reference to the issue / Description of it

Follow-on work for validating SSE-KMS Terraform backend writes to the `modernisation-platform-terraform-state` bucket.

The cooker canary proved that member workflow Terraform state writes succeed when Terraform backend init is given the state bucket customer-managed KMS key ARN.

## How does this PR fix the problem?

This PR updates the reusable member Terraform component workflow so Terraform init dynamically reads the state bucket KMS key ARN from the bucket encryption configuration and passes it to the backend:

`terraform init -backend-config="kms_key_id=<resolved-state-bucket-kms-key-arn>"`

This avoids hardcoding the Modernisation Platform account ID or KMS key ARN in the workflow.

## How has this been tested?

The approach was tested first using the cooker canary.

The canary successfully:

- dynamically resolved the `modernisation-platform-terraform-state` bucket KMS key
- ran Terraform init, plan, and apply
- created a fresh canary resource from empty state
- wrote state back to the real platform state bucket

Confirmed state object metadata:

`ServerSideEncryption = aws:kms`

`SSEKMSKeyId = arn:aws:kms:eu-west-2:946070829339:key/mrk-886857b0d52a4c308722d53f112f7c60`

Local checks run:

```bash
git diff --check
```

## Deployment Plan / Instructions

1. Confirm the Modernisation Platform permission change allowing `s3:GetEncryptionConfiguration` has been applied.
2. Review and merge this PR.
3. Monitor member Terraform plan/apply workflows.
4. Confirm new state writes continue to use SSE-KMS.

Expected service impact is low. This changes Terraform backend init behaviour only; strict KMS request-header enforcement remains disabled.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [x] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

This PR does not enable strict request-header enforcement. That should remain a separate follow-up after member workflow behaviour has been monitored.