### PR TITLE
fix: ignore lifecycle on task definition

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-file-transfer/ecs_cluster.tf
+++ b/terraform/environments/ccms-ebs/ccms-file-transfer/ecs_cluster.tf
@@ -70,11 +70,11 @@ resource "aws_ecs_service" "sftp_ecs_service" {
   launch_type                       = "EC2"
   health_check_grace_period_seconds = 120
 
-  lifecycle {
-    ignore_changes = [
-      task_definition
-    ]
-  }
+  # lifecycle {
+  #   ignore_changes = [
+  #     task_definition
+  #   ]
+  # }
 
   ordered_placement_strategy {
     field = "attribute:ecs.availability-zone"


### PR DESCRIPTION
disable lifecycle on task definition