### PR TITLE
[cloud-platform] Fix cluster-core plan failures in BU spoke accounts and TFLint warnings

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/variables.tf
+++ b/terraform/environments/cloud-platform/cluster-core/variables.tf
@@ -6,10 +6,15 @@ variable "enable_starter_pack" {
 
 # TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
 # the data source equivalent (currently only the resource exists under that name).
+#
+# Only looked up on hub clusters (argocd-role=hub tag). BU spoke accounts
+# (container-platform-* workspaces) do not have a CodeConnection and would
+# fail at plan time without this guard.
 data "aws_codestarconnections_connection" "github" {
-  name = "github-ministryofjustice"
+  count = lookup(data.aws_eks_cluster.cluster.tags, "argocd-role", "") == "hub" ? 1 : 0
+  name  = "github-ministryofjustice"
 }
 
 locals {
-  argocd_codeconnection_arn = data.aws_codestarconnections_connection.github.arn
+  argocd_codeconnection_arn = length(data.aws_codestarconnections_connection.github) > 0 ? data.aws_codestarconnections_connection.github[0].arn : ""
 }

--- a/terraform/environments/cloud-platform/cluster/eks-pod-identities.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-pod-identities.tf
@@ -21,7 +21,8 @@ module "aws_vpc_cni_pod_identity" {
 
 module "aws_ebs_csi_pod_identity" {
 
-  source = "terraform-aws-modules/eks-pod-identity/aws"
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "2.5.0"
 
   name = "aws-ebs-csi"
 

--- a/terraform/environments/cloud-platform/cluster/versions.tf
+++ b/terraform/environments/cloud-platform/cluster/versions.tf
@@ -32,6 +32,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 3.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
 
     cloudinit = {
       version = "~> 2.0"


### PR DESCRIPTION
### Summary

Fixes CI check failures introduced by #17932 that affect BU spoke account plans, and resolves pre-existing TFLint warnings in the cluster component.

### Changes

**cluster-core/variables.tf — Fix plan failure in BU spoke accounts**

The `data.aws_codestarconnections_connection.github` data source was running unconditionally across all workspaces. BU spoke accounts (`container-platform-*`) do not have a CodeConnection resource (it is only created in `cloud-platform-*` hub accounts), so the lookup failed at plan time.

Fix: Guard the data source behind the `argocd-role=hub` cluster tag. Non-hub clusters get an empty string for the ARN — safe because all downstream consumers are already gated on `local.is_argocd_hub`.

**cluster/eks-pod-identities.tf — TFLint terraform_module_version**

Added missing `version = "2.5.0"` to the `aws_ebs_csi_pod_identity` module (matching the existing `aws_vpc_cni_pod_identity` module).

**cluster/versions.tf — TFLint terraform_required_providers**

Added `kubernetes` provider to `required_providers` — it was used in `providers.tf` but not declared.

### Testing

- No functional change to hub clusters (data source still resolves when the tag is present)
- BU spoke plans will no longer error on the missing CodeConnection
- TFLint warnings for the cluster component resolved

### Issue

Follow-up to https://github.com/ministryofjustice/modernisation-platform-environments/pull/17932
