### PR TITLE
ingestion: correct permissions

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/kms-keys.tf
+++ b/terraform/environments/analytical-platform-ingestion/kms-keys.tf
@@ -346,7 +346,14 @@ module "property_datahub_staging_egress_kms" {
       principals = [
         {
           type        = "AWS"
-          identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
+          identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:root"]
+        }
+      ]
+      conditions = [
+        {
+          test     = "ArnLike"
+          variable = "aws:PrincipalArn"
+          values   = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
         }
       ]
     }

--- a/terraform/environments/analytical-platform-ingestion/s3.tf
+++ b/terraform/environments/analytical-platform-ingestion/s3.tf
@@ -590,7 +590,12 @@ data "aws_iam_policy_document" "property_datahub_staging_egress" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
+      identifiers = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:root"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/mojap-data-production-property-datahub-staging-egress"]
     }
     actions = [
       "s3:ReplicateObject",


### PR DESCRIPTION
These correct permissions which were causing failures in apply.

These will be further locked down as replication is sorted between the accounts. 