### PR TITLE
SNS notification for the end user to download the clean file.

### DIFF
--- a/scripts/poll-clean-file-notification.sh
+++ b/scripts/poll-clean-file-notification.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/poll-clean-file-notification.sh --queue-url <queue-url> [--profile <aws-profile>] [--region <aws-region>] [--delete]
+
+Description:
+  Polls an SQS queue for one clean-file-ready notification message and prints
+  the JSON payload to stdout. By default the message is left on the queue.
+
+Options:
+  --queue-url  Full SQS queue URL to poll.
+  --profile    AWS profile to use.
+  --region     AWS region (defaults to eu-west-2).
+  --delete     Delete the received message after printing it.
+EOF
+}
+
+QUEUE_URL=""
+AWS_PROFILE=""
+AWS_REGION="eu-west-2"
+DELETE_MESSAGE="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --queue-url)
+      QUEUE_URL="$2"
+      shift 2
+      ;;
+    --profile)
+      AWS_PROFILE="$2"
+      shift 2
+      ;;
+    --region)
+      AWS_REGION="$2"
+      shift 2
+      ;;
+    --delete)
+      DELETE_MESSAGE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$QUEUE_URL" ]; then
+  echo "--queue-url is required" >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+AWS_CMD=(aws)
+if [ -n "$AWS_PROFILE" ]; then
+  AWS_CMD+=(--profile "$AWS_PROFILE")
+fi
+AWS_CMD+=(--region "$AWS_REGION")
+
+MESSAGE_JSON="$("${AWS_CMD[@]}" sqs receive-message \
+  --queue-url "$QUEUE_URL" \
+  --max-number-of-messages 1 \
+  --message-attribute-names All \
+  --attribute-names All \
+  --wait-time-seconds 5 \
+  --output json)"
+
+RECEIPT_HANDLE_FILE="$(mktemp)"
+MESSAGE_JSON="$MESSAGE_JSON" RECEIPT_HANDLE_FILE="$RECEIPT_HANDLE_FILE" python3 - <<'PY'
+import json
+import os
+import sys
+
+data = json.loads(os.environ["MESSAGE_JSON"])
+messages = data.get("Messages", [])
+if not messages:
+    print("No messages available", file=sys.stderr)
+    raise SystemExit(1)
+
+message = messages[0]
+body = message.get("Body", "")
+
+try:
+    parsed_body = json.loads(body)
+except json.JSONDecodeError:
+    parsed_body = body
+
+print(json.dumps(parsed_body, indent=2, sort_keys=True))
+with open(os.environ["RECEIPT_HANDLE_FILE"], "w", encoding="utf-8") as handle:
+    handle.write(message.get("ReceiptHandle", ""))
+PY
+
+RECEIPT_HANDLE="$(cat "$RECEIPT_HANDLE_FILE")"
+rm -f "$RECEIPT_HANDLE_FILE"
+
+if [ "$DELETE_MESSAGE" = "true" ]; then
+  if [ -n "$RECEIPT_HANDLE" ]; then
+    "${AWS_CMD[@]}" sqs delete-message --queue-url "$QUEUE_URL" --receipt-handle "$RECEIPT_HANDLE" >/dev/null
+  fi
+fi

--- a/scripts/upload-file-via-api.sh
+++ b/scripts/upload-file-via-api.sh
@@ -1,0 +1,462 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/upload-file-via-api.sh \
+    --api-endpoint <https-url> \
+    --client-id <client-id> \
+    --file <local-file> \
+    --content-type <mime-type> \
+    [--basic-username <username> --basic-password <password> | --bearer-token <token>] \
+    [--requested-expiry-seconds <seconds>] \
+    [--output-dir <dir>]
+
+Description:
+  Requests an upload ticket from the Integration Hub API and performs the
+  complete upload flow automatically:
+  - single PUT uploads for smaller files
+  - multipart upload initiation, part URL pagination, part uploads, and final
+    completion for larger files
+
+Outputs:
+  Writes request/response artifacts under the chosen output directory and prints
+  a short completion summary to stderr.
+EOF
+}
+
+if [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+API_ENDPOINT=""
+CLIENT_ID=""
+LOCAL_FILE=""
+CONTENT_TYPE=""
+BASIC_USERNAME=""
+BASIC_PASSWORD=""
+BEARER_TOKEN=""
+REQUESTED_EXPIRY_SECONDS="3600"
+OUTPUT_DIR=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --api-endpoint)
+      API_ENDPOINT="$2"
+      shift 2
+      ;;
+    --client-id)
+      CLIENT_ID="$2"
+      shift 2
+      ;;
+    --file)
+      LOCAL_FILE="$2"
+      shift 2
+      ;;
+    --content-type)
+      CONTENT_TYPE="$2"
+      shift 2
+      ;;
+    --basic-username)
+      BASIC_USERNAME="$2"
+      shift 2
+      ;;
+    --basic-password)
+      BASIC_PASSWORD="$2"
+      shift 2
+      ;;
+    --bearer-token)
+      BEARER_TOKEN="$2"
+      shift 2
+      ;;
+    --requested-expiry-seconds)
+      REQUESTED_EXPIRY_SECONDS="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$API_ENDPOINT" ] || [ -z "$CLIENT_ID" ] || [ -z "$LOCAL_FILE" ] || [ -z "$CONTENT_TYPE" ]; then
+  echo "--api-endpoint, --client-id, --file, and --content-type are required" >&2
+  exit 1
+fi
+
+if [ ! -f "$LOCAL_FILE" ]; then
+  echo "Local file not found: $LOCAL_FILE" >&2
+  exit 1
+fi
+
+if [ -n "$BEARER_TOKEN" ] && { [ -n "$BASIC_USERNAME" ] || [ -n "$BASIC_PASSWORD" ]; }; then
+  echo "Use either bearer auth or basic auth, not both" >&2
+  exit 1
+fi
+
+if [ -n "$BASIC_USERNAME" ] && [ -z "$BASIC_PASSWORD" ]; then
+  echo "--basic-password is required when using --basic-username" >&2
+  exit 1
+fi
+
+if [ -z "$BEARER_TOKEN" ] && [ -z "$BASIC_USERNAME" ]; then
+  echo "Provide either --bearer-token or --basic-username/--basic-password" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+if [ -z "$OUTPUT_DIR" ]; then
+  OUTPUT_DIR="/tmp/api-upload-$(date +%s)"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+file_size_bytes() {
+  local file_path="$1"
+  if stat -f%z "$file_path" >/dev/null 2>&1; then
+    stat -f%z "$file_path"
+  else
+    stat -c%s "$file_path"
+  fi
+}
+
+FILE_SIZE_BYTES="$(file_size_bytes "$LOCAL_FILE")"
+FILE_BASENAME="$(basename "$LOCAL_FILE")"
+
+AUTH_ARGS=()
+if [ -n "$BEARER_TOKEN" ]; then
+  AUTH_ARGS=(-H "authorization: Bearer $BEARER_TOKEN")
+else
+  AUTH_ARGS=(-u "${BASIC_USERNAME}:${BASIC_PASSWORD}")
+fi
+
+TRANSFER_TICKET_REQUEST_JSON="$OUTPUT_DIR/transfer-ticket-request.json"
+TRANSFER_TICKET_RESPONSE_JSON="$OUTPUT_DIR/transfer-ticket-response.json"
+
+python3 - "$CLIENT_ID" "$FILE_BASENAME" "$CONTENT_TYPE" "$FILE_SIZE_BYTES" "$REQUESTED_EXPIRY_SECONDS" > "$TRANSFER_TICKET_REQUEST_JSON" <<'PY'
+import json
+import sys
+
+client_id, file_name, content_type, size_bytes, requested_expiry = sys.argv[1:]
+
+payload = {
+    "clientId": client_id,
+    "fileName": file_name,
+    "contentType": content_type,
+    "sizeBytes": int(size_bytes),
+    "requestedExpirySeconds": int(requested_expiry),
+}
+
+print(json.dumps(payload, indent=2))
+PY
+
+echo "Requesting upload ticket from ${API_ENDPOINT}/transfer-tickets" >&2
+curl --fail-with-body --silent --show-error \
+  "${AUTH_ARGS[@]}" \
+  -H "content-type: application/json" \
+  -X POST "${API_ENDPOINT}/transfer-tickets" \
+  --data @"$TRANSFER_TICKET_REQUEST_JSON" \
+  > "$TRANSFER_TICKET_RESPONSE_JSON"
+
+UPLOAD_MODE="$(RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+if "upload" in data:
+    print("single")
+elif "multipart" in data:
+    print("multipart")
+else:
+    raise SystemExit("Unknown transfer-ticket response shape")
+PY
+)"
+
+if [ "$UPLOAD_MODE" = "single" ]; then
+  SINGLE_UPLOAD_URL_FILE="$OUTPUT_DIR/single-upload-url.txt"
+  SINGLE_UPLOAD_HEADERS_FILE="$OUTPUT_DIR/single-upload-headers.json"
+
+  RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY' > "$SINGLE_UPLOAD_URL_FILE"
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(data["upload"]["url"], end="")
+PY
+
+  RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY' > "$SINGLE_UPLOAD_HEADERS_FILE"
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(json.dumps(data["upload"].get("headers", {}), indent=2))
+PY
+
+  mapfile_headers="$(
+    RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+for key, value in data["upload"].get("headers", {}).items():
+    print(f"{key}\t{value}")
+PY
+  )"
+
+  CURL_SINGLE_ARGS=()
+  while IFS=$'\t' read -r header_name header_value; do
+    [ -z "$header_name" ] && continue
+    CURL_SINGLE_ARGS+=(-H "${header_name}: ${header_value}")
+  done <<EOF
+$mapfile_headers
+EOF
+
+  echo "Uploading single object to S3" >&2
+  curl --fail-with-body --silent --show-error \
+    -X PUT \
+    --upload-file "$LOCAL_FILE" \
+    "${CURL_SINGLE_ARGS[@]}" \
+    "$(cat "$SINGLE_UPLOAD_URL_FILE")" \
+    > /dev/null
+
+  echo "Single upload complete." >&2
+  echo "Transfer ticket response: $TRANSFER_TICKET_RESPONSE_JSON" >&2
+  exit 0
+fi
+
+PARTS_DIR="$OUTPUT_DIR/parts"
+UPLOADS_DIR="$OUTPUT_DIR/uploads"
+mkdir -p "$PARTS_DIR" "$UPLOADS_DIR"
+
+PART_SIZE_BYTES="$(RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(data["multipart"]["partSizeBytes"], end="")
+PY
+)"
+
+TOTAL_PARTS="$(RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(data["multipart"]["totalParts"], end="")
+PY
+)"
+
+INITIAL_BATCH_SIZE="$(RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(len(data["multipart"].get("initialParts", [])), end="")
+PY
+)"
+
+TRANSFER_TICKET_ID="$(RESPONSE_JSON_PATH="$TRANSFER_TICKET_RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+
+with open(os.environ["RESPONSE_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(data["transferTicket"], end="")
+PY
+)"
+
+echo "Splitting $LOCAL_FILE into ${PART_SIZE_BYTES}-byte chunks" >&2
+split -b "$PART_SIZE_BYTES" "$LOCAL_FILE" "$PARTS_DIR/part-"
+
+ALL_PARTS_JSON="$OUTPUT_DIR/all-parts.json"
+cp "$TRANSFER_TICKET_RESPONSE_JSON" "$ALL_PARTS_JSON"
+
+NEXT_START=$((INITIAL_BATCH_SIZE + 1))
+while [ "$NEXT_START" -le "$TOTAL_PARTS" ]; do
+  NEXT_END=$((NEXT_START + INITIAL_BATCH_SIZE - 1))
+  if [ "$NEXT_END" -gt "$TOTAL_PARTS" ]; then
+    NEXT_END="$TOTAL_PARTS"
+  fi
+
+  PARTS_REQUEST_JSON="$OUTPUT_DIR/parts-${NEXT_START}-${NEXT_END}-request.json"
+  PARTS_RESPONSE_JSON="$OUTPUT_DIR/parts-${NEXT_START}-${NEXT_END}-response.json"
+
+  python3 - "$NEXT_START" "$NEXT_END" > "$PARTS_REQUEST_JSON" <<'PY'
+import json
+import sys
+
+start, end = sys.argv[1:]
+print(json.dumps({
+    "partNumberStart": int(start),
+    "partNumberEnd": int(end),
+}, indent=2))
+PY
+
+  echo "Requesting part URLs ${NEXT_START}-${NEXT_END}" >&2
+  curl --fail-with-body --silent --show-error \
+    "${AUTH_ARGS[@]}" \
+    -H "content-type: application/json" \
+    -X POST "${API_ENDPOINT}/transfer-tickets/${TRANSFER_TICKET_ID}/parts" \
+    --data @"$PARTS_REQUEST_JSON" \
+    > "$PARTS_RESPONSE_JSON"
+
+  MERGED_PARTS_JSON="$OUTPUT_DIR/all-parts-next.json"
+  python3 - "$ALL_PARTS_JSON" "$PARTS_RESPONSE_JSON" > "$MERGED_PARTS_JSON" <<'PY'
+import json
+import sys
+
+existing_path, new_path = sys.argv[1:]
+with open(existing_path, "r", encoding="utf-8") as fh:
+    existing = json.load(fh)
+with open(new_path, "r", encoding="utf-8") as fh:
+    new_data = json.load(fh)
+
+existing["multipart"]["initialParts"].extend(new_data.get("parts", []))
+print(json.dumps(existing, indent=2))
+PY
+  mv "$MERGED_PARTS_JSON" "$ALL_PARTS_JSON"
+
+  NEXT_START=$((NEXT_END + 1))
+done
+
+ETAGS_JSON="$OUTPUT_DIR/etags.json"
+
+RESPONSE_JSON_PATH="$ALL_PARTS_JSON" \
+PARTS_DIR_PATH="$PARTS_DIR" \
+UPLOADS_DIR_PATH="$UPLOADS_DIR" \
+ETAGS_JSON_PATH="$ETAGS_JSON" \
+python3 <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+response_path = Path(os.environ["RESPONSE_JSON_PATH"])
+parts_dir = Path(os.environ["PARTS_DIR_PATH"])
+uploads_dir = Path(os.environ["UPLOADS_DIR_PATH"])
+etags_path = Path(os.environ["ETAGS_JSON_PATH"])
+
+with response_path.open("r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+parts = sorted(data["multipart"].get("initialParts", []), key=lambda item: int(item["partNumber"]))
+chunk_files = sorted(parts_dir.glob("part-*"))
+if len(chunk_files) < len(parts):
+    raise SystemExit(f"Expected at least {len(parts)} chunk files, found {len(chunk_files)}")
+
+results = []
+for part in parts:
+    part_number = int(part["partNumber"])
+    chunk_file = chunk_files[part_number - 1]
+    header_file = uploads_dir / f"part-{part_number}.headers"
+
+    print(f"Uploading part {part_number} from {chunk_file}", file=sys.stderr)
+    completed = subprocess.run(
+        [
+            "curl",
+            "--fail-with-body",
+            "--silent",
+            "--show-error",
+            "--request",
+            part.get("method", "PUT"),
+            "--dump-header",
+            str(header_file),
+            "--output",
+            "/dev/null",
+            "--upload-file",
+            str(chunk_file),
+            part["url"],
+        ],
+        check=False,
+    )
+
+    if completed.returncode != 0:
+        raise SystemExit(f"Upload failed for part {part_number}")
+
+    etag = None
+    with header_file.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.lower().startswith("etag:"):
+                etag = line.split(":", 1)[1].strip()
+                break
+
+    if not etag:
+        raise SystemExit(f"ETag not found for part {part_number}")
+
+    results.append({"partNumber": part_number, "eTag": etag})
+
+with etags_path.open("w", encoding="utf-8") as fh:
+    json.dump(
+        {
+            "transferTicket": data["transferTicket"],
+            "parts": results,
+        },
+        fh,
+        indent=2,
+    )
+PY
+
+COMPLETE_REQUEST_JSON="$OUTPUT_DIR/complete-request.json"
+COMPLETE_RESPONSE_JSON="$OUTPUT_DIR/complete-response.json"
+
+ETAGS_JSON_PATH="$ETAGS_JSON" python3 <<'PY' > "$COMPLETE_REQUEST_JSON"
+import json
+import os
+
+with open(os.environ["ETAGS_JSON_PATH"], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+print(json.dumps({"parts": data["parts"]}, indent=2))
+PY
+
+echo "Completing multipart upload" >&2
+curl --fail-with-body --silent --show-error \
+  "${AUTH_ARGS[@]}" \
+  -H "content-type: application/json" \
+  -X POST "${API_ENDPOINT}/transfer-tickets/${TRANSFER_TICKET_ID}/complete" \
+  --data @"$COMPLETE_REQUEST_JSON" \
+  > "$COMPLETE_RESPONSE_JSON"
+
+echo "Multipart upload complete." >&2
+echo "Transfer ticket response: $TRANSFER_TICKET_RESPONSE_JSON" >&2
+echo "Combined parts response: $ALL_PARTS_JSON" >&2
+echo "ETag manifest: $ETAGS_JSON" >&2
+echo "Complete response: $COMPLETE_RESPONSE_JSON" >&2

--- a/scripts/upload-multipart-parts.sh
+++ b/scripts/upload-multipart-parts.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/upload-multipart-parts.sh <multipart-response.json> <local-file> [output-dir]
+
+Description:
+  Reads a multipart upload response JSON, splits the local file using the
+  advertised part size, uploads each presigned part URL contained in the
+  response, and writes the collected ETags to an output JSON file.
+
+Notes:
+  - This uploads only the part URLs present in the supplied response file.
+  - If the response contains the initial 10 parts, this script uploads only
+    those 10 parts. Request more part URLs from the API and run again for the
+    remaining parts.
+  - Presigned URLs expire. If uploads fail with signature/expiry errors, fetch
+    fresh part URLs first.
+EOF
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+RESPONSE_JSON="$1"
+LOCAL_FILE="$2"
+OUTPUT_DIR="${3:-/tmp/multipart-upload-$(date +%s)}"
+
+if [ ! -f "$RESPONSE_JSON" ]; then
+  echo "Response JSON file not found: $RESPONSE_JSON" >&2
+  exit 1
+fi
+
+if [ ! -f "$LOCAL_FILE" ]; then
+  echo "Local file not found: $LOCAL_FILE" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+PARTS_DIR="$OUTPUT_DIR/parts"
+UPLOADS_DIR="$OUTPUT_DIR/uploads"
+mkdir -p "$PARTS_DIR" "$UPLOADS_DIR"
+
+RESPONSE_META_RAW="$(
+  RESPONSE_JSON_PATH="$RESPONSE_JSON" python3 <<'PY'
+import json
+import os
+import sys
+
+path = os.environ["RESPONSE_JSON_PATH"]
+with open(path, "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+if "multipart" in data:
+    multipart = data["multipart"]
+    transfer_ticket = data.get("transferTicket", "")
+    upload_id = multipart.get("uploadId", "")
+    part_size = int(multipart["partSizeBytes"])
+    parts = multipart.get("initialParts", [])
+elif "parts" in data:
+    transfer_ticket = data.get("transferTicket", "")
+    upload_id = data.get("uploadId", "")
+    part_size = None
+    parts = data["parts"]
+else:
+    raise SystemExit("Response JSON does not contain multipart.initialParts or parts")
+
+if not parts:
+    raise SystemExit("No parts found in response JSON")
+
+part_numbers = [int(part["partNumber"]) for part in parts]
+
+print(transfer_ticket)
+print(upload_id)
+print("" if part_size is None else str(part_size))
+print(",".join(str(number) for number in part_numbers))
+PY
+)"
+
+TRANSFER_TICKET="$(printf '%s\n' "$RESPONSE_META_RAW" | sed -n '1p')"
+UPLOAD_ID="$(printf '%s\n' "$RESPONSE_META_RAW" | sed -n '2p')"
+PART_SIZE_BYTES="$(printf '%s\n' "$RESPONSE_META_RAW" | sed -n '3p')"
+PART_NUMBERS_CSV="$(printf '%s\n' "$RESPONSE_META_RAW" | sed -n '4p')"
+
+if [ -z "$PART_SIZE_BYTES" ]; then
+  echo "This response does not include partSizeBytes. Use the original transfer-ticket response for splitting." >&2
+  exit 1
+fi
+
+echo "Splitting $LOCAL_FILE into ${PART_SIZE_BYTES}-byte chunks under $PARTS_DIR" >&2
+split -b "$PART_SIZE_BYTES" "$LOCAL_FILE" "$PARTS_DIR/part-"
+
+ETAGS_JSON="$OUTPUT_DIR/etags.json"
+
+RESPONSE_JSON_PATH="$RESPONSE_JSON" \
+PARTS_DIR_PATH="$PARTS_DIR" \
+UPLOADS_DIR_PATH="$UPLOADS_DIR" \
+ETAGS_JSON_PATH="$ETAGS_JSON" \
+python3 <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+response_path = Path(os.environ["RESPONSE_JSON_PATH"])
+parts_dir = Path(os.environ["PARTS_DIR_PATH"])
+uploads_dir = Path(os.environ["UPLOADS_DIR_PATH"])
+etags_path = Path(os.environ["ETAGS_JSON_PATH"])
+
+with response_path.open("r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+if "multipart" in data:
+    parts = data["multipart"].get("initialParts", [])
+else:
+    parts = data["parts"]
+
+chunk_files = sorted(parts_dir.glob("part-*"))
+if not chunk_files:
+    raise SystemExit("No split chunk files found")
+
+results = []
+for part in parts:
+    part_number = int(part["partNumber"])
+    chunk_index = part_number - 1
+    if chunk_index >= len(chunk_files):
+        raise SystemExit(f"Missing chunk file for part {part_number}")
+
+    chunk_file = chunk_files[chunk_index]
+    header_file = uploads_dir / f"part-{part_number}.headers"
+
+    print(f"Uploading part {part_number} from {chunk_file}", file=sys.stderr)
+    with header_file.open("w", encoding="utf-8") as header_fh:
+        completed = subprocess.run(
+            [
+                "curl",
+                "--fail-with-body",
+                "--silent",
+                "--show-error",
+                "--request",
+                part.get("method", "PUT"),
+                "--dump-header",
+                str(header_file),
+                "--output",
+                "/dev/null",
+                "--upload-file",
+                str(chunk_file),
+                part["url"],
+            ],
+            check=False,
+        )
+
+    if completed.returncode != 0:
+        raise SystemExit(f"Upload failed for part {part_number}")
+
+    etag = None
+    with header_file.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.lower().startswith("etag:"):
+                etag = line.split(":", 1)[1].strip()
+                break
+
+    if not etag:
+        raise SystemExit(f"ETag not found in response headers for part {part_number}")
+
+    results.append({
+        "partNumber": part_number,
+        "eTag": etag,
+        "chunkFile": str(chunk_file),
+    })
+
+with etags_path.open("w", encoding="utf-8") as fh:
+    json.dump(
+        {
+            "transferTicket": data.get("transferTicket", ""),
+            "uploadId": data.get("uploadId", data.get("multipart", {}).get("uploadId", "")),
+            "parts": results,
+        },
+        fh,
+        indent=2,
+    )
+
+print(f"Wrote ETags to {etags_path}", file=sys.stderr)
+PY
+
+echo >&2
+echo "Upload batch complete." >&2
+echo "Transfer ticket: ${TRANSFER_TICKET}" >&2
+echo "Upload ID: ${UPLOAD_ID}" >&2
+echo "Uploaded part numbers: ${PART_NUMBERS_CSV}" >&2
+echo "ETag manifest: ${ETAGS_JSON}" >&2

--- a/scripts/upload-multipart-parts.sh
+++ b/scripts/upload-multipart-parts.sh
@@ -151,25 +151,24 @@ for part in parts:
     header_file = uploads_dir / f"part-{part_number}.headers"
 
     print(f"Uploading part {part_number} from {chunk_file}", file=sys.stderr)
-    with header_file.open("w", encoding="utf-8") as header_fh:
-        completed = subprocess.run(
-            [
-                "curl",
-                "--fail-with-body",
-                "--silent",
-                "--show-error",
-                "--request",
-                part.get("method", "PUT"),
-                "--dump-header",
-                str(header_file),
-                "--output",
-                "/dev/null",
-                "--upload-file",
-                str(chunk_file),
-                part["url"],
-            ],
-            check=False,
-        )
+    completed = subprocess.run(
+        [
+            "curl",
+            "--fail-with-body",
+            "--silent",
+            "--show-error",
+            "--request",
+            part.get("method", "PUT"),
+            "--dump-header",
+            str(header_file),
+            "--output",
+            "/dev/null",
+            "--upload-file",
+            str(chunk_file),
+            part["url"],
+        ],
+        check=False,
+    )
 
     if completed.returncode != 0:
         raise SystemExit(f"Upload failed for part {part_number}")

--- a/terraform/environments/integration-hub/api-platform/README.md
+++ b/terraform/environments/integration-hub/api-platform/README.md
@@ -18,6 +18,7 @@ It now protects the API with:
 6. For files at or below the single PUT limit, the Lambda generates a short-lived pre-signed `PUT` URL for the existing Managed File Transfer upload bucket.
 7. For larger files, the Lambda initiates an S3 multipart upload, persists the upload session, and returns the first batch of pre-signed part URLs plus follow-up API operations for the remaining parts, completion, and abort.
 8. The client uploads directly to S3 and, for multipart flows, completes the upload through the API once all parts have been transferred.
+9. When the file reaches the Managed File Transfer `clean` bucket, the downstream notifier publishes a client-facing SNS event containing the `clientId`, `transferTicket`, file details, and a presigned download URL.
 
 ## Sample request payload
 

--- a/terraform/environments/integration-hub/api-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-platform/lambda.tf
@@ -146,10 +146,10 @@ module "lambda_api_docs" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 
-  function_name                = "${local.application_name}-${local.component_name}-docs"
-  description                  = "Serves the protected Swagger UI and OpenAPI contract for the MFT API"
-  handler                      = "lambda_function.lambda_handler"
-  runtime                      = "python3.12"
+  function_name = "${local.application_name}-${local.component_name}-docs"
+  description   = "Serves the protected Swagger UI and OpenAPI contract for the MFT API"
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.12"
   # Rebuild the package on clean CI runners when the local zip is absent.
   trigger_on_package_timestamp = true
   environment_variables = {

--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -71,7 +71,7 @@ The service is built entirely from AWS managed services, provisioned with Terraf
    - `clean` — `NO_THREATS_FOUND`
    - `quarantine` — `THREATS_FOUND`
    - `investigation` — `UNSUPPORTED`, `ACCESS_DENIED` or `FAILED`
-7. **Notification.** When a clean object lands, the `send-presigned-url` module generates a time-limited presigned download URL and posts it to Slack.
+7. **Notification.** When a clean object lands, the `send-presigned-url` module generates a time-limited presigned download URL, posts it to Slack, and publishes a client-facing notification event to SNS for downstream consumers.
 
 All buckets are KMS-encrypted, versioned, block public access, and have short (one day) lifecycle expiry as befits a transfer staging area.
 
@@ -100,6 +100,23 @@ CloudWatch alarms publish to high- and low-priority SNS topics, which feed Amazo
 - **Dead-letter queues** — any message arriving on a dead-letter queue.
 - **GuardDuty Malware Protection for S3** — failed, skipped or infected object scans.
 - **Transfer ingress volume** — unexpectedly high file ingress for the MVP.
+
+## Client notification testing
+
+For the API upload flow, clean files now also emit a downstream consumer notification with the client ID, transfer ticket, file details, and a presigned download URL.
+
+In development, Terraform provisions a `products-poc` test SQS subscription for this SNS topic. Useful outputs are:
+
+- `terraform output clean_file_client_notification_topic_arn`
+- `terraform output products_poc_clean_file_notification_test_queue_url`
+
+You can poll the queue with:
+
+```bash
+scripts/poll-clean-file-notification.sh \
+  --profile integration-hub-development \
+  --queue-url "$(terraform output -raw products_poc_clean_file_notification_test_queue_url)"
+```
 
 ### **Impact of an outage:**
 

--- a/terraform/environments/integration-hub/managed-file-transfer/client-notification-test.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/client-notification-test.tf
@@ -1,0 +1,59 @@
+module "sqs_products_poc_clean_file_ready_notifications" {
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "5.2.2"
+
+  count = local.environment == "development" ? 1 : 0
+
+  name            = "${local.application_name}-products-poc-clean-file-ready"
+  use_name_prefix = false
+
+  create_queue_policy = true
+  queue_policy_statements = {
+    sns = {
+      sid     = "AllowClientNotificationTopicSendMessage"
+      actions = ["sqs:SendMessage"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["sns.amazonaws.com"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "ArnEquals"
+          variable = "aws:SourceArn"
+          values   = [module.proof_of_concept_notification.sns_clean_file_client_notifications.topic_arn]
+        }
+      ]
+    }
+  }
+
+  create_dlq = true
+  dlq_name   = "${local.application_name}-products-poc-clean-file-ready-dlq"
+
+  message_retention_seconds     = 1209600
+  visibility_timeout_seconds    = 180
+  receive_wait_time_seconds     = 20
+  dlq_message_retention_seconds = 1209600
+
+  redrive_policy = {
+    maxReceiveCount = 5
+  }
+
+  tags = local.tags
+}
+
+resource "aws_sns_topic_subscription" "products_poc_clean_file_ready_notifications" {
+  count = local.environment == "development" ? 1 : 0
+
+  topic_arn            = module.proof_of_concept_notification.sns_clean_file_client_notifications.topic_arn
+  protocol             = "sqs"
+  endpoint             = module.sqs_products_poc_clean_file_ready_notifications[0].queue_arn
+  raw_message_delivery = true
+
+  filter_policy = jsonencode({
+    clientId = ["products-poc"]
+  })
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
@@ -14,11 +14,16 @@ from aws_lambda_powertools.utilities.idempotency import (
 
 s3 = boto3.client("s3")
 sns = boto3.client("sns")
+CLIENT_NOTIFICATION_SNS_TOPIC_ARN = os.environ["CLIENT_NOTIFICATION_SNS_TOPIC_ARN"]
 DOWNLOAD_BUCKET_NAME = os.environ["DOWNLOAD_BUCKET_NAME"]
 DOWNLOAD_URL_EXPIRY_SECONDS = int(os.environ["DOWNLOAD_URL_EXPIRY_SECONDS"])
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
 MAX_DOWNLOAD_URL_EXPIRY_SECONDS = int(os.environ["MAX_DOWNLOAD_URL_EXPIRY_SECONDS"])
 SLACK_SNS_TOPIC_ARN = os.environ["SLACK_SNS_TOPIC_ARN"]
+CLIENT_ID_METADATA_KEY = "client-id"
+ORIGINAL_FILE_NAME_METADATA_KEY = "original-file-name"
+TRANSFER_TICKET_METADATA_KEY = "transfer-ticket"
+CLIENT_NOTIFICATION_EVENT_TYPE = "clean-file-ready-for-download"
 TTL_METADATA_KEY = "presigned-url-expiry-seconds"
 logger = Logger(service="managed-file-transfer-clean-file-presigned-url-notifier")
 LOG_KEY_PATH_HASH_LENGTH = 12
@@ -74,9 +79,7 @@ def get_log_fields(operation):
     }
 
 
-def get_expiry_seconds(operation):
-    # Metadata is copied forward by the existing file-mover Lambdas, which lets
-    # callers request a shorter TTL without changing infrastructure config.
+def get_object_metadata(operation):
     head_object_kwargs = {
         "Bucket": operation["bucket_name"],
         "Key": operation["object_key"],
@@ -85,7 +88,13 @@ def get_expiry_seconds(operation):
     if operation["version_id"]:
         head_object_kwargs["VersionId"] = operation["version_id"]
 
+    # Metadata is copied forward by the existing file-mover Lambdas, which lets
+    # callers request a shorter TTL without changing infrastructure config.
     metadata = s3.head_object(**head_object_kwargs).get("Metadata", {})
+    return {key.lower(): value for key, value in metadata.items()}
+
+
+def get_expiry_seconds(operation, metadata):
     expiry_value = metadata.get(TTL_METADATA_KEY, DOWNLOAD_URL_EXPIRY_SECONDS)
 
     try:
@@ -134,6 +143,52 @@ def build_notification_message(operation, expiry_seconds, presigned_url):
     }
 
 
+def build_client_notification_message(operation, metadata, expiry_seconds, presigned_url):
+    expires_at = datetime.now(UTC) + timedelta(seconds=expiry_seconds)
+    file_name = metadata.get(ORIGINAL_FILE_NAME_METADATA_KEY) or operation["object_key"].rsplit("/", 1)[-1]
+
+    return {
+        "eventType": CLIENT_NOTIFICATION_EVENT_TYPE,
+        "clientId": metadata.get(CLIENT_ID_METADATA_KEY),
+        "transferTicket": metadata.get(TRANSFER_TICKET_METADATA_KEY),
+        "fileName": file_name,
+        "bucket": operation["bucket_name"],
+        "key": operation["object_key"],
+        "versionId": operation["version_id"],
+        "downloadUrl": presigned_url,
+        "downloadUrlExpiresInSeconds": expiry_seconds,
+        "downloadUrlExpiresAtUtc": expires_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def publish_client_notification(operation, metadata, expiry_seconds, presigned_url):
+    client_id = metadata.get(CLIENT_ID_METADATA_KEY)
+    if not client_id:
+        logger.info(
+            "Skipping client notification because client metadata is not present",
+            extra=get_log_fields(operation),
+        )
+        return None
+
+    notification_message = build_client_notification_message(operation, metadata, expiry_seconds, presigned_url)
+    sns.publish(
+        TopicArn=CLIENT_NOTIFICATION_SNS_TOPIC_ARN,
+        Message=json.dumps(notification_message),
+        MessageAttributes={
+            "clientId": {
+                "DataType": "String",
+                "StringValue": client_id,
+            },
+            "eventType": {
+                "DataType": "String",
+                "StringValue": CLIENT_NOTIFICATION_EVENT_TYPE,
+            },
+        },
+    )
+    logger.info("Published client download notification", extra=get_log_fields(operation))
+    return notification_message
+
+
 @idempotent_function(
     data_keyword_argument="operation",
     persistence_store=persistence_layer,
@@ -148,7 +203,8 @@ def process_record(*, operation):
             f"Received clean file notification for unexpected bucket {operation['bucket_name']}"
         )
 
-    expiry_seconds = get_expiry_seconds(operation)
+    metadata = get_object_metadata(operation)
+    expiry_seconds = get_expiry_seconds(operation, metadata)
     presign_params = {
         "Bucket": operation["bucket_name"],
         "Key": operation["object_key"],
@@ -170,10 +226,13 @@ def process_record(*, operation):
     )
 
     logger.info("Published presigned URL notification", extra=get_log_fields(operation))
+    client_notification = publish_client_notification(operation, metadata, expiry_seconds, presigned_url)
 
     return {
         "bucket_name": operation["bucket_name"],
+        "client_id": metadata.get(CLIENT_ID_METADATA_KEY),
         "expiry_seconds": expiry_seconds,
+        "client_notification_topic_arn": CLIENT_NOTIFICATION_SNS_TOPIC_ARN if client_notification else None,
         "notification_topic_arn": operation["notification_topic_arn"],
         "object_key": operation["object_key"],
         "version_id": operation["version_id"],

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import unquote_plus
 
 import boto3
+from botocore.config import Config
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
@@ -12,7 +13,13 @@ from aws_lambda_powertools.utilities.idempotency import (
     idempotent_function,
 )
 
-s3 = boto3.client("s3")
+AWS_REGION = os.environ.get("AWS_REGION", "eu-west-2")
+s3 = boto3.client(
+    "s3",
+    region_name=AWS_REGION,
+    endpoint_url=f"https://s3.{AWS_REGION}.amazonaws.com",
+    config=Config(signature_version="s3v4", s3={"addressing_style": "virtual"}),
+)
 sns = boto3.client("sns")
 CLIENT_NOTIFICATION_SNS_TOPIC_ARN = os.environ["CLIENT_NOTIFICATION_SNS_TOPIC_ARN"]
 DOWNLOAD_BUCKET_NAME = os.environ["DOWNLOAD_BUCKET_NAME"]

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
@@ -45,7 +45,8 @@ def fake_idempotent_function(**_kwargs):
     return decorator
 
 
-sys.modules.setdefault("boto3", SimpleNamespace(client=lambda _service_name: SimpleNamespace()))
+sys.modules.setdefault("boto3", SimpleNamespace(client=lambda _service_name, **_kwargs: SimpleNamespace()))
+sys.modules.setdefault("botocore.config", SimpleNamespace(Config=lambda **_kwargs: SimpleNamespace()))
 sys.modules.setdefault("aws_lambda_powertools", SimpleNamespace(Logger=FakeLogger))
 sys.modules.setdefault(
     "aws_lambda_powertools.utilities.idempotency",

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
@@ -46,7 +46,17 @@ def fake_idempotent_function(**_kwargs):
 
 
 sys.modules.setdefault("boto3", SimpleNamespace(client=lambda _service_name, **_kwargs: SimpleNamespace()))
-sys.modules.setdefault("botocore.config", SimpleNamespace(Config=lambda **_kwargs: SimpleNamespace()))
+
+# `from botocore.config import Config` imports `botocore` first, so stub both the
+# package and the submodule to keep tests runnable without botocore installed.
+_module_type = type(sys)
+_botocore_pkg = _module_type("botocore")
+_botocore_pkg.__path__ = []
+_botocore_config = _module_type("botocore.config")
+_botocore_config.Config = lambda **_kwargs: SimpleNamespace()
+sys.modules.setdefault("botocore", _botocore_pkg)
+sys.modules.setdefault("botocore.config", _botocore_config)
+
 sys.modules.setdefault("aws_lambda_powertools", SimpleNamespace(Logger=FakeLogger))
 sys.modules.setdefault(
     "aws_lambda_powertools.utilities.idempotency",

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
@@ -1,0 +1,150 @@
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("CLIENT_NOTIFICATION_SNS_TOPIC_ARN", "arn:aws:sns:eu-west-2:111122223333:client-topic")
+os.environ.setdefault("DOWNLOAD_BUCKET_NAME", "clean-bucket")
+os.environ.setdefault("DOWNLOAD_URL_EXPIRY_SECONDS", "1800")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "idempotency-table")
+os.environ.setdefault("MAX_DOWNLOAD_URL_EXPIRY_SECONDS", "3600")
+os.environ.setdefault("SLACK_SNS_TOPIC_ARN", "arn:aws:sns:eu-west-2:111122223333:slack-topic")
+
+
+class FakeLogger:
+    def __init__(self, **_kwargs):
+        pass
+
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def exception(self, *_args, **_kwargs):
+        return None
+
+    def inject_lambda_context(self, clear_state=True, log_event=False):
+        def decorator(function):
+            return function
+
+        return decorator
+
+
+class FakeIdempotencyConfig:
+    def __init__(self, **_kwargs):
+        pass
+
+    def register_lambda_context(self, _context):
+        return None
+
+
+def fake_idempotent_function(**_kwargs):
+    def decorator(function):
+        return function
+
+    return decorator
+
+
+sys.modules.setdefault("boto3", SimpleNamespace(client=lambda _service_name: SimpleNamespace()))
+sys.modules.setdefault("aws_lambda_powertools", SimpleNamespace(Logger=FakeLogger))
+sys.modules.setdefault(
+    "aws_lambda_powertools.utilities.idempotency",
+    SimpleNamespace(
+        DynamoDBPersistenceLayer=lambda **_kwargs: SimpleNamespace(),
+        IdempotencyConfig=FakeIdempotencyConfig,
+        idempotent_function=fake_idempotent_function,
+    ),
+)
+
+import lambda_function as handler
+
+
+class FakeS3Client:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.head_calls = []
+        self.presign_calls = []
+
+    def head_object(self, **kwargs):
+        self.head_calls.append(kwargs)
+        return {"Metadata": self.metadata}
+
+    def generate_presigned_url(self, method, Params, ExpiresIn):
+        self.presign_calls.append({"method": method, "params": Params, "expires_in": ExpiresIn})
+        return "https://example.test/download"
+
+
+class FakeSnsClient:
+    def __init__(self):
+        self.publish_calls = []
+
+    def publish(self, **kwargs):
+        self.publish_calls.append(kwargs)
+        return {"MessageId": f"message-{len(self.publish_calls)}"}
+
+
+class CleanFileNotifierTests(unittest.TestCase):
+    def _event(self):
+        return {
+            "Records": [
+                {
+                    "body": json.dumps(
+                        {
+                            "Records": [
+                                {
+                                    "eventSource": "aws:s3",
+                                    "s3": {
+                                        "bucket": {"name": "clean-bucket"},
+                                        "object": {"key": "products-poc/uploads/2026/06/25/test.csv"},
+                                    },
+                                }
+                            ]
+                        }
+                    )
+                }
+            ]
+        }
+
+    @patch.object(handler, "s3")
+    @patch.object(handler, "sns")
+    def test_publishes_slack_and_client_notifications_when_client_metadata_is_present(self, patched_sns, patched_s3):
+        fake_s3 = FakeS3Client(
+            {
+                "client-id": "products-poc",
+                "original-file-name": "test.csv",
+                "transfer-ticket": "ticket-123",
+            }
+        )
+        fake_sns = FakeSnsClient()
+        patched_s3.head_object = fake_s3.head_object
+        patched_s3.generate_presigned_url = fake_s3.generate_presigned_url
+        patched_sns.publish = fake_sns.publish
+
+        handler.lambda_handler(self._event(), SimpleNamespace())
+
+        self.assertEqual(2, len(fake_sns.publish_calls))
+        client_publish = fake_sns.publish_calls[1]
+        message = json.loads(client_publish["Message"])
+        self.assertEqual(handler.CLIENT_NOTIFICATION_SNS_TOPIC_ARN, client_publish["TopicArn"])
+        self.assertEqual("products-poc", message["clientId"])
+        self.assertEqual("ticket-123", message["transferTicket"])
+        self.assertEqual("test.csv", message["fileName"])
+        self.assertEqual("products-poc", client_publish["MessageAttributes"]["clientId"]["StringValue"])
+
+    @patch.object(handler, "s3")
+    @patch.object(handler, "sns")
+    def test_skips_client_notification_when_client_metadata_is_missing(self, patched_sns, patched_s3):
+        fake_s3 = FakeS3Client({})
+        fake_sns = FakeSnsClient()
+        patched_s3.head_object = fake_s3.head_object
+        patched_s3.generate_presigned_url = fake_s3.generate_presigned_url
+        patched_sns.publish = fake_sns.publish
+
+        handler.lambda_handler(self._event(), SimpleNamespace())
+
+        self.assertEqual(1, len(fake_sns.publish_calls))
+        self.assertEqual(handler.SLACK_SNS_TOPIC_ARN, fake_sns.publish_calls[0]["TopicArn"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
@@ -172,6 +172,35 @@ module "sns_clean_file_download_notifications" {
   tags = var.tags
 }
 
+module "sns_clean_file_client_notifications" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "7.1.0"
+
+  name = "${local.resource_name_prefix}-clean-file-client-notifications"
+
+  topic_policy_statements = {
+    account_subscribe = {
+      actions = [
+        "sns:Subscribe",
+        "sns:Receive",
+      ]
+      principals = [{
+        type        = "AWS"
+        identifiers = [var.account_id]
+      }]
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "sns:Protocol"
+          values   = ["sqs"]
+        }
+      ]
+    }
+  }
+
+  tags = var.tags
+}
+
 module "lambda_clean_file_presigned_url_notifier" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
@@ -191,6 +220,7 @@ module "lambda_clean_file_presigned_url_notifier" {
   }
 
   environment_variables = {
+    CLIENT_NOTIFICATION_SNS_TOPIC_ARN = module.sns_clean_file_client_notifications.topic_arn
     DOWNLOAD_BUCKET_NAME            = var.download_bucket_name
     DOWNLOAD_URL_EXPIRY_SECONDS     = tostring(var.presigned_url_expiry_seconds)
     IDEMPOTENCY_TABLE               = module.dynamodb_idempotency.dynamodb_table_id
@@ -241,6 +271,7 @@ module "lambda_clean_file_presigned_url_notifier" {
         "sns:Publish",
       ]
       resources = [
+        module.sns_clean_file_client_notifications.topic_arn,
         module.sns_clean_file_download_notifications.topic_arn,
       ]
     }

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/outputs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/outputs.tf
@@ -23,6 +23,11 @@ output "sns_clean_file_download_notifications" {
   value       = module.sns_clean_file_download_notifications
 }
 
+output "sns_clean_file_client_notifications" {
+  description = "The full output of the SNS clean file client notifications module."
+  value       = module.sns_clean_file_client_notifications
+}
+
 output "lambda_clean_file_presigned_url_notifier" {
   description = "The full output of the Lambda clean file presigned URL notifier module."
   value       = module.lambda_clean_file_presigned_url_notifier

--- a/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
@@ -1,0 +1,9 @@
+output "clean_file_client_notification_topic_arn" {
+  description = "SNS topic ARN for client-facing clean file ready notifications."
+  value       = module.proof_of_concept_notification.sns_clean_file_client_notifications.topic_arn
+}
+
+output "products_poc_clean_file_notification_test_queue_url" {
+  description = "Development-only SQS queue URL subscribed to products-poc clean file ready notifications."
+  value       = local.environment == "development" ? module.sqs_products_poc_clean_file_ready_notifications[0].queue_url : null
+}


### PR DESCRIPTION

**What**

This change adds a downstream notification path for the MFT API flow.

When a client uploads a file via `/transfer-tickets` and that file is successfully processed into the clean bucket, the platform now publishes a notification for consumers via SNS/SQS. The notification includes the client ID, transfer ticket, clean bucket/key metadata, and a presigned `downloadUrl` so the consumer can pull the clean file.

This gives clients an integration point to react to completed file processing rather than having to poll for availability.

**Why**

The existing API flow supports file upload into the MFT pipeline, but there was no client-facing downstream event once the clean file became available. This change closes that gap and supports the use case where an external consumer wants to subscribe to a topic or queue and be notified when the clean file is ready for download.

**Implementation notes**

The notification is published by the clean-file presigned URL notifier Lambda in the managed file transfer stack.

That Lambda is triggered once the clean object is available and constructs the downstream event payload, including the presigned S3 download URL. As part of this change, the presigned URL generation was updated to use an explicitly configured regional S3 client with SigV4 settings, rather than relying on the default client configuration. This was needed to ensure the generated `downloadUrl` is valid for consumers and can be used successfully to download the clean file.

Reviewers may therefore want to focus on:
- the notification payload shape and whether it contains the right integration fields for consumers
- the SNS/SQS wiring and subscription flow for downstream consumers
- the presigned URL generation logic in the notifier Lambda
- any assumptions around expiry time, client metadata, and clean bucket object versioning

**How tested**

This was tested end to end in `integration-hub-development`.

1. Uploaded a fresh file through the existing API flow.
2. Confirmed the clean-file notification was emitted to the downstream SQS queue.
3. Verified the message contained:
- `eventType: clean-file-ready-for-download`
- the expected `clientId`
- the `transferTicket`
- clean bucket/key metadata
- a presigned `downloadUrl`
4. Used the `downloadUrl` from the notification and confirmed it returned `200 OK` and downloaded the clean file successfully.

Example command to inspect the SQS notification:

```bash
AWS_PROFILE=integration-hub-development aws sqs receive-message \
  --queue-url https://sqs.eu-west-2.amazonaws.com/508564776517/integration-hub-products-poc-clean-file-ready \
  --max-number-of-messages 1 \
  --visibility-timeout 5 \
  --wait-time-seconds 10 \
  --message-attribute-names All \
  --attribute-names All \
  --region eu-west-2 \
  --output json
```

If you only want the message body:

```bash
AWS_PROFILE=integration-hub-development aws sqs receive-message \
  --queue-url https://sqs.eu-west-2.amazonaws.com/508564776517/integration-hub-products-poc-clean-file-ready \
  --max-number-of-messages 1 \
  --visibility-timeout 5 \
  --wait-time-seconds 10 \
  --message-attribute-names All \
  --attribute-names All \
  --region eu-west-2 \
  --query 'Messages[0].Body' \
  --output text
```