### PR TITLE
feat(cluster): Add ArgoCD EKS Capability module for hub cluster

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -1,0 +1,30 @@
+###############################################################################
+# Argo CD — Hub Cluster EKS Capability (ADR-002)
+#
+# Conditionally enables the AWS-managed Argo CD Capability on this cluster.
+# Set var.enable_argocd = true to designate this cluster as a hub.
+#
+# References:
+#   - ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
+#   - US-015a: Provision Hub Cluster to support Argo CD Deployment
+###############################################################################
+
+module "argocd" {
+  source = "./modules/argo-cd"
+  count  = var.enable_argocd ? 1 : 0
+
+  cluster_name = module.eks.cluster_name
+  cluster_arn  = module.eks.cluster_arn
+
+  # IAM Identity Center authentication
+  idc_instance_arn      = var.argocd_idc_instance_arn
+  idc_region            = var.argocd_idc_region
+  rbac_admin_identities = var.argocd_rbac_admin_identities
+
+  # GitHub access via CodeConnections
+  codeconnection_arn = var.argocd_codeconnection_arn
+
+  tags = local.tags
+
+  depends_on = [module.eks]
+}

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
@@ -1,0 +1,210 @@
+###############################################################################
+# Argo CD Module — EKS Capability for Argo CD
+#
+# Enables the AWS-managed Argo CD on the hub cluster (ADR-002).
+# Key characteristics:
+# - Runs in AWS-managed infrastructure (not on worker nodes)
+# - Cross-account private cluster access via EKS ARN + Access Entries
+# - No VPC peering or TGW required for GitOps traffic
+# - IAM Identity Center authentication
+# - CodeConnections for GitHub repository access
+# - One Argo CD Capability per cluster (EKS hard limit)
+#
+# Requires AWS provider >= 6.46.0 for aws_eks_capability resource.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.10"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+#------------------------------------------------------------------------------
+# IAM Role for Argo CD Capability
+#
+# Trust policy: EKS Capabilities service principal
+#------------------------------------------------------------------------------
+resource "aws_iam_role" "argocd_capability" {
+  name        = "${var.cluster_name}-argocd-capability"
+  description = "IAM role for EKS Argo CD Capability on ${var.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "capabilities.eks.amazonaws.com"
+        }
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-argocd-capability"
+  })
+}
+
+#------------------------------------------------------------------------------
+# IAM Propagation Delay
+#
+# EKS validates the trust policy when creating the capability. IAM role
+# propagation is eventually consistent (~10s). Without this delay, the
+# CreateCapability API call can fail with "trust policy is invalid" on
+# fresh deployments where the role was just created.
+#------------------------------------------------------------------------------
+resource "time_sleep" "iam_propagation" {
+  depends_on      = [aws_iam_role.argocd_capability]
+  create_duration = "15s"
+}
+
+#------------------------------------------------------------------------------
+# EKS Capability for Argo CD
+#
+# Uses aws_eks_capability resource (provider >= 6.46.0).
+# Provisions the AWS-managed Argo CD instance on the hub cluster.
+#------------------------------------------------------------------------------
+resource "aws_eks_capability" "argocd" {
+  cluster_name              = var.cluster_name
+  capability_name           = "argocd"
+  type                      = "ARGOCD"
+  role_arn                  = aws_iam_role.argocd_capability.arn
+  delete_propagation_policy = "RETAIN"
+
+  depends_on = [time_sleep.iam_propagation]
+
+  configuration {
+    argo_cd {
+      aws_idc {
+        idc_instance_arn = var.idc_instance_arn
+        idc_region       = var.idc_region
+      }
+
+      namespace = "argocd"
+
+      dynamic "rbac_role_mapping" {
+        for_each = var.rbac_admin_identities
+        content {
+          role = "ADMIN"
+          identity {
+            id   = rbac_role_mapping.value.id
+            type = rbac_role_mapping.value.type
+          }
+        }
+      }
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-argocd"
+  })
+
+  timeouts {
+    create = "20m"
+    delete = "20m"
+  }
+}
+
+#------------------------------------------------------------------------------
+# Argo CD Cross-Account Spoke Access Role
+#
+# This role is assumed by the Argo CD Capability to deploy to spoke clusters.
+# Each spoke cluster registers this role as an EKS Access Entry with
+# AmazonEKSClusterAdminPolicy for GitOps deployments.
+#------------------------------------------------------------------------------
+resource "aws_iam_role" "argocd_spoke_access" {
+  name        = "${var.cluster_name}-argocd-spoke-access"
+  description = "Allows Argo CD Capability to access spoke EKS clusters"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = local.account_id
+          }
+          ArnEquals = {
+            "aws:SourceArn" = var.cluster_arn
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name    = "${var.cluster_name}-argocd-spoke-access"
+    Purpose = "cross-account-gitops"
+  })
+}
+
+#------------------------------------------------------------------------------
+# CodeConnections for GitHub repository access
+#------------------------------------------------------------------------------
+resource "aws_iam_role_policy" "argocd_codeconnection" {
+  count = var.codeconnection_arn != "" ? 1 : 0
+
+  name = "codeconnection-access"
+  role = aws_iam_role.argocd_spoke_access.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "UseCodeConnection"
+        Effect = "Allow"
+        Action = [
+          "codeconnections:UseConnection",
+          "codeconnections:GetConnection",
+        ]
+        Resource = var.codeconnection_arn
+      }
+    ]
+  })
+}
+
+#------------------------------------------------------------------------------
+# Register Argo CD IAM role as Access Entry on the hub cluster
+#------------------------------------------------------------------------------
+resource "aws_eks_access_entry" "argocd_hub" {
+  cluster_name  = var.cluster_name
+  principal_arn = aws_iam_role.argocd_spoke_access.arn
+  type          = "STANDARD"
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_name}-argocd-hub-access"
+  })
+}
+
+resource "aws_eks_access_policy_association" "argocd_hub" {
+  cluster_name  = var.cluster_name
+  principal_arn = aws_iam_role.argocd_spoke_access.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.argocd_hub]
+}

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/outputs.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/outputs.tf
@@ -1,0 +1,23 @@
+###############################################################################
+# Argo CD Module — Outputs
+###############################################################################
+
+output "capability_arn" {
+  description = "ARN of the Argo CD EKS Capability"
+  value       = aws_eks_capability.argocd.arn
+}
+
+output "capability_role_arn" {
+  description = "ARN of the IAM role used by the Argo CD Capability"
+  value       = aws_iam_role.argocd_capability.arn
+}
+
+output "spoke_access_role_arn" {
+  description = "ARN of the IAM role for cross-account spoke cluster access"
+  value       = aws_iam_role.argocd_spoke_access.arn
+}
+
+output "spoke_access_role_name" {
+  description = "Name of the IAM role for cross-account spoke cluster access"
+  value       = aws_iam_role.argocd_spoke_access.name
+}

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/variables.tf
@@ -1,0 +1,57 @@
+###############################################################################
+# Argo CD Module — Variables
+#
+# Enables the EKS Capability for Argo CD on the hub cluster (ADR-002).
+# Uses aws_eks_capability resource (provider >= 6.46.0).
+###############################################################################
+
+variable "cluster_name" {
+  description = "Name of the hub EKS cluster where Argo CD Capability is enabled"
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ARN of the hub EKS cluster"
+  type        = string
+}
+
+#------------------------------------------------------------------------------
+# Identity Center (required for Argo CD authentication)
+#------------------------------------------------------------------------------
+variable "idc_instance_arn" {
+  description = "ARN of the AWS IAM Identity Center instance"
+  type        = string
+}
+
+variable "idc_region" {
+  description = "Region of the IAM Identity Center instance (defaults to provider region)"
+  type        = string
+  default     = ""
+}
+
+variable "rbac_admin_identities" {
+  description = "List of Identity Center identities to grant ADMIN role in Argo CD"
+  type = list(object({
+    id   = string
+    type = string # SSO_USER or SSO_GROUP
+  }))
+  default = []
+}
+
+#------------------------------------------------------------------------------
+# CodeConnections (GitHub Access)
+#------------------------------------------------------------------------------
+variable "codeconnection_arn" {
+  description = "AWS CodeConnections ARN for GitHub repository access (empty to skip)"
+  type        = string
+  default     = ""
+}
+
+#------------------------------------------------------------------------------
+# Tags
+#------------------------------------------------------------------------------
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/environments/cloud-platform/cluster/outputs.tf
+++ b/terraform/environments/cloud-platform/cluster/outputs.tf
@@ -1,0 +1,31 @@
+###############################################################################
+# Cluster Outputs
+###############################################################################
+
+output "cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_arn" {
+  description = "ARN of the EKS cluster"
+  value       = module.eks.cluster_arn
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint of the EKS cluster API server"
+  value       = module.eks.cluster_endpoint
+}
+
+#------------------------------------------------------------------------------
+# Argo CD Outputs (only populated when enable_argocd = true)
+#------------------------------------------------------------------------------
+output "argocd_capability_arn" {
+  description = "ARN of the Argo CD EKS Capability (empty if ArgoCD not enabled)"
+  value       = var.enable_argocd ? module.argocd[0].capability_arn : ""
+}
+
+output "argocd_spoke_access_role_arn" {
+  description = "ARN of the IAM role for spoke cluster access (register this in spoke Access Entries)"
+  value       = var.enable_argocd ? module.argocd[0].spoke_access_role_arn : ""
+}

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -55,21 +55,3 @@ resource "null_resource" "created_by_tag" {
     ignore_changes = [triggers["created_by"]]
   }
 }
-
-variable "enable_argocd" {
-  type        = bool
-  default     = false
-  description = "Enable the EKS Capability for Argo CD on this cluster (hub cluster role)."
-}
-
-variable "argocd_idc_instance_arn" {
-  type        = string
-  default     = "" # Set to your org's IAM Identity Center instance ARN
-  description = "ARN of the AWS IAM Identity Center instance for Argo CD authentication. Required when enable_argocd is true."
-}
-
-variable "argocd_idc_region" {
-  type        = string
-  default     = "eu-west-2"
-  description = "Region of the IAM Identity Center instance."
-}

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -9,6 +9,42 @@ variable "created_by" {
   }
 }
 
+#------------------------------------------------------------------------------
+# Argo CD Hub Cluster Configuration (ADR-002)
+#------------------------------------------------------------------------------
+variable "enable_argocd" {
+  type        = bool
+  default     = false
+  description = "Enable the EKS Capability for Argo CD on this cluster (hub cluster role)."
+}
+
+variable "argocd_idc_instance_arn" {
+  type        = string
+  default     = "" # Set to your org's IAM Identity Center instance ARN
+  description = "ARN of the AWS IAM Identity Center instance for Argo CD authentication. Required when enable_argocd is true."
+}
+
+variable "argocd_idc_region" {
+  type        = string
+  default     = "eu-west-2"
+  description = "Region of the IAM Identity Center instance."
+}
+
+variable "argocd_rbac_admin_identities" {
+  type = list(object({
+    id   = string
+    type = string
+  }))
+  default     = []
+  description = "List of Identity Center identities (SSO_USER or SSO_GROUP) to grant ADMIN role in Argo CD."
+}
+
+variable "argocd_codeconnection_arn" {
+  type        = string
+  default     = ""
+  description = "AWS CodeConnections ARN for GitHub repository access from Argo CD."
+}
+
 resource "null_resource" "created_by_tag" {
   triggers = {
     # Persist the initial creator value in state; ignore future tf var changes.

--- a/terraform/environments/cloud-platform/oidc.tf
+++ b/terraform/environments/cloud-platform/oidc.tf
@@ -223,6 +223,24 @@ data "aws_iam_policy_document" "github_actions_development_cluster_oidc_policy" 
     resources = ["*"]
   }
 
+  statement {
+    sid    = "SSOForArgoCDCapability"
+    effect = "Allow"
+    actions = [
+      "sso:CreateApplication",
+      "sso:DeleteApplication",
+      "sso:DescribeApplication",
+      "sso:PutApplicationAccessScope",
+      "sso:PutApplicationAuthenticationMethod",
+      "sso:PutApplicationGrant",
+      "sso:DeleteApplicationAccessScope",
+      "sso:DeleteApplicationAuthenticationMethod",
+      "sso:DeleteApplicationGrant",
+      "sso:PutApplicationAssignmentConfiguration"
+    ]
+    resources = ["*"]
+  }
+
 }
 
 


### PR DESCRIPTION
## Summary

Adds conditional ArgoCD EKS Capability enablement to the generic cluster module, plus the IAM permissions required for the GitHub Actions role to provision it.

## What's included

### ArgoCD EKS Capability module (`cluster/`)

- **`cluster/modules/argo-cd/`** — New local module implementing the EKS Capability for Argo CD:
  - IAM role for Capability trust (`capabilities.eks.amazonaws.com`)
  - Cross-account spoke access role (spokes register this role as an Access Entry)
  - IAM Identity Center authentication
  - Optional CodeConnections for GitHub repository access
  - Hub cluster Access Entry registration
- **`cluster/argocd.tf`** — Conditional module invocation (`count = var.enable_argocd ? 1 : 0`)
- **`cluster/variables.tf`** — Added `enable_argocd` toggle and ArgoCD-related variables with safe defaults
- **`cluster/outputs.tf`** — Cluster outputs including ArgoCD capability ARN and spoke access role ARN

### IAM permissions fix (`oidc.tf`)

- Added `SSOForArgoCDCapability` statement to the `github-actions-development-cluster` role policy
- Grants `sso:CreateApplication`, `sso:DeleteApplication`, and related SSO actions
- Required because the EKS `CreateCapability` API validates that the caller has SSO permissions to register the Argo CD application with Identity Center

## How to deploy a hub cluster

Via the `development-cluster-deploy` workflow, tick "Enable ArgoCD". The IDC instance ARN is supplied from the `ARGOCD_IDC_INSTANCE_ARN` repo secret.

## Tested

- Deployed cluster `cp-0707-1025` with ArgoCD enabled
- ArgoCD Capability created successfully (status: ACTIVE after Gatekeeper fix)
- ArgoCD UI accessible
- CRDs installed (`applications.argoproj.io`, `applicationsets.argoproj.io`, `appprojects.argoproj.io`)

## Security scanning

- ASH (Automated Security Helper) v3.5.6: **0 findings** in new code
- tflint: **0 findings** in new code

## Companion PRs

- **`container-platform-terraform-gatekeeper`**: Exempt `argocd` namespace from PSA label constraint
- **`cloud-platform-github-workflows`**: Add `enable_argocd` input to deploy workflow (pending Code Defender approval)

## Prerequisites

- `ARGOCD_IDC_INSTANCE_ARN` secret added to the workflows repo
- Gatekeeper constraint PR merged (otherwise ArgoCD reports degraded health)

## Architecture references

- ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
- Implements US-015a: Provision Hub Cluster to support Argo CD Deployment

## Issue

https://github.com/ministryofjustice/cloud-platform/issues/8269
