### PR TITLE
fix(data-platform): allow GlobalProtect Alpha CIDR for EKS API access

### DIFF
--- a/terraform/environments/data-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/data-platform/cluster/environment-configuration.tf
@@ -3,6 +3,7 @@ locals {
     development = {
       eks_public_access_cidrs = [
         "128.77.75.64/26", # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
         "20.58.27.30/32",  # GitHub Runner (octo-production)
         # Sites
         "213.121.161.112/28", # 102PF
@@ -12,6 +13,7 @@ locals {
     test = {
       eks_public_access_cidrs = [
         "128.77.75.64/26", # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
         "20.58.27.30/32",  # GitHub Runner (octo-production)
         # Sites
         "213.121.161.112/28", # 102PF
@@ -21,6 +23,7 @@ locals {
     preproduction = {
       eks_public_access_cidrs = [
         "128.77.75.64/26", # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
         "20.58.27.30/32",  # GitHub Runner (octo-production)
         # Sites
         "213.121.161.112/28", # 102PF
@@ -30,6 +33,7 @@ locals {
     production = {
       eks_public_access_cidrs = [
         "128.77.75.64/26", # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
         "20.58.27.30/32",  # GitHub Runner (octo-production)
         # Sites
         "213.121.161.112/28", # 102PF


### PR DESCRIPTION
## What
Add the GlobalProtect Alpha VPN egress IP to the EKS public endpoint allowlist for the data-platform cluster environments.

## Why
A recent EKS endpoint lockdown restricted public API access to listed CIDRs only. The Alpha VPN CIDR (`35.176.93.186/32`) was missing, causing Terraform operations against Kubernetes resources to fail with EKS API connection timeouts.

## Changes
- Added `35.176.93.186/32` (`GlobalProtect (Alpha)`) to `eks_public_access_cidrs` for:
  - development
  - test
  - preproduction
  - production

## Validation
- Verified configuration update in `terraform/environments/data-platform/cluster/environment-configuration.tf`.
- Change is scoped to endpoint allowlist only; no resource behaviour changes beyond network access eligibility.

## Notes
This aligns cluster endpoint access controls with existing Alpha VPN usage in related data-platform configuration.
