### PR TITLE
Per-workspace spoke registration with allowlist

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -1,13 +1,36 @@
 ###############################################################################
-# Argo CD — Hub Cluster EKS Capability (ADR-002)
+# Argo CD — Hub and Spoke Configuration (ADR-002)
 #
-# Conditionally enables the AWS-managed Argo CD Capability on this cluster.
-# Set local.enable_argocd = true to designate this cluster as a hub.
+# This file handles two concerns:
+#   1. Hub enablement — provisioning the EKS-managed ArgoCD Capability
+#   2. Spoke registration — granting the hub access to deploy to this cluster
+#
+# HOW ENABLEMENT WORKS (decision tree):
+#
+#   Is this cluster a hub?
+#     YES (workspace is in local.argocd_hubs OR TF_VAR_enable_argocd=true)
+#       → Create ArgoCD Capability, CodeConnection IAM policy, hub tag
+#       → Never register as a spoke
+#
+#     NO → Is this workspace in argocd_registered_spokes (environment config)?
+#       YES → Register with the hub (create EKS Access Entry for hub role)
+#       NO  → Do nothing (cluster is neither hub nor spoke)
+#
+# WHERE TO MAKE CHANGES:
+#   - To add/remove a hub: edit argocd_hubs in locals.tf
+#   - To register a spoke: add its workspace name to argocd_registered_spokes
+#     in environment-configuration.tf (under the nonlive or live block)
+#   - For ephemeral test hubs: pass TF_VAR_enable_argocd=true at deploy time
+#   - For ephemeral test spokes: pass TF_VAR_argocd_hub_spoke_access_role_arn
 #
 # References:
 #   - ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
-#   - US-015a: Provision Hub Cluster to support Argo CD Deployment
+#   - ADR-018: Deployment Model Flexibility
 ###############################################################################
+
+#------------------------------------------------------------------------------
+# Hub: ArgoCD Capability
+#------------------------------------------------------------------------------
 
 # TODO: rename to data.aws_codeconnections_connection when the AWS provider adds
 # the data source equivalent (currently only the resource exists under that name).
@@ -23,31 +46,16 @@ module "argocd" {
   cluster_name = module.eks.cluster_name
   cluster_arn  = module.eks.cluster_arn
 
-  # IAM Identity Center authentication and RBAC
-  #
-  # Role mappings are constructed from two sources:
-  # 1. argocd_admin_group_id — the platform-engineer-admin group (ADMIN)
-  # 2. argocd_rbac_role_mappings — additional groups at any role level
-  #
-  # At scale, BU teams are added as VIEWER or EDITOR groups via
-  # argocd_rbac_role_mappings. This map is passed from a tfvars file or
-  # from the bu_configs when BU onboarding creates their IDC group.
   idc_instance_arn = var.argocd_idc_instance_arn
   idc_region       = var.argocd_idc_region
   rbac_role_mappings = merge(
-    # Platform admin group
     var.argocd_admin_group_id != "" ? {
       ADMIN = [{ id = var.argocd_admin_group_id, type = "SSO_GROUP" }]
     } : {},
-    # Additional role mappings (BU teams as VIEWER/EDITOR)
     var.argocd_rbac_role_mappings
   )
 
-  # GitHub access via CodeConnections
-  codeconnection_arn = data.aws_codestarconnections_connection.github[0].arn
-
-  # Enable pre-destroy cleanup for dev clusters (prevents cluster deletion hang)
-  # Production hubs should set this to false to prevent accidental capability removal
+  codeconnection_arn     = data.aws_codestarconnections_connection.github[0].arn
   enable_destroy_cleanup = local.cluster_environment == "development_cluster"
 
   tags = local.tags
@@ -55,48 +63,33 @@ module "argocd" {
   depends_on = [module.eks]
 }
 
-###############################################################################
-# Argo CD — Spoke Cluster Registration (ADR-002 — Spoke-Driven Model)
+#------------------------------------------------------------------------------
+# Spoke: Register with the hub's ArgoCD
 #
-# Any non-hub cluster is a spoke (see local.is_argocd_spoke). A spoke grants
-# the hub's ArgoCD spoke-access role an EKS Access Entry with
+# A spoke grants the hub's spoke-access role an EKS Access Entry with
 # AmazonEKSClusterAdminPolicy. This allows the hub's managed ArgoCD to deploy
-# workloads to this cluster without VPC peering or TGW.
-#
-# The hub's role ARN is resolved by local.resolved_hub_spoke_access_role_arn:
-#   - Permanent hubs (development/production): convention-based, no input needed
-#   - Ephemeral/test hubs: engineer passes the ARN as a workflow input
-#     (TF_VAR_argocd_hub_spoke_access_role_arn), which takes precedence.
-#
-# Cross-account: EKS Access Entries natively support cross-account IAM
-# principals — no VPC peering, TGW, or additional IAM trust policy changes
-# required on the spoke side.
-#
-# References:
-#   - ADR-002: GitOps Fleet Management — Spoke Access Model
-#   - US-015b: Spoke Registration and GitOps Configuration
-###############################################################################
+# workloads to this cluster without VPC peering or TGW. Cross-account access
+# is native to EKS Access Entries.
+#------------------------------------------------------------------------------
 
 locals {
-  # Resolve the hub spoke-access role ARN:
-  # 1. Explicit workflow input (var) — used for ephemeral/test hubs
-  # 2. Convention-based ARN for the spoke's tier — used for permanent hubs
-  resolved_hub_spoke_access_role_arn = var.argocd_hub_spoke_access_role_arn != "" ? var.argocd_hub_spoke_access_role_arn : local.argocd_hub_convention_role_arn
+  # Hub's spoke-access role ARN — resolved by convention or explicit override.
+  resolved_hub_spoke_access_role_arn = (
+    var.argocd_hub_spoke_access_role_arn != ""
+    ? var.argocd_hub_spoke_access_role_arn
+    : local.argocd_hub_convention_role_arn
+  )
 
-  # Any cluster that is not the hub is a spoke — provided we know which hub to
-  # register with. That is true when either:
-  #   1. This is a permanent cluster (in mp_environments) → hub known by convention, OR
-  #   2. An explicit hub role ARN was supplied (ephemeral/test clusters)
-  # Hub clusters (preproduction, live) are never spokes — even before ArgoCD is
-  # enabled on them. Ephemeral clusters without an explicit hub ARN are neither
-  # hub nor spoke, so they do not attempt registration.
+  # A cluster never self-identifies as both hub and spoke.
   is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
 
-  # Spoke registration requires the hub's spoke-access role to exist (created
-  # when ArgoCD is enabled on the hub). Until the hub is operational, spokes
-  # cannot register. Set local.enable_argocd_spoke_registration = true once the
-  # hub cluster has ArgoCD enabled and the spoke-access role exists.
-  is_argocd_spoke = var.enable_argocd_spoke_registration && !local.enable_argocd && !local.is_argocd_hub_cluster && (
+  # Spoke registration: workspace must appear in the argocd_registered_spokes
+  # allowlist AND must not be a hub AND must be a known permanent cluster (or
+  # have an explicit hub ARN for ephemeral spokes).
+  is_argocd_spoke = contains(
+    lookup(local.environment_configuration, "argocd_registered_spokes", []),
+    terraform.workspace
+    ) && !local.enable_argocd && !local.is_argocd_hub_cluster && (
     contains(local.mp_environments, terraform.workspace) || var.argocd_hub_spoke_access_role_arn != ""
   )
 }
@@ -116,7 +109,7 @@ resource "aws_eks_access_entry" "argocd_spoke" {
   lifecycle {
     precondition {
       condition     = local.resolved_hub_spoke_access_role_arn != ""
-      error_message = "Could not resolve the ArgoCD hub spoke-access role ARN. For a permanent hub, ensure the tier is present in local.argocd_hubs; for an ephemeral hub, pass the ARN via the workflow input (TF_VAR_argocd_hub_spoke_access_role_arn)."
+      error_message = "Could not resolve the hub spoke-access role ARN. Ensure the spoke's tier has a hub in local.argocd_hubs, or pass TF_VAR_argocd_hub_spoke_access_role_arn."
     }
   }
 }

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -355,6 +355,11 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
+      /* ArgoCD — spokes registered with the preproduction hub */
+      argocd_registered_spokes = [
+        "container-platform-octo-nonlive",
+      ]
+
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"
@@ -471,6 +476,9 @@ locals {
     live = {
       /* EKS */
       eks_cluster_version = "1.35"
+
+      /* ArgoCD — spokes registered with the live hub */
+      argocd_registered_spokes = []
 
       /* Addons */
       eks_cluster_addon_versions = {

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -53,17 +53,6 @@ variable "argocd_rbac_role_mappings" {
 
 #------------------------------------------------------------------------------
 # Argo CD Spoke Registration (ADR-002 — Spoke-Driven Model)
-#------------------------------------------------------------------------------
-variable "enable_argocd_spoke_registration" {
-  type        = bool
-  default     = false
-  description = <<-EOT
-    Enable spoke registration with the hub cluster's ArgoCD. Set to true once
-    the hub cluster for this spoke's tier (preproduction for nonlive, live for
-    live) has ArgoCD enabled and the spoke-access role exists. Defaults to false
-    to prevent failures when the hub is not yet operational.
-  EOT
-}
 
 variable "argocd_hub_spoke_access_role_arn" {
   type        = string


### PR DESCRIPTION
## Per-workspace spoke registration with allowlist

### Summary

Replaces the global `enable_argocd_spoke_registration` variable with a per-workspace allowlist in environment configuration. This allows nonlive and live spoke clusters to be registered with ArgoCD independently, and individual spokes to be on-boarded one at a time.

### Changes

**Spoke registration allowlist (environment-configuration.tf)**
- `nonlive` config: `argocd_registered_spokes = ["container-platform-octo-nonlive"]`
- `live` config: `argocd_registered_spokes = []`
- Adding a spoke is a one-line addition to the appropriate list

**Remove global variable (variables.tf)**
- Delete `enable_argocd_spoke_registration` variable (no longer needed)

**Simplify and document argocd.tf**
- Rewrite file with a clear decision-tree comment at the top explaining hub/spoke
  enablement and where to make changes
- Replace scattered comments with two labelled sections (Hub, Spoke)
- `is_argocd_spoke` now reads from the allowlist via
  `lookup(local.environment_configuration, "argocd_registered_spokes", [])`

### How to onboard a new spoke

Add the workspace name to `argocd_registered_spokes` in `environment-configuration.tf`:

```hcl
nonlive = {
  argocd_registered_spokes = [
    "container-platform-octo-nonlive",
    "container-platform-laa-nonlive",  # ← add here
  ]
}
```

### Issue

https://github.com/ministryofjustice/cloud-platform/issues/8270