### PR TITLE
TM-2120: ndmis: widen nfs egress to allow legacy nextcloud mount

### DIFF
--- a/terraform/environments/delius-mis/modules/mis_environment/bcs.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/bcs.tf
@@ -43,7 +43,7 @@ resource "aws_vpc_security_group_egress_rule" "bcs_ec2" {
     smb-to-internal      = { ip_protocol = "TCP", port = 445, cidr_ipv4 = "10.0.0.0/8" }
     oracle1521-to-vpc    = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.account_config.shared_vpc_cidr }
     oracle1521-to-legacy = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.environment_config.legacy_counterpart_vpc_cidr }
-    nfs-to-efs           = { ip_protocol = "TCP", port = 2049, referenced_security_group_id = aws_security_group.efs.id }
+    nfs-to-internal      = { ip_protocol = "TCP", port = 2049, cidr_ipv4 = "10.0.0.0/8" }
   }
 
   description       = each.key

--- a/terraform/environments/delius-mis/modules/mis_environment/bps.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/bps.tf
@@ -40,7 +40,7 @@ resource "aws_vpc_security_group_egress_rule" "bps_ec2" {
     https-to-all         = { ip_protocol = "TCP", port = 443, cidr_ipv4 = "0.0.0.0/0" }
     smb-to-core-internal = { ip_protocol = "TCP", port = 445, cidr_ipv4 = "10.0.0.0/8" }
     oracle1521-to-vpc    = { ip_protocol = "TCP", port = 1521, cidr_ipv4 = var.account_config.shared_vpc_cidr }
-    nfs-to-efs           = { ip_protocol = "TCP", port = 2049, referenced_security_group_id = aws_security_group.efs.id }
+    nfs-to-internal      = { ip_protocol = "TCP", port = 2049, cidr_ipv4 = "10.0.0.0/8" }
   }
 
   description       = each.key


### PR DESCRIPTION
Allow BCS and BPS ability to mount EFS in this account and legacy. Using a single rule for this to keep number of rules down to a minimum and consistent with the other rules.