### PR TITLE
🚅 AI Gateway Upgrade

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -12,7 +12,7 @@ locals {
       "Jacob.Woffenden@justice.gov.uk"
     ]
     development = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.90.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -47,7 +47,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.90.0"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -82,7 +82,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.90.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -117,7 +117,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.87.0"
+      litellm_version     = "1.90.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -65,6 +65,11 @@ proxy_config:
       s3_region_name: ${auditLogsRegion}
       s3_path: litellm-audit
     cache: false
+    require_auth_for_metrics_endpoint: false
+    callbacks: ["prometheus"]
+    success_callback: ["prometheus"]
+    failure_callback: ["prometheus"]
+    service_callback: ["prometheus_system"]
     default_internal_user_params:
       user_role: proxy_admin
     cache_params:
@@ -164,7 +169,7 @@ envVars: {
     DISABLE_LLM_API_ENDPOINTS: "True",
     DOCS_DESCRIPTION: "Administration interface for the AI Gateway.",
     DOCS_FILTERED: "True",
-    DOCS_TITLE: "MOJ AI Gateway Admin",
+    DOCS_TITLE: "Justice AI Gateway Admin",
     LITELLM_ASSETS_PATH: "/app/var/litellm/assets",
     LITELLM_LOG: "ERROR",
     LITELLM_MIGRATION_DIR: "/app/migrations",

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -68,6 +68,7 @@ proxy_config:
       host: os.environ/primary_endpoint_address
       port: 6379
       password: os.environ/auth_token
+    require_auth_for_metrics_endpoint: false
     callbacks: ["prometheus"]
     success_callback: ["prometheus"]
     failure_callback: ["prometheus"]
@@ -141,7 +142,7 @@ envVars: {
     DISABLE_ADMIN_UI: "True",
     DOCS_DESCRIPTION: "Contact us on Slack - #data-platform-ai-gateway-users",
     DOCS_FILTERED: "True",
-    DOCS_TITLE: "MOJ AI Gateway",
+    DOCS_TITLE: "Justice AI Gateway",
     LITELLM_LOG: "ERROR",
     LITELLM_MIGRATION_DIR: "/app/migrations",
     LITELLM_MODE: "PRODUCTION",


### PR DESCRIPTION
## Proposed Changes

- Upgrades LiteLLM to 1.90.0
- Sets `require_auth_for_metrics_endpoint` to `false`
- Changes the application title to `Justice AI Gateway`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>