### PR TITLE
Update admin values and LiteLLM version

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,7 +1,7 @@
 locals {
   environment_configurations = {
     development = {
-      litellm_version     = "1.93.0"
+      litellm_version     = "1.94.1"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -41,7 +41,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.93.0"
+      litellm_version     = "1.94.1"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.93.0"
+      litellm_version     = "1.94.1"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -121,7 +121,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.93.0"
+      litellm_version     = "1.94.1"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/helm-charts.tf
+++ b/terraform/environments/data-platform/ai-gateway/helm-charts.tf
@@ -64,6 +64,8 @@ resource "helm_release" "litellm_admin" {
     )
   ]
 
+  timeout = 700
+
   depends_on = [
     module.ai_gateway_aurora,
     module.iam_role,
@@ -133,6 +135,8 @@ resource "helm_release" "litellm" {
       }
     )
   ]
+
+  timeout = 700
 
   depends_on = [
     helm_release.litellm_admin,

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -20,10 +20,13 @@ serviceAccount:
 resources:
   requests:
     cpu: 250m
-    memory: 1Gi
+    memory: 2Gi
   limits:
     cpu: 500m
-    memory: 2Gi
+    memory: 4Gi
+
+startupProbe:
+  failureThreshold: 60
 
 db:
   deployStandalone: false


### PR DESCRIPTION
This pull request updates the AI Gateway's infrastructure configuration, focusing on upgrading the `litellm` version, improving deployment reliability, and adjusting resource allocations for the `litellm-admin` service.

**Upgrades and Version Management:**
- Upgraded `litellm_version` from `1.93.0` to `1.94.1` across all environments in `environment-configuration.tf` to ensure consistency and access to the latest features and fixes. [[1]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL4-R4) [[2]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL44-R44) [[3]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL84-R84) [[4]](diffhunk://#diff-62b20ea0e8dcb4cf7a8744119b712f9000cde513f63765741689f0c494de0d3cL124-R124)

**Deployment Reliability:**
- Increased the `timeout` for both `helm_release.litellm_admin` and `helm_release.litellm` resources to 700 seconds to reduce the likelihood of deployment failures due to timeouts. [[1]](diffhunk://#diff-2d078124f5b7527c66b2c741a96249ee834d87bb4fb5dc0e9ff347e4bd131a7fR67-R68) [[2]](diffhunk://#diff-2d078124f5b7527c66b2c741a96249ee834d87bb4fb5dc0e9ff347e4bd131a7fR139-R140)

**Resource Allocation and Probes:**
- Increased memory requests from `1Gi` to `2Gi` and limits from `2Gi` to `4Gi` for the `litellm-admin` service, and added a `startupProbe` with a higher `failureThreshold` to improve startup reliability.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>