### PR TITLE
reverting apply_immediately  rds to false

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/aurora.tf
+++ b/terraform/environments/data-platform/ai-gateway/aurora.tf
@@ -43,7 +43,7 @@ module "ai_gateway_aurora" {
   iam_role_use_name_prefix    = true
 
   iam_database_authentication_enabled = true
-  apply_immediately                   = true
+  apply_immediately                   = false
 }
 
 module "ai_gateway_aurora_secret" {


### PR DESCRIPTION
The apply_immediately option was previously enabled to roll out IAM authentication changes across all environments. Since the changes have now been successfully deployed, the apply_immediately setting has been reverted to false.

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/469) ticket.