### PR TITLE
Deploy data-platform-app 0.1.2

### DIFF
--- a/terraform/environments/data-platform/app/helm-charts.tf
+++ b/terraform/environments/data-platform/app/helm-charts.tf
@@ -3,7 +3,7 @@ resource "helm_release" "app" {
   /* https://github.com/ministryofjustice/data-platform-app */
   name       = "app"
   repository = "oci://ghcr.io/ministryofjustice/data-platform-charts"
-  version    = "0.1.1"
+  version    = "0.1.2"
   chart      = "app"
   namespace  = module.app_namespace.name
   values = [


### PR DESCRIPTION
Deploy Data Platform App version [0.1.2](https://github.com/ministryofjustice/data-platform-app/releases/tag/0.1.2)