### PR TITLE
Fix DPR cross account trust policy

### DIFF
--- a/terraform/environments/digital-prison-reporting/cross-account.tf
+++ b/terraform/environments/digital-prison-reporting/cross-account.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "dataapi_cross_assume" {
     condition {
       test = "StringLike"
       values = [
-        "system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr-dev",
+        "system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr${local.environment_configuration.analytical_platform_runner_suffix}",
         "system:serviceaccount:mwaa:hmpps-cadet-deployer-dpr-development",
       ]
       variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:sub"


### PR DESCRIPTION
This pull request updates the cross-account IAM policy document for the Digital Prison Reporting environment to make the service account name for the actions runner dynamic based on the environment configuration. This change improves flexibility and allows the policy to work across different environments.

IAM policy improvements:

* Updated the `values` array in the `condition` block of the `aws_iam_policy_document.dataapi_cross_assume` resource to use the `analytical_platform_runner_suffix` from `local.environment_configuration`, making the actions runner service account name environment-specific.

For example, in the test environment, the following change is applied:
`"system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr-dev" -> "system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr-test"`