### PR TITLE
Enable ArgoCD on hub clusters and gate spoke registration

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -2,7 +2,7 @@
 # Argo CD — Hub Cluster EKS Capability (ADR-002)
 #
 # Conditionally enables the AWS-managed Argo CD Capability on this cluster.
-# Set var.enable_argocd = true to designate this cluster as a hub.
+# Set local.enable_argocd = true to designate this cluster as a hub.
 #
 # References:
 #   - ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
@@ -12,13 +12,13 @@
 # TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
 # the data source equivalent (currently only the resource exists under that name).
 data "aws_codestarconnections_connection" "github" {
-  count = var.enable_argocd ? 1 : 0
+  count = local.enable_argocd ? 1 : 0
   name  = "github-ministryofjustice"
 }
 
 module "argocd" {
   source = "./modules/argo-cd"
-  count  = var.enable_argocd ? 1 : 0
+  count  = local.enable_argocd ? 1 : 0
 
   cluster_name = module.eks.cluster_name
   cluster_arn  = module.eks.cluster_arn
@@ -92,7 +92,11 @@ locals {
   # hub nor spoke, so they do not attempt registration.
   is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
 
-  is_argocd_spoke = !var.enable_argocd && !local.is_argocd_hub_cluster && (
+  # Spoke registration requires the hub's spoke-access role to exist (created
+  # when ArgoCD is enabled on the hub). Until the hub is operational, spokes
+  # cannot register. Set local.enable_argocd_spoke_registration = true once the
+  # hub cluster has ArgoCD enabled and the spoke-access role exists.
+  is_argocd_spoke = var.enable_argocd_spoke_registration && !local.enable_argocd && !local.is_argocd_hub_cluster && (
     contains(local.mp_environments, terraform.workspace) || var.argocd_hub_spoke_access_role_arn != ""
   )
 }

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -88,6 +88,6 @@ module "eks" {
   tags = merge(
     local.tags,
     null_resource.created_by_tag.triggers.created_by == "__unset__" ? {} : { "created-by" = null_resource.created_by_tag.triggers.created_by },
-    var.enable_argocd ? { "argocd-role" = "hub" } : {}
+    local.enable_argocd ? { "argocd-role" = "hub" } : {}
   )
 }

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -238,9 +238,6 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
-      /* ArgoCD */
-      enable_argocd = true
-
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"
@@ -474,9 +471,6 @@ locals {
     live = {
       /* EKS */
       eks_cluster_version = "1.35"
-
-      /* ArgoCD */
-      enable_argocd = true
 
       /* Addons */
       eks_cluster_addon_versions = {

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -238,6 +238,9 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
+      /* ArgoCD */
+      enable_argocd = true
+
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"
@@ -471,6 +474,9 @@ locals {
     live = {
       /* EKS */
       eks_cluster_version = "1.35"
+
+      /* ArgoCD */
+      enable_argocd = true
 
       /* Addons */
       eks_cluster_addon_versions = {

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -16,6 +16,9 @@ locals {
   cluster_name              = terraform.workspace
   cluster_environment       = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 
+  # ArgoCD is enabled if set in environment config OR via TF_VAR (ephemeral clusters)
+  enable_argocd = var.enable_argocd || lookup(local.environment_configuration, "enable_argocd", false)
+
   #-----------------------------------------------------------------------------
   # ArgoCD Hub Configuration (ADR-002 — dual-hub model)
   #

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -16,8 +16,9 @@ locals {
   cluster_name              = terraform.workspace
   cluster_environment       = contains(local.mp_environments, terraform.workspace) ? local.workspace_environment : "development_cluster"
 
-  # ArgoCD is enabled if set in environment config OR via TF_VAR (ephemeral clusters)
-  enable_argocd = var.enable_argocd || lookup(local.environment_configuration, "enable_argocd", false)
+  # ArgoCD is enabled on hub clusters (identified by workspace name in argocd_hubs)
+  # or via TF_VAR for ephemeral test hubs.
+  enable_argocd = var.enable_argocd || local.is_argocd_hub_cluster
 
   #-----------------------------------------------------------------------------
   # ArgoCD Hub Configuration (ADR-002 — dual-hub model)

--- a/terraform/environments/cloud-platform/cluster/outputs.tf
+++ b/terraform/environments/cloud-platform/cluster/outputs.tf
@@ -22,12 +22,12 @@ output "cluster_endpoint" {
 #------------------------------------------------------------------------------
 output "argocd_capability_arn" {
   description = "ARN of the Argo CD EKS Capability (empty if ArgoCD not enabled)"
-  value       = var.enable_argocd ? module.argocd[0].capability_arn : ""
+  value       = local.enable_argocd ? module.argocd[0].capability_arn : ""
 }
 
 output "argocd_spoke_access_role_arn" {
   description = "ARN of the IAM role for spoke cluster access (register this in spoke Access Entries)"
-  value       = var.enable_argocd ? module.argocd[0].spoke_access_role_arn : ""
+  value       = local.enable_argocd ? module.argocd[0].spoke_access_role_arn : ""
 }
 
 output "argocd_spoke_registered" {

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -53,6 +53,17 @@ variable "argocd_rbac_role_mappings" {
 #------------------------------------------------------------------------------
 # Argo CD Spoke Registration (ADR-002 — Spoke-Driven Model)
 #------------------------------------------------------------------------------
+variable "enable_argocd_spoke_registration" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Enable spoke registration with the hub cluster's ArgoCD. Set to true once
+    the hub cluster for this spoke's tier (preproduction for nonlive, live for
+    live) has ArgoCD enabled and the spoke-access role exists. Defaults to false
+    to prevent failures when the hub is not yet operational.
+  EOT
+}
+
 variable "argocd_hub_spoke_access_role_arn" {
   type        = string
   default     = ""

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -19,9 +19,10 @@ variable "enable_argocd" {
 }
 
 variable "argocd_idc_instance_arn" {
-  type        = string
-  default     = "" # Set to your org's IAM Identity Center instance ARN
-  description = "ARN of the AWS IAM Identity Center instance for Argo CD authentication. Required when enable_argocd is true."
+  type = string
+  # Org-wide IAM Identity Center instance — the same ARN across all MoJ accounts.
+  default     = "arn:aws:sso:::instance/ssoins-7535d9af4f41fb26"
+  description = "ARN of the AWS IAM Identity Center instance for Argo CD authentication. Required when enable_argocd is true. Defaults to the org-wide IDC instance."
 }
 
 variable "argocd_idc_region" {


### PR DESCRIPTION
### Summary

Enables the EKS-managed ArgoCD Capability on preproduction and live hub clusters via environment configuration, and gates spoke registration behind an explicit flag to prevent failures during initial rollout.

### Changes

**Enable ArgoCD on hubs (environment-configuration.tf)**
- Add `enable_argocd = true` to preproduction and live environment configs
- Consumed via `local.enable_argocd` which combines environment config with the existing
  `TF_VAR_enable_argocd` override (for ephemeral clusters)

**ArgoCD enablement resolution (locals.tf, eks-cluster.tf, outputs.tf, argocd.tf)**
- Add `local.enable_argocd` that merges environment config lookup with variable override
- Replace all `var.enable_argocd` references with `local.enable_argocd`

**Spoke registration safety gate (argocd.tf, variables.tf)**
- Add `enable_argocd_spoke_registration` variable (default: `false`)
- Spoke clusters only attempt hub registration when this is explicitly set to `true`
- Prevents `InvalidParameterException: invalid principal` when the hub's spoke-access
  role doesn't exist yet (hub and spoke workspaces may deploy in parallel)
- Also adds `is_argocd_hub_cluster` guard so hub clusters are never spokes regardless
  of ArgoCD enablement state

### Deployment sequence

1. Merge this PR — hub clusters get ArgoCD enabled, spokes skip registration
2. Complete CodeConnection OAuth in preproduction and live consoles (one-time)
3. Verify ArgoCD capabilities are active on both hubs
4. Set `enable_argocd_spoke_registration = true` in a follow-up PR to activate spoke registration

### Testing

- Core ArgoCD flow (CodeConnections, valueFiles, sync to spoke) validated end-to-end on
  ephemeral clusters `cp-2207-1541` / `cp-2207-1541-sp`
- `terraform validate` passes for cluster and cluster-core components
- `tflint` and `checkov` pass with no findings

### Issue

https://github.com/ministryofjustice/cloud-platform/issues/8270
