### PR TITLE
add cert-manager

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/cert-manager.tf
+++ b/terraform/environments/cloud-platform/cluster-core/cert-manager.tf
@@ -1,0 +1,10 @@
+module "cert_manager" {
+  source = "github.com/ministryofjustice/container-platform-terraform-cert-manager?ref=1.0.0"
+
+  cluster_name               = local.cluster_name
+  hostzones                  = ["arn:aws:route53:::hostedzone/*"]
+
+  depends_on = [
+    module.envoy_gateway
+  ]
+}


### PR DESCRIPTION
Adds cert-manager to CP3 clusters.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/8332