### PR TITLE
feat: add managed file transfer event schemas 📬

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionCompleted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionCompleted.v1.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileActionExecutionCompleted.v1",
+  "description": "A requested file action has completed with a terminal outcome.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileActionExecutionCompleted.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt"],
+              "properties": {
+                "file": {"$ref": "#/definitions/file"},
+                "actionDefinitionId": {"type": "string", "minLength": 1},
+                "actionExecutionId": {"type": "string", "format": "uuid"},
+                "status": {"type": "string", "enum": ["succeeded"]},
+                "completedAt": {"type": "string", "format": "date-time"},
+                "result": {"type": "object"}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt", "failure"],
+              "properties": {
+                "file": {"$ref": "#/definitions/file"},
+                "actionDefinitionId": {"type": "string", "minLength": 1},
+                "actionExecutionId": {"type": "string", "format": "uuid"},
+                "status": {"type": "string", "enum": ["failed"]},
+                "completedAt": {"type": "string", "format": "date-time"},
+                "failure": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["code", "message"],
+                  "properties": {
+                    "code": {"type": "string", "minLength": 1},
+                    "message": {"type": "string", "minLength": 1},
+                    "retryable": {"type": "boolean"}
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "6cf0aa2e-1df5-42a8-99f7-4b8b8df9c4f3",
+      "detail-type": "FileActionExecutionCompleted.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:05:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "2bd32cbb-c3e2-4b62-8b53-90ea0a7a4de5",
+          "idempotencyKey": "action-complete:b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "actionDefinitionId": "send-to-consumer",
+          "actionExecutionId": "b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f",
+          "status": "succeeded",
+          "completedAt": "2026-07-10T14:05:00Z",
+          "result": {
+            "consumer": "consumer-a"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionCompleted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionCompleted.v1.json
@@ -4,7 +4,7 @@
   "description": "A requested file action has completed with a terminal outcome.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -66,7 +67,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -92,7 +93,9 @@
       "id": "6cf0aa2e-1df5-42a8-99f7-4b8b8df9c4f3",
       "detail-type": "FileActionExecutionCompleted.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:05:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionRequested.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionRequested.v1.json
@@ -4,7 +4,7 @@
   "description": "A routed file has matched a configured follow-up action and execution has been requested.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -39,7 +40,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -65,7 +66,9 @@
       "id": "2bd32cbb-c3e2-4b62-8b53-90ea0a7a4de5",
       "detail-type": "FileActionExecutionRequested.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:04:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionRequested.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileActionExecutionRequested.v1.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileActionExecutionRequested.v1",
+  "description": "A routed file has matched a configured follow-up action and execution has been requested.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileActionExecutionRequested.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "actionDefinitionId", "actionExecutionId", "requestedAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "actionDefinitionId": {"type": "string", "minLength": 1},
+            "actionExecutionId": {"type": "string", "format": "uuid"},
+            "requestedAt": {"type": "string", "format": "date-time"},
+            "parameters": {"type": "object"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "2bd32cbb-c3e2-4b62-8b53-90ea0a7a4de5",
+      "detail-type": "FileActionExecutionRequested.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:04:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+          "idempotencyKey": "action-request:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501:send-to-consumer"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "actionDefinitionId": "send-to-consumer",
+          "actionExecutionId": "b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f",
+          "requestedAt": "2026-07-10T14:04:00Z",
+          "parameters": {
+            "endpoint": "consumer-a"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileManualInterventionRequired.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileManualInterventionRequired.v1.json
@@ -4,7 +4,7 @@
   "description": "A file cannot continue through automated processing and requires manual intervention.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -47,7 +48,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -73,7 +74,9 @@
       "id": "b6a791a8-cada-4fa0-9f49-26e25d4531ce",
       "detail-type": "FileManualInterventionRequired.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:06:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileManualInterventionRequired.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileManualInterventionRequired.v1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileManualInterventionRequired.v1",
+  "description": "A file cannot continue through automated processing and requires manual intervention.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileManualInterventionRequired.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "reasonCode", "description", "requiredAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "actionExecutionId": {"type": "string", "format": "uuid"},
+            "reasonCode": {
+              "type": "string",
+              "enum": [
+                "ACTION_FAILED",
+                "INVESTIGATION_REQUIRED",
+                "UNSUPPORTED_SCAN_RESULT",
+                "PROCESSING_ERROR"
+              ]
+            },
+            "description": {"type": "string", "minLength": 1},
+            "requiredAt": {"type": "string", "format": "date-time"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "b6a791a8-cada-4fa0-9f49-26e25d4531ce",
+      "detail-type": "FileManualInterventionRequired.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:06:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+          "idempotencyKey": "manual-intervention:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "investigation",
+            "key": "example/report.csv",
+            "versionId": "6Oj...",
+            "sizeBytes": 4096
+          },
+          "reasonCode": "INVESTIGATION_REQUIRED",
+          "description": "The object was routed to investigation after an inconclusive malware scan.",
+          "requiredAt": "2026-07-10T14:06:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileReceived.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileReceived.v1.json
@@ -9,7 +9,9 @@
     "id",
     "detail-type",
     "source",
+    "account",
     "time",
+    "region",
     "detail"
   ],
   "properties": {
@@ -45,6 +47,10 @@
       "items": {
         "type": "string"
       }
+    },
+    "replay-name": {
+      "type": "string",
+      "minLength": 1
     },
     "detail": {
       "type": "object",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileReceived.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileReceived.v1.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileReceived.v1",
+  "description": "A complete, versioned object has been accepted at the managed file transfer ingress boundary and is eligible for automated processing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "id",
+    "detail-type",
+    "source",
+    "time",
+    "detail"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0"]
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "detail-type": {
+      "type": "string",
+      "enum": ["FileReceived.v1"]
+    },
+    "source": {
+      "type": "string",
+      "enum": ["uk.gov.justice.service.managed-file-transfer"]
+    },
+    "account": {
+      "type": "string",
+      "pattern": "^[0-9]{12}$"
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "region": {
+      "type": "string"
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/eventMetadata"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file"],
+          "properties": {
+            "file": {
+              "$ref": "#/definitions/file"
+            },
+            "provenance": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "clientId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "transferTicket": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ingressMethod": {
+                  "type": "string",
+                  "enum": ["s3", "transfer-family", "api"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "causationId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "bucket": {
+          "type": "string",
+          "minLength": 3
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "versionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+      "detail-type": "FileReceived.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:00:00Z",
+      "region": "eu-west-2",
+      "resources": ["arn:aws:s3:::incoming/example/report.csv"],
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "idempotencyKey": "incoming/example/report.csv:3Lg..."
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "incoming",
+            "key": "example/report.csv",
+            "versionId": "3Lg...",
+            "sizeBytes": 4096
+          },
+          "provenance": {
+            "ingressMethod": "s3",
+            "clientId": "example-client"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileRouted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileRouted.v1.json
@@ -4,7 +4,7 @@
   "description": "A processing object has been moved to a destination based on its malware scan result and the source has been deleted.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -24,6 +25,26 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["sourceFile", "destinationFile", "route", "scanResultStatus", "sourceDeleted"],
+          "oneOf": [
+            {
+              "properties": {
+                "route": {"enum": ["clean"]},
+                "scanResultStatus": {"enum": ["NO_THREATS_FOUND"]}
+              }
+            },
+            {
+              "properties": {
+                "route": {"enum": ["quarantine"]},
+                "scanResultStatus": {"enum": ["THREATS_FOUND"]}
+              }
+            },
+            {
+              "properties": {
+                "route": {"enum": ["investigation"]},
+                "scanResultStatus": {"enum": ["UNSUPPORTED", "ACCESS_DENIED", "FAILED"]}
+              }
+            }
+          ],
           "properties": {
             "sourceFile": {"$ref": "#/definitions/file"},
             "destinationFile": {"$ref": "#/definitions/file"},
@@ -42,7 +63,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -68,7 +89,9 @@
       "id": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
       "detail-type": "FileRouted.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:03:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileRouted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileRouted.v1.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileRouted.v1",
+  "description": "A processing object has been moved to a destination based on its malware scan result and the source has been deleted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileRouted.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceFile", "destinationFile", "route", "scanResultStatus", "sourceDeleted"],
+          "properties": {
+            "sourceFile": {"$ref": "#/definitions/file"},
+            "destinationFile": {"$ref": "#/definitions/file"},
+            "route": {"type": "string", "enum": ["clean", "quarantine", "investigation"]},
+            "scanResultStatus": {
+              "type": "string",
+              "enum": ["NO_THREATS_FOUND", "THREATS_FOUND", "UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
+            },
+            "sourceDeleted": {"type": "boolean", "enum": [true]}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+      "detail-type": "FileRouted.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:03:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "c5dc9cb4-3b1f-4f01-a4c6-41b30e11d790",
+          "idempotencyKey": "route:clean:example/report.csv:4Mh..."
+        },
+        "data": {
+          "sourceFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "destinationFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "route": "clean",
+          "scanResultStatus": "NO_THREATS_FOUND",
+          "sourceDeleted": true
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileScanResultRecorded.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileScanResultRecorded.v1.json
@@ -4,7 +4,7 @@
   "description": "GuardDuty Malware Protection for S3 has recorded a scan result for a processing object.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -40,7 +41,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -66,7 +67,9 @@
       "id": "c5dc9cb4-3b1f-4f01-a4c6-41b30e11d790",
       "detail-type": "FileScanResultRecorded.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:02:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileScanResultRecorded.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileScanResultRecorded.v1.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileScanResultRecorded.v1",
+  "description": "GuardDuty Malware Protection for S3 has recorded a scan result for a processing object.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileScanResultRecorded.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "scanResultStatus", "recordedAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "scanResultStatus": {
+              "type": "string",
+              "enum": ["NO_THREATS_FOUND", "THREATS_FOUND", "UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
+            },
+            "recordedAt": {"type": "string", "format": "date-time"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "c5dc9cb4-3b1f-4f01-a4c6-41b30e11d790",
+      "detail-type": "FileScanResultRecorded.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:02:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "6dce6b40-6e43-49f0-a2cf-1da1d43bce22",
+          "idempotencyKey": "scan:processing:example/report.csv:4Mh..."
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "scanResultStatus": "NO_THREATS_FOUND",
+          "recordedAt": "2026-07-10T14:02:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schema/FileStagedForScanning.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileStagedForScanning.v1.json
@@ -4,7 +4,7 @@
   "description": "A file has been copied to the processing bucket, verified, and removed from its source.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
   "properties": {
     "version": {"type": "string", "enum": ["0"]},
     "id": {"type": "string", "format": "uuid"},
@@ -14,6 +14,7 @@
     "time": {"type": "string", "format": "date-time"},
     "region": {"type": "string"},
     "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
     "detail": {
       "type": "object",
       "additionalProperties": false,
@@ -27,8 +28,8 @@
           "properties": {
             "sourceFile": {"$ref": "#/definitions/file"},
             "stagedFile": {"$ref": "#/definitions/file"},
-            "metadataVerified": {"type": "boolean"},
-            "tagsVerified": {"type": "boolean"},
+            "metadataVerified": {"type": "boolean", "enum": [true]},
+            "tagsVerified": {"type": "boolean", "enum": [true]},
             "sourceDeleted": {"type": "boolean", "enum": [true]}
           }
         }
@@ -39,7 +40,7 @@
     "eventMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["correlationId", "idempotencyKey"],
+      "required": ["correlationId", "causationId", "idempotencyKey"],
       "properties": {
         "correlationId": {"type": "string", "format": "uuid"},
         "causationId": {"type": "string", "format": "uuid"},
@@ -65,7 +66,9 @@
       "id": "6dce6b40-6e43-49f0-a2cf-1da1d43bce22",
       "detail-type": "FileStagedForScanning.v1",
       "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
       "time": "2026-07-10T14:01:00Z",
+      "region": "eu-west-2",
       "detail": {
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",

--- a/terraform/environments/integration-hub-file-transfer/schema/FileStagedForScanning.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schema/FileStagedForScanning.v1.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileStagedForScanning.v1",
+  "description": "A file has been copied to the processing bucket, verified, and removed from its source.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "time", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileStagedForScanning.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceFile", "stagedFile", "metadataVerified", "tagsVerified", "sourceDeleted"],
+          "properties": {
+            "sourceFile": {"$ref": "#/definitions/file"},
+            "stagedFile": {"$ref": "#/definitions/file"},
+            "metadataVerified": {"type": "boolean"},
+            "tagsVerified": {"type": "boolean"},
+            "sourceDeleted": {"type": "boolean", "enum": [true]}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "6dce6b40-6e43-49f0-a2cf-1da1d43bce22",
+      "detail-type": "FileStagedForScanning.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "time": "2026-07-10T14:01:00Z",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "idempotencyKey": "processing/example/report.csv:3Lg..."
+        },
+        "data": {
+          "sourceFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "incoming",
+            "key": "example/report.csv",
+            "versionId": "3Lg...",
+            "sizeBytes": 4096
+          },
+          "stagedFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "metadataVerified": true,
+          "tagsVerified": true,
+          "sourceDeleted": true
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/versions.tf
+++ b/terraform/environments/integration-hub-file-transfer/versions.tf
@@ -4,22 +4,9 @@ terraform {
       version = "~> 6.0"
       source  = "hashicorp/aws"
     }
-    # Retained until the Lambda resources have been removed from state.
-    external = {
-      version = "2.4.0"
-      source  = "hashicorp/external"
-    }
     http = {
       version = "~> 3.0"
       source  = "hashicorp/http"
-    }
-    local = {
-      version = "2.9.0"
-      source  = "hashicorp/local"
-    }
-    null = {
-      version = "3.3.0"
-      source  = "hashicorp/null"
     }
   }
   required_version = "~> 1.0"

--- a/terraform/environments/integration-hub-file-transfer/versions.tf
+++ b/terraform/environments/integration-hub-file-transfer/versions.tf
@@ -4,9 +4,22 @@ terraform {
       version = "~> 6.0"
       source  = "hashicorp/aws"
     }
+    # Retained until the Lambda resources have been removed from state.
+    external = {
+      version = "2.4.0"
+      source  = "hashicorp/external"
+    }
     http = {
       version = "~> 3.0"
       source  = "hashicorp/http"
+    }
+    local = {
+      version = "2.9.0"
+      source  = "hashicorp/local"
+    }
+    null = {
+      version = "3.3.0"
+      source  = "hashicorp/null"
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
## What does this PR do? 🚚

Adds seven canonical JSON Schema Draft 4 contracts for the managed file transfer lifecycle described in [integration-hub#113](https://github.com/ministryofjustice/integration-hub/issues/113):

- `FileReceived.v1`
- `FileStagedForScanning.v1`
- `FileScanResultRecorded.v1`
- `FileRouted.v1`
- `FileActionExecutionRequested.v1`
- `FileActionExecutionCompleted.v1`
- `FileManualInterventionRequired.v1`

## Why? 🔎

These schemas give producers and consumers a stable EventBridge contract while making it easier to follow a file from ingress to its final action. The shared `fileId`, immutable S3 object identity, correlation ID, causation ID and idempotency key provide the audit trail breadcrumbs. 🍞

The schemas also:

- require complete EventBridge account and region metadata
- support EventBridge archive replays via `replay-name` 🔁
- prevent a successful staging event when verification failed
- prevent unsafe route/scan combinations, such as a detected threat reaching `clean` 🦠🚫
- require causation IDs after the root `FileReceived` event

## Future food for thought 🌱

A later iteration could require a SHA-256 content digest to prove byte-for-byte identity across copies, once producers can guarantee it. Action `parameters` and `result` could also become typed per action definition as those contracts settle.

This is a stacked PR against the recreated `chore/remove-lambda-resources` branch so the schema changes stay pleasantly small. ✨
