### PR TITLE
Fix integration-hub-api Gateway throttling defaults

### DIFF
--- a/terraform/environments/integration-hub-api/api-gateway.tf
+++ b/terraform/environments/integration-hub-api/api-gateway.tf
@@ -103,8 +103,9 @@ resource "aws_apigatewayv2_stage" "default" {
 
   default_route_settings {
     detailed_metrics_enabled = true
+    throttling_burst_limit   = local.api_gateway_throttling_configuration.burst_limit
+    throttling_rate_limit    = local.api_gateway_throttling_configuration.rate_limit
   }
-
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.api_access.arn
     format = jsonencode({

--- a/terraform/environments/integration-hub-api/application_variables.json
+++ b/terraform/environments/integration-hub-api/application_variables.json
@@ -5,6 +5,10 @@
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900,
+        "throttling": {
+          "burst_limit": 100,
+          "rate_limit": 200
+        },
         "multipart_upload": {
           "single_put_limit_bytes": 5368709120,
           "multipart_default_part_size_bytes": 67108864,
@@ -44,6 +48,10 @@
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900,
+        "throttling": {
+          "burst_limit": 100,
+          "rate_limit": 200
+        },
         "multipart_upload": {
           "single_put_limit_bytes": 5368709120,
           "multipart_default_part_size_bytes": 67108864,
@@ -63,6 +71,10 @@
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900,
+        "throttling": {
+          "burst_limit": 100,
+          "rate_limit": 200
+        },
         "multipart_upload": {
           "single_put_limit_bytes": 5368709120,
           "multipart_default_part_size_bytes": 67108864,
@@ -82,6 +94,10 @@
         "cors_allowed_origins": [],
         "max_presigned_url_expiry_seconds": 3600,
         "presigned_url_expiry_seconds": 900,
+        "throttling": {
+          "burst_limit": 100,
+          "rate_limit": 200
+        },
         "multipart_upload": {
           "single_put_limit_bytes": 5368709120,
           "multipart_default_part_size_bytes": 67108864,

--- a/terraform/environments/integration-hub-api/locals.tf
+++ b/terraform/environments/integration-hub-api/locals.tf
@@ -1,6 +1,13 @@
 locals {
   api_configuration   = try(local.application_data.accounts[local.environment].api_configuration, {})
   bootstrap_code_root = "${path.module}/bootstrap-lambdas"
+  api_gateway_throttling_configuration = merge(
+    {
+      burst_limit = 100
+      rate_limit  = 200
+    },
+    try(local.api_configuration.throttling, {})
+  )
   api_docs_configuration = merge(
     {
       basic_auth_username = "api-docs"


### PR DESCRIPTION
## Summary
- add explicit default API Gateway route throttling settings for 
- make the burst/rate limits configurable from 
- keep the defaults non-zero so authenticated  requests do not get throttled before reaching the Lambda integration

## Why
We traced the current upload failure in development to API Gateway returning  before the upload-ticket Lambda was invoked. The stage was missing explicit throttling settings, so this change pins safe defaults and keeps them configurable per environment.

## Validation
- ran 
- The configuration is valid.
- GitHub Actions plan/apply successful.