### PR TITLE
feat(analytical-platform-compute): restrict mlflow ingress to allowlisted IPs

### DIFF
--- a/terraform/environments/analytical-platform-compute/mlflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/environment-configuration.tf
@@ -13,14 +13,14 @@ locals {
         "18.169.147.172/32",
         "18.130.148.126/32",
         "35.176.148.126/32",
-        # Elastic IPs for the Legacy Development NAT Gateways
-        "3.248.51.175/32",
-        "63.32.185.181/32",
-        "54.217.86.185/32",
-        # Elastic IPs for the Development Analytical Platform Compute NAT Gateways
-        "18.133.132.50/32",
-        "18.132.51.177/32",
-        "13.42.93.133/32",
+        # Elastic IPs for the Legacy Production NAT Gateways
+        "54.195.74.96/32",
+        "63.35.122.32/32",
+        "79.125.36.56/32",
+        # Elastic IPs for the Production Analytical Platform Compute NAT Gateways
+        "18.168.85.104/32",
+        "13.42.220.232/32",
+        "18.168.158.203/32",
       ]
     }
     test = {

--- a/terraform/environments/analytical-platform-compute/mlflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/environment-configuration.tf
@@ -4,6 +4,24 @@ locals {
       mlflow_s3_bucket_name = "alpha-analytical-platform-mlflow-development"
       route53_zone          = "compute.development.analytical-platform.service.justice.gov.uk"
 
+      # CIDRs allowed to reach MLflow; joined into the ingress
+      # whitelist-source-range annotation (values.yml.tftpl).
+      mlflow_ingress_allowlist = [
+        "128.77.75.64/26", # Prisma Corporate
+        # GlobalProtect (Alpha)
+        "35.176.93.186/32",
+        "18.169.147.172/32",
+        "18.130.148.126/32",
+        "35.176.148.126/32",
+        # Elastic IPs for the Legacy Development NAT Gateways
+        "3.248.51.175/32",
+        "63.32.185.181/32",
+        "54.217.86.185/32",
+        # Elastic IPs for the Development Analytical Platform Compute NAT Gateways
+        "18.133.132.50/32",
+        "18.132.51.177/32",
+        "13.42.93.133/32",
+      ]
     }
     test = {
     }

--- a/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/helm-release.tf
@@ -11,9 +11,10 @@ resource "helm_release" "mlflow" {
     templatefile(
       "${path.module}/src/helm/values/mlflow/values.yml.tftpl",
       {
-        mlflow_hostname = "mlflow.${local.environment_configuration.route53_zone}"
-        eks_role_arn    = module.mlflow_iam_role[0].iam_role_arn
-        s3_bucket_name  = local.environment_configuration.mlflow_s3_bucket_name
+        mlflow_hostname   = "mlflow.${local.environment_configuration.route53_zone}"
+        eks_role_arn      = module.mlflow_iam_role[0].iam_role_arn
+        s3_bucket_name    = local.environment_configuration.mlflow_s3_bucket_name
+        ingress_allowlist = local.environment_configuration.mlflow_ingress_allowlist
       }
     )
   ]

--- a/terraform/environments/analytical-platform-compute/mlflow/src/helm/values/mlflow/values.yml.tftpl
+++ b/terraform/environments/analytical-platform-compute/mlflow/src/helm/values/mlflow/values.yml.tftpl
@@ -4,6 +4,7 @@ ingress:
   className: "default"
   annotations:
     external-dns.alpha.kubernetes.io/hostname: ${mlflow_hostname}
+    nginx.ingress.kubernetes.io/whitelist-source-range: ${join(",", ingress_allowlist)}
   hosts:
     - host: ${mlflow_hostname}
       paths:


### PR DESCRIPTION
Relates to this [issue](https://github.com/ministryofjustice/data-platform-security/issues/71)