### PR TITLE
adding constraint on AWS Provider

### DIFF
--- a/terraform/environments/cloud-platform/cluster-base/versions.tf
+++ b/terraform/environments/cloud-platform/cluster-base/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/cloud-platform/cluster-components/versions.tf
+++ b/terraform/environments/cloud-platform/cluster-components/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/cloud-platform/cluster-core/versions.tf
+++ b/terraform/environments/cloud-platform/cluster-core/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/cloud-platform/cluster/versions.tf
+++ b/terraform/environments/cloud-platform/cluster/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/cloud-platform/network/versions.tf
+++ b/terraform/environments/cloud-platform/network/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     dns = {

--- a/terraform/environments/cloud-platform/versions.tf
+++ b/terraform/environments/cloud-platform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
+      version = "~> 6.0, != 6.57.0"
       source  = "hashicorp/aws"
     }
     http = {


### PR DESCRIPTION
There are some with the latest AWS provider `6.57.0`, which causes [plans to fail](https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/30466146990/job/90626145570?pr=17980). 

MP has [addressed this](https://mojdt.slack.com/archives/C01A7QK5VM1/p1785324915785839) with a recommended fix by omitting this version in the provider constraint.