### PR TITLE
Bump terraform-static-analysis.yml

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@d682f41c6f6b8c6bc0e06ae38ef41a464aa8a204 # v6.1.6
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@d682f41c6f6b8c6bc0e06ae38ef41a464aa8a204 # v6.1.6
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -73,7 +73,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@d682f41c6f6b8c6bc0e06ae38ef41a464aa8a204 # v6.1.6
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Fixes current `TFLint` failure and also includes `checkov` fix applied in 6.1.7