### PR TITLE
TM-2120: delius-mis: add legacy efs resolver

### DIFF
--- a/terraform/environments/delius-mis/locals_preproduction.tf
+++ b/terraform/environments/delius-mis/locals_preproduction.tf
@@ -6,6 +6,8 @@ locals {
     legacy_counterpart_vpc_cidr            = "10.160.0.0/20"
     legacy_ad_domain_name                  = "delius-pre-prod.local"
     legacy_dns_ip_addrs                    = ["10.160.0.163", "10.160.6.66"]
+    legacy_resolver_ip_addrs               = ["10.160.3.177", "10.160.6.87", "10.160.8.61"]
+    legacy_nextcloud_efs_dns_name          = "fs-1ef14cef.efs.eu-west-2.amazonaws.com"
     ad_domain_name                         = "delius-mis-preprod.internal"
     ad_trust_domain_name                   = "azure.hmpp.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.hmpp.domain_controllers

--- a/terraform/environments/delius-mis/modules/mis_environment/directory_service.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/directory_service.tf
@@ -196,6 +196,34 @@ resource "aws_route53_resolver_rule_association" "vpc_r53_fwd_to_legacy_ad" {
   vpc_id           = var.account_config.shared_vpc_id
 }
 
+resource "aws_route53_resolver_rule" "r53_fwd_to_legacy_nextcloud_efs" {
+  count = lookup(var.environment_config, "legacy_nextcloud_efs_dns_name", null) != null ? 1 : 0
+
+  provider = aws.core-vpc
+
+  domain_name = var.environment_config.legacy_nextcloud_efs_dns_name
+  name        = "delius-mis-forward-for-legacy-nextcloud-efs"
+  rule_type   = "FORWARD"
+
+  resolver_endpoint_id = aws_route53_resolver_endpoint.resolve_local_entries_using_ad_dns.id
+
+  dynamic "target_ip" {
+    for_each = sort(var.environment_config.legacy_resolver_ip_addrs)
+    content {
+      ip = target_ip.value
+    }
+  }
+}
+
+resource "aws_route53_resolver_rule_association" "r53_fwd_to_legacy_nextcloud_efs" {
+  count = lookup(var.environment_config, "legacy_nextcloud_efs_dns_name", null) != null ? 1 : 0
+
+  provider = aws.core-vpc
+
+  resolver_rule_id = aws_route53_resolver_rule.r53_fwd_to_legacy_nextcloud_efs[0].id
+  vpc_id           = var.account_config.shared_vpc_id
+}
+
 ###
 # AD Join - Provide SG that EC2s can use if they need to join domain
 ###


### PR DESCRIPTION
Allow delius-mis ability to resolve legacy EFS DNS names. Only enabled in preprod for now.