### PR TITLE
Fix Apex bastion module version

### DIFF
--- a/terraform/environments/apex/bastion.tf
+++ b/terraform/environments/apex/bastion.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.5.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/apex/bastion.tf
+++ b/terraform/environments/apex/bastion.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v4.5.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=V4.5.0"
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/apex/bastion.tf
+++ b/terraform/environments/apex/bastion.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=V4.5.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=e4a3840d4b7b327228d1397bb684bc79cd4e76cb" # v4.5.0
 
   providers = {
     aws.share-host   = aws.core-vpc # core-vpc-(environment) holds the networking for all accounts

--- a/terraform/environments/apex/ec2.tf
+++ b/terraform/environments/apex/ec2.tf
@@ -86,14 +86,16 @@ resource "aws_vpc_security_group_ingress_rule" "db_lambda" {
   to_port                      = 22
 }
 
-resource "aws_vpc_security_group_ingress_rule" "db_bastion" {
-  security_group_id            = aws_security_group.database.id
-  description                  = "Allow Bastion SSH access"
-  referenced_security_group_id = module.bastion_linux.bastion_security_group
-  from_port                    = 22
-  ip_protocol                  = "tcp"
-  to_port                      = 22
-}
+// Temporarily disabled to remove the old bastion SG dependency before the module replacement.
+// Re-enable after the new bastion security group has been created successfully.
+# resource "aws_vpc_security_group_ingress_rule" "db_bastion" {
+#   security_group_id            = aws_security_group.database.id
+#   description                  = "Allow Bastion SSH access"
+#   referenced_security_group_id = module.bastion_linux.bastion_security_group
+#   from_port                    = 22
+#   ip_protocol                  = "tcp"
+#   to_port                      = 22
+# }
 
 resource "aws_vpc_security_group_ingress_rule" "db_workspace" {
   security_group_id = aws_security_group.database.id

--- a/terraform/environments/apex/ec2.tf
+++ b/terraform/environments/apex/ec2.tf
@@ -86,16 +86,14 @@ resource "aws_vpc_security_group_ingress_rule" "db_lambda" {
   to_port                      = 22
 }
 
-// Temporarily disabled to remove the old bastion SG dependency before the module replacement.
-// Re-enable after the new bastion security group has been created successfully.
-# resource "aws_vpc_security_group_ingress_rule" "db_bastion" {
-#   security_group_id            = aws_security_group.database.id
-#   description                  = "Allow Bastion SSH access"
-#   referenced_security_group_id = module.bastion_linux.bastion_security_group
-#   from_port                    = 22
-#   ip_protocol                  = "tcp"
-#   to_port                      = 22
-# }
+resource "aws_vpc_security_group_ingress_rule" "db_bastion" {
+  security_group_id            = aws_security_group.database.id
+  description                  = "Allow Bastion SSH access"
+  referenced_security_group_id = module.bastion_linux.bastion_security_group
+  from_port                    = 22
+  ip_protocol                  = "tcp"
+  to_port                      = 22
+}
 
 resource "aws_vpc_security_group_ingress_rule" "db_workspace" {
   security_group_id = aws_security_group.database.id


### PR DESCRIPTION
This PR updates the Apex bastion module from v4.2.0 to v4.5.0 to fix the Auto Scaling Group launch template failure caused by an AMI/instance architecture mismatch. 