### PR TITLE
add ALB security headers for AppSec compliance

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "ai_gateway_configuration" {
   name      = "${local.component_name}-configuration"
   chart     = "${path.module}/src/helm/charts/${local.component_name}-configuration"
-  version   = "1.4.1"
+  version   = "1.4.2"
   namespace = module.ai_gateway_namespace.name
 
   values = [

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/Chart.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: ai-gateway-configuration
 description: A Helm chart to deploy Gateway API configuration for ai-gateway
 type: application
-version: 1.4.1
+version: 1.4.2

--- a/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/loadbalancerconfiguration.yaml
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/charts/ai-gateway-configuration/templates/loadbalancerconfiguration.yaml
@@ -20,3 +20,13 @@ spec:
     - protocolPort: HTTPS:443
       defaultCertificate: {{ .Values.certificateArn }}
       sslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      # https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ListenerAttribute.html
+      listenerAttributes:
+        - key: routing.http.response.server.enabled
+          value: "false"         
+        - key: routing.http.response.strict_transport_security.header_value
+          value: "max-age=31536000; includeSubDomains; preload"
+        - key: routing.http.response.x_content_type_options.header_value
+          value: "nosniff"
+        - key: routing.http.response.x_frame_options.header_value
+          value: "SAMEORIGIN"

--- a/terraform/environments/data-platform/ai-gateway/versions.tf
+++ b/terraform/environments/data-platform/ai-gateway/versions.tf
@@ -16,10 +16,6 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
-    null = {
-      version = "~> 3.0"
-      source  = "hashicorp/null"
-    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/data-platform/ai-gateway/versions.tf
+++ b/terraform/environments/data-platform/ai-gateway/versions.tf
@@ -16,6 +16,10 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
+    null = {
+      version = "~> 3.0"
+      source  = "hashicorp/null"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
- Disable ALB server response header
- Add HSTS header (max-age=`31536000`, `includeSubDomains`, `preload`)
- Add X-Content-Type-Options: `nosniff`
- Add X-Frame-Options: `SAMEORIGIN`
- Bump ai-gateway configuration chart version to `1.4.2`

PR is part of [this](https://github.com/ministryofjustice/data-platform-security/issues/55) ticket.