### PR TITLE
Create isolated VPC for transfer server endpoints

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/data.tf
+++ b/terraform/environments/integration-hub-file-transfer/data.tf
@@ -1,1 +1,4 @@
 #### This file can be used to store data specific to the member account ####
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -1,5 +1,6 @@
 locals {
-  transfer_subnet_ids = local.is-production ? sort(module.vpc_isolated.public_subnets) : slice(sort(module.vpc_isolated.public_subnets), 0, 1)
+  transfer_address_allocation_ids = [for key, value in aws_eip.this : value.id]
+  transfer_subnet_ids             = local.is-production ? sort(module.vpc_isolated.public_subnets) : slice(sort(module.vpc_isolated.public_subnets), 0, 1)
 
   # Custom IdP user configuration. Add users by username and list every
   # environment in which they may authenticate. Terraform stores routing and

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -1,5 +1,5 @@
 locals {
-  transfer_subnet_ids = local.is-production ? sort(data.aws_subnets.shared-public.ids) : slice(sort(data.aws_subnets.shared-public.ids), 0, 1)
+  transfer_subnet_ids = local.is-production ? sort(module.vpc_isolated.public_subnets) : slice(sort(module.vpc_isolated.public_subnets), 0, 1)
 
   # Custom IdP user configuration. Add users by username and list every
   # environment in which they may authenticate. Terraform stores routing and

--- a/terraform/environments/integration-hub-file-transfer/locals-vpc.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-vpc.tf
@@ -1,0 +1,7 @@
+locals {
+  vpc_availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
+  vpc_cidr               = "10.0.0.0/23"
+  vpc_subnets            = [for cidr_block in cidrsubnets(local.vpc_cidr, 2, 2, 2, 2) : cidrsubnets(cidr_block, 2, 2, 2)]
+  vpc_subnets_public     = local.vpc_subnets[0]
+  vpc_subnets_private    = local.vpc_subnets[1]
+}

--- a/terraform/environments/integration-hub-file-transfer/security-group.tf
+++ b/terraform/environments/integration-hub-file-transfer/security-group.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "transfer" {
   name        = "${local.application_name}-${local.environment}-transfer"
   description = "Allow SFTP and FTPS access to the Transfer Family server"
-  vpc_id      = data.aws_vpc.shared.id
+  vpc_id      = module.vpc_isolated.vpc_id
 
   dynamic "ingress" {
     for_each = local.transfer_user_cidr_blocks

--- a/terraform/environments/integration-hub-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-server.tf
@@ -12,8 +12,8 @@ resource "aws_transfer_server" "this" {
   ]
 
   endpoint_details {
-    vpc_id     = data.aws_vpc.shared.id
-    subnet_ids = local.transfer_subnet_ids
+    vpc_id     = module.vpc_isolated.vpc_id
+    subnet_ids = module.vpc_isolated.public_subnets
     address_allocation_ids = [
       for key, value in aws_eip.this : value.id
     ]

--- a/terraform/environments/integration-hub-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-server.tf
@@ -1,25 +1,19 @@
 resource "aws_transfer_server" "this" {
   #certificate            = aws_acm_certificate.ftps.arn
-  domain                 = "S3"
-  endpoint_type          = "VPC"
-  function               = module.lambda_custom_idp.lambda_function_arn
-  identity_provider_type = "AWS_LAMBDA"
-  logging_role           = module.iam_role_transfer.arn
-  protocols              = ["SFTP"]
-  security_policy_name   = "TransferSecurityPolicy-2025-03"
-  structured_log_destinations = [
-    "${module.cloudwatch_transfer.cloudwatch_log_group_arn}:*"
-  ]
+  domain                      = "S3"
+  endpoint_type               = "VPC"
+  function                    = module.lambda_custom_idp.lambda_function_arn
+  identity_provider_type      = "AWS_LAMBDA"
+  logging_role                = module.iam_role_transfer.arn
+  protocols                   = ["SFTP"]
+  security_policy_name        = "TransferSecurityPolicy-2025-03"
+  structured_log_destinations = ["${module.cloudwatch_transfer.cloudwatch_log_group_arn}:*"]
 
   endpoint_details {
-    vpc_id     = module.vpc_isolated.vpc_id
-    subnet_ids = module.vpc_isolated.public_subnets
-    address_allocation_ids = [
-      for key, value in aws_eip.this : value.id
-    ]
-    security_group_ids = [
-      aws_security_group.transfer.id
-    ]
+    vpc_id                 = module.vpc_isolated.vpc_id
+    subnet_ids             = local.transfer_subnet_ids
+    address_allocation_ids = local.transfer_address_allocation_ids
+    security_group_ids     = [aws_security_group.transfer.id]
   }
 
   tags = merge(

--- a/terraform/environments/integration-hub-file-transfer/vpc.tf
+++ b/terraform/environments/integration-hub-file-transfer/vpc.tf
@@ -1,0 +1,21 @@
+module "vpc_isolated" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.6.1"
+
+  name            = "${local.application_name}-${local.environment}-isolated"
+  azs             = local.vpc_availability_zones
+  cidr            = local.vpc_cidr
+  public_subnets  = local.vpc_subnets_public
+  private_subnets = local.vpc_subnets_private
+
+  enable_flow_log                                 = true
+  create_flow_log_cloudwatch_log_group            = true
+  create_flow_log_cloudwatch_iam_role             = true
+  flow_log_cloudwatch_log_group_kms_key_id        = module.kms_cloudwatch_logs.key_arn
+  flow_log_cloudwatch_log_group_retention_in_days = local.cloudwatch_retention_days
+  flow_log_max_aggregation_interval               = 60
+
+  tags = local.tags
+}


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What’s this about? 🧭

The Transfer Family endpoint currently lives in the shared VPC, where platform guardrails restrict low-numbered inbound ports. Transfer protocols need us to manage ports such as 21 and 22 directly, so this PR gives the service its own VPC without relaxing controls for other tenants.

## What changed? 🏗️

- Creates an isolated `10.0.0.0/23` VPC across three available Availability Zones, with public and private subnet ranges.
- Enables VPC flow logs with 60-second aggregation, encrypted using the existing CloudWatch Logs KMS key and using the existing retention period.
- Moves the AWS Transfer Family endpoint and its security group from the shared VPC into the new VPC.
- Places the endpoint in the new public subnets while keeping inbound access scoped to the existing per-user CIDR allow lists.

No user authentication, S3 storage, or transfer workflow configuration changes are included. Nice and contained. 📦

## Why this approach? 🔐

This keeps the networking exception local to the file transfer service. We can manage the ports required by Transfer Family inside a VPC we own, while the shared platform guardrails remain untouched. Flow logs also leave a useful audit trail for network traffic.

## Checks 🧪

- ✅ Checkov: 106 passed, 0 failed
- ✅ TFLint
- ✅ OPA policy tests
- ✅ Binary and archive file check
- ⚠️ The development Terraform plan requires approval from `@ministryofjustice/modernisation-platform` because it changes protected resources

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>