### PR TITLE
Tighten which bucket guard duty malware protection for s3 can list

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/iam.tf
+++ b/terraform/environments/integration-hub-file-transfer/iam.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "guardduty_s3_permissions" {
       "s3:ListBucket"
     ]
     resources = [
-      "arn:aws:s3:::*"
+      module.s3_bucket["processing"].s3_bucket_arn
     ]
   }
   statement {


### PR DESCRIPTION
Small PR to restrict the `s3:listBucket` permission for GDMPforS3