### PR TITLE
ai-gateway: bump 1.87.0 -> 1.90.0

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -12,7 +12,7 @@ locals {
       "Jacob.Woffenden@justice.gov.uk"
     ]
     development = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.90.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
This pull request updates the `litellm_version` used in the development environment configuration for the AI Gateway from version 1.87.0 to 1.90.0.

- Updated the `litellm_version` in the `development` environment block of `environment-configuration.tf` to 1.90.0, ensuring the AI Gateway uses the latest features and fixes of the LiteLLM library.