### PR TITLE
adding central digital dns zones to R53 and ExternalDNS

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/external-dns.tf
+++ b/terraform/environments/cloud-platform/cluster-core/external-dns.tf
@@ -69,6 +69,18 @@ module "external_dns" {
       aws_zone_cache_duration = local.aws_zone_cache_duration.production
       log_level               = "info"
     }
+    container-platform-cd-nonlive = {
+      domain_name_prefix      = "cd-nonlive"
+      sync_interval           = local.sync_interval.production
+      aws_zone_cache_duration = local.aws_zone_cache_duration.production
+      log_level               = "info"
+    }
+    container-platform-cd-live = {
+      domain_name_prefix      = "cd-live"
+      sync_interval           = local.sync_interval.production
+      aws_zone_cache_duration = local.aws_zone_cache_duration.production
+      log_level               = "info"
+    }
   }
   tags = {
     application   = "External DNS"

--- a/terraform/environments/cloud-platform/route53.tf
+++ b/terraform/environments/cloud-platform/route53.tf
@@ -147,3 +147,31 @@ resource "aws_route53_record" "hmpps_live_ns" {
     "ns-1290.awsdns-33.org.",
   ]
 }
+
+resource "aws_route53_record" "cd_nonlive_ns" {
+  count   = terraform.workspace == "cloud-platform-live" ? 1 : 0
+  zone_id = aws_route53_zone.container_platform_service_justice_gov_uk[0].zone_id
+  name    = "cd-nonlive.${local.base_domain}"
+  type    = "NS"
+  ttl     = 172800
+  records = [
+    "ns-849.awsdns-42.net.",
+    "ns-214.awsdns-26.com.",
+    "ns-1808.awsdns-34.co.uk.",
+    "ns-1298.awsdns-34.org.",
+  ]
+}
+
+resource "aws_route53_record" "cd_live_ns" {
+  count   = terraform.workspace == "cloud-platform-live" ? 1 : 0
+  zone_id = aws_route53_zone.container_platform_service_justice_gov_uk[0].zone_id
+  name    = "cd-live.${local.base_domain}"
+  type    = "NS"
+  ttl     = 172800
+  records = [
+    "ns-1164.awsdns-17.org.",
+    "ns-370.awsdns-46.com.",
+    "ns-1767.awsdns-28.co.uk.",
+    "ns-788.awsdns-34.net.",
+  ]
+}


### PR DESCRIPTION
This pull request adds support for new DNS subdomains and associated Route53 records for the container platform's CD (Central Digital) environments. The main changes include updating the external DNS configuration and creating new Route53 NS records for the `cd-nonlive` and `cd-live` subdomains.

**External DNS configuration:**

* Added new entries for `container-platform-cd-nonlive` and `container-platform-cd-live` in the `external_dns` module, each with their own `domain_name_prefix` and production settings for sync interval, cache duration, and log level.

**Route53 records:**

* Created new `aws_route53_record` resources for the `cd-nonlive` and `cd-live` subdomains, each with their own set of NS records, to delegate DNS for these subdomains in the live environment.