### PR TITLE
ai-gateway: upgrade: 1.90.0 -> 1.92.0

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,7 +1,7 @@
 locals {
   environment_configurations = {
     development = {
-      litellm_version     = "1.90.0"
+      litellm_version     = "1.92.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -59,7 +59,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.90.0"
+      litellm_version     = "1.92.0"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -113,7 +113,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.90.0"
+      litellm_version     = "1.92.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -167,7 +167,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.90.0"
+      litellm_version     = "1.92.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
This PR upgrades the litellm deployment for the AI gateway and data platform services.

https://github.com/BerriAI/litellm/releases#release-v1.92.0