### PR TITLE
api consume from end user to deliver clean file

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -180,6 +180,8 @@ The consumer API must return JSON containing either a top-level upload target or
 
 The platform then streams the clean object from S3 to that presigned destination. Because Lambda retries can happen after partial progress, the consumer API should treat `transferTicket` as an idempotency key and tolerate a repeated request for a fresh presigned upload target.
 
+In `integration-hub-development`, Terraform also provisions a temporary mock consumer API for `products-poc`. It returns a presigned PUT URL into the investigation bucket so the destination-delivery flow can be exercised end to end without needing a separate external consumer system.
+
 ### **Impact of an outage:**
 
 <!-- A short description of the risks if your service is down for an extended period of time. -->

--- a/terraform/environments/integration-hub/managed-file-transfer/README.md
+++ b/terraform/environments/integration-hub/managed-file-transfer/README.md
@@ -71,7 +71,7 @@ The service is built entirely from AWS managed services, provisioned with Terraf
    - `clean` — `NO_THREATS_FOUND`
    - `quarantine` — `THREATS_FOUND`
    - `investigation` — `UNSUPPORTED`, `ACCESS_DENIED` or `FAILED`
-7. **Notification.** When a clean object lands, the `send-presigned-url` module generates a time-limited presigned download URL, posts it to Slack, and publishes a client-facing notification event to SNS for downstream consumers.
+7. **Notification and downstream delivery.** When a clean object lands, the `send-presigned-url` module generates a time-limited presigned download URL, posts it to Slack, and publishes a client-facing notification event to SNS for downstream consumers. Optionally, the same Lambda can call a client-owned API to request a presigned destination URL and then push the clean file to that destination.
 
 All buckets are KMS-encrypted, versioned, block public access, and have short (one day) lifecycle expiry as befits a transfer staging area.
 
@@ -117,6 +117,68 @@ scripts/poll-clean-file-notification.sh \
   --profile integration-hub-development \
   --queue-url "$(terraform output -raw products_poc_clean_file_notification_test_queue_url)"
 ```
+
+## Client-managed destination delivery
+
+Some consumers want the platform to deliver the clean file onward rather than only notifying them. For that case, configure `client_destination_delivery` in `application_variables.json`, keyed by `clientId`:
+
+```json
+{
+  "client_destination_delivery": {
+    "products-poc": {
+      "enabled": true,
+      "request_url": "https://consumer.example.justice.gov.uk/mft/presigned-destination",
+      "request_method": "POST",
+      "request_timeout_seconds": 30,
+      "request_auth_secret_name": "integration-hub-products-poc-destination-api-auth"
+    }
+  }
+}
+```
+
+If `request_auth_secret_name` is set, the Lambda reads that Secrets Manager value and merges `headers` from the secret JSON into the API request. Expected secret shape:
+
+```json
+{
+  "headers": {
+    "Authorization": "Bearer <token>",
+    "x-api-key": "<optional-key>"
+  }
+}
+```
+
+The consumer API receives a JSON payload in this shape:
+
+```json
+{
+  "clientId": "products-poc",
+  "transferTicket": "12345678-1234-1234-1234-123456789012",
+  "fileName": "example.csv",
+  "contentLengthBytes": 123,
+  "contentType": "text/csv",
+  "source": {
+    "bucket": "integration-hub-clean-...",
+    "key": "products-poc/uploads/2026/06/30/example.csv",
+    "versionId": "..."
+  }
+}
+```
+
+The consumer API must return JSON containing either a top-level upload target or an `upload` object:
+
+```json
+{
+  "upload": {
+    "url": "https://destination.example.test/presigned-put",
+    "method": "PUT",
+    "headers": {
+      "Content-Type": "text/csv"
+    }
+  }
+}
+```
+
+The platform then streams the clean object from S3 to that presigned destination. Because Lambda retries can happen after partial progress, the consumer API should treat `transferTicket` as an idempotency key and tolerate a repeated request for a fresh presigned upload target.
 
 ### **Impact of an outage:**
 

--- a/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
+++ b/terraform/environments/integration-hub/managed-file-transfer/application_variables.json
@@ -92,6 +92,7 @@
         "secret_prefix": "transfer/",
         "user_name_delimiter": "@@"
       },
+      "client_destination_delivery": {},
       "iam_configuration": {
         "malware_scanning_processing_bucket_key": "processing"
       },
@@ -223,6 +224,7 @@
         "secret_prefix": "transfer/",
         "user_name_delimiter": "@@"
       },
+      "client_destination_delivery": {},
       "iam_configuration": {
         "malware_scanning_processing_bucket_key": "processing"
       },

--- a/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
@@ -1,3 +1,19 @@
+resource "terraform_data" "products_poc_destination_presign_api_package" {
+  count = local.environment == "development" ? 1 : 0
+
+  input = {
+    filename = "${path.module}/builds/products-poc-destination-presign-api.zip"
+  }
+
+  triggers_replace = [
+    filesha256("${path.module}/lambda/mock-destination-presign-api/lambda_function.py"),
+  ]
+
+  provisioner "local-exec" {
+    command = "mkdir -p ${path.module}/builds && rm -f ${self.input.filename} && cd ${path.module} && zip -q -j ${self.input.filename} lambda/mock-destination-presign-api/lambda_function.py"
+  }
+}
+
 module "lambda_products_poc_destination_presign_api" {
   count = local.environment == "development" ? 1 : 0
 
@@ -9,8 +25,9 @@ module "lambda_products_poc_destination_presign_api" {
   description                  = "Development-only mock consumer API that returns a presigned destination upload URL for products-poc"
   handler                      = "lambda_function.lambda_handler"
   memory_size                  = 256
+  create_package               = false
+  local_existing_package       = terraform_data.products_poc_destination_presign_api_package[0].output.filename
   runtime                      = "python3.12"
-  source_path                  = "lambda/mock-destination-presign-api"
   timeout                      = 10
   trigger_on_package_timestamp = false
 

--- a/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
@@ -15,7 +15,6 @@ module "lambda_products_poc_destination_presign_api" {
   trigger_on_package_timestamp = false
 
   environment_variables = {
-    AWS_REGION              = data.aws_region.current.region
     DESTINATION_BUCKET_NAME = module.s3_bucket["investigation"].s3_bucket_id
     DESTINATION_KMS_KEY_ARN = module.kms_s3_bucket["investigation"].key_arn
     DESTINATION_PREFIX      = "manual-destination-tests"

--- a/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/client-destination-delivery-test.tf
@@ -1,0 +1,69 @@
+module "lambda_products_poc_destination_presign_api" {
+  count = local.environment == "development" ? 1 : 0
+
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-products-poc-destination-presign-api"
+  architectures                = ["arm64"]
+  description                  = "Development-only mock consumer API that returns a presigned destination upload URL for products-poc"
+  handler                      = "lambda_function.lambda_handler"
+  memory_size                  = 256
+  runtime                      = "python3.12"
+  source_path                  = "lambda/mock-destination-presign-api"
+  timeout                      = 10
+  trigger_on_package_timestamp = false
+
+  environment_variables = {
+    AWS_REGION              = data.aws_region.current.region
+    DESTINATION_BUCKET_NAME = module.s3_bucket["investigation"].s3_bucket_id
+    DESTINATION_KMS_KEY_ARN = module.kms_s3_bucket["investigation"].key_arn
+    DESTINATION_PREFIX      = "manual-destination-tests"
+  }
+
+  attach_policy_statements = true
+  policy_statements = {
+    destination_bucket_write = {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+      ]
+      resources = [
+        "${module.s3_bucket["investigation"].s3_bucket_arn}/manual-destination-tests/*",
+      ]
+    }
+    destination_bucket_kms_access = {
+      effect = "Allow"
+      actions = [
+        "kms:Encrypt",
+        "kms:DescribeKey",
+        "kms:GenerateDataKey*",
+      ]
+      resources = [
+        module.kms_s3_bucket["investigation"].key_arn,
+      ]
+    }
+  }
+
+  cloudwatch_logs_kms_key_id        = module.kms_cloudwatch_logs.key_arn
+  cloudwatch_logs_retention_in_days = 30
+
+  tags = local.tags
+}
+
+resource "aws_lambda_function_url" "products_poc_destination_presign_api" {
+  count = local.environment == "development" ? 1 : 0
+
+  function_name      = module.lambda_products_poc_destination_presign_api[0].lambda_function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_permission" "products_poc_destination_presign_api_url" {
+  count = local.environment == "development" ? 1 : 0
+
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = module.lambda_products_poc_destination_presign_api[0].lambda_function_name
+  function_url_auth_type = "NONE"
+  principal              = "*"
+  statement_id           = "AllowPublicInvokeFunctionUrl"
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/lambda/mock-destination-presign-api/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/lambda/mock-destination-presign-api/lambda_function.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import PurePosixPath
+from uuid import uuid4
+
+import boto3
+from botocore.config import Config
+
+AWS_REGION = os.environ.get("AWS_REGION", "eu-west-2")
+DESTINATION_BUCKET_NAME = os.environ["DESTINATION_BUCKET_NAME"]
+DESTINATION_KMS_KEY_ARN = os.environ["DESTINATION_KMS_KEY_ARN"]
+DESTINATION_PREFIX = os.environ.get("DESTINATION_PREFIX", "manual-destination-tests")
+
+s3 = boto3.client(
+    "s3",
+    region_name=AWS_REGION,
+    endpoint_url=f"https://s3.{AWS_REGION}.amazonaws.com",
+    config=Config(signature_version="s3v4", s3={"addressing_style": "virtual"}),
+)
+
+
+def _parse_body(event):
+    raw_body = event.get("body")
+    if not raw_body:
+        return {}
+
+    return json.loads(raw_body)
+
+
+def _build_destination_key(payload):
+    transfer_ticket = payload.get("transferTicket") or str(uuid4())
+    file_name = PurePosixPath(payload.get("fileName") or "clean-file.dat").name or "clean-file.dat"
+    return f"{DESTINATION_PREFIX}/{transfer_ticket}-{file_name}"
+
+
+def lambda_handler(event, context):
+    payload = _parse_body(event)
+    content_type = payload.get("contentType") or "application/octet-stream"
+    destination_key = _build_destination_key(payload)
+    presign_params = {
+        "Bucket": DESTINATION_BUCKET_NAME,
+        "Key": destination_key,
+        "ContentType": content_type,
+        "ServerSideEncryption": "aws:kms",
+        "SSEKMSKeyId": DESTINATION_KMS_KEY_ARN,
+    }
+    upload_url = s3.generate_presigned_url(
+        "put_object",
+        Params=presign_params,
+        ExpiresIn=3600,
+        HttpMethod="PUT",
+    )
+
+    response_body = {
+        "upload": {
+            "url": upload_url,
+            "method": "PUT",
+            "headers": {
+                "Content-Type": content_type,
+                "x-amz-server-side-encryption": "aws:kms",
+                "x-amz-server-side-encryption-aws-kms-key-id": DESTINATION_KMS_KEY_ARN,
+            },
+        },
+        "destination": {
+            "bucket": DESTINATION_BUCKET_NAME,
+            "key": destination_key,
+        },
+    }
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(response_body),
+    }

--- a/terraform/environments/integration-hub/managed-file-transfer/locals.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/locals.tf
@@ -5,6 +5,10 @@ locals {
   iam_configuration        = try(local.application_data.accounts[local.environment].iam_configuration, {})
   web_app_hostname         = local.is-production == false ? "web.${local.environment}.managed-file-transfer.service.justice.gov.uk" : "web.managed-file-transfer.service.justice.gov.uk"
   web_app_origin           = "https://${local.web_app_hostname}"
+  client_destination_delivery = try(
+    local.application_data.accounts[local.environment].client_destination_delivery,
+    {},
+  )
   notification_configuration = try(
     local.application_data.accounts[local.environment].notification_configuration,
     {},

--- a/terraform/environments/integration-hub/managed-file-transfer/locals.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/locals.tf
@@ -9,6 +9,19 @@ locals {
     local.application_data.accounts[local.environment].client_destination_delivery,
     {},
   )
+  client_destination_delivery_effective = local.environment == "development" ? merge(
+    local.client_destination_delivery,
+    {
+      "products-poc" = merge(
+        try(local.client_destination_delivery["products-poc"], {}),
+        {
+          enabled        = true
+          request_method = "POST"
+          request_url    = aws_lambda_function_url.products_poc_destination_presign_api[0].function_url
+        }
+      )
+    }
+  ) : local.client_destination_delivery
   notification_configuration = try(
     local.application_data.accounts[local.environment].notification_configuration,
     {},

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
@@ -241,7 +241,14 @@ def build_destination_request_headers(config):
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
-    headers.update(config["request_headers"])
+
+    request_headers = config.get("request_headers") or {}
+    if not isinstance(request_headers, dict):
+        raise ValueError(
+            f"request_headers in destination delivery config for client {config.get('client_id')} must be a JSON object"
+        )
+
+    headers.update({str(key): str(value) for key, value in request_headers.items()})
 
     secret_name = config.get("request_auth_secret_name")
     if not secret_name:

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
@@ -213,6 +213,11 @@ def get_destination_delivery_config(client_id):
     if not request_url:
         raise ValueError(f"Missing request_url in destination delivery config for client {client_id}")
 
+    from urllib.parse import urlsplit
+
+    if urlsplit(request_url).scheme != "https":
+        raise ValueError(f"Destination delivery request_url for client {client_id} must use https")
+
     return {
         "client_id": client_id,
         "request_auth_secret_name": config.get("request_auth_secret_name"),

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/lambda_function.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import unquote_plus
 
 import boto3
+import requests
 from botocore.config import Config
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.idempotency import (
@@ -14,6 +15,7 @@ from aws_lambda_powertools.utilities.idempotency import (
 )
 
 AWS_REGION = os.environ.get("AWS_REGION", "eu-west-2")
+secrets_manager = boto3.client("secretsmanager")
 s3 = boto3.client(
     "s3",
     region_name=AWS_REGION,
@@ -22,6 +24,7 @@ s3 = boto3.client(
 )
 sns = boto3.client("sns")
 CLIENT_NOTIFICATION_SNS_TOPIC_ARN = os.environ["CLIENT_NOTIFICATION_SNS_TOPIC_ARN"]
+CLIENT_DESTINATION_DELIVERY_CONFIG = json.loads(os.environ.get("CLIENT_DESTINATION_DELIVERY_CONFIG_JSON", "{}"))
 DOWNLOAD_BUCKET_NAME = os.environ["DOWNLOAD_BUCKET_NAME"]
 DOWNLOAD_URL_EXPIRY_SECONDS = int(os.environ["DOWNLOAD_URL_EXPIRY_SECONDS"])
 IDEMPOTENCY_TABLE = os.environ["IDEMPOTENCY_TABLE"]
@@ -34,6 +37,7 @@ CLIENT_NOTIFICATION_EVENT_TYPE = "clean-file-ready-for-download"
 TTL_METADATA_KEY = "presigned-url-expiry-seconds"
 logger = Logger(service="managed-file-transfer-clean-file-presigned-url-notifier")
 LOG_KEY_PATH_HASH_LENGTH = 12
+DEFAULT_DESTINATION_REQUEST_TIMEOUT_SECONDS = 30
 
 persistence_layer = DynamoDBPersistenceLayer(table_name=IDEMPOTENCY_TABLE)
 idempotency_config = IdempotencyConfig(
@@ -86,7 +90,7 @@ def get_log_fields(operation):
     }
 
 
-def get_object_metadata(operation):
+def get_object_details(operation):
     head_object_kwargs = {
         "Bucket": operation["bucket_name"],
         "Key": operation["object_key"],
@@ -95,9 +99,13 @@ def get_object_metadata(operation):
     if operation["version_id"]:
         head_object_kwargs["VersionId"] = operation["version_id"]
 
+    return s3.head_object(**head_object_kwargs)
+
+
+def normalise_metadata(object_details):
     # Metadata is copied forward by the existing file-mover Lambdas, which lets
     # callers request a shorter TTL without changing infrastructure config.
-    metadata = s3.head_object(**head_object_kwargs).get("Metadata", {})
+    metadata = object_details.get("Metadata", {})
     return {key.lower(): value for key, value in metadata.items()}
 
 
@@ -196,6 +204,184 @@ def publish_client_notification(operation, metadata, expiry_seconds, presigned_u
     return notification_message
 
 
+def get_destination_delivery_config(client_id):
+    config = CLIENT_DESTINATION_DELIVERY_CONFIG.get(client_id) or {}
+    if not config or not config.get("enabled", False):
+        return None
+
+    request_url = config.get("request_url")
+    if not request_url:
+        raise ValueError(f"Missing request_url in destination delivery config for client {client_id}")
+
+    return {
+        "client_id": client_id,
+        "request_auth_secret_name": config.get("request_auth_secret_name"),
+        "request_headers": config.get("request_headers") or {},
+        "request_method": str(config.get("request_method", "POST")).upper(),
+        "request_timeout_seconds": int(
+            config.get("request_timeout_seconds", DEFAULT_DESTINATION_REQUEST_TIMEOUT_SECONDS)
+        ),
+        "request_url": request_url,
+    }
+
+
+def load_secret_json(secret_id):
+    response = secrets_manager.get_secret_value(SecretId=secret_id)
+    secret_string = response.get("SecretString") or ""
+    return json.loads(secret_string) if secret_string else {}
+
+
+def build_destination_request_headers(config):
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    headers.update(config["request_headers"])
+
+    secret_name = config.get("request_auth_secret_name")
+    if not secret_name:
+        return headers
+
+    secret_payload = load_secret_json(secret_name)
+    secret_headers = secret_payload.get("headers") or {}
+    if not isinstance(secret_headers, dict):
+        raise ValueError(f"headers in secret {secret_name} must be a JSON object")
+
+    return {
+        **headers,
+        **{str(key): str(value) for key, value in secret_headers.items()},
+    }
+
+
+def build_destination_request_payload(operation, metadata, object_details):
+    return {
+        "clientId": metadata.get(CLIENT_ID_METADATA_KEY),
+        "transferTicket": metadata.get(TRANSFER_TICKET_METADATA_KEY),
+        "fileName": metadata.get(ORIGINAL_FILE_NAME_METADATA_KEY) or operation["object_key"].rsplit("/", 1)[-1],
+        "contentLengthBytes": object_details.get("ContentLength"),
+        "contentType": object_details.get("ContentType"),
+        "source": {
+            "bucket": operation["bucket_name"],
+            "key": operation["object_key"],
+            "versionId": operation["version_id"],
+        },
+    }
+
+
+def request_destination_upload_target(operation, metadata, object_details, config):
+    payload = json.dumps(build_destination_request_payload(operation, metadata, object_details))
+    headers = build_destination_request_headers(config)
+    logger.info(
+        "Requesting destination presigned upload URL",
+        extra={
+            **get_log_fields(operation),
+            "client_id": config["client_id"],
+            "request_url": config["request_url"],
+        },
+    )
+    response = requests.request(
+        config["request_method"],
+        config["request_url"],
+        data=payload,
+        headers=headers,
+        timeout=config["request_timeout_seconds"],
+    )
+    response.raise_for_status()
+
+    response_payload = response.json()
+    upload_target = response_payload.get("upload", response_payload)
+    upload_url = upload_target.get("url")
+    if not upload_url:
+        raise ValueError(
+            f"Destination API for client {config['client_id']} did not return an upload URL"
+        )
+
+    upload_headers = upload_target.get("headers") or {}
+    if not isinstance(upload_headers, dict):
+        raise ValueError(
+            f"Destination API for client {config['client_id']} returned non-object upload headers"
+        )
+
+    return {
+        "headers": {str(key): str(value) for key, value in upload_headers.items()},
+        "method": str(upload_target.get("method", "PUT")).upper(),
+        "url": upload_url,
+    }
+
+
+class StreamingBodyWithLength:
+    def __init__(self, body, content_length):
+        self._body = body
+        self._content_length = content_length
+
+    def __len__(self):
+        return self._content_length
+
+    def read(self, amt=None):
+        return self._body.read(amt)
+
+
+def deliver_clean_file_to_destination(operation, metadata, object_details):
+    client_id = metadata.get(CLIENT_ID_METADATA_KEY)
+    if not client_id:
+        logger.info(
+            "Skipping client destination delivery because client metadata is not present",
+            extra=get_log_fields(operation),
+        )
+        return None
+
+    config = get_destination_delivery_config(client_id)
+    if not config:
+        logger.info(
+            "Skipping client destination delivery because no client delivery config is present",
+            extra={**get_log_fields(operation), "client_id": client_id},
+        )
+        return None
+
+    upload_target = request_destination_upload_target(operation, metadata, object_details, config)
+    get_object_kwargs = {
+        "Bucket": operation["bucket_name"],
+        "Key": operation["object_key"],
+    }
+    if operation["version_id"]:
+        get_object_kwargs["VersionId"] = operation["version_id"]
+
+    logger.info(
+        "Uploading clean object to client destination",
+        extra={**get_log_fields(operation), "client_id": client_id},
+    )
+    get_object_response = s3.get_object(**get_object_kwargs)
+    body = get_object_response["Body"]
+    upload_headers = dict(upload_target["headers"])
+    upload_header_names = {header_name.lower() for header_name in upload_headers}
+    if object_details.get("ContentType") and "content-type" not in upload_header_names:
+        upload_headers["Content-Type"] = object_details["ContentType"]
+    if "content-length" not in upload_header_names:
+        upload_headers["Content-Length"] = str(object_details["ContentLength"])
+
+    try:
+        response = requests.request(
+            upload_target["method"],
+            upload_target["url"],
+            data=StreamingBodyWithLength(body, object_details["ContentLength"]),
+            headers=upload_headers,
+            timeout=config["request_timeout_seconds"],
+        )
+        response.raise_for_status()
+    finally:
+        body.close()
+
+    logger.info(
+        "Uploaded clean object to client destination",
+        extra={**get_log_fields(operation), "client_id": client_id},
+    )
+    return {
+        "client_id": client_id,
+        "destination_request_url": config["request_url"],
+        "upload_method": upload_target["method"],
+    }
+
+
 @idempotent_function(
     data_keyword_argument="operation",
     persistence_store=persistence_layer,
@@ -210,7 +396,8 @@ def process_record(*, operation):
             f"Received clean file notification for unexpected bucket {operation['bucket_name']}"
         )
 
-    metadata = get_object_metadata(operation)
+    object_details = get_object_details(operation)
+    metadata = normalise_metadata(object_details)
     expiry_seconds = get_expiry_seconds(operation, metadata)
     presign_params = {
         "Bucket": operation["bucket_name"],
@@ -225,8 +412,9 @@ def process_record(*, operation):
         Params=presign_params,
         ExpiresIn=expiry_seconds,
     )
-    notification_message = build_notification_message(operation, expiry_seconds, presigned_url)
+    destination_delivery = deliver_clean_file_to_destination(operation, metadata, object_details)
 
+    notification_message = build_notification_message(operation, expiry_seconds, presigned_url)
     sns.publish(
         TopicArn=operation["notification_topic_arn"],
         Message=json.dumps(notification_message),
@@ -242,6 +430,7 @@ def process_record(*, operation):
         "client_notification_topic_arn": CLIENT_NOTIFICATION_SNS_TOPIC_ARN if client_notification else None,
         "notification_topic_arn": operation["notification_topic_arn"],
         "object_key": operation["object_key"],
+        "destination_delivery": destination_delivery,
         "version_id": operation["version_id"],
     }
 

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/requirements.txt
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/requirements.txt
@@ -1,1 +1,2 @@
 aws-lambda-powertools==3.29.0
+requests==2.32.3

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/lambda/clean-file-presigned-url-notifier/test_lambda_function.py
@@ -6,6 +6,19 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 os.environ.setdefault("CLIENT_NOTIFICATION_SNS_TOPIC_ARN", "arn:aws:sns:eu-west-2:111122223333:client-topic")
+os.environ.setdefault(
+    "CLIENT_DESTINATION_DELIVERY_CONFIG_JSON",
+    json.dumps(
+        {
+            "products-poc": {
+                "enabled": True,
+                "request_url": "https://consumer.example.test/presigned-destination",
+                "request_timeout_seconds": 15,
+                "request_auth_secret_name": "products-poc-destination-api-auth",
+            }
+        }
+    ),
+)
 os.environ.setdefault("DOWNLOAD_BUCKET_NAME", "clean-bucket")
 os.environ.setdefault("DOWNLOAD_URL_EXPIRY_SECONDS", "1800")
 os.environ.setdefault("IDEMPOTENCY_TABLE", "idempotency-table")
@@ -46,6 +59,7 @@ def fake_idempotent_function(**_kwargs):
 
 
 sys.modules.setdefault("boto3", SimpleNamespace(client=lambda _service_name, **_kwargs: SimpleNamespace()))
+sys.modules.setdefault("requests", SimpleNamespace(request=lambda *_args, **_kwargs: SimpleNamespace()))
 
 # `from botocore.config import Config` imports `botocore` first, so stub both the
 # package and the submodule to keep tests runnable without botocore installed.
@@ -74,15 +88,40 @@ class FakeS3Client:
     def __init__(self, metadata):
         self.metadata = metadata
         self.head_calls = []
+        self.get_calls = []
         self.presign_calls = []
 
     def head_object(self, **kwargs):
         self.head_calls.append(kwargs)
-        return {"Metadata": self.metadata}
+        return {
+            "ContentLength": 28,
+            "ContentType": "text/csv",
+            "Metadata": self.metadata,
+        }
 
     def generate_presigned_url(self, method, Params, ExpiresIn):
         self.presign_calls.append({"method": method, "params": Params, "expires_in": ExpiresIn})
         return "https://example.test/download"
+
+    def get_object(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return {"Body": FakeStreamingBody(b"header1,header2\nvalue1,value2\n")}
+
+
+class FakeStreamingBody:
+    def __init__(self, payload):
+        self.payload = payload
+        self.is_closed = False
+
+    def read(self, amt=None):
+        if amt is None:
+            amt = len(self.payload)
+        chunk = self.payload[:amt]
+        self.payload = self.payload[amt:]
+        return chunk
+
+    def close(self):
+        self.is_closed = True
 
 
 class FakeSnsClient:
@@ -92,6 +131,51 @@ class FakeSnsClient:
     def publish(self, **kwargs):
         self.publish_calls.append(kwargs)
         return {"MessageId": f"message-{len(self.publish_calls)}"}
+
+
+class FakeSecretsManager:
+    def __init__(self, secret_string=None):
+        self.secret_string = secret_string or json.dumps({"headers": {"Authorization": "Bearer test-token"}})
+        self.calls = []
+
+    def get_secret_value(self, SecretId):
+        self.calls.append(SecretId)
+        return {"SecretString": self.secret_string}
+
+
+class FakeHttpResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class FakeRequests:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        if len(self.calls) == 1:
+            return FakeHttpResponse(
+                {
+                    "upload": {
+                        "url": "https://destination.example.test/upload",
+                        "method": "PUT",
+                        "headers": {
+                            "x-amz-server-side-encryption": "AES256",
+                        },
+                    }
+                }
+            )
+
+        upload_body = kwargs["data"]
+        self.uploaded_payload = upload_body.read()
+        return FakeHttpResponse({})
 
 
 class CleanFileNotifierTests(unittest.TestCase):
@@ -118,7 +202,15 @@ class CleanFileNotifierTests(unittest.TestCase):
 
     @patch.object(handler, "s3")
     @patch.object(handler, "sns")
-    def test_publishes_slack_and_client_notifications_when_client_metadata_is_present(self, patched_sns, patched_s3):
+    @patch.object(handler, "secrets_manager")
+    @patch.object(handler, "requests")
+    def test_publishes_slack_client_and_destination_delivery_when_client_metadata_is_present(
+        self,
+        patched_requests,
+        patched_secrets_manager,
+        patched_sns,
+        patched_s3,
+    ):
         fake_s3 = FakeS3Client(
             {
                 "client-id": "products-poc",
@@ -127,9 +219,14 @@ class CleanFileNotifierTests(unittest.TestCase):
             }
         )
         fake_sns = FakeSnsClient()
+        fake_requests = FakeRequests()
+        fake_secrets_manager = FakeSecretsManager()
         patched_s3.head_object = fake_s3.head_object
         patched_s3.generate_presigned_url = fake_s3.generate_presigned_url
+        patched_s3.get_object = fake_s3.get_object
         patched_sns.publish = fake_sns.publish
+        patched_requests.request = fake_requests.request
+        patched_secrets_manager.get_secret_value = fake_secrets_manager.get_secret_value
 
         handler.lambda_handler(self._event(), SimpleNamespace())
 
@@ -141,20 +238,62 @@ class CleanFileNotifierTests(unittest.TestCase):
         self.assertEqual("ticket-123", message["transferTicket"])
         self.assertEqual("test.csv", message["fileName"])
         self.assertEqual("products-poc", client_publish["MessageAttributes"]["clientId"]["StringValue"])
+        self.assertEqual("products-poc-destination-api-auth", fake_secrets_manager.calls[0])
+        self.assertEqual(2, len(fake_requests.calls))
+        self.assertEqual("POST", fake_requests.calls[0]["method"])
+        self.assertEqual("https://consumer.example.test/presigned-destination", fake_requests.calls[0]["url"])
+        self.assertEqual("PUT", fake_requests.calls[1]["method"])
+        self.assertEqual("https://destination.example.test/upload", fake_requests.calls[1]["url"])
+        self.assertEqual(b"header1,header2\nvalue1,value2\n", fake_requests.uploaded_payload)
+        self.assertEqual(
+            "Bearer test-token",
+            fake_requests.calls[0]["headers"]["Authorization"],
+        )
 
     @patch.object(handler, "s3")
     @patch.object(handler, "sns")
-    def test_skips_client_notification_when_client_metadata_is_missing(self, patched_sns, patched_s3):
+    @patch.object(handler, "requests")
+    def test_skips_client_notification_when_client_metadata_is_missing(self, patched_requests, patched_sns, patched_s3):
         fake_s3 = FakeS3Client({})
         fake_sns = FakeSnsClient()
         patched_s3.head_object = fake_s3.head_object
         patched_s3.generate_presigned_url = fake_s3.generate_presigned_url
+        patched_s3.get_object = fake_s3.get_object
         patched_sns.publish = fake_sns.publish
+        patched_requests.request = lambda *_args, **_kwargs: self.fail("requests.request should not be called")
 
         handler.lambda_handler(self._event(), SimpleNamespace())
 
         self.assertEqual(1, len(fake_sns.publish_calls))
         self.assertEqual(handler.SLACK_SNS_TOPIC_ARN, fake_sns.publish_calls[0]["TopicArn"])
+
+    @patch.object(handler, "CLIENT_DESTINATION_DELIVERY_CONFIG", new={})
+    @patch.object(handler, "s3")
+    @patch.object(handler, "sns")
+    @patch.object(handler, "requests")
+    def test_skips_destination_delivery_when_client_has_no_delivery_config(
+        self,
+        patched_requests,
+        patched_sns,
+        patched_s3,
+    ):
+        fake_s3 = FakeS3Client(
+            {
+                "client-id": "products-poc",
+                "original-file-name": "test.csv",
+                "transfer-ticket": "ticket-123",
+            }
+        )
+        fake_sns = FakeSnsClient()
+        patched_s3.head_object = fake_s3.head_object
+        patched_s3.generate_presigned_url = fake_s3.generate_presigned_url
+        patched_s3.get_object = fake_s3.get_object
+        patched_sns.publish = fake_sns.publish
+        patched_requests.request = lambda *_args, **_kwargs: self.fail("requests.request should not be called")
+
+        handler.lambda_handler(self._event(), SimpleNamespace())
+
+        self.assertEqual(2, len(fake_sns.publish_calls))
 
 
 if __name__ == "__main__":

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/main.tf
@@ -206,7 +206,7 @@ module "lambda_clean_file_presigned_url_notifier" {
   version = "8.8.0"
 
   function_name                = "${local.resource_name_prefix}-clean-file-presigned-url-notifier"
-  description                  = "Generates a presigned download URL for clean files and publishes it to SNS"
+  description                  = "Generates a presigned download URL for clean files, optionally pushes them to a client destination, and publishes notifications"
   handler                      = "lambda_function.lambda_handler"
   runtime                      = "python3.12"
   source_path                  = "${path.module}/lambda/clean-file-presigned-url-notifier"
@@ -220,62 +220,77 @@ module "lambda_clean_file_presigned_url_notifier" {
   }
 
   environment_variables = {
-    CLIENT_NOTIFICATION_SNS_TOPIC_ARN = module.sns_clean_file_client_notifications.topic_arn
-    DOWNLOAD_BUCKET_NAME            = var.download_bucket_name
-    DOWNLOAD_URL_EXPIRY_SECONDS     = tostring(var.presigned_url_expiry_seconds)
-    IDEMPOTENCY_TABLE               = module.dynamodb_idempotency.dynamodb_table_id
-    MAX_DOWNLOAD_URL_EXPIRY_SECONDS = tostring(var.max_presigned_url_expiry_seconds)
-    SLACK_SNS_TOPIC_ARN             = module.sns_clean_file_download_notifications.topic_arn
+    CLIENT_NOTIFICATION_SNS_TOPIC_ARN       = module.sns_clean_file_client_notifications.topic_arn
+    CLIENT_DESTINATION_DELIVERY_CONFIG_JSON = jsonencode(var.client_destination_delivery_config)
+    DOWNLOAD_BUCKET_NAME                    = var.download_bucket_name
+    DOWNLOAD_URL_EXPIRY_SECONDS             = tostring(var.presigned_url_expiry_seconds)
+    IDEMPOTENCY_TABLE                       = module.dynamodb_idempotency.dynamodb_table_id
+    MAX_DOWNLOAD_URL_EXPIRY_SECONDS         = tostring(var.max_presigned_url_expiry_seconds)
+    SLACK_SNS_TOPIC_ARN                     = module.sns_clean_file_download_notifications.topic_arn
   }
 
   attach_policy_statements = true
-  policy_statements = {
-    clean_bucket_read = {
-      effect = "Allow"
-      actions = [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-        "s3:GetObjectTagging",
-        "s3:GetObjectVersionTagging",
-      ]
-      resources = [
-        "${var.download_bucket_arn}/*",
-      ]
+  policy_statements = merge(
+    {
+      clean_bucket_read = {
+        effect = "Allow"
+        actions = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersionTagging",
+        ]
+        resources = [
+          "${var.download_bucket_arn}/*",
+        ]
+      }
+      clean_bucket_kms_access = {
+        effect = "Allow"
+        actions = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey*",
+        ]
+        resources = [
+          var.download_bucket_kms_key_arn,
+        ]
+      }
+      idempotency_table_access = {
+        effect = "Allow"
+        actions = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+        ]
+        resources = [
+          module.dynamodb_idempotency.dynamodb_table_arn,
+        ]
+      }
+      notification_topic_publish = {
+        effect = "Allow"
+        actions = [
+          "sns:Publish",
+        ]
+        resources = [
+          module.sns_clean_file_client_notifications.topic_arn,
+          module.sns_clean_file_download_notifications.topic_arn,
+        ]
+      }
+    },
+    length(var.client_destination_delivery_secret_names) == 0 ? {} : {
+      destination_api_secret_read = {
+        effect = "Allow"
+        actions = [
+          "secretsmanager:GetSecretValue",
+        ]
+        resources = [
+          for secret_name in var.client_destination_delivery_secret_names :
+          "arn:aws:secretsmanager:${var.aws_region}:${var.account_id}:secret:${secret_name}*"
+        ]
+      }
     }
-    clean_bucket_kms_access = {
-      effect = "Allow"
-      actions = [
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:GenerateDataKey*",
-      ]
-      resources = [
-        var.download_bucket_kms_key_arn,
-      ]
-    }
-    idempotency_table_access = {
-      effect = "Allow"
-      actions = [
-        "dynamodb:GetItem",
-        "dynamodb:PutItem",
-        "dynamodb:UpdateItem",
-        "dynamodb:DeleteItem",
-      ]
-      resources = [
-        module.dynamodb_idempotency.dynamodb_table_arn,
-      ]
-    }
-    notification_topic_publish = {
-      effect = "Allow"
-      actions = [
-        "sns:Publish",
-      ]
-      resources = [
-        module.sns_clean_file_client_notifications.topic_arn,
-        module.sns_clean_file_download_notifications.topic_arn,
-      ]
-    }
-  }
+  )
 
   attach_policies    = true
   number_of_policies = 1

--- a/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/variables.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/modules/send-presigned-url/variables.tf
@@ -6,6 +6,18 @@ variable "application_name" {
   type = string
 }
 
+variable "aws_region" {
+  type = string
+}
+
+variable "client_destination_delivery_config" {
+  type = map(any)
+}
+
+variable "client_destination_delivery_secret_names" {
+  type = list(string)
+}
+
 variable "download_bucket_arn" {
   type = string
 }

--- a/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/outputs.tf
@@ -7,3 +7,8 @@ output "products_poc_clean_file_notification_test_queue_url" {
   description = "Development-only SQS queue URL subscribed to products-poc clean file ready notifications."
   value       = local.environment == "development" ? module.sqs_products_poc_clean_file_ready_notifications[0].queue_url : null
 }
+
+output "products_poc_destination_presign_api_url" {
+  description = "Development-only mock consumer API URL that returns presigned destination upload targets for products-poc."
+  value       = local.environment == "development" ? aws_lambda_function_url.products_poc_destination_presign_api[0].function_url : null
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/products-poc.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/products-poc.tf
@@ -1,8 +1,13 @@
 module "proof_of_concept_notification" {
   source = "./modules/send-presigned-url"
 
-  account_id                  = data.aws_caller_identity.current.account_id
-  application_name            = local.application_name
+  account_id                         = data.aws_caller_identity.current.account_id
+  application_name                   = local.application_name
+  aws_region                         = data.aws_region.current.region
+  client_destination_delivery_config = local.client_destination_delivery
+  client_destination_delivery_secret_names = distinct(compact([
+    for config in values(local.client_destination_delivery) : try(config.request_auth_secret_name, null)
+  ]))
   download_bucket_arn         = module.s3_bucket["clean"].s3_bucket_arn
   download_bucket_kms_key_arn = module.kms_s3_bucket["clean"].key_arn
   download_bucket_name        = module.s3_bucket["clean"].s3_bucket_id

--- a/terraform/environments/integration-hub/managed-file-transfer/products-poc.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/products-poc.tf
@@ -4,9 +4,9 @@ module "proof_of_concept_notification" {
   account_id                         = data.aws_caller_identity.current.account_id
   application_name                   = local.application_name
   aws_region                         = data.aws_region.current.region
-  client_destination_delivery_config = local.client_destination_delivery
+  client_destination_delivery_config = local.client_destination_delivery_effective
   client_destination_delivery_secret_names = distinct(compact([
-    for config in values(local.client_destination_delivery) : try(config.request_auth_secret_name, null)
+    for config in values(local.client_destination_delivery_effective) : try(config.request_auth_secret_name, null)
   ]))
   download_bucket_arn         = module.s3_bucket["clean"].s3_bucket_arn
   download_bucket_kms_key_arn = module.kms_s3_bucket["clean"].key_arn


### PR DESCRIPTION
## What

This change adds a downstream delivery option to the MFT API flow.

When a client uploads a file via `/transfer-tickets` and the file is successfully processed into the `clean` bucket, the notifier can now call a client-owned API to request a presigned destination upload URL, and then push the clean file to that destination.

The existing client-facing notification flow remains in place. After destination delivery, the notifier still publishes the downstream SNS/SQS event with the clean file metadata and presigned `downloadUrl`.

## Why

Previously, the downstream integration story only notified consumers that a clean file was ready for download.

This change supports the additional use case where a consumer exposes an API that returns a presigned URL for their own destination, allowing the platform to deliver the clean file directly to that location rather than requiring the consumer to pull it.

## Implementation notes

The change is implemented in the clean-file notifier Lambda in the managed file transfer stack.

When a clean object lands:

1. The notifier reads the object metadata as before.
2. It checks whether the `clientId` has destination-delivery configuration.
3. If configured, it calls the consumer API with file metadata including:
   - `clientId`
   - `transferTicket`
   - `fileName`
   - `contentType`
   - `contentLengthBytes`
   - source bucket/key/version information
4. The consumer API returns a presigned upload target.
5. The notifier streams the clean object from S3 to that destination URL.
6. The notifier then continues with the existing notification behavior, including Slack and the client-facing SNS/SQS notification.

Reviewers may want to focus on:

- destination delivery is client-configurable rather than hardcoded
- request headers for the consumer API can optionally come from Secrets Manager
- the notifier continues to be idempotent around the clean-object event
- the existing downstream notification path is preserved
- for development testing, a temporary mock consumer API is provisioned via Lambda Function URL for `products-poc`

## Development-only test fixture

To validate the flow end to end in `integration-hub-development`, Terraform now provisions a temporary mock consumer API for `products-poc`.

Mock consumer API URL:

- [https://5qqrrvfzgpgpbgv3fqqavqnswe0jrefs.lambda-url.eu-west-2.on.aws/](https://5qqrrvfzgpgpbgv3fqqavqnswe0jrefs.lambda-url.eu-west-2.on.aws/)

This endpoint returns a presigned `PUT` URL into the investigation bucket under the `manual-destination-tests/` prefix, so the delivery path can be exercised without requiring a real external consumer system.

## How tested

Tested end to end in `integration-hub-development`.

1. Uploaded a fresh file via the live API flow.
2. Confirmed the clean-file notifier called the mock consumer API.
3. Confirmed the notifier received a presigned destination URL and uploaded the clean file to the destination prefix.
4. Verified the delivered object existed at:
   - `s3://integration-hub-investigation-20260508111207582900000001/manual-destination-tests/8313698f-5eb1-46d2-b242-b45a522e6e44-mft-destination-e2e.csv`
5. Downloaded the delivered object and confirmed its contents matched the uploaded CSV.
6. Confirmed the existing client-facing SQS notification still arrived for transfer ticket:
   - `8313698f-5eb1-46d2-b242-b45a522e6e44`