### PR TITLE
Add missing role to trust statement

### DIFF
--- a/terraform/environments/cloud-platform/oidc.tf
+++ b/terraform/environments/cloud-platform/oidc.tf
@@ -280,12 +280,21 @@ module "github_actions_container_platform_identity_oidc_role_plan" {
 
 data "aws_iam_policy_document" "github_actions_container_platform_identity_oidc_policy_plan" {
   statement {
-    sid    = "AssumeContainerPlatformReadOnlyRole"
+    sid    = "AssumeSSOReadOnlyRole"
     effect = "Allow"
     actions = [
       "sts:AssumeRole"
     ]
     resources = ["arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ContainerPlatformSSOReadOnly"]
+  }
+
+  statement {
+    sid    = "AssumeModernisationPlatformReadOnlyRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"]
   }
 
   statement {
@@ -338,12 +347,21 @@ module "github_actions_container_platform_identity_oidc_role_apply" {
 
 data "aws_iam_policy_document" "github_actions_container_platform_identity_oidc_policy_apply" {
   statement {
-    sid    = "AssumeContainerPlatformReadOnlyRole"
+    sid    = "AssumeSSOAdminRole"
     effect = "Allow"
     actions = [
       "sts:AssumeRole"
     ]
     resources = ["arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ContainerPlatformSSOAdministrator"]
+  }
+
+  statement {
+    sid    = "AssumeModernisationPlatformReadOnlyRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["arn:aws:iam::${data.aws_ssm_parameter.modernisation_platform_account_id.value}:role/modernisation-account-limited-read-member-access"]
   }
 
   statement {


### PR DESCRIPTION
Identity plan was failing because the role cannot assume this role.