### PR TITLE
Add configuration for claude-fable-5 model

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/configuration/models.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/models.yml
@@ -35,6 +35,12 @@ amazon_bedrock:
   #   region: eu-west-2
   #   generally_available: false
   # Anthropic
+  claude-fable-5:
+    model_id: "eu.anthropic.claude-fable-5"
+    model_family: "Anthropic Claude"
+    model_name: "Anthropic Claude Fable 5 (EU)"
+    region: eu-west-2
+    generally_available: false
   claude-haiku-4-5:
     model_id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
     model_family: "Anthropic Claude"


### PR DESCRIPTION
This pull request adds a new model configuration for Anthropic Claude Fable 5 (EU) to the `amazon_bedrock` section in the `models.yml` file. This update expands the available AI model options for the data platform environment.

**Model configuration update:**

* Added a new entry for the Anthropic Claude Fable 5 (EU) model, including its `model_id`, `model_family`, `model_name`, region (`eu-west-2`), and availability status (`generally_available: false`) in `terraform/environments/data-platform/ai-gateway/configuration/models.yml`.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>