### PR TITLE
DPR - Cross-account version 5

### DIFF
--- a/terraform/environments/digital-prison-reporting/lake_formation.tf
+++ b/terraform/environments/digital-prison-reporting/lake_formation.tf
@@ -30,7 +30,7 @@ resource "aws_lakeformation_data_lake_settings" "lake_formation" {
   }
 
   parameters = {
-    "CROSS_ACCOUNT_VERSION" = "4"
+    "CROSS_ACCOUNT_VERSION" = "5"
   }
 }
 


### PR DESCRIPTION
Upgrades Lake Formation cross-account sharing to version 5 to improve scalability and reduce AWS RAM resource-share/association overhead for large table-sharing use cases. Existing shares remain compatible, while new grants can use the version 5 sharing behaviour.