### PR TITLE
Small code refactor to put eventbridge rules/targets into local value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ out/
 
 terraform/modules/**/*.zip
 terraform/environments/integration-hub/managed-file-transfer/builds
+terraform/environments/integration-hub-file-transfer/builds
 terraform/environments/youth-justice-app-framework/modules/quicksight/assets/run_time
 
 megalinter-reports

--- a/terraform/environments/integration-hub-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge.tf
@@ -10,56 +10,9 @@ module "eventbridge_default_bus" {
   append_rule_postfix        = false
   create_role                = false
 
-  rules = {
-    "incoming-s3-object-created" = {
-      description = "Transform incoming S3 Object Created notifications into FileReceived.v1 events"
-      event_pattern = jsonencode({
-        source        = ["aws.s3"]
-        "detail-type" = ["Object Created"]
-        detail = {
-          bucket = {
-            name = [module.s3_bucket["incoming"].s3_bucket_id]
-          }
-        }
-      })
-    }
-    "guardduty-malware-scan-result" = {
-      description = "Transform GuardDuty malware scan results into FileScanResultRecorded.v1 events"
-      event_pattern = jsonencode({
-        account       = [data.aws_caller_identity.current.account_id]
-        source        = ["aws.guardduty"]
-        "detail-type" = ["GuardDuty Malware Protection Object Scan Result"]
-        resources     = [aws_guardduty_malware_protection_plan.this.arn]
-        detail = {
-          resourceType = ["S3_OBJECT"]
-          s3ObjectDetails = {
-            bucketName = [module.s3_bucket["processing"].s3_bucket_id]
-          }
-        }
-      })
-    }
-  }
+  rules = local.eventbridge_default_bus_rules
 
-  targets = {
-    "incoming-s3-object-created" = [
-      {
-        name            = "file-received-v1"
-        dead_letter_arn = module.sqs_eventbridge_default_dlq.queue_arn
-        arn             = module.lambda_file_received_adapter.lambda_function_arn
-      }
-    ]
-    "guardduty-malware-scan-result" = [
-      {
-        name            = "file-scan-result-recorded-v1"
-        dead_letter_arn = module.sqs_eventbridge_default_dlq.queue_arn
-        arn             = module.lambda_file_scan_result_recorded_adapter.lambda_function_arn
-        retry_policy = {
-          maximum_event_age_in_seconds = 21600
-          maximum_retry_attempts       = 185
-        }
-      }
-    ]
-  }
+    targets = local.eventbridge_default_bus_targets
 
   tags = local.tags
 }
@@ -79,65 +32,9 @@ module "eventbridge_file_transfer_bus" {
     module.step_function_filescanresultrecorded_workflow.state_machine_arn,
   ]
 
-  rules = {
-    "file-transfer-workflow" = {
-      description = "Start the file transfer workflow for canonical FileReceived.v1 events"
-      event_pattern = jsonencode({
-        account       = [data.aws_caller_identity.current.account_id]
-        source        = ["uk.gov.justice.service.managed-file-transfer"]
-        "detail-type" = ["FileReceived.v1"]
-        detail = {
-          data = {
-            object = {
-              bucket = [module.s3_bucket["incoming"].s3_bucket_id]
-            }
-          }
-        }
-      })
-    }
-    "file-routing-workflow" = {
-      description = "Start the file routing workflow for canonical FileScanResultRecorded.v1 events"
-      event_pattern = jsonencode({
-        account       = [data.aws_caller_identity.current.account_id]
-        source        = ["uk.gov.justice.service.managed-file-transfer"]
-        "detail-type" = ["FileScanResultRecorded.v1"]
-        detail = {
-          data = {
-            object = {
-              bucket = [module.s3_bucket["processing"].s3_bucket_id]
-            }
-          }
-        }
-      })
-    }
-  }
+  rules = local.eventbridge_file_transfer_bus_rules
 
-  targets = {
-    "file-transfer-workflow" = [
-      {
-        name            = "file-transfer-workflow"
-        arn             = module.step_function_filereceived_workflow.state_machine_arn
-        attach_role_arn = true
-        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
-        retry_policy = {
-          maximum_event_age_in_seconds = 86400
-          maximum_retry_attempts       = 185
-        }
-      }
-    ]
-    "file-routing-workflow" = [
-      {
-        name            = "file-routing-workflow"
-        arn             = module.step_function_filescanresultrecorded_workflow.state_machine_arn
-        attach_role_arn = true
-        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
-        retry_policy = {
-          maximum_event_age_in_seconds = 86400
-          maximum_retry_attempts       = 185
-        }
-      }
-    ]
-  }
+  targets = local.eventbridge_file_transfer_bus_targets
 
   archives = {
     "${local.application_name}-archive" = {

--- a/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
@@ -1,5 +1,113 @@
 locals {
   eventbridge_schema_directory = "${path.module}/schemas"
   eventbridge_schemas          = fileset("${path.module}/schemas", "*.json")
-  file_transfer_event_bus_arn  = "arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-bus/${local.application_name}"
+
+  eventbridge_default_bus_rules = {
+    "incoming-s3-object-created" = {
+      description = "Transform incoming S3 Object Created notifications into FileReceived.v1 events"
+      event_pattern = jsonencode({
+        source        = ["aws.s3"]
+        "detail-type" = ["Object Created"]
+        detail = {
+          bucket = {
+            name = [module.s3_bucket["incoming"].s3_bucket_id]
+          }
+        }
+      })
+    }
+    "guardduty-malware-scan-result" = {
+      description = "Transform GuardDuty malware scan results into FileScanResultRecorded.v1 events"
+      event_pattern = jsonencode({
+        account       = [data.aws_caller_identity.current.account_id]
+        source        = ["aws.guardduty"]
+        "detail-type" = ["GuardDuty Malware Protection Object Scan Result"]
+        resources     = [aws_guardduty_malware_protection_plan.this.arn]
+        detail = {
+          resourceType = ["S3_OBJECT"]
+          s3ObjectDetails = {
+            bucketName = [module.s3_bucket["processing"].s3_bucket_id]
+          }
+        }
+      })
+    }
+  }
+
+  eventbridge_default_bus_targets = {
+    "incoming-s3-object-created" = [
+      {
+        name            = "file-received-v1"
+        dead_letter_arn = module.sqs_eventbridge_default_dlq.queue_arn
+        arn             = module.lambda_file_received_adapter.lambda_function_arn
+      }
+    ]
+    "guardduty-malware-scan-result" = [
+      {
+        name            = "file-scan-result-recorded-v1"
+        dead_letter_arn = module.sqs_eventbridge_default_dlq.queue_arn
+        arn             = module.lambda_file_scan_result_recorded_adapter.lambda_function_arn
+        retry_policy = {
+          maximum_event_age_in_seconds = 21600
+          maximum_retry_attempts       = 185
+        }
+      }
+    ]
+  }
+
+  eventbridge_file_transfer_bus_rules = {
+    "file-transfer-workflow" = {
+      description = "Start the file transfer workflow for canonical FileReceived.v1 events"
+      event_pattern = jsonencode({
+        account       = [data.aws_caller_identity.current.account_id]
+        source        = ["uk.gov.justice.service.managed-file-transfer"]
+        "detail-type" = ["FileReceived.v1"]
+        detail = {
+          data = {
+            object = {
+              bucket = [module.s3_bucket["incoming"].s3_bucket_id]
+            }
+          }
+        }
+      })
+    }
+    "file-routing-workflow" = {
+      description = "Start the file routing workflow for canonical FileScanResultRecorded.v1 events"
+      event_pattern = jsonencode({
+        account       = [data.aws_caller_identity.current.account_id]
+        source        = ["uk.gov.justice.service.managed-file-transfer"]
+        "detail-type" = ["FileScanResultRecorded.v1"]
+        detail = {
+          data = {
+            object = {
+              bucket = [module.s3_bucket["processing"].s3_bucket_id]
+            }
+          }
+        }
+      })
+    }
+  }
+
+  eventbridge_file_transfer_bus_targets = {
+    "file-transfer-workflow" = [
+      {
+        name            = "file-transfer-workflow"
+        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
+        arn             = module.step_function_filereceived_workflow.state_machine_arn
+        retry_policy = {
+          maximum_event_age_in_seconds = 86400
+          maximum_retry_attempts       = 185
+        }
+      }
+    ]
+    "file-routing-workflow" = [
+      {
+        name            = "file-routing-workflow"
+        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
+        arn             = module.step_function_filescanresultrecorded_workflow.state_machine_arn
+        retry_policy = {
+          maximum_event_age_in_seconds = 86400
+          maximum_retry_attempts       = 185
+        }
+      }
+    ]
+  }
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-eventbridge.tf
@@ -90,8 +90,9 @@ locals {
     "file-transfer-workflow" = [
       {
         name            = "file-transfer-workflow"
-        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
         arn             = module.step_function_filereceived_workflow.state_machine_arn
+        attach_role_arn = true
+        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
         retry_policy = {
           maximum_event_age_in_seconds = 86400
           maximum_retry_attempts       = 185
@@ -101,8 +102,9 @@ locals {
     "file-routing-workflow" = [
       {
         name            = "file-routing-workflow"
-        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
         arn             = module.step_function_filescanresultrecorded_workflow.state_machine_arn
+        attach_role_arn = true
+        dead_letter_arn = module.sqs_eventbridge_file_transfer_workflow_dlq.queue_arn
         retry_policy = {
           maximum_event_age_in_seconds = 86400
           maximum_retry_attempts       = 185

--- a/terraform/environments/integration-hub-file-transfer/step-functions.tf
+++ b/terraform/environments/integration-hub-file-transfer/step-functions.tf
@@ -8,7 +8,7 @@ module "step_function_filereceived_workflow" {
 
   definition = templatefile("${path.module}/step-functions/filereceived-workflow.asl.json", {
     account_id                = jsonencode(data.aws_caller_identity.current.account_id)
-    event_bus_arn             = jsonencode(local.file_transfer_event_bus_arn)
+    event_bus_arn             = jsonencode(module.eventbridge_file_transfer_bus.eventbridge_bus_arn)
     idempotency_table_name    = jsonencode(module.dynamodb_file_transfer_idempotency.dynamodb_table_id)
     multipart_max_concurrency = 4
     part_size_bytes           = local.file_transfer_workflow_part_size_bytes
@@ -77,7 +77,7 @@ module "step_function_filereceived_workflow" {
     publish_workflow_events = {
       effect    = "Allow"
       actions   = ["events:PutEvents"]
-      resources = [local.file_transfer_event_bus_arn]
+      resources = [module.eventbridge_file_transfer_bus.eventbridge_bus_arn]
     }
   }
 
@@ -96,7 +96,7 @@ module "step_function_filescanresultrecorded_workflow" {
     account_id                = jsonencode(data.aws_caller_identity.current.account_id)
     clean_bucket_name         = jsonencode(module.s3_bucket["clean"].s3_bucket_id)
     clean_kms_key_arn         = jsonencode(module.kms_s3_bucket["clean"].key_arn)
-    event_bus_arn             = jsonencode(local.file_transfer_event_bus_arn)
+    event_bus_arn             = jsonencode(module.eventbridge_file_transfer_bus.eventbridge_bus_arn)
     idempotency_table_name    = jsonencode(module.dynamodb_file_transfer_idempotency.dynamodb_table_id)
     investigation_bucket_name = jsonencode(module.s3_bucket["investigation"].s3_bucket_id)
     investigation_kms_key_arn = jsonencode(module.kms_s3_bucket["investigation"].key_arn)
@@ -175,7 +175,7 @@ module "step_function_filescanresultrecorded_workflow" {
     publish_workflow_events = {
       effect    = "Allow"
       actions   = ["events:PutEvents"]
-      resources = [local.file_transfer_event_bus_arn]
+      resources = [module.eventbridge_file_transfer_bus.eventbridge_bus_arn]
     }
   }
 


### PR DESCRIPTION
* Move EventBridge rule/target content into local value, consistent with other code for this application.
* Add `integration-hub-file-transfer/builds` to .gitignore to prevent accidentally committing transient build artefacts.