### PR TITLE
feat: register managed file transfer event schemas

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/eventbridge-schema.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge-schema.tf
@@ -7,7 +7,7 @@ resource "aws_schemas_schema" "this" {
   for_each      = local.eventbridge_schemas
   name          = trimsuffix(basename(each.value), ".json")
   registry_name = aws_schemas_registry.this.name
-  type          = "OpenApi3"
+  type          = "JSONSchemaDraft4"
 
   content = file("${local.eventbridge_schema_directory}/${each.value}")
 }

--- a/terraform/environments/integration-hub-file-transfer/eventbridge-schema.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge-schema.tf
@@ -1,0 +1,13 @@
+resource "aws_schemas_registry" "this" {
+  name        = local.application_name
+  description = "${local.application_name} EventBridge schema registry"
+}
+
+resource "aws_schemas_schema" "this" {
+  for_each      = local.eventbridge_schemas
+  name          = trimsuffix(basename(each.value), ".json")
+  registry_name = aws_schemas_registry.this.name
+  type          = "OpenApi3"
+
+  content = file("${local.eventbridge_schema_directory}/${each.value}")
+}

--- a/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
@@ -1,0 +1,4 @@
+locals {
+  eventbridge_schema_directory = "${path.module}/schemas"
+  eventbridge_schemas          = fileset("${path.module}/schemas", "*.json")
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionCompleted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionCompleted.v1.json
@@ -26,9 +26,14 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt"],
+              "required": ["fileId", "object", "actionDefinitionId", "actionExecutionId", "status", "completedAt"],
               "properties": {
-                "file": {"$ref": "#/definitions/file"},
+                "fileId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Stable logical file identifier inherited from FileReceived.v1."
+                },
+                "object": {"$ref": "#/definitions/s3Object"},
                 "actionDefinitionId": {"type": "string", "minLength": 1},
                 "actionExecutionId": {"type": "string", "format": "uuid"},
                 "status": {"type": "string", "enum": ["succeeded"]},
@@ -39,9 +44,14 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt", "failure"],
+              "required": ["fileId", "object", "actionDefinitionId", "actionExecutionId", "status", "completedAt", "failure"],
               "properties": {
-                "file": {"$ref": "#/definitions/file"},
+                "fileId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Stable logical file identifier inherited from FileReceived.v1."
+                },
+                "object": {"$ref": "#/definitions/s3Object"},
                 "actionDefinitionId": {"type": "string", "minLength": 1},
                 "actionExecutionId": {"type": "string", "format": "uuid"},
                 "status": {"type": "string", "enum": ["failed"]},
@@ -74,12 +84,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -103,8 +113,8 @@
           "idempotencyKey": "action-complete:b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f"
         },
         "data": {
-          "file": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "object": {
             "bucket": "clean",
             "key": "example/report.csv",
             "versionId": "5Ni...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionCompleted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionCompleted.v1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileActionExecutionCompleted.v1",
+  "description": "Object file actions are completed. The requested action has taken place and a concluding succeeded or failed status has been identified.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileActionExecutionCompleted.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt"],
+              "properties": {
+                "file": {"$ref": "#/definitions/file"},
+                "actionDefinitionId": {"type": "string", "minLength": 1},
+                "actionExecutionId": {"type": "string", "format": "uuid"},
+                "status": {"type": "string", "enum": ["succeeded"]},
+                "completedAt": {"type": "string", "format": "date-time"},
+                "result": {"type": "object"}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file", "actionDefinitionId", "actionExecutionId", "status", "completedAt", "failure"],
+              "properties": {
+                "file": {"$ref": "#/definitions/file"},
+                "actionDefinitionId": {"type": "string", "minLength": 1},
+                "actionExecutionId": {"type": "string", "format": "uuid"},
+                "status": {"type": "string", "enum": ["failed"]},
+                "completedAt": {"type": "string", "format": "date-time"},
+                "failure": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["code", "message"],
+                  "properties": {
+                    "code": {"type": "string", "minLength": 1},
+                    "message": {"type": "string", "minLength": 1},
+                    "retryable": {"type": "boolean"}
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "6cf0aa2e-1df5-42a8-99f7-4b8b8df9c4f3",
+      "detail-type": "FileActionExecutionCompleted.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:05:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "2bd32cbb-c3e2-4b62-8b53-90ea0a7a4de5",
+          "idempotencyKey": "action-complete:b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "actionDefinitionId": "send-to-consumer",
+          "actionExecutionId": "b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f",
+          "status": "succeeded",
+          "completedAt": "2026-07-10T14:05:00Z",
+          "result": {
+            "consumer": "consumer-a"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionRequested.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionRequested.v1.json
@@ -24,9 +24,14 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["file", "actionDefinitionId", "actionExecutionId", "requestedAt"],
+          "required": ["fileId", "object", "actionDefinitionId", "actionExecutionId", "requestedAt"],
           "properties": {
-            "file": {"$ref": "#/definitions/file"},
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier inherited from FileReceived.v1."
+            },
+            "object": {"$ref": "#/definitions/s3Object"},
             "actionDefinitionId": {"type": "string", "minLength": 1},
             "actionExecutionId": {"type": "string", "format": "uuid"},
             "requestedAt": {"type": "string", "format": "date-time"},
@@ -47,12 +52,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -76,8 +81,8 @@
           "idempotencyKey": "action-request:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501:send-to-consumer"
         },
         "data": {
-          "file": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "object": {
             "bucket": "clean",
             "key": "example/report.csv",
             "versionId": "5Ni...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionRequested.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileActionExecutionRequested.v1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileActionExecutionRequested.v1",
+  "description": "A routed object has matched a configured follow-up action. The platform has determined that a particular action should be performed and identifies both the configured actionDefinitionId and unique actionExecutionId.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileActionExecutionRequested.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "actionDefinitionId", "actionExecutionId", "requestedAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "actionDefinitionId": {"type": "string", "minLength": 1},
+            "actionExecutionId": {"type": "string", "format": "uuid"},
+            "requestedAt": {"type": "string", "format": "date-time"},
+            "parameters": {"type": "object"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "2bd32cbb-c3e2-4b62-8b53-90ea0a7a4de5",
+      "detail-type": "FileActionExecutionRequested.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:04:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+          "idempotencyKey": "action-request:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501:send-to-consumer"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "actionDefinitionId": "send-to-consumer",
+          "actionExecutionId": "b1d4e7c2-f073-4ed4-9565-a4c31c54bd7f",
+          "requestedAt": "2026-07-10T14:04:00Z",
+          "parameters": {
+            "endpoint": "consumer-a"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileManualInterventionRequired.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileManualInterventionRequired.v1.json
@@ -24,9 +24,14 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["file", "reasonCode", "description", "requiredAt"],
+          "required": ["fileId", "object", "reasonCode", "description", "requiredAt"],
           "properties": {
-            "file": {"$ref": "#/definitions/file"},
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier inherited from FileReceived.v1."
+            },
+            "object": {"$ref": "#/definitions/s3Object"},
             "actionExecutionId": {"type": "string", "format": "uuid"},
             "reasonCode": {
               "type": "string",
@@ -55,12 +60,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -84,8 +89,8 @@
           "idempotencyKey": "manual-intervention:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501"
         },
         "data": {
-          "file": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "object": {
             "bucket": "investigation",
             "key": "example/report.csv",
             "versionId": "6Oj...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileManualInterventionRequired.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileManualInterventionRequired.v1.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileManualInterventionRequired.v1",
+  "description": "An object cannot continue automated processing. An object has failed its requested file actions or ended up in the investigation bucket without an appropriate exception action.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileManualInterventionRequired.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "reasonCode", "description", "requiredAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "actionExecutionId": {"type": "string", "format": "uuid"},
+            "reasonCode": {
+              "type": "string",
+              "enum": [
+                "ACTION_FAILED",
+                "INVESTIGATION_REQUIRED",
+                "UNSUPPORTED_SCAN_RESULT",
+                "PROCESSING_ERROR"
+              ]
+            },
+            "description": {"type": "string", "minLength": 1},
+            "requiredAt": {"type": "string", "format": "date-time"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "b6a791a8-cada-4fa0-9f49-26e25d4531ce",
+      "detail-type": "FileManualInterventionRequired.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:06:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+          "idempotencyKey": "manual-intervention:3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501"
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "investigation",
+            "key": "example/report.csv",
+            "versionId": "6Oj...",
+            "sizeBytes": 4096
+          },
+          "reasonCode": "INVESTIGATION_REQUIRED",
+          "description": "The object was routed to investigation after an inconclusive malware scan.",
+          "requiredAt": "2026-07-10T14:06:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileReceived.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileReceived.v1.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileReceived.v1",
+  "description": "A complete, versioned object has been accepted into the managed file transfer ingress boundary. A file is eligible for automated processing; its identity is its bucket, key and versionId, and its metadata and authoritative size should be read from that object version.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "id",
+    "detail-type",
+    "source",
+    "account",
+    "time",
+    "region",
+    "detail"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0"]
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "detail-type": {
+      "type": "string",
+      "enum": ["FileReceived.v1"]
+    },
+    "source": {
+      "type": "string",
+      "enum": ["uk.gov.justice.service.managed-file-transfer"]
+    },
+    "account": {
+      "type": "string",
+      "pattern": "^[0-9]{12}$"
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "region": {
+      "type": "string"
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "replay-name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/eventMetadata"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file"],
+          "properties": {
+            "file": {
+              "$ref": "#/definitions/file"
+            },
+            "provenance": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "clientId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "transferTicket": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ingressMethod": {
+                  "type": "string",
+                  "enum": ["s3", "transfer-family", "api"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "causationId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "bucket": {
+          "type": "string",
+          "minLength": 3
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "versionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+      "detail-type": "FileReceived.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:00:00Z",
+      "region": "eu-west-2",
+      "resources": ["arn:aws:s3:::incoming/example/report.csv"],
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "idempotencyKey": "incoming/example/report.csv:3Lg..."
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "incoming",
+            "key": "example/report.csv",
+            "versionId": "3Lg...",
+            "sizeBytes": 4096
+          },
+          "provenance": {
+            "ingressMethod": "s3",
+            "clientId": "example-client"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileReceived.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileReceived.v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "FileReceived.v1",
-  "description": "A complete, versioned object has been accepted into the managed file transfer ingress boundary. A file is eligible for automated processing; its identity is its bucket, key and versionId, and its metadata and authoritative size should be read from that object version.",
+  "description": "A complete, versioned object has been accepted into the managed file transfer ingress boundary. fileId is the stable identity of the logical file throughout its MFT lifecycle; object identifies its current S3 object version.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -63,10 +63,15 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["file"],
+          "required": ["fileId", "object"],
           "properties": {
-            "file": {
-              "$ref": "#/definitions/file"
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier generated when the file first enters MFT and reused in every subsequent event."
+            },
+            "object": {
+              "$ref": "#/definitions/s3Object"
             },
             "provenance": {
               "type": "object",
@@ -111,15 +116,12 @@
         }
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {
-          "type": "string",
-          "format": "uuid"
-        },
         "bucket": {
           "type": "string",
           "minLength": 3
@@ -155,8 +157,8 @@
           "idempotencyKey": "incoming/example/report.csv:3Lg..."
         },
         "data": {
-          "file": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "object": {
             "bucket": "incoming",
             "key": "example/report.csv",
             "versionId": "3Lg...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileRouted.v1",
+  "description": "A processing object has been copied to clean, quarantine or investigation; required metadata and GuardDuty status tags have been verified; and the source object was deleted. The managed file transfer flow has moved the object to a destination based on a GuardDuty Malware Protection for S3 scan outcome.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileRouted.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceFile", "destinationFile", "route", "scanResultStatus", "sourceDeleted"],
+          "oneOf": [
+            {
+              "properties": {
+                "route": {"enum": ["clean"]},
+                "scanResultStatus": {"enum": ["NO_THREATS_FOUND"]}
+              }
+            },
+            {
+              "properties": {
+                "route": {"enum": ["quarantine"]},
+                "scanResultStatus": {"enum": ["THREATS_FOUND"]}
+              }
+            },
+            {
+              "properties": {
+                "route": {"enum": ["investigation"]},
+                "scanResultStatus": {"enum": ["UNSUPPORTED", "ACCESS_DENIED", "FAILED"]}
+              }
+            }
+          ],
+          "properties": {
+            "sourceFile": {"$ref": "#/definitions/file"},
+            "destinationFile": {"$ref": "#/definitions/file"},
+            "route": {"type": "string", "enum": ["clean", "quarantine", "investigation"]},
+            "scanResultStatus": {
+              "type": "string",
+              "enum": ["NO_THREATS_FOUND", "THREATS_FOUND", "UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
+            },
+            "sourceDeleted": {"type": "boolean", "enum": [true]}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "aa88e95a-159c-40c1-9e7b-38d00b0b6169",
+      "detail-type": "FileRouted.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:03:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "c5dc9cb4-3b1f-4f01-a4c6-41b30e11d790",
+          "idempotencyKey": "route:clean:example/report.csv:4Mh..."
+        },
+        "data": {
+          "sourceFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "destinationFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "clean",
+            "key": "example/report.csv",
+            "versionId": "5Ni...",
+            "sizeBytes": 4096
+          },
+          "route": "clean",
+          "scanResultStatus": "NO_THREATS_FOUND",
+          "sourceDeleted": true
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
@@ -24,7 +24,7 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["sourceFile", "destinationFile", "route", "scanResultStatus", "sourceDeleted"],
+          "required": ["fileId", "sourceObject", "destinationObject", "route", "scanResultStatus", "sourceDeleted"],
           "oneOf": [
             {
               "properties": {
@@ -46,8 +46,13 @@
             }
           ],
           "properties": {
-            "sourceFile": {"$ref": "#/definitions/file"},
-            "destinationFile": {"$ref": "#/definitions/file"},
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier inherited from FileReceived.v1."
+            },
+            "sourceObject": {"$ref": "#/definitions/s3Object"},
+            "destinationObject": {"$ref": "#/definitions/s3Object"},
             "route": {"type": "string", "enum": ["clean", "quarantine", "investigation"]},
             "scanResultStatus": {
               "type": "string",
@@ -70,12 +75,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -99,15 +104,14 @@
           "idempotencyKey": "route:clean:example/report.csv:4Mh..."
         },
         "data": {
-          "sourceFile": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "sourceObject": {
             "bucket": "processing",
             "key": "example/report.csv",
             "versionId": "4Mh...",
             "sizeBytes": 4096
           },
-          "destinationFile": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "destinationObject": {
             "bucket": "clean",
             "key": "example/report.csv",
             "versionId": "5Ni...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileScanResultRecorded.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileScanResultRecorded.v1.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileScanResultRecorded.v1",
+  "description": "GuardDuty Malware Protection for S3 has produced a scan-result event for the processing object. GuardDuty has recorded a result for the specified object version.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileScanResultRecorded.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "scanResultStatus", "recordedAt"],
+          "properties": {
+            "file": {"$ref": "#/definitions/file"},
+            "scanResultStatus": {
+              "type": "string",
+              "enum": ["NO_THREATS_FOUND", "THREATS_FOUND", "UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
+            },
+            "recordedAt": {"type": "string", "format": "date-time"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "c5dc9cb4-3b1f-4f01-a4c6-41b30e11d790",
+      "detail-type": "FileScanResultRecorded.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:02:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "6dce6b40-6e43-49f0-a2cf-1da1d43bce22",
+          "idempotencyKey": "scan:processing:example/report.csv:4Mh..."
+        },
+        "data": {
+          "file": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "scanResultStatus": "NO_THREATS_FOUND",
+          "recordedAt": "2026-07-10T14:02:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileScanResultRecorded.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileScanResultRecorded.v1.json
@@ -24,9 +24,14 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["file", "scanResultStatus", "recordedAt"],
+          "required": ["fileId", "object", "scanResultStatus", "recordedAt"],
           "properties": {
-            "file": {"$ref": "#/definitions/file"},
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier inherited from FileReceived.v1."
+            },
+            "object": {"$ref": "#/definitions/s3Object"},
             "scanResultStatus": {
               "type": "string",
               "enum": ["NO_THREATS_FOUND", "THREATS_FOUND", "UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
@@ -48,12 +53,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -77,8 +82,8 @@
           "idempotencyKey": "scan:processing:example/report.csv:4Mh..."
         },
         "data": {
-          "file": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "object": {
             "bucket": "processing",
             "key": "example/report.csv",
             "versionId": "4Mh...",

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "FileStagedForScanning.v1",
-  "description": "An object has been copied to the processing bucket, verified, and removed from its source.",
+  "description": "A file has been copied from the incoming bucket to the processing bucket. The source object's metadata and existing tags have been preserved and verified on the processing object, and the source object has been deleted.",
   "type": "object",
   "additionalProperties": false,
   "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
@@ -24,13 +24,30 @@
         "data": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["sourceFile", "stagedFile", "metadataVerified", "tagsVerified", "sourceDeleted"],
+          "required": ["fileId", "sourceObject", "stagedObject", "metadataPreserved", "tagsPreserved", "sourceDeleted"],
           "properties": {
-            "sourceFile": {"$ref": "#/definitions/file"},
-            "stagedFile": {"$ref": "#/definitions/file"},
-            "metadataVerified": {"type": "boolean", "enum": [true]},
-            "tagsVerified": {"type": "boolean", "enum": [true]},
-            "sourceDeleted": {"type": "boolean", "enum": [true]}
+            "fileId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Stable logical file identifier inherited from FileReceived.v1."
+            },
+            "sourceObject": {"$ref": "#/definitions/s3Object"},
+            "stagedObject": {"$ref": "#/definitions/s3Object"},
+            "metadataPreserved": {
+              "type": "boolean",
+              "enum": [true],
+              "description": "The source object's metadata was preserved and verified on the staged object."
+            },
+            "tagsPreserved": {
+              "type": "boolean",
+              "enum": [true],
+              "description": "The source object's pre-scan tags were preserved and verified on the staged object. This does not refer to GuardDuty scan-result tags."
+            },
+            "sourceDeleted": {
+              "type": "boolean",
+              "enum": [true],
+              "description": "The source object version was deleted after the staged object was verified."
+            }
           }
         }
       }
@@ -47,12 +64,12 @@
         "idempotencyKey": {"type": "string", "minLength": 1}
       }
     },
-    "file": {
+    "s3Object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "description": "A particular version of an object stored in Amazon S3.",
+      "required": ["bucket", "key", "versionId", "sizeBytes"],
       "properties": {
-        "fileId": {"type": "string", "format": "uuid"},
         "bucket": {"type": "string", "minLength": 3},
         "key": {"type": "string", "minLength": 1},
         "versionId": {"type": "string", "minLength": 1},
@@ -76,22 +93,21 @@
           "idempotencyKey": "processing/example/report.csv:3Lg..."
         },
         "data": {
-          "sourceFile": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "sourceObject": {
             "bucket": "incoming",
             "key": "example/report.csv",
             "versionId": "3Lg...",
             "sizeBytes": 4096
           },
-          "stagedFile": {
-            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+          "stagedObject": {
             "bucket": "processing",
             "key": "example/report.csv",
             "versionId": "4Mh...",
             "sizeBytes": 4096
           },
-          "metadataVerified": true,
-          "tagsVerified": true,
+          "metadataPreserved": true,
+          "tagsPreserved": true,
           "sourceDeleted": true
         }
       }

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "FileStagedForScanning.v1",
+  "description": "An object has been copied to the processing bucket, verified, and removed from its source.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "id", "detail-type", "source", "account", "time", "region", "detail"],
+  "properties": {
+    "version": {"type": "string", "enum": ["0"]},
+    "id": {"type": "string", "format": "uuid"},
+    "detail-type": {"type": "string", "enum": ["FileStagedForScanning.v1"]},
+    "source": {"type": "string", "enum": ["uk.gov.justice.service.managed-file-transfer"]},
+    "account": {"type": "string", "pattern": "^[0-9]{12}$"},
+    "time": {"type": "string", "format": "date-time"},
+    "region": {"type": "string"},
+    "resources": {"type": "array", "items": {"type": "string"}},
+    "replay-name": {"type": "string", "minLength": 1},
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metadata", "data"],
+      "properties": {
+        "metadata": {"$ref": "#/definitions/eventMetadata"},
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceFile", "stagedFile", "metadataVerified", "tagsVerified", "sourceDeleted"],
+          "properties": {
+            "sourceFile": {"$ref": "#/definitions/file"},
+            "stagedFile": {"$ref": "#/definitions/file"},
+            "metadataVerified": {"type": "boolean", "enum": [true]},
+            "tagsVerified": {"type": "boolean", "enum": [true]},
+            "sourceDeleted": {"type": "boolean", "enum": [true]}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "eventMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correlationId", "causationId", "idempotencyKey"],
+      "properties": {
+        "correlationId": {"type": "string", "format": "uuid"},
+        "causationId": {"type": "string", "format": "uuid"},
+        "idempotencyKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId", "bucket", "key", "versionId", "sizeBytes"],
+      "properties": {
+        "fileId": {"type": "string", "format": "uuid"},
+        "bucket": {"type": "string", "minLength": 3},
+        "key": {"type": "string", "minLength": 1},
+        "versionId": {"type": "string", "minLength": 1},
+        "sizeBytes": {"type": "integer", "minimum": 0}
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "0",
+      "id": "6dce6b40-6e43-49f0-a2cf-1da1d43bce22",
+      "detail-type": "FileStagedForScanning.v1",
+      "source": "uk.gov.justice.service.managed-file-transfer",
+      "account": "123456789012",
+      "time": "2026-07-10T14:01:00Z",
+      "region": "eu-west-2",
+      "detail": {
+        "metadata": {
+          "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "causationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+          "idempotencyKey": "processing/example/report.csv:3Lg..."
+        },
+        "data": {
+          "sourceFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "incoming",
+            "key": "example/report.csv",
+            "versionId": "3Lg...",
+            "sizeBytes": 4096
+          },
+          "stagedFile": {
+            "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+            "bucket": "processing",
+            "key": "example/report.csv",
+            "versionId": "4Mh...",
+            "sizeBytes": 4096
+          },
+          "metadataVerified": true,
+          "tagsVerified": true,
+          "sourceDeleted": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

Register the canonical Managed File Transfer EventBridge schemas.

- add an EventBridge schema registry for the file-transfer environment
- register seven versioned JSON Schema Draft 4 event contracts from the local schema directory
- model each event's stable logical `fileId` separately from the current versioned S3 object
- define a consistent lifecycle from received, through staging and malware scanning, to routing, actions, and manual intervention
- establish consumer-ready contracts ahead of later event producers, EventBridge transformations, custom event buses, and Step Functions workflows

These schemas implement the event definitions in [integration-hub#113](https://github.com/ministryofjustice/integration-hub/issues/113).

## Impact

This is contract and registry groundwork only. It does not introduce event producers, EventBridge rules or transformers, a custom event bus, or consumer workflows. The contracts validate the complete EventBridge envelope and retain stable `fileId` values across the example file lifecycle while S3 bucket, key, and version ID change as the object moves.

## Validation

- `terraform fmt`
- `terraform validate`
- `terraform plan`
- Draft 4 JSON Schema meta-schema validation for all seven contracts
- validation of each embedded schema example

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>