### PR TITLE
Support configurable runners for Azure private networking

### DIFF
--- a/.github/workflows/data-platform.yml
+++ b/.github/workflows/data-platform.yml
@@ -55,6 +55,7 @@ jobs:
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
       component: "${{ matrix.component }}"      # If your strategy workflow also outputs "matrix.component"
+      runner: "octo-production"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -66,8 +67,8 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "development"
       action: "plan_apply"
-      plan_apply_tfargs: "-destroy"
-      # If you need component logic on destroy, pass it here as well, e.g. component: ...
+      plan_apply_tfargs: "-destroy" # If you need component logic on destroy, pass it here as well, e.g. component: ...
+      runner: "octo-production"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -46,6 +46,11 @@
             required: false
             default: "root"
             description: "Optional: subfolder in 'terraform/environments/<application>' if present."
+          runner:
+            type: string
+            required: false
+            default: "ubuntu-latest"
+            description: "GitHub Actions runner label to use for plan and apply jobs."
         secrets:
           MODERNISATION_PLATFORM_ACCOUNT_ID:
             required: true
@@ -70,7 +75,7 @@
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       plan:
         name: "plan ${{ inputs.component}}"
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         needs: fetch-secrets
         outputs:
           plan_exitcode: "${{ steps.plan.outputs.exitcode }}"
@@ -296,7 +301,7 @@
         name: "apply"
         needs: [plan, fetch-secrets]
         if: inputs.action == 'plan_apply' && needs.plan.outputs.plan_exitcode == '2'
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         environment: ${{ inputs.account_name && (inputs.component != 'root' && format('{0}-{1}', inputs.account_name, inputs.component) || inputs.account_name) || (inputs.component != 'root' && format('{0}-{1}-{2}', inputs.application, inputs.environment, inputs.component) || format('{0}-{1}', inputs.application, inputs.environment)) }}
         steps:
           - name: Checkout Repository


### PR DESCRIPTION
This change introduces a configurable `runner` input for the workflow, with `ubuntu-latest` as the default value.

This enables workflows to run on different GitHub-hosted runners when required, including runners configured for Azure private networking, while preserving the existing behavior for consumers who do not specify the input. [#13183](https://github.com/ministryofjustice/modernisation-platform/issues/13183)