### PR TITLE
increased helm timeout to 20mins

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -23,6 +23,7 @@ resource "helm_release" "litellm" {
   version    = local.environment_configuration.litellm_version
   chart      = "litellm-helm"
   namespace  = local.component_name
+  timeout    = "20m"
   values = [
     templatefile(
       "${path.module}/src/helm/values/litellm/values.yml.tftpl",
@@ -95,6 +96,7 @@ resource "helm_release" "litellm_admin" {
   version    = local.environment_configuration.litellm_version
   chart      = "litellm-helm"
   namespace  = local.component_name
+  timeout    = "20m"
   values = [
     templatefile(
       "${path.module}/src/helm/values/litellm-admin/values.yml.tftpl",

--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -23,7 +23,7 @@ resource "helm_release" "litellm" {
   version    = local.environment_configuration.litellm_version
   chart      = "litellm-helm"
   namespace  = local.component_name
-  timeout    = "20m"
+  timeout    = "1200" 
   values = [
     templatefile(
       "${path.module}/src/helm/values/litellm/values.yml.tftpl",
@@ -96,7 +96,7 @@ resource "helm_release" "litellm_admin" {
   version    = local.environment_configuration.litellm_version
   chart      = "litellm-helm"
   namespace  = local.component_name
-  timeout    = "20m"
+  timeout    = "1200"
   values = [
     templatefile(
       "${path.module}/src/helm/values/litellm-admin/values.yml.tftpl",


### PR DESCRIPTION
During rollout the pod could not be scheduled immediately because there was insufficient capacity in the `general-on-demand-arm64` node pool. Karpenter provisioned a new node, but the additional capacity was not available before the Helm timeout expired.

The deployment completed successfully once the new node became available, indicating this was a deployment timing issue rather than an application failure.