### PR TITLE
Fix ArgoCD CodeConnections access, hub topology, and baseline ApplicationSet

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
+++ b/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
@@ -21,8 +21,26 @@ locals {
   # Detect if this cluster is an ArgoCD hub by checking the cluster tag
   is_argocd_hub = lookup(data.aws_eks_cluster.cluster.tags, "argocd-role", "") == "hub"
 
-  # Shared monorepo for all BU workload manifests and baseline chart
-  environments_repo = "https://github.com/ministryofjustice/container-platform-environments"
+  # Shared monorepo for all BU workload manifests and baseline chart.
+  #
+  # The EKS-managed Argo CD capability runs in AWS-managed infrastructure and
+  # cannot reach github.com directly — it clones repositories through the
+  # CodeConnections git-http proxy. When a CodeConnection ARN is supplied we
+  # build the proxy URL; otherwise we fall back to the direct GitHub URL.
+  #
+  # Proxy URL format (see AWS docs — "Connect to Git repositories with AWS
+  # CodeConnections"):
+  #   https://codeconnections.<region>.amazonaws.com/git-http/<account-id>/<region>/<connection-id>/<org>/<repo>
+  environments_repo_org  = "ministryofjustice"
+  environments_repo_name = "container-platform-environments"
+
+  # Connection ID is the last path segment of the CodeConnection ARN
+  # (arn:aws:codeconnections:<region>:<account>:connection/<connection-id>)
+  argocd_codeconnection_id = local.resolved_codeconnection_arn != "" ? element(reverse(split("/", local.resolved_codeconnection_arn)), 0) : ""
+
+  environments_repo = local.resolved_codeconnection_arn != "" ? (
+    "https://codeconnections.${data.aws_region.current.region}.amazonaws.com/git-http/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.region}/${local.argocd_codeconnection_id}/${local.environments_repo_org}/${local.environments_repo_name}.git"
+  ) : "https://github.com/${local.environments_repo_org}/${local.environments_repo_name}"
 
   # BU configuration — defines the spoke clusters and path within the monorepo
   # Each BU gets a nonlive and live AppProject + ApplicationSet pair
@@ -351,14 +369,15 @@ resource "kubectl_manifest" "argocd_applicationset_baseline" {
             targetRevision = "main"
             path           = "charts/app-baseline"
             helm = {
-              valuesObject = {
-                product       = "{{ .product }}"
-                bu            = "{{ .bu }}"
-                targetCluster = each.value.cluster_workspace
-                owner         = "{{ .owner | toJson }}"
-                access        = "{{ .access | toJson }}"
-                environments  = "{{ .environments | toJson }}"
-              }
+              valueFiles = [
+                "../../${each.value.path_prefix}/{{ .product }}/product.yaml"
+              ]
+              parameters = [
+                {
+                  name  = "targetCluster"
+                  value = each.value.cluster_workspace
+                }
+              ]
             }
           }
           destination = {

--- a/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
+++ b/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
@@ -36,11 +36,9 @@ locals {
 
   # Connection ID is the last path segment of the CodeConnection ARN
   # (arn:aws:codeconnections:<region>:<account>:connection/<connection-id>)
-  argocd_codeconnection_id = local.resolved_codeconnection_arn != "" ? element(reverse(split("/", local.resolved_codeconnection_arn)), 0) : ""
+  argocd_codeconnection_id = element(reverse(split("/", local.argocd_codeconnection_arn)), 0)
 
-  environments_repo = local.resolved_codeconnection_arn != "" ? (
-    "https://codeconnections.${data.aws_region.current.region}.amazonaws.com/git-http/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.region}/${local.argocd_codeconnection_id}/${local.environments_repo_org}/${local.environments_repo_name}.git"
-  ) : "https://github.com/${local.environments_repo_org}/${local.environments_repo_name}"
+  environments_repo = "https://codeconnections.${data.aws_region.current.region}.amazonaws.com/git-http/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.region}/${local.argocd_codeconnection_id}/${local.environments_repo_org}/${local.environments_repo_name}.git"
 
   # BU configuration — defines the spoke clusters and path within the monorepo
   # Each BU gets a nonlive and live AppProject + ApplicationSet pair

--- a/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
+++ b/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
@@ -25,8 +25,7 @@ locals {
   #
   # The EKS-managed Argo CD capability runs in AWS-managed infrastructure and
   # cannot reach github.com directly — it clones repositories through the
-  # CodeConnections git-http proxy. When a CodeConnection ARN is supplied we
-  # build the proxy URL; otherwise we fall back to the direct GitHub URL.
+  # CodeConnections git-http proxy.
   #
   # Proxy URL format (see AWS docs — "Connect to Git repositories with AWS
   # CodeConnections"):

--- a/terraform/environments/cloud-platform/cluster-core/variables.tf
+++ b/terraform/environments/cloud-platform/cluster-core/variables.tf
@@ -3,3 +3,26 @@ variable "enable_starter_pack" {
   default     = true
   description = "Toggle to enable starter pack service"
 }
+
+variable "argocd_codeconnection_arn" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    AWS CodeConnections ARN used by the EKS-managed Argo CD to reach the GitOps
+    repository. When empty, looks up the connection by name
+    (github-ministryofjustice) via data source.
+    Falls back to direct GitHub URL if neither is available.
+  EOT
+}
+
+# TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
+# the data source equivalent (currently only the resource exists under that name).
+data "aws_codestarconnections_connection" "github" {
+  count = var.argocd_codeconnection_arn == "" && local.is_argocd_hub ? 1 : 0
+  name  = "github-ministryofjustice"
+}
+
+locals {
+  # Resolve CodeConnections ARN: explicit variable > data source > empty (direct GitHub)
+  resolved_codeconnection_arn = var.argocd_codeconnection_arn != "" ? var.argocd_codeconnection_arn : try(data.aws_codestarconnections_connection.github[0].arn, "")
+}

--- a/terraform/environments/cloud-platform/cluster-core/variables.tf
+++ b/terraform/environments/cloud-platform/cluster-core/variables.tf
@@ -4,25 +4,12 @@ variable "enable_starter_pack" {
   description = "Toggle to enable starter pack service"
 }
 
-variable "argocd_codeconnection_arn" {
-  type        = string
-  default     = ""
-  description = <<-EOT
-    AWS CodeConnections ARN used by the EKS-managed Argo CD to reach the GitOps
-    repository. When empty, looks up the connection by name
-    (github-ministryofjustice) via data source.
-    Falls back to direct GitHub URL if neither is available.
-  EOT
-}
-
 # TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
 # the data source equivalent (currently only the resource exists under that name).
 data "aws_codestarconnections_connection" "github" {
-  count = var.argocd_codeconnection_arn == "" && local.is_argocd_hub ? 1 : 0
-  name  = "github-ministryofjustice"
+  name = "github-ministryofjustice"
 }
 
 locals {
-  # Resolve CodeConnections ARN: explicit variable > data source > empty (direct GitHub)
-  resolved_codeconnection_arn = var.argocd_codeconnection_arn != "" ? var.argocd_codeconnection_arn : try(data.aws_codestarconnections_connection.github[0].arn, "")
+  argocd_codeconnection_arn = data.aws_codestarconnections_connection.github.arn
 }

--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -9,16 +9,11 @@
 #   - US-015a: Provision Hub Cluster to support Argo CD Deployment
 ###############################################################################
 
-# Resolve CodeConnections ARN: explicit variable > data source lookup
 # TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
 # the data source equivalent (currently only the resource exists under that name).
 data "aws_codestarconnections_connection" "github" {
-  count = var.argocd_codeconnection_arn == "" && var.enable_argocd ? 1 : 0
+  count = var.enable_argocd ? 1 : 0
   name  = "github-ministryofjustice"
-}
-
-locals {
-  resolved_codeconnection_arn = var.argocd_codeconnection_arn != "" ? var.argocd_codeconnection_arn : try(data.aws_codestarconnections_connection.github[0].arn, "")
 }
 
 module "argocd" {
@@ -49,7 +44,7 @@ module "argocd" {
   )
 
   # GitHub access via CodeConnections
-  codeconnection_arn = local.resolved_codeconnection_arn
+  codeconnection_arn = data.aws_codestarconnections_connection.github[0].arn
 
   # Enable pre-destroy cleanup for dev clusters (prevents cluster deletion hang)
   # Production hubs should set this to false to prevent accidental capability removal

--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -9,6 +9,18 @@
 #   - US-015a: Provision Hub Cluster to support Argo CD Deployment
 ###############################################################################
 
+# Resolve CodeConnections ARN: explicit variable > data source lookup
+# TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
+# the data source equivalent (currently only the resource exists under that name).
+data "aws_codestarconnections_connection" "github" {
+  count = var.argocd_codeconnection_arn == "" && var.enable_argocd ? 1 : 0
+  name  = "github-ministryofjustice"
+}
+
+locals {
+  resolved_codeconnection_arn = var.argocd_codeconnection_arn != "" ? var.argocd_codeconnection_arn : try(data.aws_codestarconnections_connection.github[0].arn, "")
+}
+
 module "argocd" {
   source = "./modules/argo-cd"
   count  = var.enable_argocd ? 1 : 0
@@ -37,7 +49,7 @@ module "argocd" {
   )
 
   # GitHub access via CodeConnections
-  codeconnection_arn = var.argocd_codeconnection_arn
+  codeconnection_arn = local.resolved_codeconnection_arn
 
   # Enable pre-destroy cleanup for dev clusters (prevents cluster deletion hang)
   # Production hubs should set this to false to prevent accidental capability removal
@@ -80,9 +92,12 @@ locals {
   # register with. That is true when either:
   #   1. This is a permanent cluster (in mp_environments) → hub known by convention, OR
   #   2. An explicit hub role ARN was supplied (ephemeral/test clusters)
-  # Ad-hoc ephemeral clusters with no hub ARN are neither hub nor spoke, so they
-  # do not attempt registration against a hub that may not exist yet.
-  is_argocd_spoke = !var.enable_argocd && (
+  # Hub clusters (preproduction, live) are never spokes — even before ArgoCD is
+  # enabled on them. Ephemeral clusters without an explicit hub ARN are neither
+  # hub nor spoke, so they do not attempt registration.
+  is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
+
+  is_argocd_spoke = !var.enable_argocd && !local.is_argocd_hub_cluster && (
     contains(local.mp_environments, terraform.workspace) || var.argocd_hub_spoke_access_role_arn != ""
   )
 }

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -33,8 +33,8 @@ locals {
   #-----------------------------------------------------------------------------
   argocd_hubs = {
     nonlive = {
-      account_id   = local.environment_management.account_ids["cloud-platform-development"]
-      cluster_name = "cloud-platform-development"
+      account_id   = local.environment_management.account_ids["cloud-platform-preproduction"]
+      cluster_name = "cloud-platform-preproduction"
     }
     live = {
       account_id   = local.environment_management.account_ids["cloud-platform-live"]

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
@@ -279,12 +279,18 @@ resource "aws_iam_role" "argocd_spoke_access" {
 
 #------------------------------------------------------------------------------
 # CodeConnections for GitHub repository access
+#
+# The EKS-managed Argo CD reposerver runs under the capability role
+# (aws_iam_role.argocd_capability) and reaches Git providers through the
+# CodeConnections git-http proxy. These permissions MUST be on the capability
+# role — not the spoke-access role — or the reposerver cannot authenticate to
+# the connection and fails to clone repositories.
 #------------------------------------------------------------------------------
 resource "aws_iam_role_policy" "argocd_codeconnection" {
   count = var.codeconnection_arn != "" ? 1 : 0
 
   name = "codeconnection-access"
-  role = aws_iam_role.argocd_spoke_access.id
+  role = aws_iam_role.argocd_capability.id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -50,17 +50,6 @@ variable "argocd_rbac_role_mappings" {
   EOT
 }
 
-variable "argocd_codeconnection_arn" {
-  type        = string
-  default     = ""
-  description = <<-EOT
-    AWS CodeConnections ARN for GitHub repository access from Argo CD.
-    When empty, looks up the connection by name (github-ministryofjustice)
-    via data source. Falls back to empty (no CodeConnection) if neither is
-    available.
-  EOT
-}
-
 #------------------------------------------------------------------------------
 # Argo CD Spoke Registration (ADR-002 — Spoke-Driven Model)
 #------------------------------------------------------------------------------

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -53,7 +53,12 @@ variable "argocd_rbac_role_mappings" {
 variable "argocd_codeconnection_arn" {
   type        = string
   default     = ""
-  description = "AWS CodeConnections ARN for GitHub repository access from Argo CD."
+  description = <<-EOT
+    AWS CodeConnections ARN for GitHub repository access from Argo CD.
+    When empty, looks up the connection by name (github-ministryofjustice)
+    via data source. Falls back to empty (no CodeConnection) if neither is
+    available.
+  EOT
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/cloud-platform/codeconnections.tf
+++ b/terraform/environments/cloud-platform/codeconnections.tf
@@ -1,0 +1,26 @@
+###############################################################################
+# AWS CodeConnections — GitHub access for EKS-managed ArgoCD
+#
+# The EKS ArgoCD Capability runs in AWS-managed infrastructure and cannot reach
+# github.com directly. It clones repositories through the CodeConnections
+# git-http proxy. One connection per account is sufficient — all clusters in
+# the account share it.
+#
+# After Terraform creates this resource it will be in PENDING status.
+# A one-time manual step is required to complete the GitHub OAuth handshake:
+#   1. AWS Console → Developer Tools → Settings → Connections
+#   2. Select the pending connection → "Update pending connection"
+#   3. Authorize the AWS Connector GitHub App for the ministryofjustice org
+#
+# Once AVAILABLE, downstream components (cluster, cluster-core) look up the
+# connection by name via data source — no cross-state references needed.
+###############################################################################
+
+resource "aws_codeconnections_connection" "github" {
+  name          = "github-ministryofjustice"
+  provider_type = "GitHub"
+
+  tags = merge(local.tags, {
+    Name = "github-ministryofjustice"
+  })
+}

--- a/terraform/environments/cloud-platform/codeconnections.tf
+++ b/terraform/environments/cloud-platform/codeconnections.tf
@@ -3,8 +3,14 @@
 #
 # The EKS ArgoCD Capability runs in AWS-managed infrastructure and cannot reach
 # github.com directly. It clones repositories through the CodeConnections
-# git-http proxy. One connection per account is sufficient — all clusters in
-# the account share it.
+# git-http proxy. One connection per hub account is sufficient — all clusters
+# in the account share it.
+#
+# Only created in hub accounts (cloud-platform-* workspaces). BU spoke accounts
+# (container-platform-* workspaces) do not run ArgoCD and do not need a
+# connection. The workspace prefix convention distinguishes the two:
+#   - cloud-platform-*       → hub accounts (development, preproduction, live)
+#   - container-platform-*   → BU spoke accounts (octo, laa, hmpps)
 #
 # After Terraform creates this resource it will be in PENDING status.
 # A one-time manual step is required to complete the GitHub OAuth handshake:
@@ -17,6 +23,7 @@
 ###############################################################################
 
 resource "aws_codeconnections_connection" "github" {
+  count         = startswith(terraform.workspace, "cloud-platform-") ? 1 : 0
   name          = "github-ministryofjustice"
   provider_type = "GitHub"
 


### PR DESCRIPTION
### Summary

Resolves multiple issues preventing the EKS-managed ArgoCD Capability from functioning in development and pre-production environments.

### Changes

**CodeConnections resource (root component)**
- Add `aws_codeconnections_connection` resource — one per hub account
- Only created in `cloud-platform-*` workspaces (hub accounts); skipped for `container-platform-*` workspaces (BU spoke accounts don't run ArgoCD)
- Downstream components look up the connection by name (`github-ministryofjustice`) via `data.aws_codestarconnections_connection` — fails at plan time if missing

**CodeConnections IAM (cluster component)**
- Move `codeconnections:UseConnection` IAM policy from spoke-access role to capability role (the reposerver authenticates as the capability role)

**Hub topology fix (cluster component)**
- Nonlive hub corrected from `cloud-platform-development` to `cloud-platform-preproduction`
- Hub clusters (preproduction, live) are never spokes regardless of `enable_argocd` flag
- Remove unused `argocd_codeconnection_arn` variable

**Baseline ApplicationSet (cluster-core component)**
- Replace `valuesObject` with `toJson` (this produced JSON strings breaking Helm `range`) with
  `valueFiles` pointing directly at `product.yaml` — Helm reads native YAML
- Only `targetCluster` passed as a `parameters` entry

**CodeConnections proxy URL (cluster-core component)**
- Repo URL uses the CodeConnections git-http proxy format (required — EKS-managed ArgoCD cannot reach github.com directly)

### Post-deploy action

After root component apply in each hub account, the CodeConnection will be in `PENDING` status.
Complete the GitHub OAuth in the AWS Console → Developer Tools → Connections (one-time per account).

### Testing

Tested end-to-end on ephemeral hub (`cp-2207-1541`) and spoke (`cp-2207-1541-sp`) with
ArgoCD syncing from a feature branch. All Applications reach Synced/Healthy with pods running.

### Issue

https://github.com/ministryofjustice/cloud-platform/issues/8270
