### PR TITLE
feat(terraform): add ingestion egress bucket and lot-scoped transfer access

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-ingestion/environment-configuration.tf
@@ -179,6 +179,20 @@ locals {
           egress_bucket         = try(module.shared_services_client_team_gov_29148_egress_bucket[0].s3_bucket_id, null)
           egress_bucket_kms_key = try(module.shared_services_client_team_gov_29148_egress_kms[0].key_arn, null)
         }
+        "wsm-access-lot1" = {
+          ssh_key               = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdW8CETshyJErMuSaL9gL6+2MKl7nLtbC/mrUUyr4a1"
+          cidr_blocks           = ["100.64.15.107/32"]
+          egress_bucket         = try(module.property_datahub_staging_egress_bucket[0].s3_bucket_id, null)
+          egress_bucket_kms_key = try(module.property_datahub_staging_egress_kms[0].key_arn, null)
+          egress_folder_path    = "lot1"
+        }
+        "wsm-access-lot2" = {
+          ssh_key               = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdW8CETshyJErMuSaL9gL6+2MKl7nLtbC/mrUUyr4a1"
+          cidr_blocks           = ["100.64.15.107/32"]
+          egress_bucket         = try(module.property_datahub_staging_egress_bucket[0].s3_bucket_id, null)
+          egress_bucket_kms_key = try(module.property_datahub_staging_egress_kms[0].key_arn, null)
+          egress_folder_path    = "lot2"
+        }
       }
 
       /* DataSync */

--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -322,3 +322,34 @@ module "shared_services_client_team_gov_29148_egress_kms" {
   ]
   deletion_window_in_days = 7
 }
+
+module "property_datahub_staging_egress_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  count = local.is-production ? 1 : 0
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "4.2.0"
+
+  aliases               = ["s3/property-datahub-staging-egress"]
+  description           = "Property Datahub Staging Egress"
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowAnalyticalPlatformDataProduction"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
+        }
+      ]
+    }
+  ]
+  deletion_window_in_days = 7
+}

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/main.tf
@@ -1,5 +1,9 @@
 # tflint-ignore-file: terraform_required_version, terraform_required_providers
 
+locals {
+  egress_folder_path = coalesce(var.egress_folder_path, var.name)
+}
+
 data "aws_iam_policy_document" "this" {
   statement {
     sid    = "AllowKMS"
@@ -43,7 +47,7 @@ data "aws_iam_policy_document" "this" {
       "s3:GetObjectAcl",
       "s3:GetObjectVersion"
     ]
-    resources = ["arn:aws:s3:::${var.egress_bucket}/${var.name}/*"]
+    resources = ["arn:aws:s3:::${var.egress_bucket}/${local.egress_folder_path}/*"]
   }
 }
 
@@ -99,7 +103,7 @@ resource "aws_transfer_user" "this" {
 
   home_directory_mappings {
     entry  = "/download"
-    target = "/${var.egress_bucket}/${var.name}"
+    target = "/${var.egress_bucket}/${local.egress_folder_path}"
   }
 }
 

--- a/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/variables.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/transfer-family/user-with-egress/variables.tf
@@ -26,6 +26,11 @@ variable "egress_bucket_kms_key" {
   type = string
 }
 
+variable "egress_folder_path" {
+  type    = string
+  default = null
+}
+
 variable "supplier_data_kms_key" {
   type = string
 }

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -580,3 +580,72 @@ module "shared_services_client_team_gov_29148_egress_bucket" {
     }
   }
 }
+
+data "aws_iam_policy_document" "property_datahub_staging_egress" {
+
+  count = local.is-production ? 1 : 0
+
+  statement {
+    sid    = "ReplicationPermissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
+    }
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:GetObjectVersionTagging",
+      "s3:ReplicateTags",
+      "s3:ReplicateDelete"
+    ]
+    resources = ["arn:aws:s3:::mojap-ingestion-${local.environment}-property-datahub-staging-egress/*"]
+  }
+
+  statement {
+    sid    = "DenyS3AccessSandbox"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = [local.environment == "development" ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/sandbox" : "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/developer"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-property-datahub-staging-egress/*",
+      "arn:aws:s3:::mojap-ingestion-${local.environment}-property-datahub-staging-egress"
+    ]
+  }
+}
+
+#tfsec:ignore:avd-aws-0088 - The bucket policy is attached to the bucket
+#tfsec:ignore:avd-aws-0132 - The bucket policy is attached to the bucket
+module "property_datahub_staging_egress_bucket" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  count = local.is-production ? 1 : 0
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.13.0"
+
+  bucket = "mojap-ingestion-${local.environment}-property-datahub-staging-egress"
+
+  force_destroy = true
+  attach_policy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  policy = data.aws_iam_policy_document.property_datahub_staging_egress[0].json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.property_datahub_staging_egress_kms[0].key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/transfer-user.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-user.tf
@@ -25,5 +25,6 @@ module "sftp_users_with_egress" {
   landing_bucket_kms_key = module.s3_landing_kms.key_arn
   egress_bucket          = each.value.egress_bucket
   egress_bucket_kms_key  = each.value.egress_bucket_kms_key
+  egress_folder_path     = try(each.value.egress_folder_path, each.key)
   supplier_data_kms_key  = module.supplier_data_kms.key_arn
 }


### PR DESCRIPTION
## Summary
This PR updates Analytical Platform Ingestion transfer egress configuration to support folder specific download isolation while keeping existing production users backwards compatible.

This PR relates to [this](https://github.com/ministryofjustice/data-platform-support/issues/1669) request.

I've tested the refactor to the egress module in isolation, there were no changes, as expected. So I am confident this won't effect any existing egress users.

## Why
- We need Transfer Family users to be able to download and be mapped to specific folders in egress buckets.
- Existing egress users must continue to work without migration.

## What changed
### 1) Add new ingestion egress bucket and KMS for property datahub staging
- Added production-gated KMS key module for the new egress bucket.
- Added production-gated S3 egress bucket module with:
  - KMS encryption
  - versioning
  - bucket policy including replication permissions and deny-sandbox policy pattern used elsewhere in this environment.

### 2) Add folder override support for Transfer users with egress
- Added optional `egress_folder_path` input to `user-with-egress` module.
- Introduced local fallback logic:
  - use `egress_folder_path` when set
  - fallback to username for unchanged behaviour.
- Updated IAM read scope for egress objects to use resolved folder path.
- Updated `/download` home-directory mapping to use resolved folder path.
- Passed `egress_folder_path` from environment config in `transfer-user.tf` with fallback to username.

### 3) Created WSM users with lot-specific folders
  - `wsm-lot1` mapped to folder `lot1`
  - `wsm-lot2` mapped to folder `lot2`
- Both users use the new ingestion egress bucket/KMS module outputs.

## Behaviour notes
- Existing production egress users (for example `essex-police`, `cgi-ssct-sop`) are unaffected because folder mapping defaults to username when `egress_folder_path` is not set.

Replication will still need to be setup between the bucket here and the source but this will be done in another PR. 
