### PR TITLE
associate MP shared Route53 Profile for centralised VPC Interface Endpoints DNS resolution and route traffic

### DIFF
--- a/terraform/environments/cloud-platform/network/vpc-endpoints.tf
+++ b/terraform/environments/cloud-platform/network/vpc-endpoints.tf
@@ -1,5 +1,18 @@
-# Interface VPC endpoints are defined centrally in the Modernisation Platform core-network-services account
+# VPC Endpoints Configuration
+#
+# Gateway VPC endpoints (S3, DynamoDB) are provisioned locally in this VPC
+# as they don't incur data transfer costs and provide optimal routing.
+#
+# Interface VPC endpoints are defined centrally in the Modernisation Platform core-network-services 
+# account and shared via Transit Gateway. This approach provides cost efficiency and centralised management.
+# 
+# For the complete list of centrally managed interface endpoints, see:
+# https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/core-network-services/centralised-vpc-endpoints.json
+#
+# A Route53 Profile from core-network-services is associated to this VPC to enable
+# DNS resolution for the centrally managed interface endpoints.
 
+### Gateway VPC Endpoints ###
 module "vpc-gateway-endpoints" {
   source   = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version  = "6.5.1"
@@ -18,4 +31,22 @@ module "vpc-gateway-endpoints" {
       )
     }
   }
+}
+
+
+### Route53 Profile Association and Routes to Centralised Interface VPC Endpoints ###
+
+# Associates the centralised Route53 Profile for DNS resolution of interface VPC endpoints
+resource "aws_route53profiles_association" "cp_vpc_assoc" {
+  name        = "centralised-endpoints"
+  profile_id  = "rp-ac0b20868a5a4eb4"
+  resource_id = module.cluster_vpc.vpc_id
+}
+
+# Routes to centralised interface VPC endpoints (10.20.240.0/20) via Transit Gateway
+resource "aws_route" "private_subnet_to_vpc_interface_endpoints_mp" {
+  count                  = length(module.cluster_vpc.private_route_table_ids)
+  route_table_id         = module.cluster_vpc.private_route_table_ids[count.index]
+  destination_cidr_block = "10.20.240.0/20"
+  transit_gateway_id     = "tgw-053d9dd7f1222a554"
 }


### PR DESCRIPTION
This PR allows CP VPCs to start using MP's centrally managed VPC Interface Endpoints.

* Add an `aws_route53profiles_association` resource to associate the RAM shared (from MP) Route53 Profile with the VPC, enabling DNS resolution for the centrally managed interface endpoints.
* Adds an `aws_route` resource to route traffic from private subnets to the centralised interface VPC endpoints via the Transit Gateway.

More info in this [ADR in MP](https://github.com/ministryofjustice/modernisation-platform/blob/main/architecture-decision-record/0045-centralise-vpc-endpoints-with-route53-profiles.md)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/8226

