### PR TITLE
adding new VPC for container platform - central digital BU

### DIFF
--- a/.github/config/skip-plan-evaluator-workspaces.json
+++ b/.github/config/skip-plan-evaluator-workspaces.json
@@ -14,5 +14,7 @@
   "container-platform-laa-nonlive",
   "container-platform-laa-live",
   "container-platform-hmpps-nonlive",
-  "container-platform-hmpps-live"
+  "container-platform-hmpps-live",
+  "container-platform-cd-nonlive",
+  "container-platform-cd-live"
 ]

--- a/terraform/environments/cloud-platform/accounts.json
+++ b/terraform/environments/cloud-platform/accounts.json
@@ -5,6 +5,8 @@
     "container-platform-laa-nonlive",
     "container-platform-laa-live",
     "container-platform-hmpps-nonlive",
-    "container-platform-hmpps-live"
+    "container-platform-hmpps-live",
+    "container-platform-cd-nonlive",
+    "container-platform-cd-live"
   ]
 }

--- a/terraform/environments/cloud-platform/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/environment-configuration.tf
@@ -27,5 +27,11 @@ locals {
     container-platform-hmpps-live = {
       account_subdomain_name = "hmpps-live.${local.base_domain}"
     }
+    container-platform-cd-nonlive = {
+      account_subdomain_name = "cd-nonlive.${local.base_domain}"
+    }
+    container-platform-cd-live = {
+      account_subdomain_name = "cd-live.${local.base_domain}"
+    }
   }
 }

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -51,6 +51,14 @@ locals {
       primary   = "10.41.16.0/20"
       secondary = "100.81.0.0/16"
     }
+    container-platform-cd-nonlive = {
+      primary   = "10.195.96.0/20"
+      secondary = "100.71.0.0/16"
+    }
+    container-platform-cd-live = {
+      primary   = "10.41.48.0/20"
+      secondary = "100.83.0.0/16"
+    }
   }
 
   vpc_flow_log_cloudwatch_log_group_name_prefix       = "/aws/vpc-flow-log/"


### PR DESCRIPTION
This pull request adds support for two new environments, `container-platform-cd-nonlive` and `container-platform-cd-live`, across the configuration and infrastructure codebase. The changes ensure these environments are recognized in environment lists, have appropriate subdomain mappings, and are assigned dedicated network CIDR blocks.

**Environment configuration updates:**

* Added `container-platform-cd-nonlive` and `container-platform-cd-live` to the list of recognized environments in `.github/config/skip-plan-evaluator-workspaces.json` and `terraform/environments/cloud-platform/accounts.json` to ensure they are included in relevant automation and infrastructure processes. [[1]](diffhunk://#diff-2200c7a2d2ca07ab2742e1d28732f4fca851b7049205235db6ff5803f8ea85b3L17-R19) [[2]](diffhunk://#diff-485a4ef5c0a3d922e7fd099883a3a1f76e5ebeea510268fccd2afe063dc88ef9L8-R10)
* Defined subdomain mappings for the new environments in the `environment-configuration.tf` file, assigning `cd-nonlive` and `cd-live` subdomains under the base domain.

**Network configuration updates:**

* Allocated unique primary and secondary CIDR blocks for both `container-platform-cd-nonlive` and `container-platform-cd-live` in the network locals, ensuring proper network segmentation and routing.