### PR TITLE
Enable DMS Audit Replication in Pre-Prod

### DIFF
--- a/terraform/environments/delius-core/locals_preproduction.tf
+++ b/terraform/environments/delius-core/locals_preproduction.tf
@@ -181,7 +181,7 @@ locals {
   }
 
   dms_config_preprod = {
-    deploy_dms                 = false
+    deploy_dms                 = true
     replication_enabled        = false
     replication_instance_class = "dms.t3.medium"
     engine_version             = "3.5.4"
@@ -192,13 +192,9 @@ locals {
       read_database = "PRENDAS1"
     }
     audit_target_endpoint = {
-      write_environment = "preprod" # Until production exists set dummy replication target
-      write_database    = "NONE"    # Remove this dummy attribute once production target exists
+      write_environment = "prod" 
     }
-    user_source_endpoint = { # Set this map to {} once production exists
-      read_host     = "primarydb"
-      read_database = "NONE"
-    }
+    user_source_endpoint = {}
     user_target_endpoint = {
       write_database = "PRENDA"
     }


### PR DESCRIPTION
This pull request updates the DMS (Database Migration Service) configuration for the preproduction environment in `locals_preproduction.tf`. 
**DMS Deployment Configuration:**
* Enabled DMS deployment in preproduction by setting `deploy_dms` to `true` in the `dms_config_preprod` map.

**Endpoint Settings Updates:**
* Updated the `audit_target_endpoint` to set `write_environment` to `"prod"` and removed the temporary dummy attributes, preparing for the eventual production environment.
* Set `user_source_endpoint` to an empty map, removing the previous placeholder values.