### PR TITLE
Update cross account trust policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/cross-account.tf
+++ b/terraform/environments/digital-prison-reporting/cross-account.tf
@@ -41,13 +41,16 @@ data "aws_iam_policy_document" "dataapi_cross_assume" {
     }
     condition {
       test     = "StringEquals"
-      values   = ["system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr${local.environment_configuration.analytical_platform_runner_suffix}"]
-      variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:sub"
-    }
-    condition {
-      test     = "StringEquals"
       values   = ["sts.amazonaws.com"]
       variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:aud"
+    }
+    condition {
+      test = "StringLike"
+      values = [
+        "system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr-dev",
+        "system:serviceaccount:mwaa:hmpps-cadet-deployer-dpr-development",
+      ]
+      variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:sub"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the IAM policy document for cross-account access in the `digital-prison-reporting` environment. The main change is to broaden and clarify the allowed service account subjects for OIDC federated authentication, improving support for both GitHub Actions runners and MWAA deployers.

**IAM Policy Condition Updates:**

* Removed the previous `StringEquals` condition on the `:sub` field, which only allowed a single service account (`actions-runner-mojas-create-a-derived-table-dpr${local.environment_configuration.analytical_platform_runner_suffix}`) to assume the role.
* Added a new `StringLike` condition on the `:sub` field, now allowing both the `actions-runner-mojas-create-a-derived-table-dpr-dev` and `hmpps-cadet-deployer-dpr-development` service accounts to assume the role. This expands support to additional workloads, such as MWAA deployments.