### PR TITLE
Update cross-account configuration

### DIFF
--- a/terraform/environments/digital-prison-reporting/cross-account.tf
+++ b/terraform/environments/digital-prison-reporting/cross-account.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "dataapi_cross_assume" {
       test = "StringLike"
       values = [
         "system:serviceaccount:actions-runners:actions-runner-mojas-create-a-derived-table-dpr${local.environment_configuration.analytical_platform_runner_suffix}",
-        "system:serviceaccount:mwaa:hmpps-cadet-deployer-dpr-development",
+        "system:serviceaccount:mwaa:hmpps-cadet-deployer-dpr${local.environment_configuration.analytical_platform_runner_suffix}",
       ]
       variable = "oidc.eks.eu-west-2.amazonaws.com/id/${jsondecode(data.aws_secretsmanager_secret_version.dbt_secrets.secret_string)["oidc_cluster_identifier"]}:sub"
     }


### PR DESCRIPTION
This pull request updates the IAM policy document to ensure consistency in service account naming conventions for cross-account access. The main change is to make the `mwaa` service account name dynamic based on the environment configuration, aligning it with how the `actions-runner` service account is handled.

**IAM Policy Updates:**

* Updated the `mwaa` service account name in the `aws_iam_policy_document.dataapi_cross_assume` resource to use the `analytical_platform_runner_suffix` variable, ensuring environment-specific naming and reducing hardcoding.