### PR TITLE
🚀 Deploys App 1 clone from AMI taken 0400hrs

### DIFF
--- a/terraform/environments/cica-tariff/tariff_ec2_app_clone_prod.tf
+++ b/terraform/environments/cica-tariff/tariff_ec2_app_clone_prod.tf
@@ -1,9 +1,7 @@
-/*
-
 # Clone of PROD App1 server for Weblogic build: CDI-388
 resource "aws_instance" "tariff_app_prod_clone" {
   count = local.environment == "production" ? 1 : 0
-  ami   = "ami-???" # tbc <------------ UPDATE THIS!
+  ami   = "ami-072bac695fba3a78d" # (ec2-cica-tariff-production-app-clone-20260731)
   lifecycle {
     ignore_changes = [user_data] # ami removed to allow restore
   }
@@ -52,5 +50,3 @@ resource "aws_security_group_rule" "temp_prod_ssm_only_egress" {
   protocol                 = "TCP"
   source_security_group_id = data.aws_security_group.core_vpc_protected.id
 }
-
-*/


### PR DESCRIPTION
This pull request updates the configuration to create the clone of production EC2 instance App 1, in the `cica-tariff` environment.

Infrastructure update:

* Updated the `ami` field for the `aws_instance.tariff_app_prod_clone` resource in `tariff_ec2_app_clone_prod.tf` to use the production clone AMI (`ami-072bac695fba3a78d`).