### PR TITLE
exclude env suffix in prod

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -12,7 +12,7 @@ locals {
   load_lambda_databases = [
     "staged_mdss${local.dbt_suffix}",
     "acquisitive_crime${local.dbt_suffix}",
-    local.is-production ? "allied_mdss" : "allied_mdss_${local.environment_shorthand}",
+    "allied_mdss${local.db_suffix}"
   ]
 
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -12,7 +12,7 @@ locals {
   load_lambda_databases = [
     "staged_mdss${local.dbt_suffix}",
     "acquisitive_crime${local.dbt_suffix}",
-    "allied_mdss${local.dbt_suffix}",
+    local.is-production ? "allied_mdss" : "allied_mdss_${local.environment_shorthand}",
   ]
 
 }


### PR DESCRIPTION
base dbs only have the env as the suffix - except in prod