### PR TITLE
Add Foundry OpenAI models and Unified Access Groups

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
@@ -1,3 +1,25 @@
+resource "litellm_unified_access_group" "amazon_bedrock" {
+  for_each = try(tomap(local.ai_gateway_configuration.models.amazon_bedrock), {})
+
+  access_group_name  = "bedrock-${each.key}"
+  access_model_names = [litellm_model.amazon_bedrock[each.key].model_name]
+}
+
+resource "litellm_unified_access_group" "google_gemini_enterprise_agent_platform" {
+  for_each = try(tomap(local.ai_gateway_configuration.models.google_gemini_enterprise_agent_platform), {})
+
+  access_group_name  = "gemini-${each.key}"
+  access_model_names = [litellm_model.google_gemini_enterprise_agent_platform[each.key].model_name]
+}
+
+resource "litellm_unified_access_group" "microsoft_foundry" {
+  # This is gated to non-production environments only, we don't have a Microsoft Foundry subscription in production yet
+  for_each = contains(["data-platform-development", "data-platform-test", "data-platform-preproduction"], terraform.workspace) ? try(tomap(local.ai_gateway_configuration.models.microsoft_foundry), {}) : {}
+
+  access_group_name  = "azure-${each.key}"
+  access_model_names = [litellm_model.microsoft_foundry[each.key].model_name]
+}
+
 resource "litellm_unified_access_group" "generally_available_models" {
   access_group_name = "generally-available-models"
 

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
@@ -56,7 +56,7 @@ resource "litellm_model" "microsoft_foundry" {
   base_model          = each.value.model_id
   tier                = "paid"
 
-  model_api_base = "${jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["endpoint"]}/${each.value.model_endpoint}"
+  model_api_base = can(each.value.model_endpoint) ? "${jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["endpoint"]}/${each.value.model_endpoint}" : jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["endpoint"]
   model_api_key  = jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["api_key"]
   api_version    = try(each.value.model_api_version, null)
 

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -203,7 +203,8 @@ models:
       region: eu-west-2
       generally_available: true
   google_gemini_enterprise_agent_platform: {}
-  microsoft_foundry: # {}
+  microsoft_foundry:
+    # Anthropic
     claude-fable-5:
       model_id: "claude-fable-5"
       model_family: "Claude Fable"
@@ -266,4 +267,59 @@ models:
       model_name: "Claude Sonnet 5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
+      generally_available: false
+    # OpenAI
+    gpt-5-3-codex:
+      model_id: "gpt-5.3-codex"
+      model_family: "GPT 5.3"
+      model_name: "GPT 5.3 Codex (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-4:
+      model_id: "gpt-5.4"
+      model_family: "GPT 5.4"
+      model_name: "GPT 5.4 (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-4-mini:
+      model_id: "gpt-5.4-mini"
+      model_family: "GPT 5.4"
+      model_name: "GPT 5.4 Mini (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-4-nano:
+      model_id: "gpt-5.4-nano"
+      model_family: "GPT 5.4"
+      model_name: "GPT 5.4 Nano (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-4-pro:
+      model_id: "gpt-5.4-pro"
+      model_family: "GPT 5.4"
+      model_name: "GPT 5.4 Pro (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-5:
+      model_id: "gpt-5.5"
+      model_family: "GPT 5.5"
+      model_name: "GPT 5.5 (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-6-luna:
+      model_id: "gpt-5.6-luna"
+      model_family: "GPT 5.6"
+      model_name: "GPT 5.6 Luna (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-6-sol:
+      model_id: "gpt-5.6-sol"
+      model_family: "GPT 5.6"
+      model_name: "GPT 5.6 Sol (Sweden)"
+      model_provider: "azure"
+      generally_available: false
+    gpt-5-6-terra:
+      model_id: "gpt-5.6-terra"
+      model_family: "GPT 5.6"
+      model_name: "GPT 5.6 Terra (Sweden)"
+      model_provider: "azure"
       generally_available: false

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -58,12 +58,6 @@ models:
       model_name: "Amazon Nova Pro"
       region: eu-west-2
       generally_available: true
-    amazon-titan-embed-text-v2:
-      model_id: "amazon.titan-embed-text-v2:0"
-      model_family: "Amazon Titan"
-      model_name: "Amazon Titan Text Embeddings v2"
-      region: eu-west-2
-      generally_available: true
     # Anthropic
     claude-haiku-4-5:
       model_id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -207,119 +201,119 @@ models:
     # Anthropic
     claude-fable-5:
       model_id: "claude-fable-5"
-      model_family: "Claude Fable"
-      model_name: "Claude Fable 5 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Fable 5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-haiku-4-5:
       model_id: "claude-haiku-4-5"
-      model_family: "Claude Haiku"
-      model_name: "Claude Haiku 4.5 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Haiku 4.5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-opus-4-5:
       model_id: "claude-opus-4-5"
-      model_family: "Claude Opus"
-      model_name: "Claude Opus 4.5 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Opus 4.5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-opus-4-6:
       model_id: "claude-opus-4-6"
-      model_family: "Claude Opus"
-      model_name: "Claude Opus 4.6 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Opus 4.6 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-opus-4-7:
       model_id: "claude-opus-4-7"
-      model_family: "Claude Opus"
-      model_name: "Claude Opus 4.7 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Opus 4.7 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-opus-4-8:
       model_id: "claude-opus-4-8"
-      model_family: "Claude Opus"
-      model_name: "Claude Opus 4.8 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Opus 4.8 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-opus-5:
       model_id: "claude-opus-5"
-      model_family: "Claude Opus"
-      model_name: "Claude Opus 5 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Opus 5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-sonnet-4-6:
       model_id: "claude-sonnet-4-6"
-      model_family: "Claude Sonnet"
-      model_name: "Claude Sonnet 4.6 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Sonnet 4.6 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     claude-sonnet-5:
       model_id: "claude-sonnet-5"
-      model_family: "Claude Sonnet"
-      model_name: "Claude Sonnet 5 (Sweden)"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Sonnet 5 (Sweden)"
       model_provider: "azure_ai"
       model_endpoint: "anthropic"
       generally_available: false
     # OpenAI
     gpt-5-3-codex:
       model_id: "gpt-5.3-codex"
-      model_family: "GPT 5.3"
-      model_name: "GPT 5.3 Codex (Sweden)"
+      model_family: "OpenAI GPT 5.3"
+      model_name: "OpenAI GPT 5.3 Codex (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-4:
       model_id: "gpt-5.4"
-      model_family: "GPT 5.4"
-      model_name: "GPT 5.4 (Sweden)"
+      model_family: "OpenAI GPT 5.4"
+      model_name: "OpenAI GPT 5.4 (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-4-mini:
       model_id: "gpt-5.4-mini"
-      model_family: "GPT 5.4"
-      model_name: "GPT 5.4 Mini (Sweden)"
+      model_family: "OpenAI GPT 5.4"
+      model_name: "OpenAI GPT 5.4 Mini (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-4-nano:
       model_id: "gpt-5.4-nano"
-      model_family: "GPT 5.4"
-      model_name: "GPT 5.4 Nano (Sweden)"
+      model_family: "OpenAI GPT 5.4"
+      model_name: "OpenAI GPT 5.4 Nano (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-4-pro:
       model_id: "gpt-5.4-pro"
-      model_family: "GPT 5.4"
-      model_name: "GPT 5.4 Pro (Sweden)"
+      model_family: "OpenAI GPT 5.4"
+      model_name: "OpenAI GPT 5.4 Pro (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-5:
       model_id: "gpt-5.5"
-      model_family: "GPT 5.5"
-      model_name: "GPT 5.5 (Sweden)"
+      model_family: "OpenAI GPT 5.5"
+      model_name: "OpenAI GPT 5.5 (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-6-luna:
       model_id: "gpt-5.6-luna"
-      model_family: "GPT 5.6"
-      model_name: "GPT 5.6 Luna (Sweden)"
+      model_family: "OpenAI GPT 5.6"
+      model_name: "OpenAI GPT 5.6 Luna (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-6-sol:
       model_id: "gpt-5.6-sol"
-      model_family: "GPT 5.6"
-      model_name: "GPT 5.6 Sol (Sweden)"
+      model_family: "OpenAI GPT 5.6"
+      model_name: "OpenAI GPT 5.6 Sol (Sweden)"
       model_provider: "azure"
       generally_available: false
     gpt-5-6-terra:
       model_id: "gpt-5.6-terra"
-      model_family: "GPT 5.6"
-      model_name: "GPT 5.6 Terra (Sweden)"
+      model_family: "OpenAI GPT 5.6"
+      model_name: "OpenAI GPT 5.6 Terra (Sweden)"
       model_provider: "azure"
       generally_available: false


### PR DESCRIPTION
This pull request expands support for Microsoft Foundry models in the AI Gateway configuration and access control, and improves flexibility in the Microsoft Foundry model endpoint configuration. The main changes include adding detailed Microsoft Foundry model definitions, updating access group resources to include these models (with environment gating), and making the endpoint configuration more robust.

**AI Gateway Model Configuration Updates:**

* Added detailed configuration for multiple Microsoft Foundry models (Anthropic Claude Fable and several OpenAI GPT models) in `configuration.yml`, enabling these models to be managed and provisioned by the AI Gateway. [[1]](diffhunk://#diff-266931242923208e8e491778ad99c965c656b6225147b06dca986da0240c7823L206-R207) [[2]](diffhunk://#diff-266931242923208e8e491778ad99c965c656b6225147b06dca986da0240c7823R271-R325)

**Access Group and Resource Management:**

* Added new `litellm_unified_access_group` resources for Amazon Bedrock, Google Gemini Enterprise Agent Platform, and Microsoft Foundry models in `ai-gateway-access-groups.tf`. The Microsoft Foundry access group is gated to non-production environments, reflecting current subscription limitations.

**Model Endpoint Configuration Enhancement:**

* Improved the `model_api_base` logic for Microsoft Foundry models in `ai-gateway-models.tf` to handle cases where `model_endpoint` may be missing, making the configuration more robust.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>