### PR TITLE
✨ Rebuild integration hub file transfer idempotency storage 🗃️🔐🚚

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/dynamodb.tf
+++ b/terraform/environments/integration-hub-file-transfer/dynamodb.tf
@@ -1,0 +1,26 @@
+module "dynamodb_idempotency" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.environment}-s3-idempotency"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attributes = [
+    {
+      name = "id"
+      type = "S"
+    }
+  ]
+
+  server_side_encryption_enabled     = true
+  server_side_encryption_kms_key_arn = module.kms_dynamodb.key_arn
+  table_class                        = "STANDARD"
+  ttl_attribute_name                 = "expiration"
+  ttl_enabled                        = true
+  timeouts = {
+    "create" : "60m",
+    "delete" : "60m",
+    "update" : "60m"
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub-file-transfer/kms.tf
@@ -69,3 +69,73 @@ module "kms_s3_audit" {
 
   tags = local.tags
 }
+
+module "kms_dynamodb" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "4.2.0"
+
+  aliases                 = ["dynamodb/idempotency"]
+  description             = "Key for cryptographic functions on DynamoDB tables"
+  enable_default_policy   = true
+  deletion_window_in_days = 30
+  multi_region            = false
+  is_enabled              = true
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+
+  # Allow the root account as administrator
+  key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+
+  key_statements = [
+    {
+      sid = "AllowDynamoDBUseOfTheKey"
+      actions = [
+        "kms:CreateGrant",
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*",
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["*"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "kms:CallerAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        },
+        {
+          test     = "StringLike"
+          variable = "kms:ViaService"
+          values   = ["dynamodb.*.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "AllowDynamoDBServiceToDescribeTheKey"
+      actions = [
+        "kms:Describe*",
+        "kms:Get*",
+        "kms:List*",
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["dynamodb.amazonaws.com"]
+        }
+      ]
+    }
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
## ✨ What’s changing? 🛠️🗃️

This PR adds the first bit of idempotency storage for the rebuild of the existing `integration-hub/managed-file-transfer` capability in dedicated accounts. 🚚🏗️

- 🗃️ adds a DynamoDB table used for idempotency actions
- 🔐 adds a dedicated KMS key for DynamoDB encryption
- ⏳ enables TTL using the `expiration` attribute
- 🛡️ scopes KMS usage to DynamoDB activity in this account

## 🧱 Why now? 🚀

We’re rebuilding the current integration hub managed file transfer setup with production-shaped infrastructure in dedicated accounts, and this lays down the encrypted persistence needed for idempotency operations. 🔄🔒

## 🔍 What changed? 📁

- `terraform/environments/integration-hub-file-transfer/dynamodb.tf`
- `terraform/environments/integration-hub-file-transfer/kms.tf`

## ✅ Notes 📌

- No repository PR template was present, so this description is based on the branch diff and commit history. 🧭
- Local validation was not run as part of this PR operation. 🧪
