### PR TITLE
TM-2120: delius-mis: enable legacy nextcloud efs dns resolving

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -6,6 +6,8 @@ locals {
     legacy_counterpart_vpc_cidr            = "10.162.32.0/20"
     legacy_ad_domain_name                  = null
     legacy_dns_ip_addrs                    = []
+    legacy_resolver_ip_addrs               = ["10.162.33.11", "10.162.38.123", "10.162.43.195"]
+    legacy_nextcloud_efs_dns_name          = "fs-92b7c763.efs.eu-west-2.amazonaws.com"
     ad_domain_name                         = "delius-mis-dev.internal"
     ad_trust_domain_name                   = "azure.noms.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.azure.domain_controllers

--- a/terraform/environments/delius-mis/locals_production.tf
+++ b/terraform/environments/delius-mis/locals_production.tf
@@ -6,6 +6,8 @@ locals {
     legacy_counterpart_vpc_cidr            = "10.160.16.0/20"
     legacy_ad_domain_name                  = "delius-prod.local"
     legacy_dns_ip_addrs                    = ["10.160.17.254", "10.160.22.121"]
+    legacy_resolver_ip_addrs               = ["10.160.16.135", "10.160.23.111", "10.160.27.249"]
+    legacy_nextcloud_efs_dns_name          = "fs-8a54e77b.efs.eu-west-2.amazonaws.com"
     ad_domain_name                         = "delius-mis-prod.internal"
     ad_trust_domain_name                   = "azure.hmpp.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.hmpp.domain_controllers

--- a/terraform/environments/delius-mis/locals_stage.tf
+++ b/terraform/environments/delius-mis/locals_stage.tf
@@ -6,6 +6,8 @@ locals {
     legacy_counterpart_vpc_cidr            = "10.160.32.0/20"
     legacy_ad_domain_name                  = "delius-stage.local"
     legacy_dns_ip_addrs                    = ["10.160.35.243", "10.160.38.128"]
+    legacy_resolver_ip_addrs               = ["10.160.35.130", "10.160.37.70", "10.160.42.118"]
+    legacy_nextcloud_efs_dns_name          = "fs-aaef805b.efs.eu-west-2.amazonaws.com"
     ad_domain_name                         = "delius-mis-stage.internal"
     ad_trust_domain_name                   = "azure.hmpp.root"
     ad_trust_dc_cidrs                      = module.ip_addresses.active_directory_cidrs.hmpp.domain_controllers


### PR DESCRIPTION
Enable for the other environments