### PR TITLE
chore: remove temporarily enabled general-purpose nodepool

### DIFF
--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -22,7 +22,7 @@ module "eks" {
   # enable_cluster_creator_admin_permissions = true ## CP GitHub actions access to cluster, Adds to access entries
   compute_config = {
     enabled    = true
-    node_pools = ["system", "general-purpose"] # general-purpose temporarily re-added to resolve cluster failures
+    node_pools = ["system"]
   }
   enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 


### PR DESCRIPTION
PR following on from https://github.com/ministryofjustice/modernisation-platform-environments/pull/17880 to remove temporarily enabled nodepools.

We should now have custom nodepools in the cluster so no longer need general-purpose.