### PR TITLE
Exclude NAME column from CLAIMS.POST_HOLDERS extract

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tariff.json
+++ b/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tariff.json
@@ -1464,6 +1464,10 @@
     },
     {
       "object_name": "CLAIMS.POST_HOLDERS",
+      "column_name": "NAME"
+    },
+    {
+      "object_name": "CLAIMS.POST_HOLDERS",
       "column_name": "NO_OF_BAGS"
     },
     {


### PR DESCRIPTION
This removes `name` column from the post_holders dataset