### PR TITLE
Lake formation admins: SSO role and cadet role

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -12,11 +12,13 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
     [for share in
       local.analytical_platform_share : aws_iam_role.analytical_platform_share_role[share.target_account_name].arn
     ],
-    data.aws_iam_session_context.current.issuer_arn
+    data.aws_iam_session_context.current.issuer_arn,
+    [aws_iam_role.dataapi_cross_role.arn],
+    tolist(try(data.aws_iam_roles.data_engineering_roles.arns, toset([])))
   ])
 
 
-  # Ensure permissions are null to avoid LF being
+  # Account level setting for data catalogue
   create_database_default_permissions {
     # These settings should replicate current behaviour: LakeFormation is Ignored
     permissions = ["ALL"]


### PR DESCRIPTION
I have found a solution which allows the SSO role and cadet roles to be LF admins and manage tags.

These roles were LF admins many moons ago, but we had to remove it due to a idiosyncrancy in LF and LF tags.  I have found that by giving the roles in question * permissions on the **values** of an LF tag - the role can also be an admin