### PR TITLE
feat: add gateway api module to core

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/gateway.tf
+++ b/terraform/environments/cloud-platform/cluster-core/gateway.tf
@@ -1,3 +1,19 @@
+# Base envoy installation, includes gateway api CRDs
 module "envoy_gateway" {
   source = "github.com/ministryofjustice/container-platform-terraform-envoy-gateway?ref=1.0.0"
+
+  depends_on = [module.gatekeeper]
+}
+
+# Gateway resources (Gateway, GatewayClass, ListenerSet, etc)
+module "gateway_api" {
+  source = "github.com/ministryofjustice/container-platform-terraform-gateway-api?ref=1.0.0"
+
+  lb_name_prefix      = local.workspace_slug
+  cluster_base_domain = local.cluster_domain
+
+  gateway_name         = "default"
+  envoy_proxy_replicas = 3
+
+  depends_on = [module.envoy_gateway, module.cert_manager, module.external_dns]
 }

--- a/terraform/environments/cloud-platform/cluster-core/locals.tf
+++ b/terraform/environments/cloud-platform/cluster-core/locals.tf
@@ -16,4 +16,10 @@ locals {
   cluster_environment   = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 
   node_role_name = split("/", data.aws_eks_cluster.cluster.compute_config[0].node_role_arn)[1]
+
+  base_domain = "container-platform.service.justice.gov.uk"
+
+  # Double trimprefix due to mix of cloud-platform- and container-platform- prefixes
+  workspace_slug = trimprefix(trimprefix(terraform.workspace, "cloud-platform-"), "container-platform-")
+  cluster_domain = contains(local.mp_environments, terraform.workspace) ? "${local.workspace_slug}.${local.base_domain}" : "${local.cluster_name}.development.${local.base_domain}"
 }


### PR DESCRIPTION
Adds new gateway-api module to create the gateway resources which should allow network connectivity into all clusters by provisioning an NLB.

The NLB will have a wildcard listener for each cluster, which provisions a TLS secret via a cert manager annotation, with the following pattern:

**Business Units**
- `*.octo-nonlive.container-platform.service.justice.gov.uk`
- `*.octo-live.container-platform.service.justice.gov.uk`
- `*.laa-nonlive.container-platform.service.justice.gov.uk`
- `*.laa-live.container-platform.service.justice.gov.uk`
- `*.hmpps-nonlive.container-platform.service.justice.gov.uk`
- `*.hmpps-live.container-platform.service.justice.gov.uk`

**Development Clusters** 
- `*.cp-1234-1234.development.container-platform.service.justice.gov.uk`

**nonlive, preprod and prod**

- `*.preproduction.container-platform.service.justice.gov.uk`
- `*.nonlive.container-platform.service.justice.gov.uk`
- `*.live.container-platform.service.justice.gov.uk`

If a user workload has a `ListenerSet` pointing to the shared `Gateway` named `default` with a hostname that falls into one of the above, then routing and TLS should be provided automatically through external-dns and cert-manager.

Includes Envoy Gateway's support for dynamic modules, so we can provision a coraza WAF with an `EnvoyExtensionPolicy` at either Gateway or HTTPRoute level.

Also adds a depends_on to the envoy-gateway module for gatekeeper to avoid a race condition in cluster provisioning.