### PR TITLE
Add role for CP environments repo to make eks changes

### DIFF
--- a/terraform/environments/cloud-platform/iam.tf
+++ b/terraform/environments/cloud-platform/iam.tf
@@ -1,0 +1,59 @@
+# Role to allow cloud-platform-live to make eks changes
+# Enables the container-platform-environments repo to manage eks access entries across cluster accounts
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "AllowSourceAccountAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["cloud-platform-live"]}:root"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_access" {
+  name               = "ContainerPlatformEKSAccess"
+  assume_role_policy = data.aws_iam_policy_document.trust.json
+}
+
+data "aws_iam_policy_document" "eks_access" {
+  statement {
+    sid    = "CreateAndListAccessEntriesOnApprovedClusters"
+    effect = "Allow"
+    actions = [
+      "eks:CreateAccessEntry",
+      "eks:ListAccessEntries",
+      "eks:DescribeCluster"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ManageAccessEntriesAndAssociations"
+    effect = "Allow"
+    actions = [
+      "eks:DescribeAccessEntry",
+      "eks:UpdateAccessEntry",
+      "eks:DeleteAccessEntry",
+      "eks:AssociateAccessPolicy",
+      "eks:DisassociateAccessPolicy",
+      "eks:ListAssociatedAccessPolicies",
+      "eks:ListAccessPolicies",
+      "eks:TagResource",
+      "eks:UntagResource"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "eks_access" {
+  name   = "container-platform-eks-access-policy"
+  policy = data.aws_iam_policy_document.eks_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.eks_access.name
+  policy_arn = aws_iam_policy.eks_access.arn
+}


### PR DESCRIPTION
In order to add EKS access entries to each of the clusters, we need a role that we can assume from another account.