### PR TITLE
✅ Give the file-transfer state machine a test harness

### DIFF
--- a/.github/workflows/integration-hub-file-transfer.yml
+++ b/.github/workflows/integration-hub-file-transfer.yml
@@ -42,8 +42,83 @@ jobs:
     with:
       application: "${{ github.workflow }}"
 
+  fetch-secrets-for-step-functions:
+    if: inputs.action != 'destroy'
+    uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@91d5c1efbe43e1c8fdfc55fd39e8183fc6be8fa8 # v6.1.1
+    secrets:
+      MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+  test-step-functions:
+    name: Test Step Functions
+    needs:
+      - fetch-secrets-for-step-functions
+    if: inputs.action != 'destroy'
+    runs-on: ubuntu-latest
+
+    env:
+      ACCOUNT_NAME: integration-hub-file-transfer-development
+      STEP_FUNCTIONS_DIRECTORY: terraform/environments/integration-hub-file-transfer/step-functions
+      COPY_INCOMING_OBJECT_DEFINITION: terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.definition.json
+      COPY_INCOMING_OBJECT_INPUT: terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.input.json
+      COPY_INCOMING_OBJECT_VARIABLES: terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.variables.json
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Decrypt environment data
+        uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@91d5c1efbe43e1c8fdfc55fd39e8183fc6be8fa8 # v6.1.1
+        with:
+          environment_management: ${{ needs.fetch-secrets-for-step-functions.outputs.environment_management }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+
+      - name: Get AWS account number
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACCOUNT_NUMBER="$(
+            jq \
+              --raw-output \
+              --exit-status \
+              --arg account_name "${ACCOUNT_NAME}" \
+              '.account_ids[$account_name]' \
+              <<< "${ENVIRONMENT_MANAGEMENT}"
+          )"
+          echo "::add-mask::${ACCOUNT_NUMBER}"
+          echo "ACCOUNT_NUMBER=${ACCOUNT_NUMBER}" >> "${GITHUB_ENV}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-plan
+          role-session-name: step-functions-tests
+          aws-region: eu-west-2
+
+      - name: Test Copy Incoming Object
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$(
+            aws stepfunctions test-state \
+              --definition "file://${COPY_INCOMING_OBJECT_DEFINITION}" \
+              --input "file://${COPY_INCOMING_OBJECT_INPUT}" \
+              --variables "file://${COPY_INCOMING_OBJECT_VARIABLES}" \
+              --mock '{
+                "result": "{\"VersionId\": \"test-processing-version-id\"}",
+                "fieldValidationMode": "NONE"
+              }' \
+              --inspection-level DEBUG \
+              --no-cli-pager
+          )"
+          jq . <<< "${result}"
+          jq --exit-status '.status == "SUCCEEDED"' <<< "${result}"
+
+
   terraform:
-    needs: strategy
+    needs:
+      - strategy
+      - test-step-functions
     if: inputs.action != 'destroy' && join(fromJson(needs.strategy.outputs.matrix).include) != ''
     strategy:
       fail-fast: false

--- a/terraform/environments/integration-hub-file-transfer/step-functions/tests/README.md
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/tests/README.md
@@ -1,0 +1,128 @@
+# Keeping the Step Functions test fixtures up to date
+
+This directory holds the fixtures used by the `test-step-functions` job in
+[integration-hub-file-transfer.yml](../../../../.github/workflows/integration-hub-file-transfer.yml)
+to exercise individual states from
+[file-transfer-workflow.asl.json](../file-transfer-workflow.asl.json)
+using the AWS Step Functions
+[`TestState`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_TestState.html)
+API.
+
+The purpose of this guide is to explain what each fixture is for, how they relate to
+one another, and what to check whenever the workflow definition changes.
+
+## Why fixtures live here, not in the workflow
+
+`TestState` can only test one state at a time, and it needs that state's
+definition, input and variables supplied as plain JSON — it cannot resolve the
+`${...}` placeholders that Terraform's `templatefile()` fills in when the real
+state machine is deployed (account ID, bucket names, KMS key ARNs, and so on).
+
+Rather than have the GitHub Actions workflow render those placeholders with
+made-up test values, every value a test needs is committed here as JSON. The
+workflow only wires these files into `aws stepfunctions test-state`; it does
+not construct or substitute any test data itself. Keeping test data out of the
+workflow file means:
+
+- fixtures can be reviewed and diffed like any other test data
+- adding a new test does not require editing the workflow YAML
+- there's a single, obvious place to update when a state's contract changes
+
+## File-naming convention
+
+Each tested state has three files:
+
+| File | Purpose |
+|---|---|
+| `<state-name>.definition.json` | The standalone ASL definition of **one** state, copied verbatim from `file-transfer-workflow.asl.json` |
+| `<state-name>.input.json` | The `$states.input` the state should be tested with (typically an EventBridge event) |
+| `<state-name>.variables.json` | The JSONata workflow variables (`$variableName`) the state under test dereferences |
+
+For example, the `Copy Incoming Object` state has:
+
+- [copy-incoming-object.definition.json](copy-incoming-object.definition.json)
+- [copy-incoming-object.input.json](copy-incoming-object.input.json)
+- [copy-incoming-object.variables.json](copy-incoming-object.variables.json)
+
+## `<state-name>.definition.json`
+
+This must be an exact copy of the state's object from the `States` map in
+`file-transfer-workflow.asl.json`, with one addition: a top-level
+`"QueryLanguage": "JSONata"` property. The full workflow declares
+`QueryLanguage` once at the machine level and every state inherits it, but
+`TestState` needs it set explicitly on a standalone state definition.
+
+Whenever the source state changes, copy the updated state body across again.
+Do not hand-edit the copy — if the two drift apart, the test stops being
+meaningful because it is no longer testing what will actually be deployed.
+
+Only states without unresolved `${...}` Terraform placeholders can be tested
+this way. `Copy Incoming Object` qualifies because its `Bucket`, `Key` and
+similar values all come from JSONata variables (`$processingBucket`, and so
+on) rather than Terraform interpolation.
+
+## `<state-name>.input.json`
+
+This is the JSON that would be present in `$states.input` when the state
+under test runs. For states early in the workflow (like `Initialise`), this
+is the raw EventBridge event. For states further down the chain, `$states.input`
+may be irrelevant if the state only reads assigned variables — in that case
+this file can be an empty object `{}`, but it must still exist and be valid
+JSON.
+
+When the shape of the upstream event changes (for example, a new field is
+added to `FileReceived.v1`), update this file to match the corresponding
+schema in [../../schemas](../../schemas).
+
+## `<state-name>.variables.json`
+
+This supplies every JSONata variable (`$variableName`) that the state's
+`Arguments`/`Condition`/`Assign` expressions dereference. If the state
+references a variable that isn't a key in this file, `TestState` will fail
+or return `null` for that value.
+
+When you change what a state reads:
+
+1. Re-read the state's JSONata expressions and list every `$variableName` it
+   uses.
+2. Confirm each one is present in the fixture, with a realistic value of the
+   correct type (string, number, object, array).
+3. Remove variables the state no longer reads — an unused fixture value isn't
+   harmful, but it does mislead the next person into thinking it's exercised.
+
+## Checklist when the ASL definition changes
+
+Whenever `file-transfer-workflow.asl.json` changes, check whether it affects
+any state that already has fixtures here:
+
+- [ ] Did the state's `Type`, `Resource`, `Arguments`, `Assign` or `Catch`
+      change? If so, copy the updated state body into
+      `<state-name>.definition.json`.
+- [ ] Did the set of `$variableName` references in the state change? If so,
+      add, update or remove entries in `<state-name>.variables.json`.
+- [ ] Does the state read `$states.input`? If the upstream event shape
+      changed, update `<state-name>.input.json` to match.
+- [ ] If a **new** state needs coverage, create its three fixture files
+      following the naming convention above, then add a step to the
+      `test-step-functions` job in the workflow that calls `test-state`
+      with `--definition`, `--input` and `--variables` pointing at the new
+      files (and a `--mock` if the state calls an AWS SDK action).
+
+## Running a test locally
+
+Each state test can be run without needing GitHub Actions, provided you have
+sufficient AWS credentials available to you:
+
+```bash
+aws stepfunctions test-state \
+  --definition file://terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.definition.json \
+  --input file://terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.input.json \
+  --variables file://terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.variables.json \
+  --mock '{"result": "{\"VersionId\": \"test-processing-version-id\"}", "fieldValidationMode": "NONE"}' \
+  --inspection-level DEBUG \
+  --no-cli-pager
+```
+
+A successful test returns `"status": "SUCCEEDED"`. Anything else — including
+a validation error about a missing variable — means a fixture is out of date
+with the state it's meant to test.

--- a/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.definition.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.definition.json
@@ -1,0 +1,16 @@
+{
+  "Type": "Task",
+  "QueryLanguage": "JSONata",
+  "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
+  "Arguments": "{% $merge([{'Bucket': $processingBucket, 'Key': $incomingObjectKey, 'CopySource': $incomingObjectBucket & '/' & $encodeUrlComponent($incomingObjectKey) & '?versionId=' & $encodeUrlComponent($incomingObjectVersionId), 'ExpectedBucketOwner': $expectedAccountId, 'ExpectedSourceBucketOwner': $expectedAccountId, 'MetadataDirective': 'REPLACE', 'Metadata': $expectedProcessingObjectMetadata, 'ServerSideEncryption': 'aws:kms', 'SsekmsKeyId': $processingKmsKeyArn}, $count($incomingObjectTags) > 0 ? {'TaggingDirective': 'REPLACE', 'Tagging': $incomingObjectTagging} : {}, $exists($incomingObjectHead.CacheControl) ? {'CacheControl': $incomingObjectHead.CacheControl} : {}, $exists($incomingObjectHead.ContentDisposition) ? {'ContentDisposition': $incomingObjectHead.ContentDisposition} : {}, $exists($incomingObjectHead.ContentEncoding) ? {'ContentEncoding': $incomingObjectHead.ContentEncoding} : {}, $exists($incomingObjectHead.ContentLanguage) ? {'ContentLanguage': $incomingObjectHead.ContentLanguage} : {}, $exists($incomingObjectHead.ContentType) ? {'ContentType': $incomingObjectHead.ContentType} : {}, $exists($incomingObjectHead.Expires) ? {'Expires': $incomingObjectHead.Expires} : {}, $exists($incomingObjectHead.WebsiteRedirectLocation) ? {'WebsiteRedirectLocation': $incomingObjectHead.WebsiteRedirectLocation} : {}]) %}",
+  "Assign": {
+    "processingObjectVersionId": "{% $states.result.VersionId %}"
+  },
+  "Catch": [
+    {
+      "ErrorEquals": ["States.ALL"],
+      "Next": "Reconcile Processing Object"
+    }
+  ],
+  "Next": "Checkpoint Copied"
+}

--- a/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.input.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.input.json
@@ -1,0 +1,31 @@
+{
+  "version": "0",
+  "id": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+  "detail-type": "FileReceived.v1",
+  "source": "uk.gov.justice.service.managed-file-transfer",
+  "account": "123456789012",
+  "time": "2026-07-10T14:00:00Z",
+  "region": "eu-west-2",
+  "resources": [
+    "arn:aws:s3:::integration-hub-file-transfer-development-incoming/example/report.csv"
+  ],
+  "detail": {
+    "metadata": {
+      "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
+      "idempotencyKey": "example/report.csv:3Lg..."
+    },
+    "data": {
+      "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",
+      "object": {
+        "bucket": "integration-hub-file-transfer-development-incoming",
+        "key": "example/report.csv",
+        "versionId": "3Lg...",
+        "sizeBytes": 4096
+      },
+      "provenance": {
+        "ingressMethod": "s3",
+        "clientId": "example-client"
+      }
+    }
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.variables.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/tests/copy-incoming-object.variables.json
@@ -1,0 +1,14 @@
+{
+  "expectedAccountId": "123456789012",
+  "incomingObjectBucket": "integration-hub-file-transfer-development-incoming",
+  "incomingObjectKey": "example/report.csv",
+  "incomingObjectVersionId": "3Lg...",
+  "incomingObjectHead": {},
+  "incomingObjectTags": [],
+  "incomingObjectTagging": "",
+  "processingBucket": "integration-hub-file-transfer-development-processing",
+  "processingKmsKeyArn": "arn:aws:kms:eu-west-2:123456789012:key/12345678-1234-1234-1234-123456789012",
+  "expectedProcessingObjectMetadata": {
+    "mft-file-id": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501"
+  }
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What this does

Adds a `test-step-functions` job to the `integration-hub-file-transfer` workflow that exercises states from the `file-transfer-workflow` state machine using the AWS Step Functions `TestState` API, before Terraform gets anywhere near an apply.

For now it covers the `Copy Incoming Object` state — the one responsible for actually staging an object from `incoming` into `processing` — but the fixture pattern is designed to grow to cover more states over time.

## Why fixtures, not rendered Terraform

`TestState` needs a plain ASL state definition plus JSON input and variables; it can't resolve the `${...}` placeholders Terraform fills in at deploy time. Rather than have the workflow guess at test values and render them inline, every value the test needs is committed as JSON under [`step-functions/tests/`](terraform/environments/integration-hub-file-transfer/step-functions/tests/):

- `copy-incoming-object.definition.json` — a verbatim copy of the state's ASL, with `QueryLanguage` set explicitly (it's normally inherited from the machine)
- `copy-incoming-object.input.json` — a sample `FileReceived.v1` event
- `copy-incoming-object.variables.json` — the JSONata workflow variables the state reads

The `Copy Incoming Object` task itself is mocked so the job proves the request is built correctly without needing to touch a real S3 bucket.

## Keeping it maintained

There's a short [README](terraform/environments/integration-hub-file-transfer/step-functions/tests/README.md) in the tests directory covering the naming convention and a checklist for what to update whenever the ASL definition changes — worth a skim before adding fixtures for the next state.

## Testing

- Fixture JSON parses and matches the corresponding state in `file-transfer-workflow.asl.json`
- Confirmed the state's JSONata variable references are all present in the variables fixture
- Workflow YAML parses cleanly
