### PR TITLE
feat(ai-gateway): Manage LiteLLM resources with Terraform

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
@@ -1,3 +1,5 @@
-# resource "litellm_organization" "ministryofjustice" {
-#   organization_alias = "Ministry of Justice"
-# }
+resource "litellm_organization" "organisations" {
+  for_each = local.environment_configuration.ai_gateway_configuration.organisations
+
+  organization_alias = each.value.organization_alias
+}

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
@@ -1,3 +1,3 @@
-resource "litellm_organization" "ministryofjustice" {
-  organization_alias = "Ministry of Justice"
-}
+# resource "litellm_organization" "ministryofjustice" {
+#   organization_alias = "Ministry of Justice"
+# }

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-organisations.tf
@@ -1,0 +1,3 @@
+resource "litellm_organization" "ministryofjustice" {
+  organization_alias = "Ministry of Justice"
+}

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
@@ -1,4 +1,4 @@
-resource "litellm_team" "justice_data_platform" {
-  team_alias      = "Justice Data Platform"
-  organization_id = litellm_organization.ministryofjustice.id
-}
+# resource "litellm_team" "justice_data_platform" {
+#   team_alias      = "Justice Data Platform"
+#   organization_id = litellm_organization.ministryofjustice.id
+# }

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
@@ -1,4 +1,8 @@
-# resource "litellm_team" "justice_data_platform" {
-#   team_alias      = "Justice Data Platform"
-#   organization_id = litellm_organization.ministryofjustice.id
-# }
+resource "litellm_team" "teams" {
+  for_each = local.environment_configuration.ai_gateway_configuration.teams
+
+  team_alias      = each.value.team_alias
+  organization_id = litellm_organization.organisations[each.value.organization_name].id
+
+  depends_on = [litellm_organization.organisations]
+}

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
@@ -1,0 +1,4 @@
+resource "litellm_team" "justice_data_platform" {
+  team_alias      = "Justice Data Platform"
+  organization_id = litellm_organization.ministryofjustice.id
+}

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -20,9 +20,7 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24",      # 10SC
-        # GitHub Actions
-        "20.58.27.30/32" # octo-production
+        "51.149.2.0/24"       # 10SC
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -59,9 +57,7 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24",      # 10SC
-        # GitHub Actions
-        "20.58.27.30/32" # octo-production
+        "51.149.2.0/24"       # 10SC
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -98,9 +94,7 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24",      # 10SC
-        # GitHub Actions
-        "20.58.27.30/32" # octo-production
+        "51.149.2.0/24"       # 10SC
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -137,9 +131,7 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24",      # 10SC
-        # GitHub Actions
-        "20.58.27.30/32" # octo-production
+        "51.149.2.0/24"       # 10SC
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,16 +1,5 @@
 locals {
-  environment_configuration = local.environment_configurations[local.environment]
-  ai_gateway_models         = yamldecode(file("${path.module}/configuration/models.yml"))
-  has_reader                = contains(keys(local.environment_configuration.aurora_instances), "reader")
-  dummy_password            = "iam-auth-dummy-password"
   environment_configurations = {
-    proxy_admin_emails = [
-      "Muhammad.Ahmad@justice.gov.uk",
-      "Jeremy.Collins@justice.gov.uk",
-      "Gary.Henderson1@justice.gov.uk",
-      "Lauren.Taylor-Brown@justice.gov.uk",
-      "Jacob.Woffenden@justice.gov.uk"
-    ]
     development = {
       litellm_version     = "1.90.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
@@ -37,6 +26,23 @@ locals {
         min_replicas                      = 1
         max_replicas                      = 3
         target_cpu_utilization_percentage = 60
+      }
+      ai_gateway_configuration = {
+        organisations = {
+          ministryofjustice = {
+            organization_alias = "Ministry of Justice"
+          }
+        }
+        teams = {
+          justice-data-platform = {
+            team_alias        = "Justice Data Platform"
+            organization_name = "ministryofjustice"
+          }
+          justice-engineering-ai-enablement = {
+            team_alias        = "Justice Engineering AI Enablement"
+            organization_name = "ministryofjustice"
+          }
+        }
       }
       aurora_instance_class = "db.serverless"
       aurora_engine_version = "17.7"
@@ -75,6 +81,19 @@ locals {
         max_replicas                      = 3
         target_cpu_utilization_percentage = 60
       }
+      ai_gateway_configuration = {
+        organisations = {
+          ministryofjustice = {
+            organization_alias = "Ministry of Justice"
+          }
+        }
+        teams = {
+          justice-data-platform = {
+            team_alias        = "Justice Data Platform"
+            organization_name = "ministryofjustice"
+          }
+        }
+      }
       aurora_instance_class = "db.serverless"
       aurora_engine_version = "17.7"
       aurora_instances      = { writer = {} }
@@ -112,6 +131,19 @@ locals {
         max_replicas                      = 3
         target_cpu_utilization_percentage = 60
       }
+      ai_gateway_configuration = {
+        organisations = {
+          ministryofjustice = {
+            organization_alias = "Ministry of Justice"
+          }
+        }
+        teams = {
+          justice-data-platform = {
+            team_alias        = "Justice Data Platform"
+            organization_name = "ministryofjustice"
+          }
+        }
+      }
       aurora_instance_class = "db.serverless"
       aurora_engine_version = "17.7"
       aurora_instances      = { writer = {} }
@@ -148,6 +180,19 @@ locals {
         min_replicas                      = 2
         max_replicas                      = 10
         target_cpu_utilization_percentage = 60
+      }
+      ai_gateway_configuration = {
+        organisations = {
+          ministryofjustice = {
+            organization_alias = "Ministry of Justice"
+          }
+        }
+        teams = {
+          justice-data-platform = {
+            team_alias        = "Justice Data Platform"
+            organization_name = "ministryofjustice"
+          }
+        }
       }
       aurora_instance_class                     = "db.t4g.medium"
       aurora_engine_version                     = "17.7"

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -20,7 +20,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -28,7 +30,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_models = local.ai_gateway_models
       ai_gateway_autoscaling = {
@@ -55,7 +59,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -63,7 +69,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_models = local.ai_gateway_models
       ai_gateway_autoscaling = {
@@ -90,7 +98,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -98,7 +108,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_models = local.ai_gateway_models
       ai_gateway_autoscaling = {
@@ -125,7 +137,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_admin_ingress_allowlist = [
         # VPN
@@ -133,7 +147,9 @@ locals {
         "35.176.93.186/32", # GlobalProtect (Alpha)
         # Sites
         "213.121.161.112/28", # 102PF
-        "51.149.2.0/24"       # 10SC
+        "51.149.2.0/24",      # 10SC
+        # GitHub Actions
+        "20.58.27.30/32" # octo-production
       ]
       ai_gateway_models = local.ai_gateway_models
       ai_gateway_autoscaling = {

--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -64,7 +64,7 @@ resource "helm_release" "litellm" {
         bedrockModels = try(local.environment_configuration.ai_gateway_models.bedrock, {})
 
         # Admin
-        proxyAdminEmail = join(", ", local.environment_configurations.proxy_admin_emails)
+        proxyAdminEmail = join(", ", local.proxy_admin_emails)
       }
     )
   ]
@@ -130,7 +130,7 @@ resource "helm_release" "litellm_admin" {
         auditLogsRegion = data.aws_region.current.region
 
         # Admin
-        proxyAdminEmail = join(", ", local.environment_configurations.proxy_admin_emails)
+        proxyAdminEmail = join(", ", local.proxy_admin_emails)
       }
     )
   ]

--- a/terraform/environments/data-platform/ai-gateway/locals.tf
+++ b/terraform/environments/data-platform/ai-gateway/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  environment_configuration = local.environment_configurations[local.environment]
+  ai_gateway_models         = yamldecode(file("${path.module}/configuration/models.yml"))
+  has_reader                = contains(keys(local.environment_configuration.aurora_instances), "reader")
+  dummy_password            = "iam-auth-dummy-password"
+  proxy_admin_emails = [
+    "Muhammad.Ahmad@justice.gov.uk",
+    "Jeremy.Collins@justice.gov.uk",
+    "Gary.Henderson1@justice.gov.uk",
+    "Lauren.Taylor-Brown@justice.gov.uk",
+    "Jacob.Woffenden@justice.gov.uk"
+  ]
+}

--- a/terraform/environments/data-platform/ai-gateway/providers.tf
+++ b/terraform/environments/data-platform/ai-gateway/providers.tf
@@ -11,3 +11,8 @@ provider "helm" {
     token                  = data.aws_eks_cluster_auth.cluster.token
   }
 }
+
+provider "litellm" {
+  api_base = "https://admin.${local.environment_configuration.ai_gateway_hostname}"
+  api_key  = local.litellm_master_key
+}

--- a/terraform/environments/data-platform/ai-gateway/versions.tf
+++ b/terraform/environments/data-platform/ai-gateway/versions.tf
@@ -20,6 +20,10 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/null"
     }
+    litellm = {
+      source  = "ncecere/litellm"
+      version = "~> 2.0"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
## Proposed Changes

- Adds OCTO Engineering's `octo-production` egress address to the admin ingress
- Adds [ncecere/litellm](https://registry.terraform.io/providers/ncecere/litellm)
  - I am speaking to BerriAI about their fork
- Adds Ministry of Justice org to all envs
- Adds Justice Data Platform team to all envs
- Adds Justice Engineering AI Enablement team to development

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>