### PR TITLE
Do Not Raise Alarm when DMS Tasks temporarily stopped for password rotation

### DIFF
--- a/terraform/environments/delius-core/modules/components/dms/cloudwatch-alarms.tf
+++ b/terraform/environments/delius-core/modules/components/dms/cloudwatch-alarms.tf
@@ -323,7 +323,6 @@ resource "aws_cloudwatch_metric_alarm" "dms_alarm" {
   evaluation_periods = 8
   datapoints_to_alarm = 8
 
-  evaluation_periods  = 1
   metric_name         = "DMSTaskNotRunning"
   namespace           = "Custom/DMS"
   period              = 300

--- a/terraform/environments/delius-core/modules/components/dms/cloudwatch-alarms.tf
+++ b/terraform/environments/delius-core/modules/components/dms/cloudwatch-alarms.tf
@@ -316,6 +316,13 @@ resource "aws_lambda_permission" "allow_eventbridge" {
 resource "aws_cloudwatch_metric_alarm" "dms_alarm" {
   alarm_name          = "dms-cdc-task-not-running-in-${var.env_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  # Allow a task to not be running for up to 40 minutes (8*300 seconds)
+  # to allow for weekly password rotation.  Any replication lag will
+  # catch up once it has resumed.
+  evaluation_periods = 8
+  datapoints_to_alarm = 8
+
   evaluation_periods  = 1
   metric_name         = "DMSTaskNotRunning"
   namespace           = "Custom/DMS"


### PR DESCRIPTION
This pull request updates the configuration for the DMS CloudWatch alarm to reduce false positives during expected downtime, such as weekly password rotations. The main change is to increase the tolerance for tasks not running before triggering an alarm.

**CloudWatch Alarm Configuration:**

* Increased `evaluation_periods` from 1 to 8 and set `datapoints_to_alarm` to 8 in the `aws_cloudwatch_metric_alarm.dms_alarm` resource, allowing up to 40 minutes (8×300 seconds) of downtime before the alarm triggers. This helps avoid unnecessary alerts during routine maintenance like password rotations.