### PR TITLE
fix: upgrade ccms connector memory to 3GB

### DIFF
--- a/terraform/environments/ccms-oia/application_variables.json
+++ b/terraform/environments/ccms-oia/application_variables.json
@@ -310,7 +310,7 @@
       "connector_dns_name": "https://ccms-connector.laa.service.justice.gov.uk",
       "connector_app_count": "6",
       "connector_container_cpu": "1024",
-      "connector_container_memory": "2048",
+      "connector_container_memory": "3072",
       "logging_level_com_ezgov_model": "info",
       "logging_level_com_ezgov_opa": "info",
       "logging_level_oracle_ocs_opa_laa": "info",


### PR DESCRIPTION
upgrade ccms connector memory to 3GB