### PR TITLE
Data Platform: Remove kube-system ns from resourceFilters

### DIFF
--- a/terraform/environments/data-platform/cluster/configuration/helm/kyverno/values.yml.tftpl
+++ b/terraform/environments/data-platform/cluster/configuration/helm/kyverno/values.yml.tftpl
@@ -79,7 +79,6 @@ config:
     - fluent-bit
     - karpenter
     - keda
-    - kube-system
     - kyverno
     - metrics-server
     - prometheus


### PR DESCRIPTION
Removing kube-system ns from the resourceFilters since the system namespaces kube-* are already excluded by default from kyverno admission processing.

Relates to the work being done [here](https://github.com/ministryofjustice/data-platform/issues/491)