### PR TITLE
Ingestion: Add KMS key

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -117,7 +117,8 @@ locals {
       /* Target KMS */
       target_kms_keys = [
         "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/62503ba6-316e-473d-ae4b-042f8420dd07", # s3/mojap-data-production-shared-services-client-team-gov-29148
-        "arn:aws:kms:eu-west-2:437720536440:key/d4cd0acf-5b4f-461f-ba01-886f814afec5"                                                                        # s3/property-datahub-landing-production
+        "arn:aws:kms:eu-west-2:437720536440:key/d4cd0acf-5b4f-461f-ba01-886f814afec5",                                                                       # s3/property-datahub-landing-production
+        "arn:aws:kms:eu-west-2:285499101317:key/5aa5fda6-0c5c-4a5d-9574-3b2ba9675e54"                                                                        # s3/ccms-ebs-production-bc-inbound-mp
       ]
       mojap_land_kms_key                  = "arn:aws:kms:eu-west-1:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/2855ac30-4e14-482e-85ca-53258e01f64c"
       datasync_opg_target_bucket_kms      = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["analytical-platform-data-production"]}:key/96eb04fe-8393-402c-b1f9-71fcece99e75"


### PR DESCRIPTION
This pull request makes a small update to the list of target KMS keys used in the analytical platform ingestion environment configuration. Specifically, it adds a new KMS key ARN for the `ccms-ebs-production-bc-inbound-mp` S3 bucket to the `target_kms_keys` list.

- Added the KMS key ARN for the `ccms-ebs-production-bc-inbound-mp` S3 bucket to the `target_kms_keys` array in `environment-configuration.tf` to support encryption for this new target.