### PR TITLE
Introduce step function for file transfer workflow

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
@@ -4,7 +4,7 @@ module "cloudwatch_eventbridge" {
 
   name              = "/aws/vendedlogs/events/event-bus/${local.application_name}"
   kms_key_id        = module.kms_cloudwatch_logs.key_arn
-  retention_in_days = local.eventbridge_retention_days
+  retention_in_days = local.cloudwatch_retention_days
 
   tags = local.tags
 }

--- a/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
@@ -44,7 +44,7 @@ There is an important boundary here: Powertools only deduplicates retries of the
 
 Downstream consumers should therefore be idempotent on `fileId` rather than on the EventBridge `id` of the canonical event.
 
-The file-received Step Functions workflow uses a separate DynamoDB record keyed by the canonical event's `detail.metadata.idempotencyKey`, namespaced for the workflow. This is operation-level idempotency: duplicate canonical events for the same bucket, key and version resume or reuse the same durable checkpoints rather than creating another destination version. The record stores the current owner, a short in-progress lease, and copy checkpoints until it expires with the event-retention period.
+The file-transfer Step Functions workflow uses a separate DynamoDB record keyed by the canonical event's `detail.metadata.idempotencyKey`, namespaced for the workflow. This is operation-level idempotency: duplicate canonical events for the same bucket, key and version resume or reuse the same durable checkpoints rather than creating another destination version. The record stores the current owner, a short in-progress lease, and copy checkpoints until it expires with the event-retention period.
 
 The workflow copies the exact S3 version identified by `detail.data.object.versionId` from `incoming` to the same key in `processing`. Objects up to 5 GB use `CopyObject`; larger objects up to 5 TB use resumable multipart copy. The destination version is checked for size, encryption, metadata and tags before the workflow deletes only the exact source version. A failed or expired execution can therefore resume from the last successful checkpoint without deleting a newer source version.
 
@@ -56,7 +56,7 @@ Imagine `finance/april-payroll.csv` arrives in the `incoming` bucket with versio
 
 1. S3 emits a native `Object Created` event with its own EventBridge `id`, call it `native-1`.
 2. The file-received adapter hashes the incoming bucket, key and version ID to produce `file-1`, then publishes `FileReceived.v1`. EventBridge assigns this event `id = eb-1`. The event carries `fileId = file-1`, `correlationId = file-1`, and no `causationId`.
-3. The file-received workflow picks up `FileReceived.v1`, stages the exact object version to `processing/finance/april-payroll.csv`, verifies the destination version, and deletes the exact source version. Publication of `FileStagedForScanning.v1` is outside the current workflow scope.
+3. The file-transfer workflow picks up `FileReceived.v1`, stages the exact object version to `processing/finance/april-payroll.csv`, verifies the destination version, and deletes the exact source version. Publication of `FileStagedForScanning.v1` is outside the current workflow scope.
 
 Once the next lifecycle event is introduced, the scanner and router will continue the canonical chain by copying `fileId` and `correlationId` and setting each event's `causationId` to the preceding EventBridge event ID.
 

--- a/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
@@ -44,6 +44,10 @@ There is an important boundary here: Powertools only deduplicates retries of the
 
 Downstream consumers should therefore be idempotent on `fileId` rather than on the EventBridge `id` of the canonical event.
 
+The file-received Step Functions workflow uses a separate DynamoDB record keyed by the canonical event's `detail.metadata.idempotencyKey`, namespaced for the workflow. This is operation-level idempotency: duplicate canonical events for the same bucket, key and version resume or reuse the same durable checkpoints rather than creating another destination version. The record stores the current owner, a short in-progress lease, and copy checkpoints until it expires with the event-retention period.
+
+The workflow copies the exact S3 version identified by `detail.data.object.versionId` from `incoming` to the same key in `processing`. Objects up to 5 GB use `CopyObject`; larger objects up to 5 TB use resumable multipart copy. The destination version is checked for size, encryption, metadata and tags before the workflow deletes only the exact source version. A failed or expired execution can therefore resume from the last successful checkpoint without deleting a newer source version.
+
 Idempotency records expire after 30 days in non-production environments and 400 days in production, matching event retention.
 
 ## Following a file through the lifecycle
@@ -52,9 +56,9 @@ Imagine `finance/april-payroll.csv` arrives in the `incoming` bucket with versio
 
 1. S3 emits a native `Object Created` event with its own EventBridge `id`, call it `native-1`.
 2. The file-received adapter hashes the incoming bucket, key and version ID to produce `file-1`, then publishes `FileReceived.v1`. EventBridge assigns this event `id = eb-1`. The event carries `fileId = file-1`, `correlationId = file-1`, and no `causationId`.
-3. The scanning component picks up `FileReceived.v1` and stages the file to `processing/finance/april-payroll.csv` (a new S3 key and version). It publishes `FileStagedForScanning.v1` with `id = eb-2`, `fileId = file-1`, `correlationId = file-1`, and `causationId = eb-1`.
-4. The scanner records a clean result and publishes `FileScanResultRecorded.v1` with `id = eb-3` and `causationId = eb-2`.
-5. The router delivers the file and publishes `FileRouted.v1` with `id = eb-4` and `causationId = eb-3`.
+3. The file-received workflow picks up `FileReceived.v1`, stages the exact object version to `processing/finance/april-payroll.csv`, verifies the destination version, and deletes the exact source version. Publication of `FileStagedForScanning.v1` is outside the current workflow scope.
+
+Once the next lifecycle event is introduced, the scanner and router will continue the canonical chain by copying `fileId` and `correlationId` and setting each event's `causationId` to the preceding EventBridge event ID.
 
 At every stage, `fileId` and `correlationId` stay the same. The S3 location changes, the object version changes, and each EventBridge `id` is unique — but you can follow the whole chain.
 

--- a/terraform/environments/integration-hub-file-transfer/dynamodb.tf
+++ b/terraform/environments/integration-hub-file-transfer/dynamodb.tf
@@ -24,3 +24,32 @@ module "dynamodb_idempotency" {
     "update" : "60m"
   }
 }
+
+module "dynamodb_file_received_workflow_idempotency" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.environment}-file-received-workflow-idempotency"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attributes = [
+    {
+      name = "id"
+      type = "S"
+    }
+  ]
+
+  server_side_encryption_enabled     = true
+  server_side_encryption_kms_key_arn = module.kms_dynamodb.key_arn
+  table_class                        = "STANDARD"
+  ttl_attribute_name                 = "expiration"
+  ttl_enabled                        = true
+  timeouts = {
+    "create" : "60m",
+    "delete" : "60m",
+    "update" : "60m"
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub-file-transfer/dynamodb.tf
+++ b/terraform/environments/integration-hub-file-transfer/dynamodb.tf
@@ -25,11 +25,11 @@ module "dynamodb_idempotency" {
   }
 }
 
-module "dynamodb_file_received_workflow_idempotency" {
+module "dynamodb_file_transfer_workflow_idempotency" {
   source  = "terraform-aws-modules/dynamodb-table/aws"
   version = "5.5.0"
 
-  name         = "${local.application_name}-${local.environment}-file-received-workflow-idempotency"
+  name         = "${local.application_name}-${local.environment}-file-transfer-workflow-idempotency"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "id"
 

--- a/terraform/environments/integration-hub-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge.tf
@@ -46,11 +46,11 @@ module "eventbridge_file_transfer_bus" {
   append_rule_postfix = false
 
   attach_sfn_policy = true
-  sfn_target_arns   = [module.step_function_file_received_workflow.state_machine_arn]
+  sfn_target_arns   = [module.step_function_file_transfer_workflow.state_machine_arn]
 
   rules = {
-    "file-received-workflow" = {
-      description = "Start the file received workflow for canonical FileReceived.v1 events"
+    "file-transfer-workflow" = {
+      description = "Start the file transfer workflow for canonical FileReceived.v1 events"
       event_pattern = jsonencode({
         account       = [data.aws_caller_identity.current.account_id]
         source        = ["uk.gov.justice.service.managed-file-transfer"]
@@ -67,12 +67,12 @@ module "eventbridge_file_transfer_bus" {
   }
 
   targets = {
-    "file-received-workflow" = [
+    "file-transfer-workflow" = [
       {
-        name            = "file-received-workflow"
-        arn             = module.step_function_file_received_workflow.state_machine_arn
+        name            = "file-transfer-workflow"
+        arn             = module.step_function_file_transfer_workflow.state_machine_arn
         attach_role_arn = true
-        dead_letter_arn = module.sqs_eventbridge_file_received_workflow_dlq.queue_arn
+        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
         retry_policy = {
           maximum_event_age_in_seconds = 86400
           maximum_retry_attempts       = 185
@@ -84,7 +84,7 @@ module "eventbridge_file_transfer_bus" {
   archives = {
     "${local.application_name}-archive" = {
       description    = "Archive of all file transfer events"
-      retention_days = local.eventbridge_retention_days
+      retention_days = local.cloudwatch_retention_days
     }
   }
 

--- a/terraform/environments/integration-hub-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge.tf
@@ -41,8 +41,45 @@ module "eventbridge_file_transfer_bus" {
   source  = "terraform-aws-modules/eventbridge/aws"
   version = "4.3.0"
 
-  bus_name        = local.application_name
-  create_archives = true
+  bus_name            = local.application_name
+  create_archives     = true
+  append_rule_postfix = false
+
+  attach_sfn_policy = true
+  sfn_target_arns   = [module.step_function_file_received_workflow.state_machine_arn]
+
+  rules = {
+    "file-received-workflow" = {
+      description = "Start the file received workflow for canonical FileReceived.v1 events"
+      event_pattern = jsonencode({
+        account       = [data.aws_caller_identity.current.account_id]
+        source        = ["uk.gov.justice.service.managed-file-transfer"]
+        "detail-type" = ["FileReceived.v1"]
+        detail = {
+          data = {
+            object = {
+              bucket = [module.s3_bucket["incoming"].s3_bucket_id]
+            }
+          }
+        }
+      })
+    }
+  }
+
+  targets = {
+    "file-received-workflow" = [
+      {
+        name            = "file-received-workflow"
+        arn             = module.step_function_file_received_workflow.state_machine_arn
+        attach_role_arn = true
+        dead_letter_arn = module.sqs_eventbridge_file_received_workflow_dlq.queue_arn
+        retry_policy = {
+          maximum_event_age_in_seconds = 86400
+          maximum_retry_attempts       = 185
+        }
+      }
+    ]
+  }
 
   archives = {
     "${local.application_name}-archive" = {

--- a/terraform/environments/integration-hub-file-transfer/lambda.tf
+++ b/terraform/environments/integration-hub-file-transfer/lambda.tf
@@ -6,7 +6,7 @@ module "lambda_file_received_adapter" {
   attach_dead_letter_policy         = true
   attach_tracing_policy             = true
   cloudwatch_logs_kms_key_id        = module.kms_cloudwatch_logs.key_arn
-  cloudwatch_logs_retention_in_days = local.eventbridge_retention_days
+  cloudwatch_logs_retention_in_days = local.cloudwatch_retention_days
   create_async_event_config         = true
   dead_letter_target_arn            = module.sqs_lambda_file_received_adapter_dlq.queue_arn
   description                       = "Transforms incoming S3 Object Created notifications into FileReceived.v1 events"
@@ -24,7 +24,7 @@ module "lambda_file_received_adapter" {
 
   environment_variables = {
     EVENT_BUS_ARN              = module.eventbridge_file_transfer_bus.eventbridge_bus_arn
-    IDEMPOTENCY_EXPIRY_SECONDS = tostring(local.eventbridge_retention_days * 24 * 60 * 60)
+    IDEMPOTENCY_EXPIRY_SECONDS = tostring(local.cloudwatch_retention_days * 24 * 60 * 60)
     IDEMPOTENCY_TABLE          = module.dynamodb_idempotency.dynamodb_table_id
     INCOMING_BUCKET_NAME       = module.s3_bucket["incoming"].s3_bucket_id
     POWERTOOLS_LOG_LEVEL       = "INFO"

--- a/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
@@ -79,6 +79,111 @@ locals {
       statistic          = "Maximum"
       threshold          = 0
     }
+    "eventbridge-file-received-workflow-failed-invocations" = {
+      alarm_description   = "The FileReceived.v1 EventBridge rule has failed to start the file received workflow"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        EventBusName = module.eventbridge_file_transfer_bus.eventbridge_bus_name
+        RuleName     = module.eventbridge_file_transfer_bus.eventbridge_rules["file-received-workflow"].name
+      }
+      evaluation_periods = 1
+      metric_name        = "FailedInvocations"
+      namespace          = "AWS/Events"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "eventbridge-file-received-workflow-dlq-visible-messages" = {
+      alarm_description   = "The file received workflow EventBridge dead-letter queue contains failed events"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        QueueName = module.sqs_eventbridge_file_received_workflow_dlq.queue_name
+      }
+      evaluation_periods = 1
+      metric_name        = "ApproximateNumberOfMessagesVisible"
+      namespace          = "AWS/SQS"
+      period             = 300
+      statistic          = "Maximum"
+      threshold          = 0
+    }
+    "step-functions-file-received-workflow-failures" = {
+      alarm_description   = "The file received workflow has failed one or more executions"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+      }
+      evaluation_periods = 1
+      metric_name        = "ExecutionsFailed"
+      namespace          = "AWS/States"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "step-functions-file-received-workflow-timeouts" = {
+      alarm_description   = "The file received workflow has timed out one or more executions"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+      }
+      evaluation_periods = 1
+      metric_name        = "ExecutionsTimedOut"
+      namespace          = "AWS/States"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "step-functions-file-received-workflow-aborts" = {
+      alarm_description   = "The file received workflow has aborted one or more executions"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+      }
+      evaluation_periods = 1
+      metric_name        = "ExecutionsAborted"
+      namespace          = "AWS/States"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "step-functions-file-received-workflow-throttles" = {
+      alarm_description   = "The file received workflow has experienced state transition throttling"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+      }
+      evaluation_periods = 1
+      metric_name        = "ExecutionThrottled"
+      namespace          = "AWS/States"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "dynamodb-file-received-workflow-idempotency-read-throttles" = {
+      alarm_description   = "The file received workflow idempotency table has throttled one or more read requests"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        TableName = module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id
+      }
+      evaluation_periods = 1
+      metric_name        = "ReadThrottleEvents"
+      namespace          = "AWS/DynamoDB"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
+    "dynamodb-file-received-workflow-idempotency-write-throttles" = {
+      alarm_description   = "The file received workflow idempotency table has throttled one or more write requests"
+      comparison_operator = "GreaterThanThreshold"
+      dimensions = {
+        TableName = module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id
+      }
+      evaluation_periods = 1
+      metric_name        = "WriteThrottleEvents"
+      namespace          = "AWS/DynamoDB"
+      period             = 300
+      statistic          = "Sum"
+      threshold          = 0
+    }
     "lambda-file-received-adapter-dlq-visible-messages" = {
       alarm_description   = "The file received adapter Lambda dead-letter queue contains failed events"
       comparison_operator = "GreaterThanThreshold"

--- a/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
@@ -1,4 +1,9 @@
 locals {
+  cloudwatch_guardduty_malware_protection_dimensions = {
+    "Malware Protection Plan Id" = aws_guardduty_malware_protection_plan.this.id
+    "Resource Name"              = module.s3_bucket["processing"].s3_bucket_id
+  }
+
   cloudwatch_metric_alarms = {
     "lambda-file-received-adapter-errors" = {
       alarm_description   = "The file received adapter Lambda function has failed to process one or more events"
@@ -79,12 +84,12 @@ locals {
       statistic          = "Maximum"
       threshold          = 0
     }
-    "eventbridge-file-received-workflow-failed-invocations" = {
-      alarm_description   = "The FileReceived.v1 EventBridge rule has failed to start the file received workflow"
+    "eventbridge-file-transfer-workflow-failed-invocations" = {
+      alarm_description   = "The FileReceived.v1 EventBridge rule has failed to start the file transfer workflow"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
         EventBusName = module.eventbridge_file_transfer_bus.eventbridge_bus_name
-        RuleName     = module.eventbridge_file_transfer_bus.eventbridge_rules["file-received-workflow"].name
+        RuleName     = module.eventbridge_file_transfer_bus.eventbridge_rules["file-transfer-workflow"].name
       }
       evaluation_periods = 1
       metric_name        = "FailedInvocations"
@@ -93,11 +98,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "eventbridge-file-received-workflow-dlq-visible-messages" = {
-      alarm_description   = "The file received workflow EventBridge dead-letter queue contains failed events"
+    "eventbridge-file-transfer-workflow-dlq-visible-messages" = {
+      alarm_description   = "The file transfer workflow EventBridge dead-letter queue contains failed events"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        QueueName = module.sqs_eventbridge_file_received_workflow_dlq.queue_name
+        QueueName = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_name
       }
       evaluation_periods = 1
       metric_name        = "ApproximateNumberOfMessagesVisible"
@@ -106,11 +111,11 @@ locals {
       statistic          = "Maximum"
       threshold          = 0
     }
-    "step-functions-file-received-workflow-failures" = {
-      alarm_description   = "The file received workflow has failed one or more executions"
+    "step-functions-file-transfer-workflow-failures" = {
+      alarm_description   = "The file transfer workflow has failed one or more executions"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+        StateMachineArn = module.step_function_file_transfer_workflow.state_machine_arn
       }
       evaluation_periods = 1
       metric_name        = "ExecutionsFailed"
@@ -119,11 +124,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "step-functions-file-received-workflow-timeouts" = {
-      alarm_description   = "The file received workflow has timed out one or more executions"
+    "step-functions-file-transfer-workflow-timeouts" = {
+      alarm_description   = "The file transfer workflow has timed out one or more executions"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+        StateMachineArn = module.step_function_file_transfer_workflow.state_machine_arn
       }
       evaluation_periods = 1
       metric_name        = "ExecutionsTimedOut"
@@ -132,11 +137,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "step-functions-file-received-workflow-aborts" = {
-      alarm_description   = "The file received workflow has aborted one or more executions"
+    "step-functions-file-transfer-workflow-aborts" = {
+      alarm_description   = "The file transfer workflow has aborted one or more executions"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+        StateMachineArn = module.step_function_file_transfer_workflow.state_machine_arn
       }
       evaluation_periods = 1
       metric_name        = "ExecutionsAborted"
@@ -145,11 +150,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "step-functions-file-received-workflow-throttles" = {
-      alarm_description   = "The file received workflow has experienced state transition throttling"
+    "step-functions-file-transfer-workflow-throttles" = {
+      alarm_description   = "The file transfer workflow has experienced state transition throttling"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        StateMachineArn = module.step_function_file_received_workflow.state_machine_arn
+        StateMachineArn = module.step_function_file_transfer_workflow.state_machine_arn
       }
       evaluation_periods = 1
       metric_name        = "ExecutionThrottled"
@@ -158,11 +163,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "dynamodb-file-received-workflow-idempotency-read-throttles" = {
-      alarm_description   = "The file received workflow idempotency table has throttled one or more read requests"
+    "dynamodb-file-transfer-workflow-idempotency-read-throttles" = {
+      alarm_description   = "The file transfer workflow idempotency table has throttled one or more read requests"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        TableName = module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id
+        TableName = module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_id
       }
       evaluation_periods = 1
       metric_name        = "ReadThrottleEvents"
@@ -171,11 +176,11 @@ locals {
       statistic          = "Sum"
       threshold          = 0
     }
-    "dynamodb-file-received-workflow-idempotency-write-throttles" = {
-      alarm_description   = "The file received workflow idempotency table has throttled one or more write requests"
+    "dynamodb-file-transfer-workflow-idempotency-write-throttles" = {
+      alarm_description   = "The file transfer workflow idempotency table has throttled one or more write requests"
       comparison_operator = "GreaterThanThreshold"
       dimensions = {
-        TableName = module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id
+        TableName = module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_id
       }
       evaluation_periods = 1
       metric_name        = "WriteThrottleEvents"
@@ -273,8 +278,5 @@ locals {
     }
   }
 
-  cloudwatch_guardduty_malware_protection_dimensions = {
-    "Malware Protection Plan Id" = aws_guardduty_malware_protection_plan.this.id
-    "Resource Name"              = module.s3_bucket["processing"].s3_bucket_id
-  }
+  cloudwatch_retention_days = local.is-production ? 400 : 30
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
@@ -1,6 +1,4 @@
 locals {
   eventbridge_schema_directory = "${path.module}/schemas"
   eventbridge_schemas          = fileset("${path.module}/schemas", "*.json")
-
-  eventbridge_retention_days = local.is-production ? 400 : 30
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-step-functions.tf
@@ -1,0 +1,6 @@
+locals {
+  file_transfer_workflow_maximum_size_bytes = 5000000000000
+  file_transfer_workflow_part_size_bytes    = 5000000000
+  file_transfer_workflow_timeout_seconds    = 86400
+  file_transfer_workflow_lease_seconds      = local.file_transfer_workflow_timeout_seconds + 3600
+}

--- a/terraform/environments/integration-hub-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub-file-transfer/sqs.tf
@@ -51,3 +51,46 @@ module "sqs_lambda_file_received_adapter_dlq" {
 
   tags = local.tags
 }
+
+module "sqs_eventbridge_file_received_workflow_dlq" {
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "5.2.2"
+
+  name            = "${local.application_name}-file-received-workflow-dlq"
+  use_name_prefix = false
+
+  message_retention_seconds  = 1209600
+  visibility_timeout_seconds = 180
+  receive_wait_time_seconds  = 20
+
+  create_dlq          = false
+  create_queue_policy = true
+  queue_policy_statements = {
+    eventbridge = {
+      sid     = "AllowEventBridgeSendMessage"
+      actions = ["sqs:SendMessage"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "ArnEquals"
+          variable = "aws:SourceArn"
+          values   = [module.eventbridge_file_transfer_bus.eventbridge_rule_arns["file-received-workflow"]]
+        },
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        }
+      ]
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub-file-transfer/sqs.tf
@@ -52,11 +52,11 @@ module "sqs_lambda_file_received_adapter_dlq" {
   tags = local.tags
 }
 
-module "sqs_eventbridge_file_received_workflow_dlq" {
+module "sqs_eventbridge_file_transfer_workflow_dlq" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "5.2.2"
 
-  name            = "${local.application_name}-file-received-workflow-dlq"
+  name            = "${local.application_name}-file-transfer-workflow-dlq"
   use_name_prefix = false
 
   message_retention_seconds  = 1209600
@@ -81,7 +81,7 @@ module "sqs_eventbridge_file_received_workflow_dlq" {
         {
           test     = "ArnEquals"
           variable = "aws:SourceArn"
-          values   = [module.eventbridge_file_transfer_bus.eventbridge_rule_arns["file-received-workflow"]]
+          values   = [module.eventbridge_file_transfer_bus.eventbridge_rule_arns["file-transfer-workflow"]]
         },
         {
           test     = "StringEquals"

--- a/terraform/environments/integration-hub-file-transfer/step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions.tf
@@ -7,7 +7,7 @@ module "step_function_file_transfer_workflow" {
 
   definition = templatefile("${path.module}/step-functions/file-transfer-workflow.asl.json", {
     account_id                 = jsonencode(data.aws_caller_identity.current.account_id)
-    destination_kms_key_arn    = jsonencode(module.kms_s3_bucket["processing"].key_arn)
+    processing_kms_key_arn     = jsonencode(module.kms_s3_bucket["processing"].key_arn)
     idempotency_table_name     = jsonencode(module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_id)
     incoming_bucket_name       = jsonencode(module.s3_bucket["incoming"].s3_bucket_id)
     lease_seconds              = local.file_transfer_workflow_lease_seconds

--- a/terraform/environments/integration-hub-file-transfer/step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions.tf
@@ -1,29 +1,22 @@
-locals {
-  file_received_workflow_maximum_size_bytes = 5000000000000
-  file_received_workflow_part_size_bytes    = 5000000000
-  file_received_workflow_timeout_seconds    = 86400
-  file_received_workflow_lease_seconds      = local.file_received_workflow_timeout_seconds + 3600
-}
-
-module "step_function_file_received_workflow" {
+module "step_function_file_transfer_workflow" {
   source  = "terraform-aws-modules/step-functions/aws"
   version = "5.1.0"
 
-  name = "${local.application_name}-${local.environment}-file-received-workflow"
+  name = "${local.application_name}-${local.environment}-file-transfer-workflow"
   type = "STANDARD"
 
-  definition = templatefile("${path.module}/step-functions/file-received-workflow.asl.json", {
+  definition = templatefile("${path.module}/step-functions/file-transfer-workflow.asl.json", {
     account_id                 = jsonencode(data.aws_caller_identity.current.account_id)
     destination_kms_key_arn    = jsonencode(module.kms_s3_bucket["processing"].key_arn)
-    idempotency_table_name     = jsonencode(module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id)
+    idempotency_table_name     = jsonencode(module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_id)
     incoming_bucket_name       = jsonencode(module.s3_bucket["incoming"].s3_bucket_id)
-    lease_seconds              = local.file_received_workflow_lease_seconds
-    maximum_size_bytes         = local.file_received_workflow_maximum_size_bytes
+    lease_seconds              = local.file_transfer_workflow_lease_seconds
+    maximum_size_bytes         = local.file_transfer_workflow_maximum_size_bytes
     multipart_max_concurrency  = 4
-    part_size_bytes            = local.file_received_workflow_part_size_bytes
+    part_size_bytes            = local.file_transfer_workflow_part_size_bytes
     processing_bucket_name     = jsonencode(module.s3_bucket["processing"].s3_bucket_id)
-    record_retention_seconds   = local.eventbridge_retention_days * 24 * 60 * 60
-    state_machine_timeout_secs = local.file_received_workflow_timeout_seconds
+    record_retention_seconds   = local.cloudwatch_retention_days * 24 * 60 * 60
+    state_machine_timeout_secs = local.file_transfer_workflow_timeout_seconds
   })
 
   logging_configuration = {
@@ -31,8 +24,8 @@ module "step_function_file_received_workflow" {
     level                  = "ALL"
   }
 
-  cloudwatch_log_group_name              = "/aws/vendedlogs/states/${local.application_name}-${local.environment}-file-received-workflow"
-  cloudwatch_log_group_retention_in_days = local.eventbridge_retention_days
+  cloudwatch_log_group_name              = "/aws/vendedlogs/states/${local.application_name}-${local.environment}-file-transfer-workflow"
+  cloudwatch_log_group_retention_in_days = local.cloudwatch_retention_days
   cloudwatch_log_group_kms_key_id        = module.kms_cloudwatch_logs.key_arn
   cloudwatch_log_group_tags              = local.tags
 
@@ -45,7 +38,7 @@ module "step_function_file_received_workflow" {
         "dynamodb:PutItem",
         "dynamodb:UpdateItem",
       ]
-      resources = [module.dynamodb_file_received_workflow_idempotency.dynamodb_table_arn]
+      resources = [module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_arn]
     }
     incoming_object_read = {
       effect = "Allow"

--- a/terraform/environments/integration-hub-file-transfer/step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions.tf
@@ -1,0 +1,98 @@
+locals {
+  file_received_workflow_maximum_size_bytes = 5000000000000
+  file_received_workflow_part_size_bytes    = 5000000000
+  file_received_workflow_timeout_seconds    = 86400
+  file_received_workflow_lease_seconds      = local.file_received_workflow_timeout_seconds + 3600
+}
+
+module "step_function_file_received_workflow" {
+  source  = "terraform-aws-modules/step-functions/aws"
+  version = "5.1.0"
+
+  name = "${local.application_name}-${local.environment}-file-received-workflow"
+  type = "STANDARD"
+
+  definition = templatefile("${path.module}/step-functions/file-received-workflow.asl.json", {
+    account_id                 = jsonencode(data.aws_caller_identity.current.account_id)
+    destination_kms_key_arn    = jsonencode(module.kms_s3_bucket["processing"].key_arn)
+    idempotency_table_name     = jsonencode(module.dynamodb_file_received_workflow_idempotency.dynamodb_table_id)
+    incoming_bucket_name       = jsonencode(module.s3_bucket["incoming"].s3_bucket_id)
+    lease_seconds              = local.file_received_workflow_lease_seconds
+    maximum_size_bytes         = local.file_received_workflow_maximum_size_bytes
+    multipart_max_concurrency  = 4
+    part_size_bytes            = local.file_received_workflow_part_size_bytes
+    processing_bucket_name     = jsonencode(module.s3_bucket["processing"].s3_bucket_id)
+    record_retention_seconds   = local.eventbridge_retention_days * 24 * 60 * 60
+    state_machine_timeout_secs = local.file_received_workflow_timeout_seconds
+  })
+
+  logging_configuration = {
+    include_execution_data = false
+    level                  = "ALL"
+  }
+
+  cloudwatch_log_group_name              = "/aws/vendedlogs/states/${local.application_name}-${local.environment}-file-received-workflow"
+  cloudwatch_log_group_retention_in_days = local.eventbridge_retention_days
+  cloudwatch_log_group_kms_key_id        = module.kms_cloudwatch_logs.key_arn
+  cloudwatch_log_group_tags              = local.tags
+
+  attach_policy_statements = true
+  policy_statements = {
+    workflow_idempotency = {
+      effect = "Allow"
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+      ]
+      resources = [module.dynamodb_file_received_workflow_idempotency.dynamodb_table_arn]
+    }
+    incoming_object_read = {
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionTagging",
+      ]
+      resources = ["${module.s3_bucket["incoming"].s3_bucket_arn}/*"]
+    }
+    incoming_object_delete = {
+      effect    = "Allow"
+      actions   = ["s3:DeleteObjectVersion"]
+      resources = ["${module.s3_bucket["incoming"].s3_bucket_arn}/*"]
+    }
+    processing_object = {
+      effect = "Allow"
+      actions = [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionTagging",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject",
+        "s3:PutObjectTagging",
+      ]
+      resources = ["${module.s3_bucket["processing"].s3_bucket_arn}/*"]
+    }
+    incoming_kms = {
+      effect    = "Allow"
+      actions   = ["kms:Decrypt"]
+      resources = [module.kms_s3_bucket["incoming"].key_arn]
+    }
+    processing_kms = {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+      ]
+      resources = [module.kms_s3_bucket["processing"].key_arn]
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub-file-transfer/step-functions/file-received-workflow.asl.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/file-received-workflow.asl.json
@@ -1,0 +1,1021 @@
+{
+  "Comment": "Stage an exact incoming S3 object version in processing with durable idempotency checkpoints",
+  "QueryLanguage": "JSONata",
+  "StartAt": "Initialise",
+  "TimeoutSeconds": ${state_machine_timeout_secs},
+  "States": {
+    "Initialise": {
+      "Type": "Pass",
+      "Assign": {
+        "event": "{% $states.input %}",
+        "eventId": "{% $exists($states.input.id) ? $states.input.id : null %}",
+        "fileId": "{% $exists($states.input.detail.data.fileId) ? $states.input.detail.data.fileId : null %}",
+        "correlationId": "{% $exists($states.input.detail.metadata.correlationId) ? $states.input.detail.metadata.correlationId : null %}",
+        "idempotencyKey": "{% $exists($states.input.detail.metadata.idempotencyKey) ? $states.input.detail.metadata.idempotencyKey : null %}",
+        "sourceBucket": "{% $exists($states.input.detail.data.object.bucket) ? $states.input.detail.data.object.bucket : null %}",
+        "sourceKey": "{% $exists($states.input.detail.data.object.key) ? $states.input.detail.data.object.key : null %}",
+        "sourceVersionId": "{% $exists($states.input.detail.data.object.versionId) ? $states.input.detail.data.object.versionId : null %}",
+        "sizeBytes": "{% $exists($states.input.detail.data.object.sizeBytes) ? $states.input.detail.data.object.sizeBytes : null %}",
+        "expectedAccountId": ${account_id},
+        "incomingBucket": ${incoming_bucket_name},
+        "processingBucket": ${processing_bucket_name},
+        "destinationKmsKeyArn": ${destination_kms_key_arn},
+        "partSize": ${part_size_bytes},
+        "maximumSize": ${maximum_size_bytes},
+        "leaseSeconds": ${lease_seconds},
+        "recordRetentionSeconds": ${record_retention_seconds},
+        "nowEpoch": "{% $floor($toMillis($states.context.Execution.StartTime) / 1000) %}",
+        "multipartAttempt": 0
+      },
+      "Next": "Validate Event"
+    },
+    "Validate Event": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $event.version = '0' and $event.`detail-type` = 'FileReceived.v1' and $event.source = 'uk.gov.justice.service.managed-file-transfer' and $event.account = $expectedAccountId and $sourceBucket = $incomingBucket and $type($eventId) = 'string' and $length($eventId) > 0 and $type($fileId) = 'string' and $length($fileId) > 0 and $type($correlationId) = 'string' and $length($correlationId) > 0 and $type($idempotencyKey) = 'string' and $length($idempotencyKey) > 0 and $type($sourceKey) = 'string' and $length($sourceKey) > 0 and $type($sourceVersionId) = 'string' and $length($sourceVersionId) > 0 and $type($sizeBytes) = 'number' and $floor($sizeBytes) = $sizeBytes and $sizeBytes >= 0 and $sizeBytes <= $maximumSize %}",
+          "Next": "Prepare Operation"
+        }
+      ],
+      "Default": "Invalid Event"
+    },
+    "Invalid Event": {
+      "Type": "Fail",
+      "Error": "InvalidFileReceivedEvent",
+      "Cause": "The event does not satisfy the FileReceived.v1 workflow contract"
+    },
+    "Prepare Operation": {
+      "Type": "Pass",
+      "Assign": {
+        "operationId": "{% 'file-received-workflow#' & $idempotencyKey %}"
+      },
+      "Next": "Claim Operation"
+    },
+    "Claim Operation": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Item": {
+          "id": { "S": "{% $operationId %}" },
+          "status": { "S": "INPROGRESS" },
+          "execution_arn": { "S": "{% $states.context.Execution.Id %}" },
+          "event_id": { "S": "{% $eventId %}" },
+          "file_id": { "S": "{% $fileId %}" },
+          "correlation_id": { "S": "{% $correlationId %}" },
+          "source_bucket": { "S": "{% $sourceBucket %}" },
+          "source_key": { "S": "{% $sourceKey %}" },
+          "source_version_id": { "S": "{% $sourceVersionId %}" },
+          "created_at": { "S": "{% $states.context.Execution.StartTime %}" },
+          "updated_at": { "S": "{% $states.context.Execution.StartTime %}" },
+          "expiration": { "N": "{% $string($nowEpoch + $recordRetentionSeconds) %}" },
+          "in_progress_expiration": { "N": "{% $string($nowEpoch + $leaseSeconds) %}" }
+        },
+        "ConditionExpression": "attribute_not_exists(id) OR expiration < :now",
+        "ExpressionAttributeValues": {
+          ":now": { "N": "{% $string($nowEpoch) %}" }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.InternalServerError",
+            "DynamoDB.ProvisionedThroughputExceededException",
+            "DynamoDB.RequestLimitExceeded"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
+          "Next": "Get Existing Operation"
+        }
+      ],
+      "Next": "Set New Operation Status"
+    },
+    "Set New Operation Status": {
+      "Type": "Pass",
+      "Assign": {
+        "resumeStatus": "INPROGRESS"
+      },
+      "Next": "Inspect Source Object"
+    },
+    "Get Existing Operation": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "ConsistentRead": true,
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.InternalServerError",
+            "DynamoDB.ProvisionedThroughputExceededException",
+            "DynamoDB.RequestLimitExceeded"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "existingItem": "{% $exists($states.result.Item) ? $states.result.Item : {} %}"
+      },
+      "Next": "Evaluate Existing Operation"
+    },
+    "Evaluate Existing Operation": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $exists($existingItem.status.S) and $existingItem.status.S = 'COMPLETED' %}",
+          "Next": "Duplicate Event"
+        },
+        {
+          "Condition": "{% $exists($existingItem.in_progress_expiration.N) and $number($existingItem.in_progress_expiration.N) >= $nowEpoch %}",
+          "Next": "Operation In Progress"
+        },
+        {
+          "Condition": "{% $exists($existingItem.status.S) and $exists($existingItem.execution_arn.S) %}",
+          "Next": "Take Over Expired Operation"
+        }
+      ],
+      "Default": "Invalid Stored Operation"
+    },
+    "Duplicate Event": {
+      "Type": "Succeed"
+    },
+    "Operation In Progress": {
+      "Type": "Succeed"
+    },
+    "Invalid Stored Operation": {
+      "Type": "Fail",
+      "Error": "InvalidStoredOperation",
+      "Cause": "The idempotency record is missing required workflow state"
+    },
+    "Take Over Expired Operation": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET execution_arn = :execution, in_progress_expiration = :lease, updated_at = :updated",
+        "ConditionExpression": "execution_arn = :previous_execution AND in_progress_expiration < :now AND #status <> :completed",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":previous_execution": { "S": "{% $existingItem.execution_arn.S %}" },
+          ":lease": { "N": "{% $string($nowEpoch + $leaseSeconds) %}" },
+          ":now": { "N": "{% $string($nowEpoch) %}" },
+          ":updated": { "S": "{% $states.context.Execution.StartTime %}" },
+          ":completed": { "S": "COMPLETED" }
+        },
+        "ReturnValues": "ALL_NEW"
+      },
+      "Assign": {
+        "resumeStatus": "{% $states.result.Attributes.status.S %}",
+        "uploadId": "{% $exists($states.result.Attributes.upload_id.S) ? $states.result.Attributes.upload_id.S : null %}",
+        "partCount": "{% $exists($states.result.Attributes.part_count.N) ? $number($states.result.Attributes.part_count.N) : null %}",
+        "destinationVersionId": "{% $exists($states.result.Attributes.destination_version_id.S) ? $states.result.Attributes.destination_version_id.S : null %}",
+        "copyMethod": "{% $exists($states.result.Attributes.copy_method.S) ? $states.result.Attributes.copy_method.S : ($states.result.Attributes.status.S in ['MULTIPART_CREATED', 'PARTS_COPIED', 'MULTIPART_ABORTED'] ? 'MULTIPART' : null) %}"
+      },
+      "Next": "Route Stored Checkpoint"
+    },
+    "Route Stored Checkpoint": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $resumeStatus = 'VERIFIED' %}",
+          "Next": "Delete Exact Source Version"
+        },
+        {
+          "Condition": "{% $resumeStatus in ['INPROGRESS', 'MULTIPART_CREATED', 'PARTS_COPIED', 'MULTIPART_ABORTED', 'COPIED'] %}",
+          "Next": "Inspect Source Object"
+        }
+      ],
+      "Default": "Invalid Stored Operation"
+    },
+    "Inspect Source Object": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+      "Arguments": {
+        "Bucket": "{% $sourceBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $sourceVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}",
+        "ChecksumMode": "ENABLED"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "sourceHead": "{% $states.result %}"
+      },
+      "Next": "Get Source Tags"
+    },
+    "Get Source Tags": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
+      "Arguments": {
+        "Bucket": "{% $sourceBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $sourceVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "sourceTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "sourceTagging": "{% $count($states.result.TagSet) > 0 ? $join($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) }), '&') : '' %}",
+        "sourceTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}",
+        "expectedMetadata": "{% $merge([$exists($sourceHead.Metadata) ? $sourceHead.Metadata : {}, {'mft-file-id': $fileId}]) %}"
+      },
+      "Next": "Validate Source Object"
+    },
+    "Validate Source Object": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $sourceHead.ContentLength = $sizeBytes and ($not($exists($sourceHead.Metadata)) or $not($exists($lookup($sourceHead.Metadata, 'mft-file-id')))) %}",
+          "Next": "Route Copy Checkpoint"
+        }
+      ],
+      "Default": "Invalid Source Object"
+    },
+    "Invalid Source Object": {
+      "Type": "Fail",
+      "Error": "InvalidSourceObject",
+      "Cause": "The exact source version does not match the event or uses reserved metadata"
+    },
+    "Route Copy Checkpoint": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $resumeStatus = 'COPIED' %}",
+          "Next": "Inspect Destination Object"
+        },
+        {
+          "Condition": "{% $resumeStatus = 'MULTIPART_CREATED' %}",
+          "Next": "Build Resumed Multipart Ranges"
+        },
+        {
+          "Condition": "{% $resumeStatus = 'PARTS_COPIED' %}",
+          "Next": "List Parts For Completion"
+        },
+        {
+          "Condition": "{% $resumeStatus = 'MULTIPART_ABORTED' %}",
+          "Next": "Prepare Multipart Copy"
+        },
+        {
+          "Condition": "{% $resumeStatus = 'INPROGRESS' and $sizeBytes <= $partSize %}",
+          "Next": "Prepare Single Copy"
+        },
+        {
+          "Condition": "{% $resumeStatus = 'INPROGRESS' and $sizeBytes > $partSize %}",
+          "Next": "Prepare Multipart Copy"
+        }
+      ],
+      "Default": "Invalid Stored Operation"
+    },
+    "Prepare Single Copy": {
+      "Type": "Pass",
+      "Assign": {
+        "copyMethod": "SINGLE"
+      },
+      "Next": "Copy Source Object"
+    },
+    "Copy Source Object": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'CopySource': $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Assign": {
+        "destinationVersionId": "{% $states.result.VersionId %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Reconcile Destination Object"
+        }
+      ],
+      "Next": "Checkpoint Copied"
+    },
+    "Prepare Multipart Copy": {
+      "Type": "Pass",
+      "Assign": {
+        "copyMethod": "MULTIPART",
+        "partCount": "{% $ceil($sizeBytes / $partSize) %}",
+        "multipartAttempt": "{% $multipartAttempt + 1 %}"
+      },
+      "Next": "Build Multipart Ranges"
+    },
+    "Build Multipart Ranges": {
+      "Type": "Pass",
+      "Assign": {
+        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $sizeBytes - 1]), 'ExpectedSize': $min([$partSize, $sizeBytes - ($index * $partSize)])} }) %}"
+      },
+      "Next": "Create Multipart Upload"
+    },
+    "Build Resumed Multipart Ranges": {
+      "Type": "Pass",
+      "Assign": {
+        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $sizeBytes - 1]), 'ExpectedSize': $min([$partSize, $sizeBytes - ($index * $partSize)])} }) %}"
+      },
+      "Next": "List Existing Parts"
+    },
+    "Multipart Reconciliation Failure": {
+      "Type": "Fail",
+      "Error": "MultipartReconciliationFailure",
+      "Cause": "An ambiguous multipart upload could not be reconciled safely"
+    },
+    "Create Multipart Upload": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:createMultipartUpload",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'ExpectedBucketOwner': $expectedAccountId, 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Assign": {
+        "uploadId": "{% $states.result.UploadId %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Multipart Reconciliation Failure"
+        }
+      ],
+      "Next": "Checkpoint Multipart Created"
+    },
+    "Checkpoint Multipart Created": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, upload_id = :upload_id, part_count = :part_count, part_size = :part_size, updated_at = :updated, in_progress_expiration = :lease",
+        "ConditionExpression": "execution_arn = :execution AND #status IN (:inprogress, :aborted)",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "MULTIPART_CREATED" },
+          ":inprogress": { "S": "INPROGRESS" },
+          ":aborted": { "S": "MULTIPART_ABORTED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":upload_id": { "S": "{% $uploadId %}" },
+          ":part_count": { "N": "{% $string($partCount) %}" },
+          ":part_size": { "N": "{% $string($partSize) %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Abort Multipart Upload"
+        }
+      ],
+      "Next": "List Existing Parts"
+    },
+    "List Existing Parts": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "MaxParts": 1000,
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Assign": {
+        "listedParts": "{% $exists($states.result.Parts) ? $map($states.result.Parts, function($part) { {'PartNumber': $part.PartNumber, 'Size': $part.Size, 'ETag': $part.ETag} }) : [] %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Reconcile Destination Object"
+        }
+      ],
+      "Next": "Build Missing Parts"
+    },
+    "Build Missing Parts": {
+      "Type": "Pass",
+      "Assign": {
+        "missingParts": "{% $filter($parts, function($expected) { $count($filter($listedParts, function($listed) { $listed.PartNumber = $expected.PartNumber and $listed.Size = $expected.ExpectedSize })) = 0 }) %}"
+      },
+      "Next": "Copy Missing Parts"
+    },
+    "Copy Missing Parts": {
+      "Type": "Map",
+      "Items": "{% $missingParts %}",
+      "MaxConcurrency": ${multipart_max_concurrency},
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Copy Part",
+        "States": {
+          "Copy Part": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::aws-sdk:s3:uploadPartCopy",
+            "Arguments": {
+              "Bucket": "{% $processingBucket %}",
+              "Key": "{% $sourceKey %}",
+              "UploadId": "{% $uploadId %}",
+              "PartNumber": "{% $states.input.PartNumber %}",
+              "CopySource": "{% $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId) %}",
+              "CopySourceRange": "{% 'bytes=' & $string($states.input.RangeStart) & '-' & $string($states.input.RangeEnd) %}",
+              "ExpectedBucketOwner": "{% $expectedAccountId %}",
+              "ExpectedSourceBucketOwner": "{% $expectedAccountId %}"
+            },
+            "Retry": [
+              {
+                "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+                "IntervalSeconds": 2,
+                "MaxAttempts": 5,
+                "BackoffRate": 2,
+                "MaxDelaySeconds": 60,
+                "JitterStrategy": "FULL"
+              }
+            ],
+            "Output": {},
+            "End": true
+          }
+        }
+      },
+      "Output": [],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Abort Multipart Upload"
+        }
+      ],
+      "Next": "Release Part Planning Data"
+    },
+    "Release Part Planning Data": {
+      "Type": "Pass",
+      "Assign": {
+        "parts": null,
+        "listedParts": null,
+        "missingParts": null
+      },
+      "Next": "List Parts For Completion"
+    },
+    "List Parts For Completion": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "MaxParts": 1000,
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Assign": {
+        "partsListTruncated": "{% $states.result.IsTruncated %}",
+        "completedParts": "{% $exists($states.result.Parts) ? $map($states.result.Parts, function($part) { {'PartNumber': $part.PartNumber, 'Size': $part.Size, 'ETag': $part.ETag} }) : [] %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Reconcile Destination Object"
+        }
+      ],
+      "Next": "Validate Completed Parts"
+    },
+    "Validate Completed Parts": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $partsListTruncated = false and $count($completedParts) = $partCount and $count($filter($completedParts, function($part) { $part.PartNumber >= 1 and $part.PartNumber <= $partCount and $part.Size = ($part.PartNumber = $partCount ? $sizeBytes - (($partCount - 1) * $partSize) : $partSize) })) = $partCount %}",
+          "Next": "Checkpoint Parts Copied"
+        }
+      ],
+      "Default": "Abort Multipart Upload"
+    },
+    "Checkpoint Parts Copied": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, updated_at = :updated, in_progress_expiration = :lease",
+        "ConditionExpression": "execution_arn = :execution AND #status IN (:created, :parts)",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "PARTS_COPIED" },
+          ":created": { "S": "MULTIPART_CREATED" },
+          ":parts": { "S": "PARTS_COPIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
+      "Next": "Complete Multipart Upload"
+    },
+    "Complete Multipart Upload": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:completeMultipartUpload",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}",
+        "MpuObjectSize": "{% $sizeBytes %}",
+        "MultipartUpload": {
+          "Parts": "{% $map($completedParts, function($part) { {'PartNumber': $part.PartNumber, 'ETag': $part.ETag} }) %}"
+        }
+      },
+      "Assign": {
+        "destinationVersionId": "{% $states.result.VersionId %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "List Parts After Completion Failure"
+        }
+      ],
+      "Next": "Checkpoint Copied"
+    },
+    "List Parts After Completion Failure": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "MaxParts": 1000,
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Assign": {
+        "completedParts": "{% $map($states.result.Parts, function($part) { {'PartNumber': $part.PartNumber, 'Size': $part.Size, 'ETag': $part.ETag} }) %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Reconcile Destination Object"
+        }
+      ],
+      "Next": "Retry Complete Multipart Upload"
+    },
+    "Retry Complete Multipart Upload": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:completeMultipartUpload",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}",
+        "MpuObjectSize": "{% $sizeBytes %}",
+        "MultipartUpload": {
+          "Parts": "{% $map($completedParts, function($part) { {'PartNumber': $part.PartNumber, 'ETag': $part.ETag} }) %}"
+        }
+      },
+      "Assign": {
+        "destinationVersionId": "{% $states.result.VersionId %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Reconcile Destination Object"
+        }
+      ],
+      "Next": "Checkpoint Copied"
+    },
+    "Reconcile Destination Object": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}",
+        "ChecksumMode": "ENABLED"
+      },
+      "Assign": {
+        "destinationHead": "{% $states.result %}",
+        "destinationVersionId": "{% $states.result.VersionId %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Ambiguous Copy Failure"
+        }
+      ],
+      "Next": "Get Reconciled Destination Tags"
+    },
+    "Get Reconciled Destination Tags": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $destinationVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Assign": {
+        "destinationTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "destinationTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Ambiguous Copy Failure"
+        }
+      ],
+      "Next": "Validate Reconciled Destination"
+    },
+    "Validate Reconciled Destination": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SSEKMSKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Next": "Checkpoint Copied"
+        }
+      ],
+      "Default": "Ambiguous Copy Failure"
+    },
+    "Ambiguous Copy Failure": {
+      "Type": "Fail",
+      "Error": "AmbiguousCopyFailure",
+      "Cause": "The copy outcome could not be reconciled without risking a duplicate destination version"
+    },
+    "Checkpoint Copied": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, copy_method = :copy_method, destination_bucket = :destination_bucket, destination_key = :destination_key, destination_version_id = :destination_version_id, updated_at = :updated, in_progress_expiration = :lease",
+        "ConditionExpression": "execution_arn = :execution AND #status IN (:inprogress, :parts, :copied)",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "COPIED" },
+          ":inprogress": { "S": "INPROGRESS" },
+          ":parts": { "S": "PARTS_COPIED" },
+          ":copied": { "S": "COPIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":copy_method": { "S": "{% $copyMethod %}" },
+          ":destination_bucket": { "S": "{% $processingBucket %}" },
+          ":destination_key": { "S": "{% $sourceKey %}" },
+          ":destination_version_id": { "S": "{% $destinationVersionId %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.InternalServerError",
+            "DynamoDB.ProvisionedThroughputExceededException",
+            "DynamoDB.RequestLimitExceeded"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Get Copied Checkpoint"
+        }
+      ],
+      "Next": "Inspect Destination Object"
+    },
+    "Get Copied Checkpoint": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "ConsistentRead": true,
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.InternalServerError",
+            "DynamoDB.ProvisionedThroughputExceededException",
+            "DynamoDB.RequestLimitExceeded"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "copiedCheckpointItem": "{% $exists($states.result.Item) ? $states.result.Item : {} %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Ambiguous Copied Checkpoint Failure"
+        }
+      ],
+      "Next": "Evaluate Copied Checkpoint"
+    },
+    "Evaluate Copied Checkpoint": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $exists($copiedCheckpointItem.status.S) and $copiedCheckpointItem.status.S = 'COPIED' and $exists($copiedCheckpointItem.execution_arn.S) and $copiedCheckpointItem.execution_arn.S = $states.context.Execution.Id and $exists($copiedCheckpointItem.destination_version_id.S) and $copiedCheckpointItem.destination_version_id.S = $destinationVersionId %}",
+          "Next": "Inspect Destination Object"
+        },
+        {
+          "Condition": "{% $exists($copiedCheckpointItem.status.S) and $copiedCheckpointItem.status.S in ['INPROGRESS', 'PARTS_COPIED'] and $exists($copiedCheckpointItem.execution_arn.S) and $copiedCheckpointItem.execution_arn.S = $states.context.Execution.Id %}",
+          "Next": "Delete Uncheckpointed Destination Version"
+        }
+      ],
+      "Default": "Ambiguous Copied Checkpoint Failure"
+    },
+    "Delete Uncheckpointed Destination Version": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $destinationVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 5,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 60,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Uncheckpointed Destination Cleanup Failure"
+        }
+      ],
+      "Next": "Route Uncheckpointed Copy Rollback"
+    },
+    "Route Uncheckpointed Copy Rollback": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $copyMethod = 'MULTIPART' %}",
+          "Next": "Checkpoint Multipart Aborted"
+        }
+      ],
+      "Default": "Uncheckpointed Copy Rolled Back"
+    },
+    "Uncheckpointed Copy Rolled Back": {
+      "Type": "Fail",
+      "Error": "UncheckpointedCopyRolledBack",
+      "Cause": "The exact destination version was removed because its durable checkpoint did not commit"
+    },
+    "Ambiguous Copied Checkpoint Failure": {
+      "Type": "Fail",
+      "Error": "AmbiguousCopiedCheckpointFailure",
+      "Cause": "The copy checkpoint outcome could not be reconciled safely"
+    },
+    "Uncheckpointed Destination Cleanup Failure": {
+      "Type": "Fail",
+      "Error": "UncheckpointedDestinationCleanupFailure",
+      "Cause": "The uncheckpointed destination version could not be removed safely"
+    },
+    "Abort Multipart Upload": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:abortMultipartUpload",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "UploadId": "{% $uploadId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 5,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 60,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Checkpoint Multipart Aborted"
+    },
+    "Checkpoint Multipart Aborted": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, updated_at = :updated, in_progress_expiration = :lease REMOVE upload_id, part_count, part_size",
+        "ConditionExpression": "execution_arn = :execution AND #status IN (:inprogress, :created, :parts)",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "MULTIPART_ABORTED" },
+          ":inprogress": { "S": "INPROGRESS" },
+          ":created": { "S": "MULTIPART_CREATED" },
+          ":parts": { "S": "PARTS_COPIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
+      "Next": "Allow Multipart Retry"
+    },
+    "Allow Multipart Retry": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $multipartAttempt < 2 %}",
+          "Next": "Prepare Multipart Copy"
+        }
+      ],
+      "Default": "Multipart Copy Failure"
+    },
+    "Multipart Copy Failure": {
+      "Type": "Fail",
+      "Error": "MultipartCopyFailure",
+      "Cause": "The multipart copy failed after its bounded recovery attempt"
+    },
+    "Inspect Destination Object": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $destinationVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}",
+        "ChecksumMode": "ENABLED"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "destinationHead": "{% $states.result %}"
+      },
+      "Next": "Get Destination Tags"
+    },
+    "Get Destination Tags": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
+      "Arguments": {
+        "Bucket": "{% $processingBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $destinationVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 4,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 30,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "destinationTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "destinationTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
+      },
+      "Next": "Verify Destination Object"
+    },
+    "Verify Destination Object": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SSEKMSKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Next": "Checkpoint Verified"
+        }
+      ],
+      "Default": "Destination Verification Failure"
+    },
+    "Destination Verification Failure": {
+      "Type": "Fail",
+      "Error": "DestinationVerificationFailure",
+      "Cause": "The destination version does not match the exact source object attributes"
+    },
+    "Checkpoint Verified": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, verified_at = :verified, updated_at = :updated, in_progress_expiration = :lease",
+        "ConditionExpression": "execution_arn = :execution AND #status = :copied",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "VERIFIED" },
+          ":copied": { "S": "COPIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":verified": { "S": "{% $now() %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
+      "Next": "Delete Exact Source Version"
+    },
+    "Delete Exact Source Version": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
+      "Arguments": {
+        "Bucket": "{% $sourceBucket %}",
+        "Key": "{% $sourceKey %}",
+        "VersionId": "{% $sourceVersionId %}",
+        "ExpectedBucketOwner": "{% $expectedAccountId %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["S3.InternalErrorException", "S3.RequestTimeoutException", "S3.ServiceUnavailableException", "S3.SlowDownException", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 5,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 60,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Checkpoint Completed"
+    },
+    "Checkpoint Completed": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, completed_at = :completed, updated_at = :updated REMOVE in_progress_expiration",
+        "ConditionExpression": "execution_arn = :execution AND #status = :verified",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "COMPLETED" },
+          ":verified": { "S": "VERIFIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":completed": { "S": "{% $now() %}" },
+          ":updated": { "S": "{% $now() %}" }
+        }
+      },
+      "Next": "Workflow Completed"
+    },
+    "Workflow Completed": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
@@ -12,14 +12,14 @@
         "fileId": "{% $exists($states.input.detail.data.fileId) ? $states.input.detail.data.fileId : null %}",
         "correlationId": "{% $exists($states.input.detail.metadata.correlationId) ? $states.input.detail.metadata.correlationId : null %}",
         "idempotencyKey": "{% $exists($states.input.detail.metadata.idempotencyKey) ? $states.input.detail.metadata.idempotencyKey : null %}",
-        "sourceBucket": "{% $exists($states.input.detail.data.object.bucket) ? $states.input.detail.data.object.bucket : null %}",
-        "sourceKey": "{% $exists($states.input.detail.data.object.key) ? $states.input.detail.data.object.key : null %}",
-        "sourceVersionId": "{% $exists($states.input.detail.data.object.versionId) ? $states.input.detail.data.object.versionId : null %}",
-        "sizeBytes": "{% $exists($states.input.detail.data.object.sizeBytes) ? $states.input.detail.data.object.sizeBytes : null %}",
+        "incomingObjectBucket": "{% $exists($states.input.detail.data.object.bucket) ? $states.input.detail.data.object.bucket : null %}",
+        "incomingObjectKey": "{% $exists($states.input.detail.data.object.key) ? $states.input.detail.data.object.key : null %}",
+        "incomingObjectVersionId": "{% $exists($states.input.detail.data.object.versionId) ? $states.input.detail.data.object.versionId : null %}",
+        "incomingObjectSizeBytes": "{% $exists($states.input.detail.data.object.sizeBytes) ? $states.input.detail.data.object.sizeBytes : null %}",
         "expectedAccountId": ${account_id},
         "incomingBucket": ${incoming_bucket_name},
         "processingBucket": ${processing_bucket_name},
-        "destinationKmsKeyArn": ${destination_kms_key_arn},
+        "processingKmsKeyArn": ${processing_kms_key_arn},
         "partSize": ${part_size_bytes},
         "maximumSize": ${maximum_size_bytes},
         "leaseSeconds": ${lease_seconds},
@@ -33,7 +33,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $event.version = '0' and $event.`detail-type` = 'FileReceived.v1' and $event.source = 'uk.gov.justice.service.managed-file-transfer' and $event.account = $expectedAccountId and $sourceBucket = $incomingBucket and $type($eventId) = 'string' and $length($eventId) > 0 and $type($fileId) = 'string' and $length($fileId) > 0 and $type($correlationId) = 'string' and $length($correlationId) > 0 and $type($idempotencyKey) = 'string' and $length($idempotencyKey) > 0 and $type($sourceKey) = 'string' and $length($sourceKey) > 0 and $type($sourceVersionId) = 'string' and $length($sourceVersionId) > 0 and $type($sizeBytes) = 'number' and $floor($sizeBytes) = $sizeBytes and $sizeBytes >= 0 and $sizeBytes <= $maximumSize %}",
+          "Condition": "{% $event.version = '0' and $event.`detail-type` = 'FileReceived.v1' and $event.source = 'uk.gov.justice.service.managed-file-transfer' and $event.account = $expectedAccountId and $incomingObjectBucket = $incomingBucket and $type($eventId) = 'string' and $length($eventId) > 0 and $type($fileId) = 'string' and $length($fileId) > 0 and $type($correlationId) = 'string' and $length($correlationId) > 0 and $type($idempotencyKey) = 'string' and $length($idempotencyKey) > 0 and $type($incomingObjectKey) = 'string' and $length($incomingObjectKey) > 0 and $type($incomingObjectVersionId) = 'string' and $length($incomingObjectVersionId) > 0 and $type($incomingObjectSizeBytes) = 'number' and $floor($incomingObjectSizeBytes) = $incomingObjectSizeBytes and $incomingObjectSizeBytes >= 0 and $incomingObjectSizeBytes <= $maximumSize %}",
           "Next": "Prepare Operation"
         }
       ],
@@ -63,9 +63,9 @@
           "event_id": { "S": "{% $eventId %}" },
           "file_id": { "S": "{% $fileId %}" },
           "correlation_id": { "S": "{% $correlationId %}" },
-          "source_bucket": { "S": "{% $sourceBucket %}" },
-          "source_key": { "S": "{% $sourceKey %}" },
-          "source_version_id": { "S": "{% $sourceVersionId %}" },
+          "incoming_bucket": { "S": "{% $incomingObjectBucket %}" },
+          "incoming_key": { "S": "{% $incomingObjectKey %}" },
+          "incoming_version_id": { "S": "{% $incomingObjectVersionId %}" },
           "created_at": { "S": "{% $states.context.Execution.StartTime %}" },
           "updated_at": { "S": "{% $states.context.Execution.StartTime %}" },
           "expiration": { "N": "{% $string($nowEpoch + $recordRetentionSeconds) %}" },
@@ -103,7 +103,7 @@
       "Assign": {
         "resumeStatus": "INPROGRESS"
       },
-      "Next": "Inspect Source Object"
+      "Next": "Inspect Incoming Object"
     },
     "Get Existing Operation": {
       "Type": "Task",
@@ -190,7 +190,7 @@
         "resumeStatus": "{% $states.result.Attributes.status.S %}",
         "uploadId": "{% $exists($states.result.Attributes.upload_id.S) ? $states.result.Attributes.upload_id.S : null %}",
         "partCount": "{% $exists($states.result.Attributes.part_count.N) ? $number($states.result.Attributes.part_count.N) : null %}",
-        "destinationVersionId": "{% $exists($states.result.Attributes.destination_version_id.S) ? $states.result.Attributes.destination_version_id.S : null %}",
+        "processingObjectVersionId": "{% $exists($states.result.Attributes.processing_version_id.S) ? $states.result.Attributes.processing_version_id.S : null %}",
         "copyMethod": "{% $exists($states.result.Attributes.copy_method.S) ? $states.result.Attributes.copy_method.S : ($states.result.Attributes.status.S in ['MULTIPART_CREATED', 'PARTS_COPIED', 'MULTIPART_ABORTED'] ? 'MULTIPART' : null) %}"
       },
       "Next": "Route Stored Checkpoint"
@@ -200,22 +200,22 @@
       "Choices": [
         {
           "Condition": "{% $resumeStatus = 'VERIFIED' %}",
-          "Next": "Delete Exact Source Version"
+          "Next": "Delete Exact Incoming Object Version"
         },
         {
           "Condition": "{% $resumeStatus in ['INPROGRESS', 'MULTIPART_CREATED', 'PARTS_COPIED', 'MULTIPART_ABORTED', 'COPIED'] %}",
-          "Next": "Inspect Source Object"
+          "Next": "Inspect Incoming Object"
         }
       ],
       "Default": "Invalid Stored Operation"
     },
-    "Inspect Source Object": {
+    "Inspect Incoming Object": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
       "Arguments": {
-        "Bucket": "{% $sourceBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $sourceVersionId %}",
+        "Bucket": "{% $incomingObjectBucket %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $incomingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}",
         "ChecksumMode": "ENABLED"
       },
@@ -230,17 +230,17 @@
         }
       ],
       "Assign": {
-        "sourceHead": "{% $states.result %}"
+        "incomingObjectHead": "{% $states.result %}"
       },
-      "Next": "Get Source Tags"
+      "Next": "Get Incoming Object Tags"
     },
-    "Get Source Tags": {
+    "Get Incoming Object Tags": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
       "Arguments": {
-        "Bucket": "{% $sourceBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $sourceVersionId %}",
+        "Bucket": "{% $incomingObjectBucket %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $incomingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
       "Retry": [
@@ -254,34 +254,34 @@
         }
       ],
       "Assign": {
-        "sourceTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
-        "sourceTagging": "{% $count($states.result.TagSet) > 0 ? $join($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) }), '&') : '' %}",
-        "sourceTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}",
-        "expectedMetadata": "{% $merge([$exists($sourceHead.Metadata) ? $sourceHead.Metadata : {}, {'mft-file-id': $fileId}]) %}"
+        "incomingObjectTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "incomingObjectTagging": "{% $count($states.result.TagSet) > 0 ? $join($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) }), '&') : '' %}",
+        "incomingObjectTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}",
+        "expectedProcessingObjectMetadata": "{% $merge([$exists($incomingObjectHead.Metadata) ? $incomingObjectHead.Metadata : {}, {'mft-file-id': $fileId}]) %}"
       },
-      "Next": "Validate Source Object"
+      "Next": "Validate Incoming Object"
     },
-    "Validate Source Object": {
+    "Validate Incoming Object": {
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $sourceHead.ContentLength = $sizeBytes and ($not($exists($sourceHead.Metadata)) or $not($exists($lookup($sourceHead.Metadata, 'mft-file-id')))) %}",
+          "Condition": "{% $incomingObjectHead.ContentLength = $incomingObjectSizeBytes and ($not($exists($incomingObjectHead.Metadata)) or $not($exists($lookup($incomingObjectHead.Metadata, 'mft-file-id')))) %}",
           "Next": "Route Copy Checkpoint"
         }
       ],
-      "Default": "Invalid Source Object"
+      "Default": "Invalid Incoming Object"
     },
-    "Invalid Source Object": {
+    "Invalid Incoming Object": {
       "Type": "Fail",
-      "Error": "InvalidSourceObject",
-      "Cause": "The exact source version does not match the event or uses reserved metadata"
+      "Error": "InvalidIncomingObject",
+      "Cause": "The exact incoming version does not match the event or uses reserved metadata"
     },
     "Route Copy Checkpoint": {
       "Type": "Choice",
       "Choices": [
         {
           "Condition": "{% $resumeStatus = 'COPIED' %}",
-          "Next": "Inspect Destination Object"
+          "Next": "Inspect Processing Object"
         },
         {
           "Condition": "{% $resumeStatus = 'MULTIPART_CREATED' %}",
@@ -296,11 +296,11 @@
           "Next": "Prepare Multipart Copy"
         },
         {
-          "Condition": "{% $resumeStatus = 'INPROGRESS' and $sizeBytes <= $partSize %}",
+          "Condition": "{% $resumeStatus = 'INPROGRESS' and $incomingObjectSizeBytes <= $partSize %}",
           "Next": "Prepare Single Copy"
         },
         {
-          "Condition": "{% $resumeStatus = 'INPROGRESS' and $sizeBytes > $partSize %}",
+          "Condition": "{% $resumeStatus = 'INPROGRESS' and $incomingObjectSizeBytes > $partSize %}",
           "Next": "Prepare Multipart Copy"
         }
       ],
@@ -311,19 +311,19 @@
       "Assign": {
         "copyMethod": "SINGLE"
       },
-      "Next": "Copy Source Object"
+      "Next": "Copy Incoming Object"
     },
-    "Copy Source Object": {
+    "Copy Incoming Object": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
-      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'CopySource': $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $incomingObjectKey, 'CopySource': $incomingObjectBucket & '/' & $encodeUrlComponent($incomingObjectKey) & '?versionId=' & $encodeUrlComponent($incomingObjectVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedProcessingObjectMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $processingKmsKeyArn}, $count($incomingObjectTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $incomingObjectTagging} : {}, $exists($incomingObjectHead.CacheControl) ? {'CacheControl': $incomingObjectHead.CacheControl} : {}, $exists($incomingObjectHead.ContentDisposition) ? {'ContentDisposition': $incomingObjectHead.ContentDisposition} : {}, $exists($incomingObjectHead.ContentEncoding) ? {'ContentEncoding': $incomingObjectHead.ContentEncoding} : {}, $exists($incomingObjectHead.ContentLanguage) ? {'ContentLanguage': $incomingObjectHead.ContentLanguage} : {}, $exists($incomingObjectHead.ContentType) ? {'ContentType': $incomingObjectHead.ContentType} : {}, $exists($incomingObjectHead.Expires) ? {'Expires': $incomingObjectHead.Expires} : {}, $exists($incomingObjectHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $incomingObjectHead.WebsiteRedirectLocation} : {}]) %}",
       "Assign": {
-        "destinationVersionId": "{% $states.result.VersionId %}"
+        "processingObjectVersionId": "{% $states.result.VersionId %}"
       },
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Reconcile Destination Object"
+          "Next": "Reconcile Processing Object"
         }
       ],
       "Next": "Checkpoint Copied"
@@ -332,7 +332,7 @@
       "Type": "Pass",
       "Assign": {
         "copyMethod": "MULTIPART",
-        "partCount": "{% $ceil($sizeBytes / $partSize) %}",
+        "partCount": "{% $ceil($incomingObjectSizeBytes / $partSize) %}",
         "multipartAttempt": "{% $multipartAttempt + 1 %}"
       },
       "Next": "Build Multipart Ranges"
@@ -340,14 +340,14 @@
     "Build Multipart Ranges": {
       "Type": "Pass",
       "Assign": {
-        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $sizeBytes - 1]), 'ExpectedSize': $min([$partSize, $sizeBytes - ($index * $partSize)])} }) %}"
+        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $incomingObjectSizeBytes - 1]), 'ExpectedSize': $min([$partSize, $incomingObjectSizeBytes - ($index * $partSize)])} }) %}"
       },
       "Next": "Create Multipart Upload"
     },
     "Build Resumed Multipart Ranges": {
       "Type": "Pass",
       "Assign": {
-        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $sizeBytes - 1]), 'ExpectedSize': $min([$partSize, $sizeBytes - ($index * $partSize)])} }) %}"
+        "parts": "{% $map($range(0, $partCount - 1, 1), function($index) { {'PartNumber': $index + 1, 'RangeStart': $index * $partSize, 'RangeEnd': $min([(($index + 1) * $partSize) - 1, $incomingObjectSizeBytes - 1]), 'ExpectedSize': $min([$partSize, $incomingObjectSizeBytes - ($index * $partSize)])} }) %}"
       },
       "Next": "List Existing Parts"
     },
@@ -359,7 +359,7 @@
     "Create Multipart Upload": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:createMultipartUpload",
-      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'ExpectedBucketOwner': $expectedAccountId, 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $incomingObjectKey, 'ExpectedBucketOwner': $expectedAccountId, 'Metadata': $expectedProcessingObjectMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $processingKmsKeyArn}, $count($incomingObjectTags) > 0 ? {'Tagging': $incomingObjectTagging} : {}, $exists($incomingObjectHead.CacheControl) ? {'CacheControl': $incomingObjectHead.CacheControl} : {}, $exists($incomingObjectHead.ContentDisposition) ? {'ContentDisposition': $incomingObjectHead.ContentDisposition} : {}, $exists($incomingObjectHead.ContentEncoding) ? {'ContentEncoding': $incomingObjectHead.ContentEncoding} : {}, $exists($incomingObjectHead.ContentLanguage) ? {'ContentLanguage': $incomingObjectHead.ContentLanguage} : {}, $exists($incomingObjectHead.ContentType) ? {'ContentType': $incomingObjectHead.ContentType} : {}, $exists($incomingObjectHead.Expires) ? {'Expires': $incomingObjectHead.Expires} : {}, $exists($incomingObjectHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $incomingObjectHead.WebsiteRedirectLocation} : {}]) %}",
       "Assign": {
         "uploadId": "{% $states.result.UploadId %}"
       },
@@ -409,7 +409,7 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "MaxParts": 1000,
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
@@ -420,7 +420,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Reconcile Destination Object"
+          "Next": "Reconcile Processing Object"
         }
       ],
       "Next": "Build Missing Parts"
@@ -447,10 +447,10 @@
             "Resource": "arn:aws:states:::aws-sdk:s3:uploadPartCopy",
             "Arguments": {
               "Bucket": "{% $processingBucket %}",
-              "Key": "{% $sourceKey %}",
+              "Key": "{% $incomingObjectKey %}",
               "UploadId": "{% $uploadId %}",
               "PartNumber": "{% $states.input.PartNumber %}",
-              "CopySource": "{% $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId) %}",
+              "CopySource": "{% $incomingObjectBucket & '/' & $encodeUrlComponent($incomingObjectKey) & '?versionId=' & $encodeUrlComponent($incomingObjectVersionId) %}",
               "CopySourceRange": "{% 'bytes=' & $string($states.input.RangeStart) & '-' & $string($states.input.RangeEnd) %}",
               "ExpectedBucketOwner": "{% $expectedAccountId %}",
               "ExpectedSourceBucketOwner": "{% $expectedAccountId %}"
@@ -493,7 +493,7 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "MaxParts": 1000,
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
@@ -505,7 +505,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Reconcile Destination Object"
+          "Next": "Reconcile Processing Object"
         }
       ],
       "Next": "Validate Completed Parts"
@@ -514,7 +514,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $partsListTruncated = false and $count($completedParts) = $partCount and $count($filter($completedParts, function($part) { $part.PartNumber >= 1 and $part.PartNumber <= $partCount and $part.Size = ($part.PartNumber = $partCount ? $sizeBytes - (($partCount - 1) * $partSize) : $partSize) })) = $partCount %}",
+          "Condition": "{% $partsListTruncated = false and $count($completedParts) = $partCount and $count($filter($completedParts, function($part) { $part.PartNumber >= 1 and $part.PartNumber <= $partCount and $part.Size = ($part.PartNumber = $partCount ? $incomingObjectSizeBytes - (($partCount - 1) * $partSize) : $partSize) })) = $partCount %}",
           "Next": "Checkpoint Parts Copied"
         }
       ],
@@ -549,16 +549,16 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:completeMultipartUpload",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}",
-        "MpuObjectSize": "{% $sizeBytes %}",
+        "MpuObjectSize": "{% $incomingObjectSizeBytes %}",
         "MultipartUpload": {
           "Parts": "{% $map($completedParts, function($part) { {'PartNumber': $part.PartNumber, 'ETag': $part.ETag} }) %}"
         }
       },
       "Assign": {
-        "destinationVersionId": "{% $states.result.VersionId %}"
+        "processingObjectVersionId": "{% $states.result.VersionId %}"
       },
       "Catch": [
         {
@@ -573,7 +573,7 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:listParts",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "MaxParts": 1000,
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
@@ -584,7 +584,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Reconcile Destination Object"
+          "Next": "Reconcile Processing Object"
         }
       ],
       "Next": "Retry Complete Multipart Upload"
@@ -594,37 +594,37 @@
       "Resource": "arn:aws:states:::aws-sdk:s3:completeMultipartUpload",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}",
-        "MpuObjectSize": "{% $sizeBytes %}",
+        "MpuObjectSize": "{% $incomingObjectSizeBytes %}",
         "MultipartUpload": {
           "Parts": "{% $map($completedParts, function($part) { {'PartNumber': $part.PartNumber, 'ETag': $part.ETag} }) %}"
         }
       },
       "Assign": {
-        "destinationVersionId": "{% $states.result.VersionId %}"
+        "processingObjectVersionId": "{% $states.result.VersionId %}"
       },
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Reconcile Destination Object"
+          "Next": "Reconcile Processing Object"
         }
       ],
       "Next": "Checkpoint Copied"
     },
-    "Reconcile Destination Object": {
+    "Reconcile Processing Object": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}",
         "ChecksumMode": "ENABLED"
       },
       "Assign": {
-        "destinationHead": "{% $states.result %}",
-        "destinationVersionId": "{% $states.result.VersionId %}"
+        "processingObjectHead": "{% $states.result %}",
+        "processingObjectVersionId": "{% $states.result.VersionId %}"
       },
       "Catch": [
         {
@@ -632,20 +632,20 @@
           "Next": "Ambiguous Copy Failure"
         }
       ],
-      "Next": "Get Reconciled Destination Tags"
+      "Next": "Get Reconciled Processing Object Tags"
     },
-    "Get Reconciled Destination Tags": {
+    "Get Reconciled Processing Object Tags": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $destinationVersionId %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $processingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
       "Assign": {
-        "destinationTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
-        "destinationTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
+        "processingObjectTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "processingObjectTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
       },
       "Catch": [
         {
@@ -653,13 +653,13 @@
           "Next": "Ambiguous Copy Failure"
         }
       ],
-      "Next": "Validate Reconciled Destination"
+      "Next": "Validate Reconciled Processing Object"
     },
-    "Validate Reconciled Destination": {
+    "Validate Reconciled Processing Object": {
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SsekmsKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Condition": "{% $processingObjectHead.ContentLength = $incomingObjectSizeBytes and $processingObjectHead.ServerSideEncryption = 'aws:kms' and $processingObjectHead.SsekmsKeyId = $processingKmsKeyArn and $count($keys($processingObjectHead.Metadata)) = $count($keys($expectedProcessingObjectMetadata)) and $count($filter($keys($expectedProcessingObjectMetadata), function($key) { $lookup($processingObjectHead.Metadata, $key) = $lookup($expectedProcessingObjectMetadata, $key) })) = $count($keys($expectedProcessingObjectMetadata)) and $processingObjectTagFingerprint = $incomingObjectTagFingerprint %}",
           "Next": "Checkpoint Copied"
         }
       ],
@@ -668,7 +668,7 @@
     "Ambiguous Copy Failure": {
       "Type": "Fail",
       "Error": "AmbiguousCopyFailure",
-      "Cause": "The copy outcome could not be reconciled without risking a duplicate destination version"
+      "Cause": "The copy outcome could not be reconciled without risking a duplicate processing version"
     },
     "Checkpoint Copied": {
       "Type": "Task",
@@ -678,7 +678,7 @@
         "Key": {
           "id": { "S": "{% $operationId %}" }
         },
-        "UpdateExpression": "SET #status = :status, copy_method = :copy_method, destination_bucket = :destination_bucket, destination_key = :destination_key, destination_version_id = :destination_version_id, updated_at = :updated, in_progress_expiration = :lease",
+        "UpdateExpression": "SET #status = :status, copy_method = :copy_method, processing_bucket = :processing_bucket, processing_key = :processing_key, processing_version_id = :processing_version_id, updated_at = :updated, in_progress_expiration = :lease",
         "ConditionExpression": "execution_arn = :execution AND #status IN (:inprogress, :parts, :copied)",
         "ExpressionAttributeNames": {
           "#status": "status"
@@ -690,9 +690,9 @@
           ":copied": { "S": "COPIED" },
           ":execution": { "S": "{% $states.context.Execution.Id %}" },
           ":copy_method": { "S": "{% $copyMethod %}" },
-          ":destination_bucket": { "S": "{% $processingBucket %}" },
-          ":destination_key": { "S": "{% $sourceKey %}" },
-          ":destination_version_id": { "S": "{% $destinationVersionId %}" },
+          ":processing_bucket": { "S": "{% $processingBucket %}" },
+          ":processing_key": { "S": "{% $incomingObjectKey %}" },
+          ":processing_version_id": { "S": "{% $processingObjectVersionId %}" },
           ":updated": { "S": "{% $now() %}" },
           ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
         }
@@ -717,7 +717,7 @@
           "Next": "Get Copied Checkpoint"
         }
       ],
-      "Next": "Inspect Destination Object"
+      "Next": "Inspect Processing Object"
     },
     "Get Copied Checkpoint": {
       "Type": "Task",
@@ -758,23 +758,23 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $exists($copiedCheckpointItem.status.S) and $copiedCheckpointItem.status.S = 'COPIED' and $exists($copiedCheckpointItem.execution_arn.S) and $copiedCheckpointItem.execution_arn.S = $states.context.Execution.Id and $exists($copiedCheckpointItem.destination_version_id.S) and $copiedCheckpointItem.destination_version_id.S = $destinationVersionId %}",
-          "Next": "Inspect Destination Object"
+          "Condition": "{% $exists($copiedCheckpointItem.status.S) and $copiedCheckpointItem.status.S = 'COPIED' and $exists($copiedCheckpointItem.execution_arn.S) and $copiedCheckpointItem.execution_arn.S = $states.context.Execution.Id and $exists($copiedCheckpointItem.processing_version_id.S) and $copiedCheckpointItem.processing_version_id.S = $processingObjectVersionId %}",
+          "Next": "Inspect Processing Object"
         },
         {
           "Condition": "{% $exists($copiedCheckpointItem.status.S) and $copiedCheckpointItem.status.S in ['INPROGRESS', 'PARTS_COPIED'] and $exists($copiedCheckpointItem.execution_arn.S) and $copiedCheckpointItem.execution_arn.S = $states.context.Execution.Id %}",
-          "Next": "Delete Uncheckpointed Destination Version"
+          "Next": "Delete Uncheckpointed Processing Version"
         }
       ],
       "Default": "Ambiguous Copied Checkpoint Failure"
     },
-    "Delete Uncheckpointed Destination Version": {
+    "Delete Uncheckpointed Processing Version": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $destinationVersionId %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $processingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
       "Retry": [
@@ -790,7 +790,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "Uncheckpointed Destination Cleanup Failure"
+          "Next": "Uncheckpointed Processing Cleanup Failure"
         }
       ],
       "Next": "Route Uncheckpointed Copy Rollback"
@@ -808,24 +808,24 @@
     "Uncheckpointed Copy Rolled Back": {
       "Type": "Fail",
       "Error": "UncheckpointedCopyRolledBack",
-      "Cause": "The exact destination version was removed because its durable checkpoint did not commit"
+      "Cause": "The exact processing version was removed because its durable checkpoint did not commit"
     },
     "Ambiguous Copied Checkpoint Failure": {
       "Type": "Fail",
       "Error": "AmbiguousCopiedCheckpointFailure",
       "Cause": "The copy checkpoint outcome could not be reconciled safely"
     },
-    "Uncheckpointed Destination Cleanup Failure": {
+    "Uncheckpointed Processing Cleanup Failure": {
       "Type": "Fail",
-      "Error": "UncheckpointedDestinationCleanupFailure",
-      "Cause": "The uncheckpointed destination version could not be removed safely"
+      "Error": "UncheckpointedProcessingCleanupFailure",
+      "Cause": "The uncheckpointed processing version could not be removed safely"
     },
     "Abort Multipart Upload": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:abortMultipartUpload",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
+        "Key": "{% $incomingObjectKey %}",
         "UploadId": "{% $uploadId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
@@ -881,13 +881,13 @@
       "Error": "MultipartCopyFailure",
       "Cause": "The multipart copy failed after its bounded recovery attempt"
     },
-    "Inspect Destination Object": {
+    "Inspect Processing Object": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $destinationVersionId %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $processingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}",
         "ChecksumMode": "ENABLED"
       },
@@ -902,17 +902,17 @@
         }
       ],
       "Assign": {
-        "destinationHead": "{% $states.result %}"
+        "processingObjectHead": "{% $states.result %}"
       },
-      "Next": "Get Destination Tags"
+      "Next": "Get Processing Object Tags"
     },
-    "Get Destination Tags": {
+    "Get Processing Object Tags": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:getObjectTagging",
       "Arguments": {
         "Bucket": "{% $processingBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $destinationVersionId %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $processingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
       "Retry": [
@@ -926,25 +926,25 @@
         }
       ],
       "Assign": {
-        "destinationTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
-        "destinationTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
+        "processingObjectTags": "{% $exists($states.result.TagSet) ? $states.result.TagSet : [] %}",
+        "processingObjectTagFingerprint": "{% $count($states.result.TagSet) > 0 ? $join($sort($map($states.result.TagSet, function($tag) { $encodeUrlComponent($tag.Key) & '=' & $encodeUrlComponent($tag.Value) })), '&') : '' %}"
       },
-      "Next": "Verify Destination Object"
+      "Next": "Verify Processing Object"
     },
-    "Verify Destination Object": {
+    "Verify Processing Object": {
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SsekmsKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Condition": "{% $processingObjectHead.ContentLength = $incomingObjectSizeBytes and $processingObjectHead.ServerSideEncryption = 'aws:kms' and $processingObjectHead.SsekmsKeyId = $processingKmsKeyArn and $count($keys($processingObjectHead.Metadata)) = $count($keys($expectedProcessingObjectMetadata)) and $count($filter($keys($expectedProcessingObjectMetadata), function($key) { $lookup($processingObjectHead.Metadata, $key) = $lookup($expectedProcessingObjectMetadata, $key) })) = $count($keys($expectedProcessingObjectMetadata)) and $processingObjectTagFingerprint = $incomingObjectTagFingerprint %}",
           "Next": "Checkpoint Verified"
         }
       ],
-      "Default": "Destination Verification Failure"
+      "Default": "Processing Object Verification Failure"
     },
-    "Destination Verification Failure": {
+    "Processing Object Verification Failure": {
       "Type": "Fail",
-      "Error": "DestinationVerificationFailure",
-      "Cause": "The destination version does not match the exact source object attributes"
+      "Error": "ProcessingObjectVerificationFailure",
+      "Cause": "The processing version does not match the exact incoming object attributes"
     },
     "Checkpoint Verified": {
       "Type": "Task",
@@ -968,15 +968,15 @@
           ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
         }
       },
-      "Next": "Delete Exact Source Version"
+      "Next": "Delete Exact Incoming Object Version"
     },
-    "Delete Exact Source Version": {
+    "Delete Exact Incoming Object Version": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
       "Arguments": {
-        "Bucket": "{% $sourceBucket %}",
-        "Key": "{% $sourceKey %}",
-        "VersionId": "{% $sourceVersionId %}",
+        "Bucket": "{% $incomingObjectBucket %}",
+        "Key": "{% $incomingObjectKey %}",
+        "VersionId": "{% $incomingObjectVersionId %}",
         "ExpectedBucketOwner": "{% $expectedAccountId %}"
       },
       "Retry": [

--- a/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
@@ -316,7 +316,7 @@
     "Copy Source Object": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
-      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'CopySource': $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'CopySource': $sourceBucket & '/' & $encodeUrlComponent($sourceKey) & '?versionId=' & $encodeUrlComponent($sourceVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
       "Assign": {
         "destinationVersionId": "{% $states.result.VersionId %}"
       },
@@ -359,7 +359,7 @@
     "Create Multipart Upload": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:s3:createMultipartUpload",
-      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'ExpectedBucketOwner': $expectedAccountId, 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
+      "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $sourceKey, 'ExpectedBucketOwner': $expectedAccountId, 'Metadata': $expectedMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $destinationKmsKeyArn}, $count($sourceTags) > 0 ? {'Tagging': $sourceTagging} : {}, $exists($sourceHead.CacheControl) ? {'CacheControl': $sourceHead.CacheControl} : {}, $exists($sourceHead.ContentDisposition) ? {'ContentDisposition': $sourceHead.ContentDisposition} : {}, $exists($sourceHead.ContentEncoding) ? {'ContentEncoding': $sourceHead.ContentEncoding} : {}, $exists($sourceHead.ContentLanguage) ? {'ContentLanguage': $sourceHead.ContentLanguage} : {}, $exists($sourceHead.ContentType) ? {'ContentType': $sourceHead.ContentType} : {}, $exists($sourceHead.Expires) ? {'Expires': $sourceHead.Expires} : {}, $exists($sourceHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $sourceHead.WebsiteRedirectLocation} : {}]) %}",
       "Assign": {
         "uploadId": "{% $states.result.UploadId %}"
       },
@@ -659,7 +659,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SSEKMSKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SsekmsKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
           "Next": "Checkpoint Copied"
         }
       ],
@@ -935,7 +935,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SSEKMSKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
+          "Condition": "{% $destinationHead.ContentLength = $sizeBytes and $destinationHead.ServerSideEncryption = 'aws:kms' and $destinationHead.SsekmsKeyId = $destinationKmsKeyArn and $count($keys($destinationHead.Metadata)) = $count($keys($expectedMetadata)) and $count($filter($keys($expectedMetadata), function($key) { $lookup($destinationHead.Metadata, $key) = $lookup($expectedMetadata, $key) })) = $count($keys($expectedMetadata)) and $destinationTagFingerprint = $sourceTagFingerprint %}",
           "Next": "Checkpoint Verified"
         }
       ],

--- a/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
@@ -47,7 +47,7 @@
     "Prepare Operation": {
       "Type": "Pass",
       "Assign": {
-        "operationId": "{% 'file-received-workflow#' & $idempotencyKey %}"
+        "operationId": "{% 'file-transfer-workflow#' & $idempotencyKey %}"
       },
       "Next": "Claim Operation"
     },


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed

Introduces the first stage of the file transfer workflow: moving an exact versioned S3 object from `incoming` to `processing`. 📦

- Adds a Standard Step Functions workflow with idempotency checkpoints in DynamoDB.
- Uses a single copy for smaller files and resumable multipart copy for larger files.
- Verifies the destination object before deleting the matching source version. ✅
- Connects the workflow to canonical `FileReceived.v1` events through EventBridge.
- Adds operational alarms, dead-letter queues and least-privilege permissions. 🚨
- Names the workflow `file-transfer-workflow` so it can grow to support clean, quarantine and investigation routes.
- Moves workflow configuration into dedicated locals and uses the shared CloudWatch retention local.

## Validation

- `terraform validate` ✅

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>