### PR TITLE
Remove Step Function validation

### DIFF
--- a/.github/workflows/integration-hub-file-transfer.yml
+++ b/.github/workflows/integration-hub-file-transfer.yml
@@ -48,8 +48,6 @@ jobs:
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}
-
-  test-step-functions:
     name: Test Step Functions
     needs:
       - fetch-secrets-for-step-functions


### PR DESCRIPTION
Given that we can get a validation from a failed deployment to development, I don't think we're going to get a lot of value out of unit testing every template we deploy. That said, I'm open to revisiting this later.