### PR TITLE
Use KMS key with SQS queue modules

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub-file-transfer/sqs.tf
@@ -5,6 +5,7 @@ module "sqs_eventbridge_default_dlq" {
   name            = "${local.application_name}-eventbridge-default-dlq"
   use_name_prefix = false
 
+  kms_master_key_id         = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -46,6 +47,7 @@ module "sqs_lambda_file_received_adapter_dlq" {
   name            = "${local.application_name}-lambda-file-received-adapter-dlq"
   use_name_prefix = false
 
+  kms_master_key_id         = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -62,6 +64,7 @@ module "sqs_lambda_file_scan_result_recorded_adapter_dlq" {
   name            = "${local.application_name}-lambda-file-scan-result-recorded-adapter-dlq"
   use_name_prefix = false
 
+  kms_master_key_id         = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -78,6 +81,7 @@ module "sqs_eventbridge_file_transfer_workflow_dlq" {
   name            = "${local.application_name}-file-transfer-workflow-dlq"
   use_name_prefix = false
 
+  kms_master_key_id         = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20


### PR DESCRIPTION
Noticed that I have a perfectly usable KMS key for SQS modules, but I'm not using it. This PR corrects that gap.