### PR TITLE
added od contact point and removed slack references

### DIFF
--- a/terraform/environments/data-platform/iac/iam-roles.tf
+++ b/terraform/environments/data-platform/iac/iam-roles.tf
@@ -47,7 +47,7 @@ module "data_platform_access_iam_role" {
         module.entra_secret[0].secret_arn,
         module.github_app_secret[0].secret_arn,
         module.pagerduty_api_key_secret[0].secret_arn,
-        module.slack_token_secret[0].secret_arn,
+        module.slack_token_secret[0].secret_arn
       ]
     }
     SecretsManagerWriteAccess = {

--- a/terraform/environments/data-platform/iac/iam-roles.tf
+++ b/terraform/environments/data-platform/iac/iam-roles.tf
@@ -48,8 +48,6 @@ module "data_platform_access_iam_role" {
         module.github_app_secret[0].secret_arn,
         module.pagerduty_api_key_secret[0].secret_arn,
         module.slack_token_secret[0].secret_arn,
-        module.pagerduty_slack_connection_api_key_secret[0].secret_arn,
-        # module.pagerduty_orchestrator_integration_key_secret[0].secret_arn
       ]
     }
     SecretsManagerWriteAccess = {

--- a/terraform/environments/data-platform/iac/iam-roles.tf
+++ b/terraform/environments/data-platform/iac/iam-roles.tf
@@ -49,7 +49,7 @@ module "data_platform_access_iam_role" {
         module.pagerduty_api_key_secret[0].secret_arn,
         module.slack_token_secret[0].secret_arn,
         module.pagerduty_slack_connection_api_key_secret[0].secret_arn,
-        module.pagerduty_orchestrator_integration_key_secret[0].secret_arn
+        # module.pagerduty_orchestrator_integration_key_secret[0].secret_arn
       ]
     }
     SecretsManagerWriteAccess = {

--- a/terraform/environments/data-platform/iac/iam-roles.tf
+++ b/terraform/environments/data-platform/iac/iam-roles.tf
@@ -48,7 +48,8 @@ module "data_platform_access_iam_role" {
         module.github_app_secret[0].secret_arn,
         module.pagerduty_api_key_secret[0].secret_arn,
         module.slack_token_secret[0].secret_arn,
-        module.pagerduty_slack_connection_api_key_secret[0].secret_arn
+        module.pagerduty_slack_connection_api_key_secret[0].secret_arn,
+        module.pagerduty_orchestrator_integration_key_secret[0].secret_arn
       ]
     }
     SecretsManagerWriteAccess = {

--- a/terraform/environments/data-platform/iac/secrets.tf
+++ b/terraform/environments/data-platform/iac/secrets.tf
@@ -59,7 +59,7 @@ module "pagerduty_api_key_secret" {
 }
 
 module "pagerduty_slack_connection_api_key_secret" {
-  count = terraform.workspace == "data-platform-development" ? 1 : 0
+  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
 

--- a/terraform/environments/data-platform/iac/secrets.tf
+++ b/terraform/environments/data-platform/iac/secrets.tf
@@ -58,38 +58,6 @@ module "pagerduty_api_key_secret" {
   )
 }
 
-module "pagerduty_slack_connection_api_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
-
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
-
-  name = "pagerduty/slack-connection-api-key"
-
-  secret_string         = "CHANGEME"
-  ignore_secret_changes = true
-
-  tags = merge(
-    local.tags,
-    { "credential-expiration" = "none" }
-  )
-}
-
-module "pagerduty_orchestrator_integration_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
-
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
-
-  name = "pagerduty/orchestrator-integration-key"
-
-  secret_string         = "CHANGEME"
-  ignore_secret_changes = true
-
-  tags = merge(
-    local.tags,
-    { "credential-expiration" = "none" }
-  )
-}
-
 module "slack_token_secret" {
   count = terraform.workspace == "data-platform-development" ? 1 : 0
 

--- a/terraform/environments/data-platform/iac/secrets.tf
+++ b/terraform/environments/data-platform/iac/secrets.tf
@@ -74,6 +74,22 @@ module "pagerduty_slack_connection_api_key_secret" {
   )
 }
 
+module "pagerduty_orchestrator_integration_key_secret" {
+  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
+
+  name = "pagerduty/orchestrator-integration-key"
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    { "credential-expiration" = "none" }
+  )
+}
+
 module "slack_token_secret" {
   count = terraform.workspace == "data-platform-development" ? 1 : 0
 

--- a/terraform/environments/data-platform/iac/versions.tf
+++ b/terraform/environments/data-platform/iac/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/data-platform/monitoring/README.md
+++ b/terraform/environments/data-platform/monitoring/README.md
@@ -23,8 +23,7 @@ alerting-defaults.tf           Threshold values (warning/critical) referenced
 
 alerting-rules.tf              The engine: expands golden signals into one
                                 Grafana alert rule per resource/account/severity,
-                                builds the CloudWatch/Prometheus query pipeline,
-                                and resolves Slack routing.
+                                builds the CloudWatch/Prometheus query pipeline.
 
 alerting.tf                    Terraform resources (grafana_folder,
                                 grafana_rule_group) that actually create the
@@ -161,18 +160,6 @@ alerts_configured_accounts = [
       rds_cpu_crit = 95
     }
 
-    # Account-wide fallback Slack channel, used when a golden signal has no
-    # slack_channel of its own
-    slack_channel = "dev-slack"
-
-    # Per-rule, per-severity Slack overrides — the key is the combo_key
-    # (rule key plus resource suffix, e.g.
-    # "s3_bucket_5xx_errors_data-platform-dev-landing")
-    slack_channel_overrides = {
-      rds_cpu_utilization  = { critical = "dev-slack-critical" }
-      s3_bucket_5xx_errors = { warning = "disabled" } # suppresses the label entirely
-    }
-
     # How often Grafana evaluates rules for this account (defaults to "1m")
     evaluation_interval = "5m"
 
@@ -204,7 +191,6 @@ Every key inside `alerting_golden_signals` (in `alerting-golden-signals.tf`) is 
 | `capacity_metric` | with `use_metric_math` | CloudWatch metric name used as the denominator (`A2`) in the metric-math expression, e.g. `"PermittedThroughput"`. |
 | `capacity_statistic` | no (default `"Minimum"`) | CloudWatch statistic applied to the capacity metric. Only used with `use_metric_math`. |
 | `ok_when_nodata` | no (default `false`) | If `true`, sets `noDataState: OK` so the rule resolves to Normal when CloudWatch/Prometheus returns nothing (e.g. zero failed nodes), rather than going to `NoData`. |
-| `slack_channel` | no | Slack channel(s) for this signal. Either a string (same channel both severities) or an object `{ warning = "...", critical = "..." }` (omit a key to emit no label for that severity). Resolution order per severity: rule's per-severity key → rule's string value → the account's `slack_channel` default. If nothing resolves, no `slack-channel` label is set and Grafana's catch-all policy handles routing. |
 | `warning` | one of `warning`/`critical` required | Key into `alert_defaults` (or an account's `threshold_overrides`) for the warning threshold. Omit to make the rule critical-only. |
 | `critical` | one of `warning`/`critical` required | Same, for the critical threshold. Omit to make the rule warning-only. |
 | `query_window_seconds` | no (default `300`) | Lookback window, in seconds, for the current-value queries (refs `A`, `A2`, `B`, `C`). |
@@ -241,8 +227,6 @@ Each entry in `alerts_configured_accounts` (in `environment-configuration.tf`) c
 | `efs_file_systems` | with `FileSystemId`-dimensioned rules | `[]` | List of EFS file system IDs. One rule per filesystem for `dim_key = "FileSystemId"`. |
 | `disabled_rules` | no | `[]` | List of golden-signal rule keys (the keys in `alerting_golden_signals`) to skip entirely for this account — no rule, no Grafana UID, regardless of `enabled_groups`. |
 | `threshold_overrides` | no | `{}` | Map of threshold key → value, merged over `alert_defaults` for this account only (`merge(alert_defaults, threshold_overrides)`). Use the same keys referenced by golden signals' `warning`/`critical` fields. |
-| `slack_channel` | no | none | Account-wide fallback Slack channel. Used for a rule's severity only when neither the golden signal's own `slack_channel` nor a `slack_channel_overrides` entry resolves one. |
-| `slack_channel_overrides` | no | `{}` | Map keyed by `combo_key` (the rule key, plus a resource suffix such as `_<bucket-name>` when the rule is dimensioned) → `{ warning = "...", critical = "..." }`. Takes priority over everything else, including the golden signal's own `slack_channel`. Set a severity's value to `"disabled"` to force no Slack label for that severity (overriding even the account's `slack_channel` fallback). |
 | `evaluation_interval` | no | `"1m"` (`local.evaluation_interval`) | How often Grafana evaluates every rule group for this account. Accepts `"30s"`, `"1m"`, `"5m"`, `"2h"`-style duration strings. |
 | `prometheus_datasource_uid` | no | `"<uid>-prometheus"` | Grafana datasource UID used for Prometheus (`datasource_type = "prometheus"`) queries. Override if the Amazon Managed Prometheus datasource was provisioned under a different UID. |
 | `aws_region` | no | current provider region (`data.aws_region.current.region`) | AWS region passed to CloudWatch queries for this account. Override for accounts monitored cross-region. |
@@ -265,21 +249,6 @@ disabled_rules = ["rds_cpu_utilization", "litellm_provider_state"]
 threshold_overrides = {
   rds_cpu_warn = 85
   rds_cpu_crit = 95
-}
-```
-
-**`slack_channel`** — account-wide fallback channel, used whenever a rule's severity has no more specific channel resolved:
-
-```hcl
-slack_channel = "dev-alerts"
-```
-
-**`slack_channel_overrides`** — redirect (or silence) one specific rule's severity for this account, keyed by `combo_key` (rule key + resource suffix if the rule is dimensioned):
-
-```hcl
-slack_channel_overrides = {
-  rds_cpu_utilization                          = { critical = "oncall-critical" }
-  s3_bucket_5xx_errors_data-platform-dev-landing = { warning = "disabled" }
 }
 ```
 

--- a/terraform/environments/data-platform/monitoring/alerting-golden-signals.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-golden-signals.tf
@@ -65,19 +65,6 @@ locals {
   #   ok_when_nodata = (optional, default: false)
   #                    if true, sets noDataState: OK so rules resolve to Normal
   #                    when CloudWatch emits nothing (e.g. zero failed nodes)
-  #   slack_channel  = (optional) Slack channel to route this signal's alerts.
-  #                    Two forms accepted:
-  #                      a) string — same channel for both severities
-  #                         slack_channel = "dev-slack"
-  #                      b) object — different channel per severity;
-  #                         omit a key to emit no label for that severity
-  #                         slack_channel = { warning = "dev-slack", critical = "dev-slack-critical" }
-  #                    Resolution order per severity (first non-null wins):
-  #                      1. per-severity key on this field  (e.g. .critical)
-  #                      2. string value on this field
-  #                      3. slack_channel in environment_configurations  (env default)
-  #                    If none of the above is set the label is omitted entirely
-  #                    and Grafana's root / catch-all policy handles the alert.
   #   warning        = key in locals.defaults (or threshold_overrides) for warning level
   #   critical       = key in locals.defaults (or threshold_overrides) for critical level
   #   query_window_seconds    = (optional, default: 300) lookback window for the

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -3,45 +3,45 @@
 # Creates a Grafana contact point that sends alerts to PagerDuty Event
 # Orchestrator. The routing key is read from Secrets Manager.
 # ------------------------------------------------------------------------------
-resource "grafana_contact_point" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# resource "grafana_contact_point" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-  name = "pagerduty"
+#   name = "pagerduty"
 
-  pagerduty {
-    integration_key = local.pagerduty_integration_key
-    severity        = "{{ .CommonLabels.severity }}"
-    component       = "{{ .CommonLabels.component }}"
-    group           = "{{ .CommonLabels.environment }}"
+#   pagerduty {
+#     integration_key = local.pagerduty_integration_key
+#     severity        = "{{ .CommonLabels.severity }}"
+#     component       = "{{ .CommonLabels.component }}"
+#     group           = "{{ .CommonLabels.environment }}"
 
-    # Include all labels as custom details in the PagerDuty payload
-    details = {
-      environment = "{{ .CommonLabels.environment }}"
-      severity    = "{{ .CommonLabels.severity }}"
-      component   = "{{ .CommonLabels.component }}"
-      metric      = "{{ .CommonLabels.metric }}"
-      alertname   = "{{ .CommonLabels.alertname }}"
-      summary     = "{{ .CommonAnnotations.summary }}"
-      description = "{{ .CommonAnnotations.description }}"
-    }
-  }
+#     # Include all labels as custom details in the PagerDuty payload
+#     details = {
+#       environment = "{{ .CommonLabels.environment }}"
+#       severity    = "{{ .CommonLabels.severity }}"
+#       component   = "{{ .CommonLabels.component }}"
+#       metric      = "{{ .CommonLabels.metric }}"
+#       alertname   = "{{ .CommonLabels.alertname }}"
+#       summary     = "{{ .CommonAnnotations.summary }}"
+#       description = "{{ .CommonAnnotations.description }}"
+#     }
+#   }
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }
 
 # ------------------------------------------------------------------------------
 # NOTIFICATION POLICY
 # Routes alerts to the PagerDuty contact point. Each alert fires individually
 # without grouping.
 # ------------------------------------------------------------------------------
-resource "grafana_notification_policy" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# resource "grafana_notification_policy" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-  contact_point   = grafana_contact_point.pagerduty[0].name
-  group_by        = ["..."]
-  group_wait      = "0s"
-  group_interval  = "1m"
-  repeat_interval = "4h"
+#   contact_point   = grafana_contact_point.pagerduty[0].name
+#   group_by        = ["..."]
+#   group_wait      = "0s"
+#   group_interval  = "1m"
+#   repeat_interval = "4h"
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# ------------------------------------------------------------------------------
-# PAGERDUTY CONTACT POINT
-# Creates a Grafana contact point that sends alerts to PagerDuty Event
-# Orchestrator. The routing key is read from Secrets Manager.
-# ------------------------------------------------------------------------------
-resource "grafana_contact_point" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # PAGERDUTY CONTACT POINT
+# # Creates a Grafana contact point that sends alerts to PagerDuty Event
+# # Orchestrator. The routing key is read from Secrets Manager.
+# # ------------------------------------------------------------------------------
+# resource "grafana_contact_point" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-  name = "pagerduty"
+#   name = "pagerduty"
 
-  pagerduty {
-    integration_key = local.pagerduty_integration_key
-    severity        = "{{ .CommonLabels.severity }}"
-    component       = "{{ .CommonLabels.component }}"
-    group           = "{{ .CommonLabels.environment }}"
+#   pagerduty {
+#     integration_key = local.pagerduty_integration_key
+#     severity        = "{{ .CommonLabels.severity }}"
+#     component       = "{{ .CommonLabels.component }}"
+#     group           = "{{ .CommonLabels.environment }}"
 
-    # Include all labels as custom details in the PagerDuty payload
-    details = {
-      environment = "{{ .CommonLabels.environment }}"
-      severity    = "{{ .CommonLabels.severity }}"
-      component   = "{{ .CommonLabels.component }}"
-      metric      = "{{ .CommonLabels.metric }}"
-      alertname   = "{{ .CommonLabels.alertname }}"
-      summary     = "{{ .CommonAnnotations.summary }}"
-      description = "{{ .CommonAnnotations.description }}"
-    }
-  }
+#     # Include all labels as custom details in the PagerDuty payload
+#     details = {
+#       environment = "{{ .CommonLabels.environment }}"
+#       severity    = "{{ .CommonLabels.severity }}"
+#       component   = "{{ .CommonLabels.component }}"
+#       metric      = "{{ .CommonLabels.metric }}"
+#       alertname   = "{{ .CommonLabels.alertname }}"
+#       summary     = "{{ .CommonAnnotations.summary }}"
+#       description = "{{ .CommonAnnotations.description }}"
+#     }
+#   }
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }
 
-# ------------------------------------------------------------------------------
-# NOTIFICATION POLICY
-# Routes alerts to the PagerDuty contact point. Each alert fires individually
-# without grouping.
-# ------------------------------------------------------------------------------
-resource "grafana_notification_policy" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # NOTIFICATION POLICY
+# # Routes alerts to the PagerDuty contact point. Each alert fires individually
+# # without grouping.
+# # ------------------------------------------------------------------------------
+# resource "grafana_notification_policy" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-  contact_point   = grafana_contact_point.pagerduty[0].name
-  group_by        = ["..."]
-  group_wait      = "0s"
-  group_interval  = "1m"
-  repeat_interval = "4h"
+#   contact_point   = grafana_contact_point.pagerduty[0].name
+#   group_by        = ["..."]
+#   group_wait      = "0s"
+#   group_interval  = "1m"
+#   repeat_interval = "4h"
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# ------------------------------------------------------------------------------
-# PAGERDUTY CONTACT POINT
-# Creates a Grafana contact point that sends alerts to PagerDuty Event
-# Orchestrator. The routing key is read from Secrets Manager.
-# ------------------------------------------------------------------------------
-resource "grafana_contact_point" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # PAGERDUTY CONTACT POINT
+# # Creates a Grafana contact point that sends alerts to PagerDuty Event
+# # Orchestrator. The routing key is read from Secrets Manager.
+# # ------------------------------------------------------------------------------
+# resource "grafana_contact_point" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-  name = "pagerduty"
+#   name = "pagerduty"
 
-  pagerduty {
-    integration_key = local.pagerduty_routing_key
-    severity        = "{{ .CommonLabels.severity }}"
-    component       = "{{ .CommonLabels.component }}"
-    group           = "{{ .CommonLabels.environment }}"
+#   pagerduty {
+#     integration_key = local.pagerduty_routing_key
+#     severity        = "{{ .CommonLabels.severity }}"
+#     component       = "{{ .CommonLabels.component }}"
+#     group           = "{{ .CommonLabels.environment }}"
 
-    # Include all labels as custom details in the PagerDuty payload
-    details = {
-      environment = "{{ .CommonLabels.environment }}"
-      severity    = "{{ .CommonLabels.severity }}"
-      component   = "{{ .CommonLabels.component }}"
-      metric      = "{{ .CommonLabels.metric }}"
-      alertname   = "{{ .CommonLabels.alertname }}"
-      summary     = "{{ .CommonAnnotations.summary }}"
-      description = "{{ .CommonAnnotations.description }}"
-    }
-  }
+#     # Include all labels as custom details in the PagerDuty payload
+#     details = {
+#       environment = "{{ .CommonLabels.environment }}"
+#       severity    = "{{ .CommonLabels.severity }}"
+#       component   = "{{ .CommonLabels.component }}"
+#       metric      = "{{ .CommonLabels.metric }}"
+#       alertname   = "{{ .CommonLabels.alertname }}"
+#       summary     = "{{ .CommonAnnotations.summary }}"
+#       description = "{{ .CommonAnnotations.description }}"
+#     }
+#   }
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }
 
-# ------------------------------------------------------------------------------
-# NOTIFICATION POLICY
-# Routes alerts to the PagerDuty contact point. Each alert fires individually
-# without grouping.
-# ------------------------------------------------------------------------------
-resource "grafana_notification_policy" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # NOTIFICATION POLICY
+# # Routes alerts to the PagerDuty contact point. Each alert fires individually
+# # without grouping.
+# # ------------------------------------------------------------------------------
+# resource "grafana_notification_policy" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-  contact_point   = grafana_contact_point.pagerduty[0].name
-  group_by        = ["..."]
-  group_wait      = "0s"
-  group_interval  = "1m"
-  repeat_interval = "4h"
+#   contact_point   = grafana_contact_point.pagerduty[0].name
+#   group_by        = ["..."]
+#   group_wait      = "0s"
+#   group_interval  = "1m"
+#   repeat_interval = "4h"
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+
+  name = "pagerduty"
+
+  pagerduty {
+    integration_key = local.pagerduty_integration_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
+
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
+
+  depends_on = [helm_release.grafana]
+}
+
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
+
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# # ------------------------------------------------------------------------------
-# # PAGERDUTY CONTACT POINT
-# # Creates a Grafana contact point that sends alerts to PagerDuty Event
-# # Orchestrator. The routing key is read from Secrets Manager.
-# # ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_integration_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_routing_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# # ------------------------------------------------------------------------------
-# # NOTIFICATION POLICY
-# # Routes alerts to the PagerDuty contact point. Each alert fires individually
-# # without grouping.
-# # ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,8 +1,8 @@
-------------------------------------------------------------------------------
-PAGERDUTY CONTACT POINT
-Creates a Grafana contact point that sends alerts to PagerDuty Event
-Orchestrator. The routing key is read from Secrets Manager.
-------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
 resource "grafana_contact_point" "pagerduty" {
   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
@@ -29,11 +29,11 @@ resource "grafana_contact_point" "pagerduty" {
   depends_on = [helm_release.grafana]
 }
 
-------------------------------------------------------------------------------
-NOTIFICATION POLICY
-Routes alerts to the PagerDuty contact point. Each alert fires individually
-without grouping.
-------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
 resource "grafana_notification_policy" "pagerduty" {
   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# ------------------------------------------------------------------------------
-# PAGERDUTY CONTACT POINT
-# Creates a Grafana contact point that sends alerts to PagerDuty Event
-# Orchestrator. The routing key is read from Secrets Manager.
-# ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+------------------------------------------------------------------------------
+PAGERDUTY CONTACT POINT
+Creates a Grafana contact point that sends alerts to PagerDuty Event
+Orchestrator. The routing key is read from Secrets Manager.
+------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_integration_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_integration_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# ------------------------------------------------------------------------------
-# NOTIFICATION POLICY
-# Routes alerts to the PagerDuty contact point. Each alert fires individually
-# without grouping.
-# ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
+------------------------------------------------------------------------------
+NOTIFICATION POLICY
+Routes alerts to the PagerDuty contact point. Each alert fires individually
+without grouping.
+------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_integration_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# # ------------------------------------------------------------------------------
-# # PAGERDUTY CONTACT POINT
-# # Creates a Grafana contact point that sends alerts to PagerDuty Event
-# # Orchestrator. The routing key is read from Secrets Manager.
-# # ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_routing_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_routing_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# # ------------------------------------------------------------------------------
-# # NOTIFICATION POLICY
-# # Routes alerts to the PagerDuty contact point. Each alert fires individually
-# # without grouping.
-# # ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/alerting-rules.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-rules.tf
@@ -74,30 +74,7 @@ locals {
     }
   }
 
-  # ── 4. SLACK CHANNEL RESOLUTION ───────────────────────────────────────────
-  # Resolves alert routing by evaluating hierarchy:
-  # 1. Custom rule override per severity -> 2. Rule default -> 3. Account fallback.
-  sc_resolved = {
-    for env, cfg in local.grafana_monitored_accounts_by_uid :
-    env => {
-      for combo_key, combo in local.rule_combos_by_env[env] :
-      combo_key => {
-        for severity in local.active_severities_by_combo[env][combo_key] :
-        severity => (
-          try(cfg.slack_channel_overrides[combo_key][severity], null) == "disabled" ? null :
-          try(cfg.slack_channel_overrides[combo_key][severity], null) != null
-          ? cfg.slack_channel_overrides[combo_key][severity] :
-          try(combo.rule.slack_channel[severity], null) != null
-          ? combo.rule.slack_channel[severity]
-          : try(tostring(combo.rule.slack_channel), null) != null && try(tostring(combo.rule.slack_channel), null) != "null"
-          ? tostring(combo.rule.slack_channel)
-          : try(cfg.slack_channel, null)
-        )
-      }
-    }
-  }
-
-  # ── 5. BASELINE MATHEMATICAL EXPRESSIONS ──────────────────────────────────
+  # ── 4. BASELINE MATHEMATICAL EXPRESSIONS ──────────────────────────────────
   # Generates the Grafana math string used to evaluate baseline drift alerts
   # (e.g., checking if deviation is worse than a specific percentage threshold).
   baseline_math_expr = {
@@ -115,7 +92,7 @@ locals {
     }
   }
 
-  # ── 6. GRAFANA ALERT QUERY PIPELINE (rule_data) ───────────────────────────
+  # ── 5. GRAFANA ALERT QUERY PIPELINE (rule_data) ───────────────────────────
   # Constructs the block of queries, reducers, and expressions for the Grafana Alerting API.
   rule_data = {
     for env, cfg in local.grafana_monitored_accounts_by_uid :
@@ -291,7 +268,7 @@ locals {
     }
   }
 
-  # ── 7. FINAL GRAFANA RULE DEFINITIONS ──────────────────────────────────────
+  # ── 6. FINAL GRAFANA RULE DEFINITIONS ──────────────────────────────────────
   # Builds structural configurations for individual alerts, generating deterministic
   # UIDs based on md5 hashing, and establishing threshold routing logic (C vs D).
   rule_objects = {
@@ -306,25 +283,20 @@ locals {
           condition   = contains(["baseline_gt", "baseline_lt"], combo.rule.type) ? "D" : "C"
           for         = try(combo.rule.for_duration, "5m")
           noDataState = try(combo.rule.ok_when_nodata, false) ? "OK" : "NoData"
-          labels = merge(
-            {
-              severity    = severity
-              environment = cfg.name
-              service     = lower(replace(combo.rule.group, " ", "_"))
-              component   = combo.rule.group
-              metric      = combo.rule.metric
-            },
-            local.sc_resolved[env][combo_key][severity] != null
-            ? { "slack-channel" = local.sc_resolved[env][combo_key][severity] }
-            : {}
-          )
+          labels = {
+            severity    = severity
+            environment = cfg.name
+            service     = lower(replace(combo.rule.group, " ", "_"))
+            component   = combo.rule.group
+            metric      = combo.rule.metric
+          }
           data = local.rule_data[env][combo_key][severity]
         }
       }
     }
   }
 
-  # ── 8. ACCOUNT RULE GROUPS ─────────────────────────────────────────────────
+  # ── 7. ACCOUNT RULE GROUPS ─────────────────────────────────────────────────
   # Segregates rule objects into environment-specific structures, ensuring
   # groups are only created if they contain active generated rules.
   group_blocks_by_env = {
@@ -349,7 +321,7 @@ locals {
     ]
   }
 
-  # ── 9. FLAT MAP OUTPUT ─────────────────────────────────────────────────────
+  # ── 8. FLAT MAP OUTPUT ─────────────────────────────────────────────────────
   # Flattens nested group maps into a unified root-level map, perfect for consumption 
   # inside a `for_each` loop in standard `grafana_rule_group` resource declarations.
   rule_groups_flat = merge([

--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -24,6 +24,15 @@ data "aws_secretsmanager_secret_version" "grafana_entra_id" {
   secret_id = module.grafana_entra_id_secret[0].secret_id
 }
 
+# PagerDuty Event Orchestration routing key used by the Grafana contact point.
+# The secret is created and populated in the data-platform-products repo and
+# read here to configure the PagerDuty alerting contact point.
+data "aws_secretsmanager_secret_version" "pagerduty_grafana_routing_key" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  secret_id = "pagerduty/global/integration-keys/grafana"
+}
+
 # Grafana service-account token used by the Terraform grafana provider. The secret
 # is created with a placeholder value in secrets.tf and populated out-of-band, so
 # it is read back here to configure the provider in providers.tf.
@@ -33,10 +42,3 @@ data "aws_secretsmanager_secret_version" "grafana_api_token" {
   secret_id = module.grafana_api_token_secret[0].secret_id
 }
 
-# PagerDuty integration key (routing key) for the Event Orchestrator. The secret
-# is managed in the data-platform-pagerduty repository.
-data "aws_secretsmanager_secret_version" "pagerduty_integration_key" {
-  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
-
-  secret_id = module.pagerduty_integration_key[0].secret_id
-}

--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -32,3 +32,11 @@ data "aws_secretsmanager_secret_version" "grafana_api_token" {
 
   secret_id = module.grafana_api_token_secret[0].secret_id
 }
+
+# PagerDuty integration key (routing key) for the Event Orchestrator. The secret
+# is managed in the data-platform-pagerduty repository.
+data "aws_secretsmanager_secret_version" "pagerduty_integration_key" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  secret_id = module.pagerduty_integration_key[0].secret_id
+}

--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -33,3 +33,12 @@ data "aws_secretsmanager_secret_version" "grafana_api_token" {
   secret_id = module.grafana_api_token_secret[0].secret_id
 }
 
+# PagerDuty event orchestration routing key used to send alerts. The secret is
+# created with a placeholder value in the iac component and populated out-of-band,
+# so it is read back here to configure alerting.
+data "aws_secretsmanager_secret_version" "pagerduty_orchestrator_integration_key_secret" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  secret_id = "pagerduty/orchestrator-integration-key"
+}
+

--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -24,15 +24,6 @@ data "aws_secretsmanager_secret_version" "grafana_entra_id" {
   secret_id = module.grafana_entra_id_secret[0].secret_id
 }
 
-# PagerDuty Event Orchestration routing key used by the Grafana contact point.
-# The secret is created and populated in the data-platform-products repo and
-# read here to configure the PagerDuty alerting contact point.
-data "aws_secretsmanager_secret_version" "pagerduty_grafana_routing_key" {
-  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
-
-  secret_id = "pagerduty/global/integration-keys/grafana"
-}
-
 # Grafana service-account token used by the Terraform grafana provider. The secret
 # is created with a placeholder value in secrets.tf and populated out-of-band, so
 # it is read back here to configure the provider in providers.tf.

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -12,7 +12,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  pagerduty_integration_key = try(data.aws_secretsmanager_secret_version.pagerduty_integration_key[0].secret_string, "")
+  pagerduty_integration_key = try(data.aws_secretsmanager_secret_version.pagerduty_grafana_routing_key[0].secret_string, "")
 
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -12,6 +12,8 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
+  pagerduty_integration_key = try(data.aws_secretsmanager_secret_version.pagerduty_integration_key[0].secret_string, "")
+
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk
   # directory name and the value is the folder's display name. Drop a dashboard

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -12,7 +12,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  pagerduty_integration_key = try(data.aws_secretsmanager_secret_version.pagerduty_grafana_routing_key[0].secret_string, "")
+  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_grafana_routing_key[0].secret_string, "")
 
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -13,7 +13,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
+  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key_secret[0].secret_string, null)
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk
   # directory name and the value is the folder's display name. Drop a dashboard

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -13,7 +13,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  #pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
+  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk
   # directory name and the value is the folder's display name. Drop a dashboard

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -13,7 +13,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
+  #pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk
   # directory name and the value is the folder's display name. Drop a dashboard

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -1,4 +1,5 @@
 locals {
+
   # Microsoft Entra ID (Azure AD) OAuth credentials for Grafana. The secret is
   # provisioned with placeholder values in secrets.tf and populated out-of-band,
   # then read back via the data source in data.tf. try() keeps this resolvable in
@@ -12,8 +13,7 @@ locals {
   # monitoring stack is disabled and the data source has no instances.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
-  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_grafana_routing_key[0].secret_string, "")
-
+  pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key[0].secret_string, null)
   # Dashboards as code, organised into Grafana folders. Each subdirectory of
   # src/helm/dashboards/ maps to one Grafana folder: the map key is the on-disk
   # directory name and the value is the folder's display name. Drop a dashboard

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -65,3 +65,19 @@ module "pagerduty_orchestrator_integration_key_secret" {
     { "credential-expiration" = "none" }
   )
 }
+
+module "pagerduty_slack_connection_api_key_secret" {
+  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
+
+  name = "pagerduty/slack-connection-api-key"
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    { "credential-expiration" = "none" }
+  )
+}

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -49,3 +49,19 @@ module "cloud_platform_live_namespace_secret" {
   })
   ignore_secret_changes = true
 }
+
+module "pagerduty_orchestrator_integration_key_secret" {
+  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
+
+  name = "pagerduty/orchestrator-integration-key"
+
+  secret_string         = "CHANGEME"
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    { "credential-expiration" = "none" }
+  )
+}

--- a/terraform/environments/data-platform/monitoring/versions.tf
+++ b/terraform/environments/data-platform/monitoring/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {


### PR DESCRIPTION
**Alert Routing and PagerDuty Integration**

* Added a new secret (`pagerduty/orchestrator-integration-key`) and associated module for PagerDuty Event Orchestrator integration, with logic to read this secret for configuring alerting. [
* Introduced (commented-out) Terraform resources to configure a Grafana contact point and notification policy for PagerDuty, enabling future direct routing of alerts to PagerDuty.
* Updated IAM role configuration to remove the now-unnecessary `pagerduty_slack_connection_api_key_secret` from the list of secrets with read access.

**Removal of Slack-Based Alert Routing**

* Removed all Slack channel resolution logic from alerting rules, including the `sc_resolved` local and the `slack-channel` label from generated alerts. 
* Deleted the `pagerduty_slack_connection_api_key_secret` module from the main secrets configuration, and moved its definition to the monitoring stack (now only provisioned for dev/prod). 
* Cleaned up documentation and example configs to remove references to Slack alert routing, including all mentions of `slack_channel`, `slack_channel_overrides`, and related resolution order.

**Provider Version Pinning**

* Updated the AWS provider version constraint to explicitly exclude version 6.57.0 due to mod-platform issue.

These changes collectively migrate the alert notification system away from Slack and towards PagerDuty, simplifying configuration and aligning with best practices for incident management.