### PR TITLE
Need to use fixed role names defined by AWS

### DIFF
--- a/terraform/environments/delius-core/main_development.tf
+++ b/terraform/environments/delius-core/main_development.tf
@@ -29,7 +29,7 @@ module "environment_dev" {
 
   ldap_config        = local.ldap_config_dev
   db_config          = local.db_config_dev
-  create_backup_role = true
+  create_account_service_roles = true
   create_ecs_lambda  = true
 
   delius_microservice_configs = local.delius_microservices_configs_dev
@@ -72,7 +72,7 @@ module "environment_poc" {
 
   ldap_config        = local.ldap_config_poc
   db_config          = local.db_config_poc
-  create_backup_role = false
+  create_account_service_roles = false
   create_ecs_lambda  = false
 
   delius_microservice_configs = local.delius_microservices_configs_poc

--- a/terraform/environments/delius-core/main_preproduction.tf
+++ b/terraform/environments/delius-core/main_preproduction.tf
@@ -30,7 +30,7 @@ module "environment_stage" {
 
   ldap_config        = local.ldap_config_stage
   db_config          = local.db_config_stage
-  create_backup_role = false
+  create_account_service_roles = false
   create_ecs_lambda  = false
 
   delius_microservice_configs = local.delius_microservices_configs_stage
@@ -73,7 +73,7 @@ module "environment_preprod" {
 
   ldap_config        = local.ldap_config_preprod
   db_config          = local.db_config_preprod
-  create_backup_role = true
+  create_account_service_roles = true
   create_ecs_lambda  = true
 
   delius_microservice_configs = local.delius_microservices_configs_preprod

--- a/terraform/environments/delius-core/main_production.tf
+++ b/terraform/environments/delius-core/main_production.tf
@@ -30,7 +30,7 @@ module "environment_prod" {
 
   ldap_config        = local.ldap_config_prod
   db_config          = local.db_config_prod
-  create_backup_role = true
+  create_account_service_roles = true
   create_ecs_lambda  = true
 
   delius_microservice_configs = local.delius_microservices_configs_prod

--- a/terraform/environments/delius-core/main_test.tf
+++ b/terraform/environments/delius-core/main_test.tf
@@ -30,7 +30,7 @@ module "environment_test" {
 
   ldap_config        = local.ldap_config_test
   db_config          = local.db_config_test
-  create_backup_role = true
+  create_account_service_roles = true
   create_ecs_lambda  = true
 
   delius_microservice_configs = local.delius_microservices_configs_test

--- a/terraform/environments/delius-core/modules/components/dms/dms_iam.tf
+++ b/terraform/environments/delius-core/modules/components/dms/dms_iam.tf
@@ -10,23 +10,31 @@ data "aws_iam_policy_document" "dms_assume_role" {
 }
 
 resource "aws_iam_role" "dms-cloudwatch-logs-role" {
+  count = var.create_dms_cloudwatch_logs_role ? 1 : 0
+
   assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
-  name               = "${var.env_name}-dms-cloudwatch-logs-role"
+  name               = "dms-cloudwatch-logs-role"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-cloudwatch-logs-role-AmazonDMSCloudWatchLogsRole" {
+  count = var.create_dms_cloudwatch_logs_role ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole"
-  role       = aws_iam_role.dms-cloudwatch-logs-role.name
+  role       = aws_iam_role.dms-cloudwatch-logs-role[0].name
 }
 
 resource "aws_iam_role" "dms-vpc-role" {
+  count = var.create_dms_vpc_role ? 1 : 0
+
   assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
-  name               = "${var.env_name}-dms-vpc-role"
+  name               = "dms-vpc-role"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
+  count = var.create_dms_vpc_role ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-  role       = aws_iam_role.dms-vpc-role.name
+  role       = aws_iam_role.dms-vpc-role[0].name
 }
 
 # The following role, dms_s3_writer_role, allows the DMS service to write to the local S3 DMS bucket 

--- a/terraform/environments/delius-core/modules/components/dms/variables.tf
+++ b/terraform/environments/delius-core/modules/components/dms/variables.tf
@@ -52,3 +52,15 @@ variable "env_name_to_dms_config_map" {
   description = "Map of delius-core environments to DMS configs"
   type        = any
 }
+
+variable "create_dms_cloudwatch_logs_role" {
+  description = "Create the account-wide DMS CloudWatch logs role"
+  type        = bool
+  default     = false
+}
+
+variable "create_dms_vpc_role" {
+  description = "Create the account-wide DMS VPC role"
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/delius-core/modules/components/oracle_db_shared/iam.tf
+++ b/terraform/environments/delius-core/modules/components/oracle_db_shared/iam.tf
@@ -194,7 +194,7 @@ resource "aws_iam_policy" "combined_instance_policy" {
 
 # AWS Backup Role
 resource "aws_iam_role" "aws_backup_default_service_role" {
-  count = var.create_backup_role ? 1 : 0
+  count = var.create_aws_backup_service_role ? 1 : 0
   name  = "AWSBackupDefaultServiceRole"
 
   assume_role_policy = jsonencode({
@@ -212,19 +212,19 @@ resource "aws_iam_role" "aws_backup_default_service_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "backup_policy" {
-  count      = var.create_backup_role ? 1 : 0
+  count      = var.create_aws_backup_service_role ? 1 : 0
   role       = aws_iam_role.aws_backup_default_service_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
 }
 
 resource "aws_iam_role_policy_attachment" "restore_policy" {
-  count      = var.create_backup_role ? 1 : 0
+  count      = var.create_aws_backup_service_role ? 1 : 0
   role       = aws_iam_role.aws_backup_default_service_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
 }
 
 data "aws_iam_policy_document" "business_unit_kms_key_access" {
-  count = var.create_backup_role ? 1 : 0
+  count = var.create_aws_backup_service_role ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -244,14 +244,14 @@ data "aws_iam_policy_document" "business_unit_kms_key_access" {
 }
 
 resource "aws_iam_policy" "business_unit_kms_key_access" {
-  count  = var.create_backup_role ? 1 : 0
+  count  = var.create_aws_backup_service_role ? 1 : 0
   name   = "${var.env_name}-${var.db_suffix}-business-unit-kms-key-access-policy"
   path   = "/"
   policy = data.aws_iam_policy_document.business_unit_kms_key_access[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "backup_service_kms_policy_attachment" {
-  count      = var.create_backup_role ? 1 : 0
+  count      = var.create_aws_backup_service_role ? 1 : 0
   role       = aws_iam_role.aws_backup_default_service_role[0].name
   policy_arn = aws_iam_policy.business_unit_kms_key_access[0].arn
 }

--- a/terraform/environments/delius-core/modules/components/oracle_db_shared/variables.tf
+++ b/terraform/environments/delius-core/modules/components/oracle_db_shared/variables.tf
@@ -103,8 +103,8 @@ variable "ecs_cluster_arn" {
 }
 
 # Only create one per account
-variable "create_backup_role" {
-  description = "Role used to run AWS Backups i.e. AWSBackupDefaultServiceRole"
+variable "create_aws_backup_service_role" {
+  description = "Create the AWS Backup default service role"
   type        = bool
   default     = false
 }

--- a/terraform/environments/delius-core/modules/delius_environment/database.tf
+++ b/terraform/environments/delius-core/modules/delius_environment/database.tf
@@ -29,7 +29,7 @@ module "oracle_db_shared" {
   cluster_security_group_id   = aws_security_group.cluster.id
   delius_microservice_configs = var.delius_microservice_configs
   ecs_cluster_arn             = module.ecs.ecs_cluster_arn
-  create_backup_role          = var.create_backup_role
+  create_aws_backup_service_role = var.create_account_service_roles
 
   providers = {
     aws.bucket-replication    = aws

--- a/terraform/environments/delius-core/modules/delius_environment/dms.tf
+++ b/terraform/environments/delius-core/modules/delius_environment/dms.tf
@@ -12,6 +12,8 @@ module "dms" {
   oracle_db_server_names                    = local.oracle_db_server_names
   db_ec2_sg_id                              = module.oracle_db_shared.db_ec2_sg_id
   env_name_to_dms_config_map                = var.env_name_to_dms_config_map
+  create_dms_cloudwatch_logs_role           = var.create_account_service_roles
+  create_dms_vpc_role                       = var.create_account_service_roles
 
   providers = {
     aws                        = aws

--- a/terraform/environments/delius-core/modules/delius_environment/variables.tf
+++ b/terraform/environments/delius-core/modules/delius_environment/variables.tf
@@ -115,9 +115,9 @@ variable "env_name_to_dms_config_map" {
   type        = any
 }
 
-# Only create one per account
-variable "create_backup_role" {
-  description = "Role used to run AWS Backups i.e. AWSBackupDefaultServiceRole"
+# Only create one set of account-wide service roles per account
+variable "create_account_service_roles" {
+  description = "Create the account-wide service IAM roles shared by DMS and AWS Backup"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
We piggy back on existing create_backup_role that only creates IAM resources for certain environments in shared accounts and rename it to create_account_service_roles since this now affects things other than backups.

This pull request refactors how account-wide IAM service roles are created and managed for DMS and AWS Backup across different environments. It replaces the previous `create_backup_role` variable with a new, more general `create_account_service_roles` variable, and splits out DMS-specific role creation into their own variables. This improves clarity and flexibility in managing IAM roles and ensures only one set of shared roles is created per account.

The most important changes are:

**Refactoring account-wide IAM role creation:**
* Replaces the `create_backup_role` variable with `create_account_service_roles` in environment configuration files (`main_development.tf`, `main_preproduction.tf`, `main_production.tf`, `main_test.tf`), ensuring only one set of shared service roles (for DMS and AWS Backup) is created per account. [[1]](diffhunk://#diff-f9fc13f8d5b2e4af0e9b884b2479db7b0750916c499249ea6e4bc51f72b194feL32-R32) [[2]](diffhunk://#diff-f9fc13f8d5b2e4af0e9b884b2479db7b0750916c499249ea6e4bc51f72b194feL75-R75) [[3]](diffhunk://#diff-98550a19bf8ead730239a6948a6ee7911a7048035ce34b2c9cf4bed4a65db7d0L33-R33) [[4]](diffhunk://#diff-98550a19bf8ead730239a6948a6ee7911a7048035ce34b2c9cf4bed4a65db7d0L76-R76) [[5]](diffhunk://#diff-0e776b49bbaadcea3d4b0ecf3a841c874fe96ac492d6a4e00223995ed915f8c8L33-R33) [[6]](diffhunk://#diff-0a6872795f9c1c0528c2ef75366a52c2890e387ceabd598865f957be06311ed3L33-R33)
* Updates module interfaces and variable names to use the new `create_account_service_roles` variable, and passes it to submodules responsible for DMS and AWS Backup roles. [[1]](diffhunk://#diff-6fa27b9c117fe4d6fe9d2229d967314cf16ae027b6a729ce2b22ad430d1cee5eL32-R32) [[2]](diffhunk://#diff-2378c23c9545b01ce7d302884135041e8aef5000a3c53aa27769a97a61dfabd7R15-R16) [[3]](diffhunk://#diff-29abf5ca9b89e895af325b86116384c51402f14bdac6dd6d08fd1feb1beb9b1eL118-R120)

**DMS IAM roles improvements:**
* Adds new variables `create_dms_cloudwatch_logs_role` and `create_dms_vpc_role` to control creation of DMS-specific roles, and updates resources to use these variables with `count` for conditional creation. [[1]](diffhunk://#diff-a215a34c981a0c78936f523ee0a2b0297ffa8f4eb5486284b7d89447b20d7c73R13-R37) [[2]](diffhunk://#diff-b7970e582cf7c712e5cdc8118f553c01a1ec5871b4bc73908a415d5de3c213eeR55-R66)

**AWS Backup IAM roles improvements:**
* Renames `create_backup_role` to `create_aws_backup_service_role` for clarity, and updates all related resources to use this new variable for conditional creation. [[1]](diffhunk://#diff-22ac3c276de7d73a3ecddce476f20aceeb5c70f80cca3e46502b16d1b488d348L197-R197) [[2]](diffhunk://#diff-22ac3c276de7d73a3ecddce476f20aceeb5c70f80cca3e46502b16d1b488d348L215-R227) [[3]](diffhunk://#diff-22ac3c276de7d73a3ecddce476f20aceeb5c70f80cca3e46502b16d1b488d348L247-R254) [[4]](diffhunk://#diff-8ec414fe4a78e8c4a42a2c43a39bc59beaa53261bf40a12823ea6f9e9b8b25f9L106-R107)

