### PR TITLE
🤐  Update App Secrets

### DIFF
--- a/terraform/environments/data-platform/app/secrets.tf
+++ b/terraform/environments/data-platform/app/secrets.tf
@@ -5,8 +5,11 @@ module "app_secrets" {
   kms_key_id = data.aws_kms_key.secrets_manager_common.arn
 
   secret_string = jsonencode({
-    secret_key = random_password.app_secrets.result
-    sentry_dsn = "CHANGEME"
+    secret_key          = random_password.app_secrets.result
+    sentry_dsn          = "CHANGEME"
+    azure_authority     = "CHANGEME"
+    azure_client_id     = "CHANGEME"
+    azure_client_secret = "CHANGEME"
   })
   ignore_secret_changes = true
 }

--- a/terraform/environments/data-platform/app/secrets.tf
+++ b/terraform/environments/data-platform/app/secrets.tf
@@ -5,11 +5,12 @@ module "app_secrets" {
   kms_key_id = data.aws_kms_key.secrets_manager_common.arn
 
   secret_string = jsonencode({
-    secret_key          = random_password.app_secrets.result
-    sentry_dsn          = "CHANGEME"
-    azure_authority     = "CHANGEME"
-    azure_client_id     = "CHANGEME"
-    azure_client_secret = "CHANGEME"
+    secret_key           = random_password.app_secrets.result
+    sentry_dsn           = "CHANGEME"
+    azure_authority      = "CHANGEME"
+    azure_client_id      = "CHANGEME"
+    azure_client_secret  = "CHANGEME"
+    field_encryption_key = "CHANGEME"
   })
   ignore_secret_changes = true
 }


### PR DESCRIPTION
This pull request updates the application secrets managed by Terraform to include placeholders for Azure authentication credentials. These new fields will allow the application to integrate with Azure services once real values are provided.

**Secrets management updates:**

* Added `azure_authority`, `azure_client_id`, and `azure_client_secret` fields to the `app_secrets` module in `secrets.tf` to support Azure integration.