### PR TITLE
✨ Add secure web access for Integration Hub file transfers

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/data.tf
+++ b/terraform/environments/integration-hub-file-transfer/data.tf
@@ -1,4 +1,1 @@
 #### This file can be used to store data specific to the member account ####
-data "aws_availability_zones" "available" {
-  state = "available"
-}

--- a/terraform/environments/integration-hub-file-transfer/iam-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/iam-transfer-web-app.tf
@@ -1,0 +1,68 @@
+data "aws_iam_policy_document" "transfer_web_app" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetDataAccess",
+      "s3:ListCallerAccessGrants",
+    ]
+    resources = ["arn:aws:s3:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:access-grants/*"]
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "s3:ResourceAccount"
+    }
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListAccessGrantsInstances"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "s3:ResourceAccount"
+    }
+  }
+}
+
+module "iam_policy_transfer_web_app" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.1"
+
+  name        = "${local.application_name}-transfer-web-app-policy"
+  description = "AWS Transfer web app access grants policy"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.transfer_web_app.json
+}
+
+module "iam_role_transfer_web_app" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.1"
+
+  create          = true
+  use_name_prefix = false
+  name            = "transfer-web-app"
+  description     = "AWS Transfer web app role"
+
+  trust_policy_permissions = {
+    AllowTransferWebApp = {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole", "sts:SetContext"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["transfer.amazonaws.com"]
+      }]
+      condition = [{
+        test     = "StringEquals"
+        values   = [data.aws_caller_identity.current.account_id]
+        variable = "aws:SourceAccount"
+      }]
+    }
+  }
+
+  policies = {
+    transfer_web_app = module.iam_policy_transfer_web_app.arn
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/iam-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/iam-transfer-web-app.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "transfer_web_app" {
 }
 
 module "iam_policy_transfer_web_app" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "6.6.1"
 
@@ -35,9 +36,12 @@ module "iam_policy_transfer_web_app" {
   path        = "/"
 
   policy = data.aws_iam_policy_document.transfer_web_app.json
+
+  tags = local.tags
 }
 
 module "iam_role_transfer_web_app" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
   version = "6.6.1"
 
@@ -65,4 +69,168 @@ module "iam_role_transfer_web_app" {
   policies = {
     transfer_web_app = module.iam_policy_transfer_web_app.arn
   }
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "s3_access_grants_location" {
+  statement {
+    sid    = "AllowIncomingBucketReads"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.s3_bucket["incoming"].s3_bucket_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingObjectReads"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = [
+      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingObjectWrites"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingKMSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+    ]
+    resources = [
+      module.kms_s3_bucket["incoming"].key_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "kms:CallerAccount"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
+      variable = "kms:ViaService"
+    }
+  }
+}
+
+module "iam_policy_s3_access_grants_location" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.1"
+
+  name        = "${local.application_name}-s3-access-grants-location-policy"
+  description = "AWS S3 Access Grants read/write access to the incoming bucket"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.s3_access_grants_location.json
+
+  tags = local.tags
+}
+
+module "iam_role_s3_access_grants_location" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.1"
+
+  name            = "transfer-s3-access-grants-location"
+  use_name_prefix = false
+  description     = "Role to allow AWS S3 Access Grants to read and write to the incoming bucket"
+
+  trust_policy_permissions = {
+    AllowAccessGrants = {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+        "sts:SetContext",
+        "sts:SetSourceIdentity",
+      ]
+
+      principals = [{
+        type        = "Service"
+        identifiers = ["access-grants.s3.amazonaws.com"]
+      }]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          values   = [data.aws_caller_identity.current.account_id]
+          variable = "aws:SourceAccount"
+        },
+        {
+          test     = "ArnEquals"
+          values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+          variable = "aws:SourceArn"
+        }
+      ]
+    }
+  }
+
+  policies = {
+    incoming_access = module.iam_policy_s3_access_grants_location.arn
+  }
+
+  tags = local.tags
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
@@ -1,19 +1,3 @@
-data "aws_identitystore_group" "this" {
-  for_each          = toset(local.transfer_iam_identity_center_groups)
-  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
-
-  alternate_identifier {
-    unique_attribute {
-      attribute_path  = "DisplayName"
-      attribute_value = each.key
-    }
-  }
-}
-
-data "aws_ssoadmin_instances" "this" {
-  provider = aws.sso-readonly
-}
-
 locals {
   transfer_iam_identity_center_groups = toset([
     "integration-hub"

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
@@ -1,0 +1,21 @@
+data "aws_identitystore_group" "this" {
+  for_each          = toset(local.transfer_iam_identity_center_groups)
+  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "integration-hub"
+    }
+  }
+}
+
+data "aws_ssoadmin_instances" "this" {
+  provider = aws.sso-readonly
+}
+
+locals {
+  transfer_iam_identity_center_groups = toset([
+    "integration-hub"
+  ])
+}

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
@@ -5,7 +5,7 @@ data "aws_identitystore_group" "this" {
   alternate_identifier {
     unique_attribute {
       attribute_path  = "DisplayName"
-      attribute_value = "integration-hub"
+      attribute_value = each.key
     }
   }
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer-web-app.tf
@@ -1,5 +1,17 @@
+data "aws_ssoadmin_instances" "this" {
+  provider = aws.sso-readonly
+}
+
+data "aws_identitystore_group" "this" {
+  for_each          = local.transfer_iam_identity_center_groups
+  provider          = aws.sso-readonly
+  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
+  group_id          = each.value
+}
+
 locals {
-  transfer_iam_identity_center_groups = toset([
-    "integration-hub"
-  ])
+  # GetGroupId does not reliably resolve groups by display name, so IDs are explicit here.
+  transfer_iam_identity_center_groups = {
+    integration-hub = "8662e2b4-3021-7017-56ba-8794aa2047cd"
+  }
 }

--- a/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
@@ -1,0 +1,198 @@
+data "in" "integration_hub" {
+  provider          = aws.sso-readonly
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+  group_id          = "8662e2b4-3021-7017-56ba-8794aa2047cd" # "integration-hub" group ID in AWS SSO Identity Store
+}
+
+resource "aws_transfer_web_app" "this" {
+  identity_provider_details {
+    identity_center_config {
+      instance_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+      role         = module.iam_role_transfer_web_app.arn
+    }
+  }
+  web_app_units {
+    provisioned = 1
+  }
+}
+
+resource "aws_s3control_access_grants_instance" "this" {
+  identity_center_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+}
+
+data "aws_iam_policy_document" "s3_access_grants_location" {
+  statement {
+    sid    = "AllowIncomingBucketReads"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.s3_bucket["incoming"].s3_bucket_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingObjectReads"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = [
+      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingObjectWrites"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:ResourceAccount"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+      variable = "s3:AccessGrantsInstanceArn"
+    }
+  }
+
+  statement {
+    sid    = "AllowIncomingKMSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+    ]
+    resources = [
+      module.kms_s3_bucket["incoming"].key_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "kms:CallerAccount"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
+      variable = "kms:ViaService"
+    }
+  }
+}
+
+module "s3_access_grants_location_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.1"
+
+  name        = "${local.application_name}-s3-access-grants-location-policy"
+  description = "AWS S3 Access Grants read/write access to the incoming bucket"
+  path        = "/"
+
+  policy = data.aws_iam_policy_document.s3_access_grants_location.json
+}
+
+module "s3_access_grants_location_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.1"
+
+  name            = "transfer-s3-access-grants-location"
+  use_name_prefix = false
+  description     = "Role to allow AWS S3 Access Grants to read and write to the incoming bucket"
+
+  trust_policy_permissions = {
+    AllowAccessGrants = {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+        "sts:SetContext",
+        "sts:SetSourceIdentity",
+      ]
+
+      principals = [{
+        type        = "Service"
+        identifiers = ["access-grants.s3.amazonaws.com"]
+      }]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          values   = [data.aws_caller_identity.current.account_id]
+          variable = "aws:SourceAccount"
+        },
+        {
+          test     = "ArnEquals"
+          values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
+          variable = "aws:SourceArn"
+        }
+      ]
+    }
+  }
+
+  policies = {
+    incoming_access = module.s3_access_grants_location_policy.arn
+  }
+}
+
+resource "aws_s3control_access_grants_location" "incoming" {
+  depends_on = [aws_s3control_access_grants_instance.this]
+
+  iam_role_arn   = module.s3_access_grants_location_role.arn
+  location_scope = "s3://${module.s3_bucket["incoming"].s3_bucket_id}"
+}
+
+resource "aws_s3control_access_grant" "incoming_uploaders" {
+  access_grants_location_id = aws_s3control_access_grants_location.incoming.access_grants_location_id
+  permission                = "READWRITE"
+
+  access_grants_location_configuration {
+    s3_sub_prefix = "*"
+  }
+
+  grantee {
+    grantee_type       = "DIRECTORY_GROUP"
+    grantee_identifier = data.aws_identitystore_group.integration_hub.group_id
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
@@ -1,7 +1,24 @@
+data "aws_ssoadmin_instances" "this" {
+  provider = aws.sso-readonly
+}
+
+data "aws_identitystore_group" "this" {
+  for_each          = local.transfer_iam_identity_center_groups
+  provider          = aws.sso-readonly
+  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.key
+    }
+  }
+}
+
 resource "aws_transfer_web_app" "this" {
   identity_provider_details {
     identity_center_config {
-      instance_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+      instance_arn = one(data.aws_ssoadmin_instances.this.arns)
       role         = module.iam_role_transfer_web_app.arn
     }
   }
@@ -11,163 +28,7 @@ resource "aws_transfer_web_app" "this" {
 }
 
 resource "aws_s3control_access_grants_instance" "this" {
-  identity_center_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
-}
-
-data "aws_iam_policy_document" "s3_access_grants_location" {
-  statement {
-    sid    = "AllowIncomingBucketReads"
-    effect = "Allow"
-    actions = [
-      "s3:ListBucket",
-    ]
-    resources = [
-      module.s3_bucket["incoming"].s3_bucket_arn,
-    ]
-
-    condition {
-      test     = "StringEquals"
-      values   = [data.aws_caller_identity.current.account_id]
-      variable = "aws:ResourceAccount"
-    }
-
-    condition {
-      test     = "ArnEquals"
-      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
-      variable = "s3:AccessGrantsInstanceArn"
-    }
-  }
-
-  statement {
-    sid    = "AllowIncomingObjectReads"
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersion",
-      "s3:ListMultipartUploadParts",
-    ]
-    resources = [
-      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
-    ]
-
-    condition {
-      test     = "StringEquals"
-      values   = [data.aws_caller_identity.current.account_id]
-      variable = "aws:ResourceAccount"
-    }
-
-    condition {
-      test     = "ArnEquals"
-      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
-      variable = "s3:AccessGrantsInstanceArn"
-    }
-  }
-
-  statement {
-    sid    = "AllowIncomingObjectWrites"
-    effect = "Allow"
-    actions = [
-      "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
-      "s3:PutObject",
-      "s3:PutObjectTagging",
-    ]
-    resources = [
-      "${module.s3_bucket["incoming"].s3_bucket_arn}/*",
-    ]
-
-    condition {
-      test     = "StringEquals"
-      values   = [data.aws_caller_identity.current.account_id]
-      variable = "aws:ResourceAccount"
-    }
-
-    condition {
-      test     = "ArnEquals"
-      values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
-      variable = "s3:AccessGrantsInstanceArn"
-    }
-  }
-
-  statement {
-    sid    = "AllowIncomingKMSAccess"
-    effect = "Allow"
-    actions = [
-      "kms:DescribeKey",
-      "kms:Decrypt",
-      "kms:Encrypt",
-      "kms:GenerateDataKey*",
-    ]
-    resources = [
-      module.kms_s3_bucket["incoming"].key_arn,
-    ]
-
-    condition {
-      test     = "StringEquals"
-      values   = [data.aws_caller_identity.current.account_id]
-      variable = "kms:CallerAccount"
-    }
-
-    condition {
-      test     = "StringEquals"
-      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
-      variable = "kms:ViaService"
-    }
-  }
-}
-
-module "iam_policy_s3_access_grants_location" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.1"
-
-  name        = "${local.application_name}-s3-access-grants-location-policy"
-  description = "AWS S3 Access Grants read/write access to the incoming bucket"
-  path        = "/"
-
-  policy = data.aws_iam_policy_document.s3_access_grants_location.json
-}
-
-module "iam_role_s3_access_grants_location" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.1"
-
-  name            = "transfer-s3-access-grants-location"
-  use_name_prefix = false
-  description     = "Role to allow AWS S3 Access Grants to read and write to the incoming bucket"
-
-  trust_policy_permissions = {
-    AllowAccessGrants = {
-      effect = "Allow"
-      actions = [
-        "sts:AssumeRole",
-        "sts:SetContext",
-        "sts:SetSourceIdentity",
-      ]
-
-      principals = [{
-        type        = "Service"
-        identifiers = ["access-grants.s3.amazonaws.com"]
-      }]
-
-      condition = [
-        {
-          test     = "StringEquals"
-          values   = [data.aws_caller_identity.current.account_id]
-          variable = "aws:SourceAccount"
-        },
-        {
-          test     = "ArnEquals"
-          values   = [aws_s3control_access_grants_instance.this.access_grants_instance_arn]
-          variable = "aws:SourceArn"
-        }
-      ]
-    }
-  }
-
-  policies = {
-    incoming_access = module.iam_policy_s3_access_grants_location.arn
-  }
+  identity_center_arn = one(data.aws_ssoadmin_instances.this.arns)
 }
 
 resource "aws_s3control_access_grants_location" "incoming" {

--- a/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
@@ -1,20 +1,3 @@
-data "aws_ssoadmin_instances" "this" {
-  provider = aws.sso-readonly
-}
-
-data "aws_identitystore_group" "this" {
-  for_each          = local.transfer_iam_identity_center_groups
-  provider          = aws.sso-readonly
-  identity_store_id = one(data.aws_ssoadmin_instances.this.identity_store_ids)
-
-  alternate_identifier {
-    unique_attribute {
-      attribute_path  = "DisplayName"
-      attribute_value = each.key
-    }
-  }
-}
-
 resource "aws_transfer_web_app" "this" {
   identity_provider_details {
     identity_center_config {

--- a/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-web-app.tf
@@ -1,9 +1,3 @@
-data "in" "integration_hub" {
-  provider          = aws.sso-readonly
-  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
-  group_id          = "8662e2b4-3021-7017-56ba-8794aa2047cd" # "integration-hub" group ID in AWS SSO Identity Store
-}
-
 resource "aws_transfer_web_app" "this" {
   identity_provider_details {
     identity_center_config {
@@ -123,7 +117,7 @@ data "aws_iam_policy_document" "s3_access_grants_location" {
   }
 }
 
-module "s3_access_grants_location_policy" {
+module "iam_policy_s3_access_grants_location" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "6.6.1"
 
@@ -134,7 +128,7 @@ module "s3_access_grants_location_policy" {
   policy = data.aws_iam_policy_document.s3_access_grants_location.json
 }
 
-module "s3_access_grants_location_role" {
+module "iam_role_s3_access_grants_location" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
   version = "6.6.1"
 
@@ -172,27 +166,29 @@ module "s3_access_grants_location_role" {
   }
 
   policies = {
-    incoming_access = module.s3_access_grants_location_policy.arn
+    incoming_access = module.iam_policy_s3_access_grants_location.arn
   }
 }
 
 resource "aws_s3control_access_grants_location" "incoming" {
   depends_on = [aws_s3control_access_grants_instance.this]
 
-  iam_role_arn   = module.s3_access_grants_location_role.arn
+  iam_role_arn   = module.iam_role_s3_access_grants_location.arn
   location_scope = "s3://${module.s3_bucket["incoming"].s3_bucket_id}"
 }
 
 resource "aws_s3control_access_grant" "incoming_uploaders" {
+  for_each = data.aws_identitystore_group.this
+
   access_grants_location_id = aws_s3control_access_grants_location.incoming.access_grants_location_id
   permission                = "READWRITE"
 
   access_grants_location_configuration {
-    s3_sub_prefix = "*"
+    s3_sub_prefix = "group/${each.key}/*"
   }
 
   grantee {
     grantee_type       = "DIRECTORY_GROUP"
-    grantee_identifier = data.aws_identitystore_group.integration_hub.group_id
+    grantee_identifier = each.value.group_id
   }
 }

--- a/terraform/environments/integration-hub-file-transfer/vpc.tf
+++ b/terraform/environments/integration-hub-file-transfer/vpc.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc_isolated" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What this changes

This gives the Integration Hub team a browser-based way to work with files in the incoming S3 bucket through AWS Transfer Family Web Apps. 📁

People sign in with IAM Identity Center, and access follows their team membership. Each configured group gets its own space under `group/{group-name}/*`, so teams can work independently without wandering into one another's files. 🔐

Behind the scenes, this adds the Transfer Family web app, S3 Access Grants, and the IAM and KMS permissions needed to read and write files safely. The Identity Center group names live in one small local set, making another team's access straightforward to add later.

The IAM resources have also been gathered into the dedicated web app IAM file, while the service and access-grant resources stay together in the web app file. A nearby availability-zone lookup was moved alongside the VPC that uses it. 🧹

## How this was checked

- `terraform validate`
- `terraform fmt -check`
- `git diff --check`

CI can now take it for a proper spin. 🚀

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>