### PR TITLE
Cc 4630 security rule tight part2

### DIFF
--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -103,6 +103,47 @@ data "aws_subnet" "public_subnets_c" {
   }
 }
 
+# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
+data "aws_security_groups" "vpce_security_groups" {
+  provider = aws.core-vpc
+
+  filter {
+    name   = "tag:Name"
+    values = [
+      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a",
+      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b",
+      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c",
+    ]
+  }
+}
+
+data "aws_security_group" "vpce_security_group_a" {
+  provider = aws.core-vpc
+
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a"]
+  }
+}
+
+data "aws_security_group" "vpce_security_group_b" {
+  provider = aws.core-vpc
+
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b"]
+  }
+}
+
+data "aws_security_group" "vpce_security_group_c" {
+  provider = aws.core-vpc
+
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c"]
+  }
+}
+
 # Route53 DNS data
 data "aws_route53_zone" "external" {
   provider = aws.core-vpc

--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -103,44 +103,35 @@ data "aws_subnet" "public_subnets_c" {
   }
 }
 
-# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
-data "aws_security_groups" "vpce_security_groups" {
-  provider = aws.core-vpc
-
+# VPC Endpoint subnet lookup (used to identify VPCE subnets)
+data "aws_subnets" "vpce_subnets" {
   filter {
-    name   = "tag:Name"
-    values = [
-      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a",
-      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b",
-      "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c",
-    ]
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint*"
   }
 }
 
-data "aws_security_group" "vpce_security_group_a" {
-  provider = aws.core-vpc
-
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a"]
+data "aws_subnet" "vpce_subnet_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}a"
   }
 }
 
-data "aws_security_group" "vpce_security_group_b" {
-  provider = aws.core-vpc
-
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b"]
+data "aws_subnet" "vpce_subnet_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}b"
   }
 }
 
-data "aws_security_group" "vpce_security_group_c" {
-  provider = aws.core-vpc
-
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c"]
+data "aws_subnet" "vpce_subnet_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}c"
   }
 }
 

--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -103,35 +103,40 @@ data "aws_subnet" "public_subnets_c" {
   }
 }
 
-# VPC Endpoint subnet lookup (used to identify VPCE subnets)
-data "aws_subnets" "vpce_subnets" {
+# VPC Endpoint subnet lookup (used to identify shared VPCE subnets)
+data "aws_subnets" "shared_vpce" {
+  provider = aws.core-vpc
+
   filter {
     name   = "vpc-id"
     values = [data.aws_vpc.shared.id]
   }
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint*"
+    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint*"
   }
 }
 
-data "aws_subnet" "vpce_subnet_a" {
-  vpc_id = data.aws_vpc.shared.id
+data "aws_subnet" "vpce_subnets_a" {
+  provider = aws.core-vpc
+  vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a"
   }
 }
 
-data "aws_subnet" "vpce_subnet_b" {
-  vpc_id = data.aws_vpc.shared.id
+data "aws_subnet" "vpce_subnets_b" {
+  provider = aws.core-vpc
+  vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b"
   }
 }
 
-data "aws_subnet" "vpce_subnet_c" {
-  vpc_id = data.aws_vpc.shared.id
+data "aws_subnet" "vpce_subnets_c" {
+  provider = aws.core-vpc
+  vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-int-endpoint-${data.aws_region.current.name}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c"
   }
 }
 

--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -140,15 +140,6 @@ data "aws_subnet" "vpce_subnets_c" {
   }
 }
 
-data "aws_security_group" "vpce" {
-  provider = aws.core-vpc
-
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
-  }
-}
-
 # Route53 DNS data
 data "aws_route53_zone" "external" {
   provider = aws.core-vpc

--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -140,6 +140,15 @@ data "aws_subnet" "vpce_subnets_c" {
   }
 }
 
+data "aws_security_group" "vpce" {
+  provider = aws.core-vpc
+
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
+  }
+}
+
 # Route53 DNS data
 data "aws_route53_zone" "external" {
   provider = aws.core-vpc

--- a/terraform/environments/ccms-edrms/platform_data.tf
+++ b/terraform/environments/ccms-edrms/platform_data.tf
@@ -112,7 +112,7 @@ data "aws_subnets" "shared_vpce" {
     values = [data.aws_vpc.shared.id]
   }
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint*"
+    Name = "${var.networking[0].business-unit}-${local.environment}-protected*"
   }
 }
 
@@ -120,7 +120,7 @@ data "aws_subnet" "vpce_subnets_a" {
   provider = aws.core-vpc
   vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-protected-${data.aws_region.current.name}a"
   }
 }
 
@@ -128,7 +128,7 @@ data "aws_subnet" "vpce_subnets_b" {
   provider = aws.core-vpc
   vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-protected-${data.aws_region.current.name}b"
   }
 }
 
@@ -136,7 +136,7 @@ data "aws_subnet" "vpce_subnets_c" {
   provider = aws.core-vpc
   vpc_id   = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-int-endpoint-${data.aws_region.current.name}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-protected-${data.aws_region.current.name}c"
   }
 }
 

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -174,19 +174,19 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
 }
 
 
-resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
-  security_group_id = aws_security_group.cluster_ec2.id
-  type              = "egress"
-  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
-  protocol          = "TCP"
-  from_port         = 443
-  to_port           = 443
-  source_security_group_id = data.aws_security_group.vpce_security_group.id
+#resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
+#  security_group_id = aws_security_group.cluster_ec2.id
+#  type              = "egress"
+#  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
+#  protocol          = "TCP"
+#  from_port         = 443
+#  to_port           = 443
+#  source_security_group_id = data.aws_security_group.vpce_security_group.id
 
-  lifecycle {
-    ignore_changes = [source_security_group_id]
-  }
-}
+#  lifecycle {
+#    ignore_changes = [source_security_group_id]
+#  }
+#}
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {
   security_group_id = aws_security_group.cluster_ec2.id
@@ -216,6 +216,16 @@ resource "aws_security_group_rule" "cluster_ec2_egress_NEC" {
   from_port         = 443
   to_port           = 443
   cidr_blocks       = ["10.120.0.0/24"]
+}
+
+resource "aws_security_group_rule" "cluster_ec2_egress_all" {
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "All Egress"
+  protocol          = -1
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 # RDS Security Group

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -64,11 +64,11 @@ resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   protocol          = "TCP"
   from_port         = 443
   to_port           = 443
-  source_security_group_id = data.aws_security_groups.vpce_security_groups.ids[0]
-
-  lifecycle {
-    ignore_changes = [source_security_group_id]
-  }
+  cidr_blocks = [
+    data.aws_subnet.vpce_subnet_a.cidr_block,
+    data.aws_subnet.vpce_subnet_b.cidr_block,
+    data.aws_subnet.vpce_subnet_c.cidr_block,
+  ]
 }
 
 resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
@@ -162,11 +162,11 @@ resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   protocol          = "TCP"
   from_port         = 443
   to_port           = 443
-  source_security_group_id = data.aws_security_groups.vpce_security_groups.ids[0]
-
-  lifecycle {
-    ignore_changes = [source_security_group_id]
-  }
+  cidr_blocks = [
+    data.aws_subnet.vpce_subnet_a.cidr_block,
+    data.aws_subnet.vpce_subnet_b.cidr_block,
+    data.aws_subnet.vpce_subnet_c.cidr_block,
+  ]
 }
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -35,15 +35,6 @@ data "aws_prefix_list" "s3" {
   name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
-# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
-data "aws_security_group" "vpce_security_group" {
-  provider = aws.core-vpc
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
-  }
-}
-
 ### Container Security Group
 
 resource "aws_security_group" "ecs_tasks_edrms" {
@@ -73,7 +64,7 @@ resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   protocol          = "TCP"
   from_port         = 443
   to_port           = 443
-  source_security_group_id = data.aws_security_group.vpce_security_group.id
+  source_security_group_id = data.aws_security_groups.vpce_security_groups.ids[0]
 
   lifecycle {
     ignore_changes = [source_security_group_id]
@@ -171,7 +162,7 @@ resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   protocol          = "TCP"
   from_port         = 443
   to_port           = 443
-  source_security_group_id = data.aws_security_group.vpce_security_group.id
+  source_security_group_id = data.aws_security_groups.vpce_security_groups.ids[0]
 
   lifecycle {
     ignore_changes = [source_security_group_id]

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -127,6 +127,26 @@ resource "aws_security_group_rule" "cluster_ec2_egress_all" {
   cidr_blocks       = ["0.0.0.0/0"] # Restrict to what's needed
 }
 
+resource "aws_security_group_rule" "cluster_ec2_egress_s3" {
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "Allow S3 access via gateway endpoint (prefix list)"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
+}
+
+resource "aws_security_group_rule" "cluster_ec2_egress_NEC" {
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "Allow outbound HTTPS to 10.120.0.0/24"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["10.120.0.0/24"]
+}
+
 # RDS Security Group
 resource "aws_security_group" "tds_db" {
   name        = "${local.application_name}-tds-allow-db"

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -66,19 +66,29 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
   source_security_group_id = aws_security_group.load_balancer.id
 }
 
-resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
+resource "aws_security_group_rule" "ecs_tasks_egress_all" {
   security_group_id = aws_security_group.ecs_tasks_edrms.id
   type              = "egress"
-  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
-  protocol          = "TCP"
-  from_port         = 443
-  to_port           = 443
-  source_security_group_id = data.aws_security_group.vpce_security_group.id
-
-  lifecycle {
-    ignore_changes = [source_security_group_id]
-  }
+  description       = "All"
+  protocol          = -1
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
 }
+
+#resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
+#  security_group_id = aws_security_group.ecs_tasks_edrms.id
+#  type              = "egress"
+#  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
+#  protocol          = "TCP"
+#  from_port         = 443
+#  to_port           = 443
+#  source_security_group_id = data.aws_security_group.vpce_security_group.id
+
+#  lifecycle {
+#    ignore_changes = [source_security_group_id]
+#  }
+#}
 
 resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
   security_group_id = aws_security_group.ecs_tasks_edrms.id

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -127,6 +127,10 @@ resource "aws_security_group_rule" "cluster_ec2_egress_all" {
   cidr_blocks       = ["0.0.0.0/0"] # Restrict to what's needed
 }
 
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {
   security_group_id = aws_security_group.cluster_ec2.id
   type              = "egress"

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -31,6 +31,18 @@ resource "aws_security_group_rule" "alb_egress_ec2" {
   source_security_group_id = aws_security_group.cluster_ec2.id
 }
 
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
+# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
+data "aws_security_group" "vpce_security_group" {
+  provider = aws.core-vpc
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
+  }
+}
 
 ### Container Security Group
 
@@ -62,6 +74,40 @@ resource "aws_security_group_rule" "ecs_tasks_egress_all" {
   from_port         = 0
   to_port           = 0
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
+  security_group_id = aws_security_group.ecs_tasks_edrms.id
+  type              = "egress"
+  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  source_security_group_id = data.aws_security_group.vpce_security_group.id
+
+  lifecycle {
+    ignore_changes = [source_security_group_id]
+  }
+}
+
+resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
+  security_group_id = aws_security_group.ecs_tasks_edrms.id
+  type              = "egress"
+  description       = "Allow S3 access via gateway endpoint (prefix list)"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
+}
+
+resource "aws_security_group_rule" "ecs_tasks_egress_db" {
+  security_group_id = aws_security_group.ecs_tasks_edrms.id
+  type              = "egress"
+  description       = "Allow outbound DB access to TDS"
+  protocol          = "TCP"
+  from_port         = 1521
+  to_port           = 1521
+  source_security_group_id = aws_security_group.tds_db.id
 }
 
 
@@ -117,14 +163,6 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
   source_security_group_id = aws_security_group.load_balancer.id # Allow the LB to access the EC2 instances
 }
 
-# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
-data "aws_security_group" "vpce_security_group" {
-  provider = aws.core-vpc
-  filter {
-    name   = "tag:Name"
-    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
-  }
-}
 
 resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   security_group_id = aws_security_group.cluster_ec2.id
@@ -138,10 +176,6 @@ resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   lifecycle {
     ignore_changes = [source_security_group_id]
   }
-}
-
-data "aws_prefix_list" "s3" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -117,14 +117,18 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
   source_security_group_id = aws_security_group.load_balancer.id # Allow the LB to access the EC2 instances
 }
 
-resource "aws_security_group_rule" "cluster_ec2_egress_all" {
+resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   security_group_id = aws_security_group.cluster_ec2.id
   type              = "egress"
-  description       = "All Egress"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"] # Restrict to what's needed
+  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  source_security_group_id = data.aws_security_group.vpce_security_group.id
+
+  lifecycle {
+    ignore_changes = [source_security_group_id]
+  }
 }
 
 data "aws_prefix_list" "s3" {
@@ -139,6 +143,16 @@ resource "aws_security_group_rule" "cluster_ec2_egress_s3" {
   from_port         = 443
   to_port           = 443
   prefix_list_ids   = [data.aws_prefix_list.s3.id]
+}
+
+resource "aws_security_group_rule" "cluster_ec2_egress_db" {
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "Allow outbound DB access to TDS"
+  protocol          = "TCP"
+  from_port         = 1521
+  to_port           = 1521
+  source_security_group_id = aws_security_group.tds_db.id
 }
 
 resource "aws_security_group_rule" "cluster_ec2_egress_NEC" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -66,29 +66,19 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
   source_security_group_id = aws_security_group.load_balancer.id
 }
 
-resource "aws_security_group_rule" "ecs_tasks_egress_all" {
+resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   security_group_id = aws_security_group.ecs_tasks_edrms.id
   type              = "egress"
-  description       = "All"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  source_security_group_id = data.aws_security_group.vpce_security_group.id
+
+  lifecycle {
+    ignore_changes = [source_security_group_id]
+  }
 }
-
-#resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
-#  security_group_id = aws_security_group.ecs_tasks_edrms.id
-#  type              = "egress"
-#  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
-#  protocol          = "TCP"
-#  from_port         = 443
-#  to_port           = 443
-#  source_security_group_id = data.aws_security_group.vpce_security_group.id
-
-#  lifecycle {
-#    ignore_changes = [source_security_group_id]
-#  }
-#}
 
 resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
   security_group_id = aws_security_group.ecs_tasks_edrms.id
@@ -174,19 +164,19 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
 }
 
 
-#resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
-#  security_group_id = aws_security_group.cluster_ec2.id
-#  type              = "egress"
-#  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
-#  protocol          = "TCP"
-#  from_port         = 443
-#  to_port           = 443
-#  source_security_group_id = data.aws_security_group.vpce_security_group.id
+resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  source_security_group_id = data.aws_security_group.vpce_security_group.id
 
-#  lifecycle {
-#    ignore_changes = [source_security_group_id]
-#  }
-#}
+  lifecycle {
+    ignore_changes = [source_security_group_id]
+  }
+}
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {
   security_group_id = aws_security_group.cluster_ec2.id
@@ -218,15 +208,6 @@ resource "aws_security_group_rule" "cluster_ec2_egress_NEC" {
   cidr_blocks       = ["10.120.0.0/24"]
 }
 
-resource "aws_security_group_rule" "cluster_ec2_egress_all" {
-  security_group_id = aws_security_group.cluster_ec2.id
-  type              = "egress"
-  description       = "All Egress"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-}
 
 # RDS Security Group
 resource "aws_security_group" "tds_db" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -58,13 +58,17 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
 }
 
 resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
-  security_group_id        = aws_security_group.ecs_tasks_edrms.id
-  type                     = "egress"
-  description              = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
-  protocol                 = "TCP"
-  from_port                = 443
-  to_port                  = 443
-  source_security_group_id = data.aws_security_group.vpce.id
+  security_group_id = aws_security_group.ecs_tasks_edrms.id
+  type              = "egress"
+  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks = [
+    data.aws_subnet.vpce_subnets_a.cidr_block,
+    data.aws_subnet.vpce_subnets_b.cidr_block,
+    data.aws_subnet.vpce_subnets_c.cidr_block,
+  ]
 }
 
 resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
@@ -152,13 +156,17 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
 
 
 resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
-  security_group_id        = aws_security_group.cluster_ec2.id
-  type                     = "egress"
-  description              = "Allow egress to VPC endpoints (logs/ecs/secrets)"
-  protocol                 = "TCP"
-  from_port                = 443
-  to_port                  = 443
-  source_security_group_id = data.aws_security_group.vpce.id
+  security_group_id = aws_security_group.cluster_ec2.id
+  type              = "egress"
+  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks = [
+    data.aws_subnet.vpce_subnets_a.cidr_block,
+    data.aws_subnet.vpce_subnets_b.cidr_block,
+    data.aws_subnet.vpce_subnets_c.cidr_block,
+  ]
 }
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -65,9 +65,9 @@ resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   from_port         = 443
   to_port           = 443
   cidr_blocks = [
-    data.aws_subnet.vpce_subnet_a.cidr_block,
-    data.aws_subnet.vpce_subnet_b.cidr_block,
-    data.aws_subnet.vpce_subnet_c.cidr_block,
+    data.aws_subnet.vpce_subnets_a.cidr_block,
+    data.aws_subnet.vpce_subnets_b.cidr_block,
+    data.aws_subnet.vpce_subnets_c.cidr_block,
   ]
 }
 
@@ -163,9 +163,9 @@ resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   from_port         = 443
   to_port           = 443
   cidr_blocks = [
-    data.aws_subnet.vpce_subnet_a.cidr_block,
-    data.aws_subnet.vpce_subnet_b.cidr_block,
-    data.aws_subnet.vpce_subnet_c.cidr_block,
+    data.aws_subnet.vpce_subnets_a.cidr_block,
+    data.aws_subnet.vpce_subnets_b.cidr_block,
+    data.aws_subnet.vpce_subnets_c.cidr_block,
   ]
 }
 

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -58,17 +58,13 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
 }
 
 resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
-  security_group_id = aws_security_group.ecs_tasks_edrms.id
-  type              = "egress"
-  description       = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
-  protocol          = "TCP"
-  from_port         = 443
-  to_port           = 443
-  cidr_blocks = [
-    data.aws_subnet.vpce_subnets_a.cidr_block,
-    data.aws_subnet.vpce_subnets_b.cidr_block,
-    data.aws_subnet.vpce_subnets_c.cidr_block,
-  ]
+  security_group_id        = aws_security_group.ecs_tasks_edrms.id
+  type                     = "egress"
+  description              = "Allow egress to VPC endpoints"
+  protocol                 = "TCP"
+  from_port                = 443
+  to_port                  = 443
+  source_security_group_id = data.aws_security_group.vpce.id
 }
 
 resource "aws_security_group_rule" "ecs_tasks_egress_s3" {
@@ -156,17 +152,13 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
 
 
 resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
-  security_group_id = aws_security_group.cluster_ec2.id
-  type              = "egress"
-  description       = "Allow egress to VPC endpoints (logs/ecs/secrets)"
-  protocol          = "TCP"
-  from_port         = 443
-  to_port           = 443
-  cidr_blocks = [
-    data.aws_subnet.vpce_subnets_a.cidr_block,
-    data.aws_subnet.vpce_subnets_b.cidr_block,
-    data.aws_subnet.vpce_subnets_c.cidr_block,
-  ]
+  security_group_id        = aws_security_group.cluster_ec2.id
+  type                     = "egress"
+  description              = "Allow egress to VPC endpoints"
+  protocol                 = "TCP"
+  from_port                = 443
+  to_port                  = 443
+  source_security_group_id = data.aws_security_group.vpce.id
 }
 
 resource "aws_security_group_rule" "cluster_ec2_egress_s3" {

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
 resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   security_group_id        = aws_security_group.ecs_tasks_edrms.id
   type                     = "egress"
-  description              = "Allow egress to VPC endpoints"
+  description              = "Allow egress to VPC endpoints (S3 / Secrets Manager)"
   protocol                 = "TCP"
   from_port                = 443
   to_port                  = 443
@@ -154,7 +154,7 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
 resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   security_group_id        = aws_security_group.cluster_ec2.id
   type                     = "egress"
-  description              = "Allow egress to VPC endpoints"
+  description              = "Allow egress to VPC endpoints (logs/ecs/secrets)"
   protocol                 = "TCP"
   from_port                = 443
   to_port                  = 443

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -117,6 +117,15 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
   source_security_group_id = aws_security_group.load_balancer.id # Allow the LB to access the EC2 instances
 }
 
+# VPC Endpoint security group lookup (used to restrict egress to VPC endpoints)
+data "aws_security_group" "vpce_security_group" {
+  provider = aws.core-vpc
+  filter {
+    name   = "tag:Name"
+    values = ["${var.networking[0].business-unit}-${local.environment}-int-endpoint"]
+  }
+}
+
 resource "aws_security_group_rule" "cluster_ec2_egress_vpce" {
   security_group_id = aws_security_group.cluster_ec2.id
   type              = "egress"

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -21,14 +21,14 @@ resource "aws_security_group_rule" "alb_ingress_443" {
 }
 
 
-resource "aws_security_group_rule" "alb_egress_all" {
+resource "aws_security_group_rule" "alb_egress_ec2" {
   security_group_id = aws_security_group.load_balancer.id
   type              = "egress"
-  description       = "All"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow LB to reach EC2 cluster ephemeral ports"
+  protocol          = "TCP"
+  from_port         = 32768
+  to_port           = 61000
+  source_security_group_id = aws_security_group.cluster_ec2.id
 }
 
 
@@ -112,8 +112,8 @@ resource "aws_security_group_rule" "cluster_ec2_ingress_lb" {
   type                     = "ingress"
   description              = "Application Traffic"
   protocol                 = "TCP"
-  from_port                = 0
-  to_port                  = 65535
+  from_port                = 32768
+  to_port                  = 61000
   source_security_group_id = aws_security_group.load_balancer.id # Allow the LB to access the EC2 instances
 }
 
@@ -153,12 +153,4 @@ resource "aws_vpc_security_group_ingress_rule" "tds_db_workspace_ingress" {
   cidr_ipv4         = local.application_data.accounts[local.environment].aws_workspace
 }
 
-resource "aws_security_group_rule" "tds_db_egress_all" {
-  security_group_id = aws_security_group.tds_db.id
-  type              = "egress"
-  description       = "All Egress"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-}
+

--- a/terraform/environments/ccms-edrms/security.tf
+++ b/terraform/environments/ccms-edrms/security.tf
@@ -66,16 +66,6 @@ resource "aws_security_group_rule" "ecs_tasks_edrms" {
   source_security_group_id = aws_security_group.load_balancer.id
 }
 
-resource "aws_security_group_rule" "ecs_tasks_egress_all" {
-  security_group_id = aws_security_group.ecs_tasks_edrms.id
-  type              = "egress"
-  description       = "All"
-  protocol          = -1
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "ecs_tasks_egress_vpce" {
   security_group_id = aws_security_group.ecs_tasks_edrms.id
   type              = "egress"
@@ -108,6 +98,16 @@ resource "aws_security_group_rule" "ecs_tasks_egress_db" {
   from_port         = 1521
   to_port           = 1521
   source_security_group_id = aws_security_group.tds_db.id
+}
+
+resource "aws_security_group_rule" "ecs_tasks_egress_NEC" {
+  security_group_id = aws_security_group.ecs_tasks_edrms.id
+  type              = "egress"
+  description       = "Allow outbound HTTPS to 10.120.0.0/24"
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["10.120.0.0/24"]
 }
 
 


### PR DESCRIPTION
Tightening security group egress rules to enforce least‑privilege network access by removing broad outbound internet access (0.0.0.0/0).
Achieved by identifying required dependencies and restricting traffic to specific AWS services (via endpoints) and controlled DB access while preserving application functionality.