### PR TITLE
[cloud-platform] Add CNI custom networking NodeClass and NodePool (US-028)

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
+++ b/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
@@ -12,6 +12,7 @@ resource "kubectl_manifest" "nodeclass_custom_networking" {
       subnetSelectorTerms:
         - tags:
             SubnetType: "Private"
+            Cluster: "${local.cp_vpc_name}"
 
       # Node security group
       securityGroupSelectorTerms:
@@ -22,6 +23,7 @@ resource "kubectl_manifest" "nodeclass_custom_networking" {
       podSubnetSelectorTerms:
         - tags:
             SubnetType: "pod-private"
+            Cluster: "${local.cp_vpc_name}"
 
       # Pod security group
       podSecurityGroupSelectorTerms:

--- a/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
+++ b/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
@@ -12,7 +12,7 @@ resource "kubectl_manifest" "nodeclass_custom_networking" {
       subnetSelectorTerms:
         - tags:
             SubnetType: "Private"
-            Cluster: "${local.cp_vpc_name}"
+            environment-name: "${local.cp_vpc_name}"
 
       # Node security group
       securityGroupSelectorTerms:

--- a/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
+++ b/terraform/environments/cloud-platform/cluster-core/cni-custom-networking.tf
@@ -1,0 +1,68 @@
+
+resource "kubectl_manifest" "nodeclass_custom_networking" {
+  yaml_body = <<-YAML
+    apiVersion: eks.amazonaws.com/v1
+    kind: NodeClass
+    metadata:
+      name: custom-networking
+    spec:
+      role: ${local.node_role_name}
+
+      # Node subnets (primary CIDR)
+      subnetSelectorTerms:
+        - tags:
+            SubnetType: "Private"
+
+      # Node security group
+      securityGroupSelectorTerms:
+        - tags:
+            aws:eks:cluster-name: "${local.cluster_name}"
+
+      # Pod subnets (secondary CIDR — 100.64.x.x)
+      podSubnetSelectorTerms:
+        - tags:
+            SubnetType: "pod-private"
+
+      # Pod security group
+      podSecurityGroupSelectorTerms:
+        - tags:
+            aws:eks:cluster-name: "${local.cluster_name}"
+  YAML
+}
+
+resource "kubectl_manifest" "nodepool_custom_networking" {
+  yaml_body = <<-YAML
+    apiVersion: karpenter.sh/v1
+    kind: NodePool
+    metadata:
+      name: custom-networking
+    spec:
+      template:
+        spec:
+          requirements:
+            - key: karpenter.sh/capacity-type
+              operator: In
+              values: ["on-demand"]
+            - key: kubernetes.io/arch
+              operator: In
+              values: ["amd64"]
+            - key: eks.amazonaws.com/instance-category
+              operator: In
+              values: ["c", "m", "r"]
+            - key: eks.amazonaws.com/instance-generation
+              operator: Gt
+              values: ["4"]
+          nodeClassRef:
+            group: eks.amazonaws.com
+            kind: NodeClass
+            name: custom-networking
+      disruption:
+        consolidationPolicy: WhenEmptyOrUnderutilized
+        consolidateAfter: 60s
+      limits:
+        cpu: "100"
+        memory: 400Gi
+  YAML
+
+  depends_on = [kubectl_manifest.nodeclass_custom_networking]
+}

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -14,4 +14,6 @@ locals {
   workspace_environment = element(reverse(split("-", terraform.workspace)), 0)
   cluster_name          = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : terraform.workspace
   cluster_environment   = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
+
+  node_role_name = split("/", data.aws_eks_cluster.cluster.compute_config[0].node_role_arn)[1]
 }

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -16,7 +16,7 @@ module "eks" {
   # enable_cluster_creator_admin_permissions = true ## CP GitHub actions access to cluster, Adds to access entries
   compute_config = {
     enabled    = true
-    node_pools = [] # US-028: no built-in NodePools — all workloads use custom-networking NodePool
+    node_pools = ["system"] # US-028: general-purpose removed — user workloads use custom-networking NodePool only
   }
   enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -16,7 +16,7 @@ module "eks" {
   # enable_cluster_creator_admin_permissions = true ## CP GitHub actions access to cluster, Adds to access entries
   compute_config = {
     enabled    = true
-    node_pools = ["general-purpose", "system"]
+    node_pools = ["system"] # US-028: general-purpose disabled — user workloads use custom-networking NodePool
   }
   enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -16,7 +16,7 @@ module "eks" {
   # enable_cluster_creator_admin_permissions = true ## CP GitHub actions access to cluster, Adds to access entries
   compute_config = {
     enabled    = true
-    node_pools = ["system"] # US-028: general-purpose disabled — user workloads use custom-networking NodePool
+    node_pools = [] # US-028: no built-in NodePools — all workloads use custom-networking NodePool
   }
   enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -19,3 +19,21 @@ resource "null_resource" "created_by_tag" {
     ignore_changes = [triggers["created_by"]]
   }
 }
+
+variable "enable_argocd" {
+  type        = bool
+  default     = false
+  description = "Enable the EKS Capability for Argo CD on this cluster (hub cluster role)."
+}
+
+variable "argocd_idc_instance_arn" {
+  type        = string
+  default     = "" # Set to your org's IAM Identity Center instance ARN
+  description = "ARN of the AWS IAM Identity Center instance for Argo CD authentication. Required when enable_argocd is true."
+}
+
+variable "argocd_idc_region" {
+  type        = string
+  default     = "eu-west-2"
+  description = "Region of the IAM Identity Center instance."
+}


### PR DESCRIPTION
Implements CNI Custom Networking for EKS Auto Mode using the NodeClass podSubnetSelectorTerms mechanism. Pods get IPs from the secondary CIDR (100.64.x.x) instead of the primary CIDR (10.x.x.x), enabling the platform to scale to 18+ clusters without IP exhaustion.

Changes
**cni-custom-networking.tf**
 — new file deploying a custom NodeClass and NodePool via kubectl_manifest. NodeClass directs pod ENIs to secondary CIDR subnets (SubnetType=pod-private), node ENIs to primary CIDR subnets (SubnetType=Private).

**locals.tf**
 — added node_role_name local (extracted from cluster's computeConfig.nodeRoleArn).

**eks-cluster.tf**
 — removed general-purpose from node_pools (retained system only). Prevents user workloads landing on nodes with primary CIDR IPs.

**variables.tf**
— (Unrelated to ticket) added missing ArgoCD variable declarations to unblock pipeline. These are identical to feature/US-015a-Hub-Cluster and can be dropped from this PR once that branch merges.


Validated
Deployed and tested on fresh cluster cp-0707-1751:

All workload pods get 100.66.x.x IPs ✓
Prefix delegation active (/28 prefixes on pod ENIs) ✓
Cross-AZ pod communication works (1.9ms) ✓
TGW routing to centralised VPC endpoints works (DNS resolves to private IPs, HTTPS succeeds) ✓
Instance types: c6a.large (c family, gen 6, on-demand) ✓
system NodePool deploys 0 nodes ✓