### PR TITLE
✨ Publish FileStagedForScanning.v1 events

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
@@ -56,11 +56,14 @@ Imagine `finance/april-payroll.csv` arrives in the `incoming` bucket with versio
 
 1. S3 emits a native `Object Created` event with its own EventBridge `id`, call it `native-1`.
 2. The file-received adapter hashes the incoming bucket, key and version ID to produce `file-1`, then publishes `FileReceived.v1`. EventBridge assigns this event `id = eb-1`. The event carries `fileId = file-1`, `correlationId = file-1`, and no `causationId`.
-3. The file-transfer workflow picks up `FileReceived.v1`, stages the exact object version to `processing/finance/april-payroll.csv`, verifies the destination version, and deletes the exact source version. Publication of `FileStagedForScanning.v1` is outside the current workflow scope.
+3. The file-transfer workflow picks up `FileReceived.v1`, stages the exact object version to `processing/finance/april-payroll.csv`, verifies the destination version, and deletes the exact source version.
+4. The workflow publishes `FileStagedForScanning.v1` as an audit record that the object is ready for GuardDuty Malware Protection for S3. It copies `fileId` and `correlationId`, sets `causationId` to the `FileReceived.v1` EventBridge ID, and identifies the exact source and staged S3 versions.
 
-Once the next lifecycle event is introduced, the scanner and router will continue the canonical chain by copying `fileId` and `correlationId` and setting each event's `causationId` to the preceding EventBridge event ID.
+The future GuardDuty adapter and router will continue the canonical chain with `FileScanResultRecorded.v1` and `FileRouted.v1`, copying `fileId` and `correlationId` and setting each event's `causationId` to the preceding EventBridge event ID.
 
 At every stage, `fileId` and `correlationId` stay the same. The S3 location changes, the object version changes, and each EventBridge `id` is unique — but you can follow the whole chain.
+
+The workflow records a `PUBLISHED` checkpoint containing the `FileStagedForScanning.v1` EventBridge ID before marking the transfer `COMPLETED`. If EventBridge accepts the event but the checkpoint write fails, recovery can publish the event again. Consumers must therefore treat delivery as at least once and deduplicate using `detail.metadata.idempotencyKey`, which is derived from the exact processing bucket, key and version ID.
 
 ## Rules for event producers
 

--- a/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
@@ -1,4 +1,5 @@
 locals {
   eventbridge_schema_directory = "${path.module}/schemas"
   eventbridge_schemas          = fileset("${path.module}/schemas", "*.json")
+  file_transfer_event_bus_arn  = "arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-bus/${local.application_name}"
 }

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileStagedForScanning.v1.json
@@ -109,7 +109,7 @@
         "metadata": {
           "correlationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
           "causationId": "7d9f4e4c-0e0f-4a5b-8b4e-4ab1f28fd1d1",
-          "idempotencyKey": "processing/example/report.csv:3Lg..."
+          "idempotencyKey": "processing:example/report.csv:4Mh..."
         },
         "data": {
           "fileId": "3f4e3d7a-4e2f-4bc2-9c4e-5f1ef2d4c501",

--- a/terraform/environments/integration-hub-file-transfer/step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions.tf
@@ -7,6 +7,7 @@ module "step_function_file_transfer_workflow" {
 
   definition = templatefile("${path.module}/step-functions/file-transfer-workflow.asl.json", {
     account_id                 = jsonencode(data.aws_caller_identity.current.account_id)
+    event_bus_arn              = jsonencode(local.file_transfer_event_bus_arn)
     processing_kms_key_arn     = jsonencode(module.kms_s3_bucket["processing"].key_arn)
     idempotency_table_name     = jsonencode(module.dynamodb_file_transfer_workflow_idempotency.dynamodb_table_id)
     incoming_bucket_name       = jsonencode(module.s3_bucket["incoming"].s3_bucket_id)
@@ -84,6 +85,11 @@ module "step_function_file_transfer_workflow" {
         "kms:GenerateDataKey*",
       ]
       resources = [module.kms_s3_bucket["processing"].key_arn]
+    }
+    publish_file_staged_events = {
+      effect    = "Allow"
+      actions   = ["events:PutEvents"]
+      resources = [local.file_transfer_event_bus_arn]
     }
   }
 

--- a/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/file-transfer-workflow.asl.json
@@ -22,6 +22,7 @@
         "processingKmsKeyArn": ${processing_kms_key_arn},
         "partSize": ${part_size_bytes},
         "maximumSize": ${maximum_size_bytes},
+        "eventBusArn": ${event_bus_arn},
         "leaseSeconds": ${lease_seconds},
         "recordRetentionSeconds": ${record_retention_seconds},
         "nowEpoch": "{% $floor($toMillis($states.context.Execution.StartTime) / 1000) %}",
@@ -198,6 +199,10 @@
     "Route Stored Checkpoint": {
       "Type": "Choice",
       "Choices": [
+        {
+          "Condition": "{% $resumeStatus = 'PUBLISHED' %}",
+          "Next": "Checkpoint Completed"
+        },
         {
           "Condition": "{% $resumeStatus = 'VERIFIED' %}",
           "Next": "Delete Exact Incoming Object Version"
@@ -989,6 +994,68 @@
           "JitterStrategy": "FULL"
         }
       ],
+      "Next": "Prepare File Staged Event"
+    },
+    "Prepare File Staged Event": {
+      "Type": "Pass",
+      "Assign": {
+        "stagedEventIdempotencyKey": "{% $processingBucket & ':' & $incomingObjectKey & ':' & $processingObjectVersionId %}",
+        "fileStagedEventDetail": "{% {'metadata': {'correlationId': $correlationId, 'causationId': $eventId, 'idempotencyKey': $processingBucket & ':' & $incomingObjectKey & ':' & $processingObjectVersionId}, 'data': {'fileId': $fileId, 'sourceObject': {'bucket': $incomingObjectBucket, 'key': $incomingObjectKey, 'versionId': $incomingObjectVersionId, 'sizeBytes': $incomingObjectSizeBytes}, 'stagedObject': {'bucket': $processingBucket, 'key': $incomingObjectKey, 'versionId': $processingObjectVersionId, 'sizeBytes': $incomingObjectSizeBytes}, 'metadataPreserved': true, 'tagsPreserved': true, 'sourceDeleted': true}} %}"
+      },
+      "Next": "Publish File Staged Event"
+    },
+    "Publish File Staged Event": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::events:putEvents",
+      "Arguments": {
+        "Entries": [
+          {
+            "Detail": "{% $fileStagedEventDetail %}",
+            "DetailType": "FileStagedForScanning.v1",
+            "EventBusName": "{% $eventBusArn %}",
+            "Source": "uk.gov.justice.service.managed-file-transfer"
+          }
+        ]
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["EventBridge.FailedEntry", "States.Timeout"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 5,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 60,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Assign": {
+        "stagedEventId": "{% $states.result.Entries[0].EventId %}"
+      },
+      "Next": "Checkpoint Published"
+    },
+    "Checkpoint Published": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": ${idempotency_table_name},
+        "Key": {
+          "id": { "S": "{% $operationId %}" }
+        },
+        "UpdateExpression": "SET #status = :status, staged_event_id = :event_id, staged_event_idempotency_key = :idempotency_key, published_at = :published, updated_at = :updated, in_progress_expiration = :lease",
+        "ConditionExpression": "execution_arn = :execution AND #status = :verified",
+        "ExpressionAttributeNames": {
+          "#status": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":status": { "S": "PUBLISHED" },
+          ":verified": { "S": "VERIFIED" },
+          ":execution": { "S": "{% $states.context.Execution.Id %}" },
+          ":event_id": { "S": "{% $stagedEventId %}" },
+          ":idempotency_key": { "S": "{% $stagedEventIdempotencyKey %}" },
+          ":published": { "S": "{% $now() %}" },
+          ":updated": { "S": "{% $now() %}" },
+          ":lease": { "N": "{% $string($floor($toMillis($now()) / 1000) + $leaseSeconds) %}" }
+        }
+      },
       "Next": "Checkpoint Completed"
     },
     "Checkpoint Completed": {
@@ -1000,13 +1067,13 @@
           "id": { "S": "{% $operationId %}" }
         },
         "UpdateExpression": "SET #status = :status, completed_at = :completed, updated_at = :updated REMOVE in_progress_expiration",
-        "ConditionExpression": "execution_arn = :execution AND #status = :verified",
+        "ConditionExpression": "execution_arn = :execution AND #status = :published",
         "ExpressionAttributeNames": {
           "#status": "status"
         },
         "ExpressionAttributeValues": {
           ":status": { "S": "COMPLETED" },
-          ":verified": { "S": "VERIFIED" },
+          ":published": { "S": "PUBLISHED" },
           ":execution": { "S": "{% $states.context.Execution.Id %}" },
           ":completed": { "S": "{% $now() %}" },
           ":updated": { "S": "{% $now() %}" }

--- a/terraform/environments/integration-hub-file-transfer/step-functions/tests/render/main.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions/tests/render/main.tf
@@ -1,0 +1,21 @@
+locals {
+  definition = templatefile("../../file-transfer-workflow.asl.json", {
+    account_id                 = jsonencode("123456789012")
+    event_bus_arn              = jsonencode("arn:aws:events:eu-west-2:123456789012:event-bus/integration-hub-file-transfer")
+    event_idempotency_table    = jsonencode("integration-hub-file-transfer-development-idempotency")
+    processing_kms_key_arn     = jsonencode("arn:aws:kms:eu-west-2:123456789012:key/12345678-1234-1234-1234-123456789012")
+    idempotency_table_name     = jsonencode("integration-hub-file-transfer-development-file-transfer-workflow-idempotency")
+    incoming_bucket_name       = jsonencode("integration-hub-file-transfer-development-incoming")
+    lease_seconds              = 90000
+    maximum_size_bytes         = 5000000000000
+    multipart_max_concurrency  = 4
+    part_size_bytes            = 5000000000
+    processing_bucket_name     = jsonencode("integration-hub-file-transfer-development-processing")
+    record_retention_seconds   = 2592000
+    state_machine_timeout_secs = 86400
+  })
+}
+
+output "definition" {
+  value = local.definition
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changes for people

When a file has been safely staged and is ready for malware scanning, the file-transfer workflow now publishes a `FileStagedForScanning.v1` EventBridge event. This gives downstream services a clear, dependable signal to begin scanning without having to infer state from workflow internals. ✨

The event carries the existing lifecycle identifiers so teams can trace a file through the workflow and handle retries safely.

## Also corrected

The schema's `idempotencyKey` example now matches the documented `stage:path:version` format, making the contract a little less surprising for consumers. This was honestly an unintentional omission corrected in this PR. 🧹

## Checks

- `git diff --check origin/main...HEAD`
- `terraform validate` was run by a real person 👨‍🎨 

Signed-off-by: David Sibley <david.sibley@justice.gov.uk>