### PR TITLE
feat(ai-gateway): add LiteLLM TOON pre-call hook

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -73,6 +73,7 @@ resource "helm_release" "litellm" {
     helm_release.litellm_admin,
     module.iam_role,
     kubernetes_service_account_v1.ai_gateway,
+    kubernetes_config_map_v1.litellm_hooks,
     kubernetes_secret_v1.litellm_master_key,
     kubernetes_manifest.external_secret_litellm_license,
     kubernetes_manifest.external_secret_litellm_salt_key,

--- a/terraform/environments/data-platform/ai-gateway/kubernetes-config-maps.tf
+++ b/terraform/environments/data-platform/ai-gateway/kubernetes-config-maps.tf
@@ -1,0 +1,10 @@
+resource "kubernetes_config_map_v1" "litellm_hooks" {
+  metadata {
+    namespace = module.ai_gateway_namespace.name
+    name      = "litellm-hooks"
+  }
+
+  data = {
+    "custom_callbacks.py" = file("${path.module}/src/litellm-hooks/custom_callbacks.py")
+  }
+}

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -69,7 +69,7 @@ proxy_config:
       port: 6379
       password: os.environ/auth_token
     require_auth_for_metrics_endpoint: false
-    callbacks: ["prometheus"]
+    callbacks: ["custom_callbacks.proxy_handler_instance", "prometheus"]
     success_callback: ["prometheus"]
     failure_callback: ["prometheus"]
     prometheus_initialize_budget_metrics: true
@@ -124,12 +124,19 @@ volumes:
   - name: migrations
     emptyDir:
       sizeLimit: 64Mi
+  - name: litellm-hooks
+    configMap:
+      name: litellm-hooks
 
 volumeMounts:
   - name: app-cache
     mountPath: /app/cache
   - name: migrations
     mountPath: /app/migrations
+  - name: litellm-hooks
+    mountPath: /app/custom_callbacks.py
+    subPath: custom_callbacks.py
+    readOnly: true
 
 migrationJob:
   enabled: false

--- a/terraform/environments/data-platform/ai-gateway/src/litellm-hooks/custom_callbacks.py
+++ b/terraform/environments/data-platform/ai-gateway/src/litellm-hooks/custom_callbacks.py
@@ -1,0 +1,124 @@
+import json
+import re
+from typing import Any
+
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy.proxy_server import DualCache, UserAPIKeyAuth
+
+
+class ToonTransformHook(CustomLogger):
+    """Convert selected JSON prompt blocks to TOON before provider calls."""
+
+    _json_fence_pattern = re.compile(
+        r"```json\s*(?P<payload>\{.*?\}|\[.*?\])\s*```",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: str,
+    ) -> dict:
+        if call_type not in {"completion", "text_completion"}:
+            return data
+
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            return data
+
+        for message in messages:
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = self._transform_prompt_content(content)
+
+        return data
+
+    def _transform_prompt_content(self, text: str) -> str:
+        def replace_json_fence(match: re.Match[str]) -> str:
+            payload = match.group("payload")
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                return match.group(0)
+
+            toon = self._json_to_toon(parsed)
+            if toon is None:
+                return match.group(0)
+
+            return f"Data is in TOON format:\n\n```toon\n{toon}\n```"
+
+        return self._json_fence_pattern.sub(replace_json_fence, text)
+
+    def _json_to_toon(self, payload: Any) -> str | None:
+        if isinstance(payload, list):
+            return self._render_uniform_array("items", payload)
+
+        if isinstance(payload, dict):
+            if len(payload) != 1:
+                return None
+
+            key, value = next(iter(payload.items()))
+            if not isinstance(value, list):
+                return None
+
+            return self._render_uniform_array(str(key), value)
+
+        return None
+
+    def _render_uniform_array(self, name: str, items: list[Any]) -> str | None:
+        if not items:
+            return None
+
+        if not all(isinstance(item, dict) for item in items):
+            return None
+
+        headers = list(items[0].keys())
+        if not headers:
+            return None
+
+        for item in items:
+            if list(item.keys()) != headers:
+                return None
+
+        rows: list[str] = []
+        for item in items:
+            row_values: list[str] = []
+            for header in headers:
+                scalar = self._to_toon_scalar(item[header])
+                if scalar is None:
+                    return None
+                row_values.append(scalar)
+            rows.append("  " + ",".join(row_values))
+
+        header_csv = ",".join(headers)
+        lines = [f"{name}[{len(items)}]{{{header_csv}}}:"]
+        lines.extend(rows)
+        return "\n".join(lines)
+
+    def _to_toon_scalar(self, value: Any) -> str | None:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+
+        if value is None:
+            return "null"
+
+        if isinstance(value, (int, float)):
+            return str(value)
+
+        if not isinstance(value, str):
+            return None
+
+        needs_quotes = (
+            value == ""
+            or value != value.strip()
+            or any(char in value for char in [",", "\n", '"'])
+        )
+        if needs_quotes:
+            return json.dumps(value, ensure_ascii=True)
+
+        return value
+
+
+proxy_handler_instance = ToonTransformHook()


### PR DESCRIPTION
## Summary\n- add a native LiteLLM  callback to transform suitable prompt JSON blocks into TOON\n- add a Kubernetes ConfigMap to deliver  into the LiteLLM pod\n- update LiteLLM Helm values to mount the callback module and register  alongside existing Prometheus callbacks\n- update Terraform  to ensure the hook ConfigMap exists before the LiteLLM Helm release\n\n## Why\nThis delivers the TOON PoC through LiteLLM native hook functionality without changing client request format (OpenAI-compatible JSON remains unchanged at the API layer).\n\n## Scope and behaviour\n- only transforms fenced  blocks found in \n- only transforms conservative candidates (uniform arrays of objects)\n- leaves unsupported/invalid payloads unchanged\n\n## Validation\n- Terraform formatting run on changed Terraform files\n- Python syntax check run for \n\nCloses https://github.com/ministryofjustice/data-platform/issues/502