### PR TITLE
✨ feat: introduce the Integration Hub transfer server

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
@@ -32,3 +32,15 @@ module "cloudwatch_metric_alarms" {
 
   tags = local.tags
 }
+
+module "cloudwatch_transfer" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "5.7.2"
+
+  name              = "/aws/transfer/${local.application_name}"
+  kms_key_id        = module.kms_cloudwatch_logs.key_arn
+  retention_in_days = local.cloudwatch_retention_days
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub-file-transfer/dynamodb.tf
+++ b/terraform/environments/integration-hub-file-transfer/dynamodb.tf
@@ -24,6 +24,8 @@ module "dynamodb_adapter_idempotency" {
     "delete" : "60m",
     "update" : "60m"
   }
+
+  tags = local.tags
 }
 
 module "dynamodb_file_transfer_idempotency" {

--- a/terraform/environments/integration-hub-file-transfer/eip.tf
+++ b/terraform/environments/integration-hub-file-transfer/eip.tf
@@ -1,4 +1,4 @@
 resource "aws_eip" "this" {
-  count  = local.is-production ==  true ? length(data.aws_subnets.shared-public.ids) : 1
+  count  = length(local.transfer_subnet_ids)
   domain = "vpc"
 }

--- a/terraform/environments/integration-hub-file-transfer/eip.tf
+++ b/terraform/environments/integration-hub-file-transfer/eip.tf
@@ -1,0 +1,4 @@
+resource "aws_eip" "this" {
+  count  = local.is-production ==  true ? length(data.aws_subnets.shared-public.ids) : 1
+  domain = "vpc"
+}

--- a/terraform/environments/integration-hub-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge.tf
@@ -12,7 +12,7 @@ module "eventbridge_default_bus" {
 
   rules = local.eventbridge_default_bus_rules
 
-    targets = local.eventbridge_default_bus_targets
+  targets = local.eventbridge_default_bus_targets
 
   tags = local.tags
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -1,0 +1,3 @@
+locals {
+  transfer_subnet_ids = local.is-production ? sort(data.aws_subnets.shared-public.ids) : slice(sort(data.aws_subnets.shared-public.ids), 0, 1)
+}

--- a/terraform/environments/integration-hub-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/s3.tf
@@ -42,6 +42,8 @@ module "s3_audit_bucket" {
     status     = true
     mfa_delete = false
   }
+
+  tags = local.tags
 }
 
 module "s3_bucket" {

--- a/terraform/environments/integration-hub-file-transfer/security-group.tf
+++ b/terraform/environments/integration-hub-file-transfer/security-group.tf
@@ -4,7 +4,17 @@ module "security_group_transfer" {
 
   vpc_id = data.aws_vpc.shared.id
 
-/*
+  egress_rules = {
+    all-ipv4 = {
+      ip_protocol = "-1"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "Allow all outbound IPv4 traffic"
+    }
+  }
+
+  tags = local.tags
+
+  /*
   ingress_rules = {
     ssh-from-internet = {
       from_port   = 22

--- a/terraform/environments/integration-hub-file-transfer/security-group.tf
+++ b/terraform/environments/integration-hub-file-transfer/security-group.tf
@@ -4,6 +4,7 @@ module "security_group_transfer" {
 
   vpc_id = data.aws_vpc.shared.id
 
+/*
   ingress_rules = {
     ssh-from-internet = {
       from_port   = 22
@@ -27,4 +28,5 @@ module "security_group_transfer" {
       description = "FTPS data from Internet"
     }
   }
+*/
 }

--- a/terraform/environments/integration-hub-file-transfer/security-group.tf
+++ b/terraform/environments/integration-hub-file-transfer/security-group.tf
@@ -1,0 +1,30 @@
+module "security_group_transfer" {
+  source  = "terraform-aws-modules/security-group/aws//"
+  version = "6.0.0"
+
+  vpc_id = data.aws_vpc.shared.id
+
+  ingress_rules = {
+    ssh-from-internet = {
+      from_port   = 22
+      to_port     = 22
+      ip_protocol = "tcp"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "SSH from Internet"
+    }
+    ftps-control-from-internet = {
+      from_port   = 21
+      to_port     = 21
+      ip_protocol = "tcp"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "FTPS control from Internet"
+    }
+    ftps-data-from-internet = {
+      from_port   = 8192
+      to_port     = 8200
+      ip_protocol = "tcp"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "FTPS data from Internet"
+    }
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/sqs.tf
+++ b/terraform/environments/integration-hub-file-transfer/sqs.tf
@@ -6,7 +6,7 @@ module "sqs_eventbridge_default_dlq" {
   name            = "${local.application_name}-eventbridge-default-dlq"
   use_name_prefix = false
 
-  kms_master_key_id         = module.kms_sqs.key_arn
+  kms_master_key_id          = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -49,7 +49,7 @@ module "sqs_lambda_file_received_adapter_dlq" {
   name            = "${local.application_name}-lambda-file-received-adapter-dlq"
   use_name_prefix = false
 
-  kms_master_key_id         = module.kms_sqs.key_arn
+  kms_master_key_id          = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -67,7 +67,7 @@ module "sqs_lambda_file_scan_result_recorded_adapter_dlq" {
   name            = "${local.application_name}-lambda-file-scan-result-recorded-adapter-dlq"
   use_name_prefix = false
 
-  kms_master_key_id         = module.kms_sqs.key_arn
+  kms_master_key_id          = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20
@@ -85,7 +85,7 @@ module "sqs_eventbridge_file_transfer_workflow_dlq" {
   name            = "${local.application_name}-file-transfer-workflow-dlq"
   use_name_prefix = false
 
-  kms_master_key_id         = module.kms_sqs.key_arn
+  kms_master_key_id          = module.kms_sqs.key_arn
   message_retention_seconds  = 1209600
   visibility_timeout_seconds = 180
   receive_wait_time_seconds  = 20

--- a/terraform/environments/integration-hub-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-server.tf
@@ -1,0 +1,33 @@
+resource "aws_transfer_server" "this" {
+  #certificate            = aws_acm_certificate.ftps.arn
+  domain                 = "S3"
+  endpoint_type          = "VPC"
+  identity_provider_type = "SERVICE_MANAGED"
+  logging_role           = module.iam_role_transfer.arn
+  protocols              = ["SFTP"]
+  security_policy_name   = "TransferSecurityPolicy-2025-03"
+  structured_log_destinations = [
+    "${module.cloudwatch_transfer.cloudwatch_log_group_arn}:*"
+  ]
+
+  endpoint_details {
+    vpc_id     = data.aws_vpc.shared.id
+    subnet_ids = data.aws_subnets.shared-public.ids
+    address_allocation_ids = [
+      for key, value in aws_eip.this : value.id
+    ]
+    security_group_ids = [
+      module.security_group_transfer.id
+    ]
+  }
+
+  protocol_details {
+    passive_ip = "AUTO"
+  }
+
+  tags = {
+    #"transfer:customHostname"      = local.is-production == false ? "sftp.${local.environment}.managed-file-transfer.service.justice.gov.uk" : "sftp.managed-file-transfer.service.justice.gov.uk"
+    #"transfer:route53HostedZoneId" = "/hostedzone/${data.aws_route53_zone.service.zone_id}"
+  }
+
+}

--- a/terraform/environments/integration-hub-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-server.tf
@@ -12,17 +12,13 @@ resource "aws_transfer_server" "this" {
 
   endpoint_details {
     vpc_id     = data.aws_vpc.shared.id
-    subnet_ids = data.aws_subnets.shared-public.ids
+    subnet_ids = local.transfer_subnet_ids
     address_allocation_ids = [
       for key, value in aws_eip.this : value.id
     ]
     security_group_ids = [
       module.security_group_transfer.id
     ]
-  }
-
-  protocol_details {
-    passive_ip = "AUTO"
   }
 
   tags = {


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What does this change? 🚚

This puts the AWS Transfer Family server in place as the next step in moving managed file transfer from the proof of concept in `integration-hub/managed-file-transfer` to the dedicated `integration-hub-file-transfer` environment.

It creates:

- a VPC-hosted, service-managed SFTP server in development for now
- public Elastic IP addresses for stable endpoints (1 when the environment is not `production`.)
- a security group with placeholders needed for file transfer traffic
- an encrypted CloudWatch log group for structured transfer logs

The file-transfer workspaces are also excluded from the Terraform plan evaluator because they now contain AWS Transfer Family server resources.

## Why now? 🧭

The server needs to exist before users can be implemented. Keeping that work separate makes the rollout easier to review and gives us a clear infrastructure foundation for the user migration that follows.

## How has this been tested? 🧪

Validation is delegated to the repository's automated CI checks. No account-backed Terraform plan was run locally.

## Anything else reviewers should know? 👀

This change deliberately introduces the server before creating transfer users. The current protocol is SFTP; the wider security group rules leave room for the planned transfer configuration as the migration develops.

Signed-off-by: David Sibley &lt;david.sibley@justice.gov.uk&gt;