### PR TITLE
chore: temporarily re-enable general-purpose nodepools

### DIFF
--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -22,7 +22,7 @@ module "eks" {
   # enable_cluster_creator_admin_permissions = true ## CP GitHub actions access to cluster, Adds to access entries
   compute_config = {
     enabled    = true
-    node_pools = ["system"] # US-028: general-purpose removed — user workloads use custom-networking NodePool only
+    node_pools = ["system", "general-purpose"] # general-purpose temporarily re-added to resolve cluster failures
   }
   enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 


### PR DESCRIPTION
BU clusters currently have no nodes provisioned which has orphaned gatekeeper. This is blocking the `cluster` terraform layer from being applied. The GuardDuty addon is failing since the k8s admissions webhook is timing out due to gatekeeper technically being enabled, but in a broken state with no pods.

Re-adding the general purpose nodepools will allow the gatekeeper pods to schedule, then we can get past the `cluster` layer apply. Once a full apply run is done, we can remove the general purpose node pools again since we'll have our custom nodepools working.