### PR TITLE
DMS User data production read needs to be taken from ADG Standby

### DIFF
--- a/terraform/environments/delius-core/locals_production.tf
+++ b/terraform/environments/delius-core/locals_production.tf
@@ -191,7 +191,7 @@ locals {
       write_database = "PRDNDA"
     }
     user_source_endpoint = { 
-      read_host     = "primarydb"
+      read_host     = "standbydb2"
       read_database = "PRDNDAS2"
     }
     user_target_endpoint = {}


### PR DESCRIPTION
This pull request makes a small change to the `locals_production.tf` file, updating the `read_host` value for the `user_source_endpoint`. The new host is now `standbydb2` instead of `primarydb`.  This is intended to allow the DMS task which replications users from the production Delius database to other live-like environments source this data from a standby database instead of the primary database which reduces the load on the primary database.