### PR TITLE
Add dbo.JOB.JOB_STATUS to keep-as-int

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPProcessPlatform.json
+++ b/terraform/environments/analytical-platform-ingestion/dms/metadata/cica_tempus_SPPProcessPlatform.json
@@ -730,6 +730,11 @@
       "object_name": "dbo.JOB_HISTORY",
       "column_name": "OVERDUE",
       "apply_to_environments": ["development", "production"]
+    },
+    {
+      "object_name": "dbo.JOB",
+      "column_name": "JOB_STATUS",
+      "apply_to_environments": ["development", "production"]
     }
   ]
 }


### PR DESCRIPTION
Keep dbo.JOB.JOB_STATUS as int 
Adds JOB_STATUS to [columns_to_keep_as_int] in cica_tempus_SPPProcessPlatform to fix Athena HIVE_BAD_DATA 