### PR TITLE
Expand application's allowlist

### DIFF
--- a/terraform/environments/data-platform/app/environment-configuration.tf
+++ b/terraform/environments/data-platform/app/environment-configuration.tf
@@ -7,7 +7,12 @@ locals {
       app_hostname            = "development.data-platform.service.justice.gov.uk"
       app_google_analytics_id = "G-2SDQPC682J"
       app_ingress_allowlist = [
-        "128.77.75.64/26", # Prisma Corporate
+        # VPN
+        "128.77.75.64/26",  # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
+        # Sites
+        "213.121.161.112/28", # 102PF
+        "51.149.2.0/24"       # 10SC
       ]
       rds = {
         engine_version          = "18.4"
@@ -23,7 +28,12 @@ locals {
       app_hostname            = "test.data-platform.service.justice.gov.uk"
       app_google_analytics_id = "G-L4KMR1DY8G"
       app_ingress_allowlist = [
-        "128.77.75.64/26", # Prisma Corporate
+        # VPN
+        "128.77.75.64/26",  # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
+        # Sites
+        "213.121.161.112/28", # 102PF
+        "51.149.2.0/24"       # 10SC
       ]
       rds = {
         engine_version          = "18.4"
@@ -39,7 +49,12 @@ locals {
       app_hostname            = "preproduction.data-platform.service.justice.gov.uk"
       app_google_analytics_id = "G-LQW8L51Z8E"
       app_ingress_allowlist = [
-        "128.77.75.64/26", # Prisma Corporate
+        # VPN
+        "128.77.75.64/26",  # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
+        # Sites
+        "213.121.161.112/28", # 102PF
+        "51.149.2.0/24"       # 10SC
       ]
       rds = {
         engine_version          = "18.4"
@@ -55,7 +70,12 @@ locals {
       app_hostname            = "data-platform.service.justice.gov.uk"
       app_google_analytics_id = "G-KWQSR1Q3VN"
       app_ingress_allowlist = [
-        "128.77.75.64/26", # Prisma Corporate
+        # VPN
+        "128.77.75.64/26",  # Prisma Corporate
+        "35.176.93.186/32", # GlobalProtect (Alpha)
+        # Sites
+        "213.121.161.112/28", # 102PF
+        "51.149.2.0/24"       # 10SC
       ]
       rds = {
         engine_version          = "18.4"


### PR DESCRIPTION
This pull request updates the `app_ingress_allowlist` in the `environment-configuration.tf` file for all data platform environments. The main change is the addition of new IP ranges for VPN and site access, which will allow traffic from specific networks.

Network access updates:

* Added `35.176.93.186/32` (GlobalProtect VPN - Alpha) to the ingress allowlist for all environments. [[1]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R10-R15) [[2]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R31-R36) [[3]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R52-R57) [[4]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R73-R78)
* Added `213.121.161.112/28` (102PF site) and `51.149.2.0/24` (10SC site) to the ingress allowlist for all environments. [[1]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R10-R15) [[2]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R31-R36) [[3]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R52-R57) [[4]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R73-R78)
* Improved documentation in the allowlist by adding comments to clearly label VPN and site IPs. [[1]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R10-R15) [[2]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R31-R36) [[3]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R52-R57) [[4]](diffhunk://#diff-a375c596d84ffe9a0bfe2323d52511ace0da2414f26374cec87271f2c85bc435R73-R78)