### PR TITLE
fix: resolve ARG_MAX error in signed-commit action

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -23,7 +23,7 @@ jobs:
         run: bash ./scripts/git-setup.sh
 
       - name: Run Format Code Action
-        uses: ministryofjustice/modernisation-platform-github-actions/ministryofjustice/modernisation-platform-github-actions/format-code@91d5c1efbe43e1c8fdfc55fd39e8183fc6be8fa8 # v6.1.1
+        uses: ministryofjustice/modernisation-platform-github-actions/format-code@91d5c1efbe43e1c8fdfc55fd39e8183fc6be8fa8 # v6.1.1
         with:
           APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
           APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)


### PR DESCRIPTION
## Problem

The `signed-commit` action was failing with `jq: Argument list too long` (exit code 126) when building the GraphQL commit payload. As files were processed in the loop, their base64-encoded contents were accumulated in a shell variable (`$files_for_commit`) and passed to `jq` via `echo "$files_for_commit" | jq ...`. With enough files (as produced by the format-code workflow across the full codebase), the variable exceeds the OS `ARG_MAX` limit.

## Fix

The JSON payload is now built entirely on disk using a temp file (`/tmp/files_for_commit.json`), updated in-place on each loop iteration with `jq ... input.json > output.json && mv`. Only the new file's base64 content is passed as a `jq` `--arg`, which is well within argument size limits.

The fix is in [`ministryofjustice/modernisation-platform-github-actions@fix/signed-commit-arg-max`](https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/fix/signed-commit-arg-max).

## Testing

This PR pins the `signed-commit` step to the `fix/signed-commit-arg-max` branch in `modernisation-platform-github-actions` to validate the fix. Once confirmed working, that branch will be merged, released, and the pin updated to the new release SHA.