### PR TITLE
set table-type=all on selection rules to migrate views

### DIFF
--- a/terraform/environments/analytical-platform-ingestion/modules/dms/replication-task.tf
+++ b/terraform/environments/analytical-platform-ingestion/modules/dms/replication-task.tf
@@ -11,9 +11,11 @@ locals {
         rule-id     = idx + 1 # Using iteration number (1-based index)
         rule-name   = "include-${lower(obj)}"
         rule-action = "explicit"
+        # table-type "all" ensures views (not just tables) are migrated, e.g. pol_vict_details
         object-locator = {
           schema-name = length(split(".", obj)) > 1 ? split(".", obj)[0] : local.input_data.schema
           table-name  = length(split(".", obj)) > 1 ? split(".", obj)[1] : obj
+          table-type  = "all"
         }
       }
     ],


### PR DESCRIPTION
Views were silently skipped because selection rules omitted table-type, which defaults to tables only, so adding all to table-type.