### PR TITLE
tidy slack alert

### DIFF
--- a/terraform/environments/data-platform/monitoring/README.md
+++ b/terraform/environments/data-platform/monitoring/README.md
@@ -23,8 +23,7 @@ alerting-defaults.tf           Threshold values (warning/critical) referenced
 
 alerting-rules.tf              The engine: expands golden signals into one
                                 Grafana alert rule per resource/account/severity,
-                                builds the CloudWatch/Prometheus query pipeline,
-                                and resolves Slack routing.
+                                builds the CloudWatch/Prometheus query pipeline.
 
 alerting.tf                    Terraform resources (grafana_folder,
                                 grafana_rule_group) that actually create the
@@ -135,7 +134,7 @@ alerts_configured_accounts = [
 ]
 ```
 
-This same entry is where every other account-level lives — resourse lists for the `dim_key` fan-out, threshold overrides, Slack routing, disabled rules, and query settings. Every field below is optional; add only what you need. See [Account configuration fields](#account-configuration-fields-alerts_configured_accounts)
+This same entry is where every other account-level lives — resourse lists for the `dim_key` fan-out, threshold overrides, disabled rules, and query settings. Every field below is optional; add only what you need. See [Account configuration fields](#account-configuration-fields-alerts_configured_accounts)
 for the full reference.
 
 ```hcl
@@ -159,18 +158,6 @@ alerts_configured_accounts = [
     threshold_overrides = {
       rds_cpu_warn = 85
       rds_cpu_crit = 95
-    }
-
-    # Account-wide fallback Slack channel, used when a golden signal has no
-    # slack_channel of its own
-    slack_channel = "dev-slack"
-
-    # Per-rule, per-severity Slack overrides — the key is the combo_key
-    # (rule key plus resource suffix, e.g.
-    # "s3_bucket_5xx_errors_data-platform-dev-landing")
-    slack_channel_overrides = {
-      rds_cpu_utilization  = { critical = "dev-slack-critical" }
-      s3_bucket_5xx_errors = { warning = "disabled" } # suppresses the label entirely
     }
 
     # How often Grafana evaluates rules for this account (defaults to "1m")
@@ -204,7 +191,6 @@ Every key inside `alerting_golden_signals` (in `alerting-golden-signals.tf`) is 
 | `capacity_metric` | with `use_metric_math` | CloudWatch metric name used as the denominator (`A2`) in the metric-math expression, e.g. `"PermittedThroughput"`. |
 | `capacity_statistic` | no (default `"Minimum"`) | CloudWatch statistic applied to the capacity metric. Only used with `use_metric_math`. |
 | `ok_when_nodata` | no (default `false`) | If `true`, sets `noDataState: OK` so the rule resolves to Normal when CloudWatch/Prometheus returns nothing (e.g. zero failed nodes), rather than going to `NoData`. |
-| `slack_channel` | no | Slack channel(s) for this signal. Either a string (same channel both severities) or an object `{ warning = "...", critical = "..." }` (omit a key to emit no label for that severity). Resolution order per severity: rule's per-severity key → rule's string value → the account's `slack_channel` default. If nothing resolves, no `slack-channel` label is set and Grafana's catch-all policy handles routing. |
 | `warning` | one of `warning`/`critical` required | Key into `alert_defaults` (or an account's `threshold_overrides`) for the warning threshold. Omit to make the rule critical-only. |
 | `critical` | one of `warning`/`critical` required | Same, for the critical threshold. Omit to make the rule warning-only. |
 | `query_window_seconds` | no (default `300`) | Lookback window, in seconds, for the current-value queries (refs `A`, `A2`, `B`, `C`). |
@@ -241,8 +227,6 @@ Each entry in `alerts_configured_accounts` (in `environment-configuration.tf`) c
 | `efs_file_systems` | with `FileSystemId`-dimensioned rules | `[]` | List of EFS file system IDs. One rule per filesystem for `dim_key = "FileSystemId"`. |
 | `disabled_rules` | no | `[]` | List of golden-signal rule keys (the keys in `alerting_golden_signals`) to skip entirely for this account — no rule, no Grafana UID, regardless of `enabled_groups`. |
 | `threshold_overrides` | no | `{}` | Map of threshold key → value, merged over `alert_defaults` for this account only (`merge(alert_defaults, threshold_overrides)`). Use the same keys referenced by golden signals' `warning`/`critical` fields. |
-| `slack_channel` | no | none | Account-wide fallback Slack channel. Used for a rule's severity only when neither the golden signal's own `slack_channel` nor a `slack_channel_overrides` entry resolves one. |
-| `slack_channel_overrides` | no | `{}` | Map keyed by `combo_key` (the rule key, plus a resource suffix such as `_<bucket-name>` when the rule is dimensioned) → `{ warning = "...", critical = "..." }`. Takes priority over everything else, including the golden signal's own `slack_channel`. Set a severity's value to `"disabled"` to force no Slack label for that severity (overriding even the account's `slack_channel` fallback). |
 | `evaluation_interval` | no | `"1m"` (`local.evaluation_interval`) | How often Grafana evaluates every rule group for this account. Accepts `"30s"`, `"1m"`, `"5m"`, `"2h"`-style duration strings. |
 | `prometheus_datasource_uid` | no | `"<uid>-prometheus"` | Grafana datasource UID used for Prometheus (`datasource_type = "prometheus"`) queries. Override if the Amazon Managed Prometheus datasource was provisioned under a different UID. |
 | `aws_region` | no | current provider region (`data.aws_region.current.region`) | AWS region passed to CloudWatch queries for this account. Override for accounts monitored cross-region. |
@@ -265,21 +249,6 @@ disabled_rules = ["rds_cpu_utilization", "litellm_provider_state"]
 threshold_overrides = {
   rds_cpu_warn = 85
   rds_cpu_crit = 95
-}
-```
-
-**`slack_channel`** — account-wide fallback channel, used whenever a rule's severity has no more specific channel resolved:
-
-```hcl
-slack_channel = "dev-alerts"
-```
-
-**`slack_channel_overrides`** — redirect (or silence) one specific rule's severity for this account, keyed by `combo_key` (rule key + resource suffix if the rule is dimensioned):
-
-```hcl
-slack_channel_overrides = {
-  rds_cpu_utilization                          = { critical = "oncall-critical" }
-  s3_bucket_5xx_errors_data-platform-dev-landing = { warning = "disabled" }
 }
 ```
 

--- a/terraform/environments/data-platform/monitoring/alerting-golden-signals.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-golden-signals.tf
@@ -65,19 +65,6 @@ locals {
   #   ok_when_nodata = (optional, default: false)
   #                    if true, sets noDataState: OK so rules resolve to Normal
   #                    when CloudWatch emits nothing (e.g. zero failed nodes)
-  #   slack_channel  = (optional) Slack channel to route this signal's alerts.
-  #                    Two forms accepted:
-  #                      a) string — same channel for both severities
-  #                         slack_channel = "dev-slack"
-  #                      b) object — different channel per severity;
-  #                         omit a key to emit no label for that severity
-  #                         slack_channel = { warning = "dev-slack", critical = "dev-slack-critical" }
-  #                    Resolution order per severity (first non-null wins):
-  #                      1. per-severity key on this field  (e.g. .critical)
-  #                      2. string value on this field
-  #                      3. slack_channel in environment_configurations  (env default)
-  #                    If none of the above is set the label is omitted entirely
-  #                    and Grafana's root / catch-all policy handles the alert.
   #   warning        = key in locals.defaults (or threshold_overrides) for warning level
   #   critical       = key in locals.defaults (or threshold_overrides) for critical level
   #   query_window_seconds    = (optional, default: 300) lookback window for the

--- a/terraform/environments/data-platform/monitoring/alerting-rules.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-rules.tf
@@ -74,30 +74,7 @@ locals {
     }
   }
 
-  # ── 4. SLACK CHANNEL RESOLUTION ───────────────────────────────────────────
-  # Resolves alert routing by evaluating hierarchy:
-  # 1. Custom rule override per severity -> 2. Rule default -> 3. Account fallback.
-  sc_resolved = {
-    for env, cfg in local.grafana_monitored_accounts_by_uid :
-    env => {
-      for combo_key, combo in local.rule_combos_by_env[env] :
-      combo_key => {
-        for severity in local.active_severities_by_combo[env][combo_key] :
-        severity => (
-          try(cfg.slack_channel_overrides[combo_key][severity], null) == "disabled" ? null :
-          try(cfg.slack_channel_overrides[combo_key][severity], null) != null
-          ? cfg.slack_channel_overrides[combo_key][severity] :
-          try(combo.rule.slack_channel[severity], null) != null
-          ? combo.rule.slack_channel[severity]
-          : try(tostring(combo.rule.slack_channel), null) != null && try(tostring(combo.rule.slack_channel), null) != "null"
-          ? tostring(combo.rule.slack_channel)
-          : try(cfg.slack_channel, null)
-        )
-      }
-    }
-  }
-
-  # ── 5. BASELINE MATHEMATICAL EXPRESSIONS ──────────────────────────────────
+  # ── 4. BASELINE MATHEMATICAL EXPRESSIONS ──────────────────────────────────
   # Generates the Grafana math string used to evaluate baseline drift alerts
   # (e.g., checking if deviation is worse than a specific percentage threshold).
   baseline_math_expr = {
@@ -115,7 +92,7 @@ locals {
     }
   }
 
-  # ── 6. GRAFANA ALERT QUERY PIPELINE (rule_data) ───────────────────────────
+  # ── 5. GRAFANA ALERT QUERY PIPELINE (rule_data) ───────────────────────────
   # Constructs the block of queries, reducers, and expressions for the Grafana Alerting API.
   rule_data = {
     for env, cfg in local.grafana_monitored_accounts_by_uid :
@@ -291,7 +268,7 @@ locals {
     }
   }
 
-  # ── 7. FINAL GRAFANA RULE DEFINITIONS ──────────────────────────────────────
+  # ── 6. FINAL GRAFANA RULE DEFINITIONS ──────────────────────────────────────
   # Builds structural configurations for individual alerts, generating deterministic
   # UIDs based on md5 hashing, and establishing threshold routing logic (C vs D).
   rule_objects = {
@@ -313,10 +290,7 @@ locals {
               service     = lower(replace(combo.rule.group, " ", "_"))
               component   = combo.rule.group
               metric      = combo.rule.metric
-            },
-            local.sc_resolved[env][combo_key][severity] != null
-            ? { "slack-channel" = local.sc_resolved[env][combo_key][severity] }
-            : {}
+            }
           )
           data = local.rule_data[env][combo_key][severity]
         }
@@ -324,7 +298,7 @@ locals {
     }
   }
 
-  # ── 8. ACCOUNT RULE GROUPS ─────────────────────────────────────────────────
+  # ── 7. ACCOUNT RULE GROUPS ─────────────────────────────────────────────────
   # Segregates rule objects into environment-specific structures, ensuring
   # groups are only created if they contain active generated rules.
   group_blocks_by_env = {
@@ -349,7 +323,7 @@ locals {
     ]
   }
 
-  # ── 9. FLAT MAP OUTPUT ─────────────────────────────────────────────────────
+  # ── 8. FLAT MAP OUTPUT ─────────────────────────────────────────────────────
   # Flattens nested group maps into a unified root-level map, perfect for consumption 
   # inside a `for_each` loop in standard `grafana_rule_group` resource declarations.
   rule_groups_flat = merge([


### PR DESCRIPTION
Alerts are currently generated via PagerDuty using a set of three labels(`severity`,`service` and `component`). Slack channel names do not need to be specified in the alert definition, as this is handled automatically by PagerDuty.