### PR TITLE
Add VPC gateway endpoints

### DIFF
--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -58,4 +58,9 @@ locals {
   vpc_flow_log_cloudwatch_log_group_retention_in_days = 400
   vpc_flow_log_max_aggregation_interval               = 60
 
+  vpc_gateway_endpoint_service_names = [
+    "s3",      # S3
+    "dynamodb" # DynamoDB
+  ]
+
 }

--- a/terraform/environments/cloud-platform/network/vpc-endpoints.tf
+++ b/terraform/environments/cloud-platform/network/vpc-endpoints.tf
@@ -1,0 +1,21 @@
+# Interface VPC endpoints are defined centrally in the Modernisation Platform core-network-services account
+
+module "vpc-gateway-endpoints" {
+  source   = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version  = "6.5.1"
+  for_each = toset(local.vpc_gateway_endpoint_service_names)
+
+  vpc_id = module.cluster_vpc.vpc_id
+
+  endpoints = {
+    (each.value) = {
+      service         = each.value
+      service_type    = "Gateway"
+      route_table_ids = module.cluster_vpc.private_route_table_ids
+      tags = merge(
+        local.tags,
+        { Name = "${module.cluster_vpc.name}-${each.value}" }
+      )
+    }
+  }
+}


### PR DESCRIPTION
These should be local to the VPC and not managed centrally in the same way that interface endpoints are.

Deployed to dev and test cluster created succesfully