### PR TITLE
add FMS dashboard failure widgets

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
@@ -414,32 +414,17 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
                     @timestamp,
                     0
                   )
-                ) as rejected_at,
+                ) as latest_rejection_at,
                 max(
                   if(message.event = "FMS_FILE_OK", @timestamp, 0)
-                ) as loaded_at,
+                ) as latest_loaded_at,
                 latest(message.bucket) as bucket,
                 latest(message.s3path) as s3path,
                 latest(message.load_status) as latest_load_status,
                 latest(message.reason) as latest_reason
               by message.table, message.delivery_date, message.file_name
-            | filter rejected_at > 0
-            | fields
-                message.table,
-                message.delivery_date,
-                message.file_name,
-                rejected_at,
-                loaded_at,
-                if(
-                  loaded_at > rejected_at,
-                  "reloaded",
-                  "still_rejected"
-                ) as recovery_status,
-                latest_load_status,
-                bucket,
-                s3path,
-                latest_reason
-            | sort rejected_at desc
+            | filter latest_rejection_at > 0
+            | sort latest_rejection_at desc
             | limit 200
           EOT
         }

--- a/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-dashboard-fms.tf
@@ -356,6 +356,214 @@ resource "aws_cloudwatch_dashboard" "fms_ops" {
             ]
           ]
         }
+      },
+
+      # --------------------------
+      # load_fms file-level diagnostics
+      # --------------------------
+      {
+        type   = "log"
+        x      = 0
+        y      = 42
+        width  = 24
+        height = 8
+        properties = {
+          title  = "Validation schema failures: load_fms"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event = "FMS_FILE_REJECTED_VALIDATION"
+            | fields
+                @timestamp,
+                message.table,
+                message.delivery_date,
+                message.file_name,
+                message.bucket,
+                message.s3path,
+                message.dataset,
+                message.load_status,
+                message.reason
+            | sort @timestamp desc
+            | limit 200
+          EOT
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 50
+        width  = 24
+        height = 8
+        properties = {
+          title  = "Validation rejections recovery status"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event in [
+                "FMS_FILE_REJECTED_VALIDATION",
+                "FMS_FILE_OK"
+              ]
+            | stats
+                max(
+                  if(
+                    message.event = "FMS_FILE_REJECTED_VALIDATION",
+                    @timestamp,
+                    0
+                  )
+                ) as rejected_at,
+                max(
+                  if(message.event = "FMS_FILE_OK", @timestamp, 0)
+                ) as loaded_at,
+                latest(message.bucket) as bucket,
+                latest(message.s3path) as s3path,
+                latest(message.load_status) as latest_load_status,
+                latest(message.reason) as latest_reason
+              by message.table, message.delivery_date, message.file_name
+            | filter rejected_at > 0
+            | fields
+                message.table,
+                message.delivery_date,
+                message.file_name,
+                rejected_at,
+                loaded_at,
+                if(
+                  loaded_at > rejected_at,
+                  "reloaded",
+                  "still_rejected"
+                ) as recovery_status,
+                latest_load_status,
+                bucket,
+                s3path,
+                latest_reason
+            | sort rejected_at desc
+            | limit 200
+          EOT
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 58
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Validation failures by table"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event = "FMS_FILE_REJECTED_VALIDATION"
+            | stats
+                count_distinct(message.s3path) as rejected_files,
+                latest(@timestamp) as latest_rejection,
+                latest(message.reason) as latest_reason
+              by message.table
+            | sort rejected_files desc, latest_rejection desc
+            | limit 100
+          EOT
+        }
+      },
+      {
+        type   = "log"
+        x      = 12
+        y      = 58
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Failure reasons: load_fms"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event in [
+                "FMS_FILE_FAIL",
+                "FMS_FILE_REJECTED_VALIDATION"
+              ]
+            | stats
+                count_distinct(message.s3path) as affected_files,
+                latest(@timestamp) as latest_seen,
+                latest(message.table) as latest_table,
+                latest(message.file_name) as latest_file
+              by message.reason
+            | sort affected_files desc, latest_seen desc
+            | limit 100
+          EOT
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 64
+        width  = 24
+        height = 8
+        properties = {
+          title  = "Final failures: load_fms"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event = "FMS_FILE_FAIL"
+            | stats
+                latest(@timestamp) as latest_failure,
+                latest(message.bucket) as bucket,
+                latest(message.s3path) as s3path,
+                latest(message.dataset) as dataset,
+                latest(message.load_status) as load_status,
+                latest(message.reason) as reason
+              by message.table, message.delivery_date, message.file_name
+            | sort latest_failure desc
+            | limit 200
+          EOT
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 72
+        width  = 24
+        height = 8
+        properties = {
+          title  = "FMS outcome summary by table"
+          region = "eu-west-2"
+          view   = "table"
+          query  = <<-EOT
+            SOURCE '${module.load_fms_lambda.cloudwatch_log_group.name}'
+            | filter ispresent(message.event)
+            | filter message.event in [
+                "FMS_FILE_OK",
+                "FMS_FILE_FAIL",
+                "FMS_FILE_REJECTED_VALIDATION"
+              ]
+            | stats
+                count_distinct(
+                  if(message.event = "FMS_FILE_OK", message.s3path, null)
+                ) as ok_files,
+                count_distinct(
+                  if(message.event = "FMS_FILE_FAIL", message.s3path, null)
+                ) as failed_files,
+                count_distinct(
+                  if(
+                    message.event = "FMS_FILE_REJECTED_VALIDATION",
+                    message.s3path,
+                    null
+                  )
+                ) as validation_rejected_files,
+                latest(@timestamp) as latest_event
+              by message.table
+            | sort
+                validation_rejected_files desc,
+                failed_files desc,
+                ok_files desc
+            | limit 100
+          EOT
+        }
       }
     ]
   })


### PR DESCRIPTION
Adds file level FMS diagnostic widgets to the CloudWatch dashboard.

Changes
Adds:
FMS validation schema failure detail widget.
validation rejection recovery status widget.
validation failure summary by table.
final load_fms failure widget.
FMS outcome summary by table.
failure reason summary widget.

Does not add reconciler widgets, as FMS does not have an MDSS-style reconciler.

Outcome
FMS validation and load failures are easier to investigate from the dashboard without relying only on SNS alerts or the daily handover and almost matches MDSS format