### PR TITLE
fix: update CCMS eventbridge schedule and re-point SG to SAFE01

### DIFF
--- a/terraform/environments/laa-enterprise-service-bus/application_variables.json
+++ b/terraform/environments/laa-enterprise-service-bus/application_variables.json
@@ -28,7 +28,7 @@
       "example_var": "preproduction-data"
     },
     "production": {
-      "cwa_database_ip": ["10.205.15.0/26", "10.205.15.64/26"],
+      "cwa_database_ip": ["10.205.14.0/26", "10.205.14.64/26"],
       "vpc_endpoint_sg": "sg-0e7c18081199d1cf1",
       "ccms_database_ip": "10.27.68.169/32",
       "s3_vpc_endpoint_prefix": "pl-7ca54015",

--- a/terraform/environments/laa-enterprise-service-bus/eventbridge_schedule.tf
+++ b/terraform/environments/laa-enterprise-service-bus/eventbridge_schedule.tf
@@ -32,8 +32,8 @@ resource "aws_scheduler_schedule" "ccms_load_schedule" {
   schedule_expression_timezone = "Europe/London"
 
   # The time has been changed to 1 hour earlier due to a bug that ignores the timezone, and uses UTC.
-  start_date = local.environment == "production" ? "2026-07-02T06:30:00Z" : null
-  end_date   = local.environment == "production" ? "2026-07-02T08:00:00Z" : null
+  start_date = local.environment == "production" ? "2026-08-06T06:30:00Z" : null
+  end_date   = local.environment == "production" ? "2026-08-06T08:00:00Z" : null
 
   target {
     arn      = aws_lambda_function.ccms_provider_load.arn


### PR DESCRIPTION
## Summary
- Bumps the CCMS load schedule `start_date`/`end_date` from 2026-07-02 to 2026-08-06 (next Thursday activity), keeping the existing time-of-day values that already account for the timezone bug (resolves to 7:30-9:00 Europe/London).
- Re-points the CWA extract lambda security group egress (`cwa_database_ip`) from SAFE02 (10.205.15.0/26, 10.205.15.64/26) to SAFE01 (10.205.14.0/26, 10.205.14.64/26), matching the pattern in #15340.

## Test plan
- [ ] `terraform plan` shows only the date change for `aws_scheduler_schedule.ccms_load_schedule` in production
- [ ] `terraform plan` shows only the CIDR change for `aws_security_group_rule.cwa_extract_egress_oracle_new` in production