### PR TITLE
Add live feed incident automation infrastructure

### DIFF
--- a/terraform/environments/electronic-monitoring-data/cloudwatch-alarms.tf
+++ b/terraform/environments/electronic-monitoring-data/cloudwatch-alarms.tf
@@ -172,3 +172,43 @@ resource "aws_cloudwatch_metric_alarm" "glue_database_count_high" {
     aws_sns_topic.emds_alerts.arn
   ]
 }
+
+# ------------------------------------------------------------------------------
+# Live-feed incident automation DLQ alarm
+#
+# This alarm publishes directly to the alerts topic. It is deliberately not
+# included in local.sqs_dlq_alarm_queues because failures in incident automation
+# must not recursively create another automated incident.
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "live_feed_incident_events_dlq" {
+  alarm_name = "live_feed_incident_events_dlq_has_messages"
+
+  alarm_description = (
+    "Triggered when live-feed incident automation messages reach its DLQ"
+  )
+
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  actions_enabled = true
+
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  namespace   = "AWS/SQS"
+  period      = 60
+  statistic   = "Maximum"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.live_feed_incident_events_dlq.name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.emds_alerts.arn,
+  ]
+
+  ok_actions = [
+    aws_sns_topic.emds_alerts.arn,
+  ]
+}

--- a/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
+++ b/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
@@ -458,3 +458,58 @@ resource "aws_lambda_permission" "update_p1_export_api_gw" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.update_p1_export[0].execution_arn}/*/*"
 }
+
+# ------------------------------------------------------------------------------
+# Live-feed incident event queue
+# ------------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "live_feed_incident_events_dlq" {
+  name = "live-feed-incident-events-dlq"
+
+  message_retention_seconds = 1209600
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue" "live_feed_incident_events" {
+  name = "live-feed-incident-events"
+
+  visibility_timeout_seconds = 365
+  message_retention_seconds  = 1209600
+  sqs_managed_sse_enabled    = true
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.live_feed_incident_events_dlq.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "live_feed_incident_events" {
+  queue_url = aws_sqs_queue.live_feed_incident_events_dlq.id
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns = [
+      aws_sqs_queue.live_feed_incident_events.arn,
+    ]
+  })
+}
+
+resource "aws_lambda_event_source_mapping" "live_feed_incident_events" {
+  event_source_arn = aws_sqs_queue.live_feed_incident_events.arn
+  function_name    = module.live_feed_incident_manager.lambda_function_name
+
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 5
+
+  function_response_types = [
+    "ReportBatchItemFailures",
+  ]
+
+  scaling_config {
+    maximum_concurrency = 2
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.live_feed_incident_manager_attach,
+  ]
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -2824,3 +2824,46 @@ resource "aws_iam_role_policy_attachment" "write_to_sharepoint_iam_role_attach" 
   role       = aws_iam_role.write_to_sharepoint[0].name
   policy_arn = aws_iam_policy.write_to_sharepoint_iam_policy[0].arn
 }
+
+# ------------------------------------------------------------------------------
+# IAM role and policy for the live-feed incident manager Lambda
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "live_feed_incident_manager" {
+  name               = "live_feed_incident_manager_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "live_feed_incident_manager_policy_document" {
+  statement {
+    sid    = "ConsumeIncidentEvents"
+    effect = "Allow"
+
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+    ]
+
+    resources = [
+      aws_sqs_queue.live_feed_incident_events.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "live_feed_incident_manager" {
+  name = "live_feed_incident_manager_lambda_policy"
+
+  policy = (
+    data.aws_iam_policy_document
+      .live_feed_incident_manager_policy_document
+      .json
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "live_feed_incident_manager_attach" {
+  role       = aws_iam_role.live_feed_incident_manager.name
+  policy_arn = aws_iam_policy.live_feed_incident_manager.arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1117,7 +1117,10 @@ module "write_to_sharepoint" {
 # Live-feed incident manager
 # ------------------------------------------------------------------------------
 
-resource "aws_secretsmanager_secret" "live_feed_github_app" {
+module "live_feed_github_app" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
   name = "live-feed-github-app-${local.environment_shorthand}"
 
   description = (
@@ -1126,33 +1129,13 @@ resource "aws_secretsmanager_secret" "live_feed_github_app" {
 
   recovery_window_in_days = 7
 
+  ignore_secret_changes = true
+  secret_string         = jsonencode({})
+
   tags = local.tags
 }
 
-module "live_feed_incident_manager" {
-  source                         = "./modules/lambdas"
-  is_image                       = true
-  function_name                  = "live_feed_incident_manager"
-  role_name                      = aws_iam_role.live_feed_incident_manager.name
-  role_arn                       = aws_iam_role.live_feed_incident_manager.arn
-  handler                        = "live_feed_incident_manager.handler"
-  memory_size                    = 512
-  timeout                        = 60
-  reserved_concurrent_executions = 2
-
-  core_shared_services_id = local.environment_management.account_ids[
-    "core-shared-services-production"
-  ]
-
-  production_dev = local.is-production ? "prod" : (
-    local.is-preproduction ? "preprod" : (
-      local.is-test ? "test" : "dev"
-    )
-  )
-
-  environment_variables = {
-    ENVIRONMENT             = local.environment_shorthand
-    POWERTOOLS_LOG_LEVEL    = "INFO"
-    POWERTOOLS_SERVICE_NAME = "live-feed-incident-manager"
-  }
+moved {
+  from = aws_secretsmanager_secret.live_feed_github_app
+  to   = module.live_feed_github_app.aws_secretsmanager_secret.this[0]
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1134,3 +1134,31 @@ module "live_feed_github_app" {
 
   tags = local.tags
 }
+
+module "live_feed_incident_manager" {
+  source                         = "./modules/lambdas"
+  is_image                       = true
+  function_name                  = "live_feed_incident_manager"
+  role_name                      = aws_iam_role.live_feed_incident_manager.name
+  role_arn                       = aws_iam_role.live_feed_incident_manager.arn
+  handler                        = "live_feed_incident_manager.handler"
+  memory_size                    = 512
+  timeout                        = 60
+  reserved_concurrent_executions = 2
+
+  core_shared_services_id = local.environment_management.account_ids[
+    "core-shared-services-production"
+  ]
+
+  production_dev = local.is-production ? "prod" : (
+    local.is-preproduction ? "preprod" : (
+      local.is-test ? "test" : "dev"
+    )
+  )
+
+  environment_variables = {
+    ENVIRONMENT             = local.environment_shorthand
+    POWERTOOLS_LOG_LEVEL    = "INFO"
+    POWERTOOLS_SERVICE_NAME = "live-feed-incident-manager"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1134,36 +1134,3 @@ module "live_feed_github_app" {
 
   tags = local.tags
 }
-
-moved {
-  from = aws_secretsmanager_secret.live_feed_github_app
-  to   = module.live_feed_github_app.aws_secretsmanager_secret.this[0]
-}
-
-module "live_feed_incident_manager" {
-  source                         = "./modules/lambdas"
-  is_image                       = true
-  function_name                  = "live_feed_incident_manager"
-  role_name                      = aws_iam_role.live_feed_incident_manager.name
-  role_arn                       = aws_iam_role.live_feed_incident_manager.arn
-  handler                        = "live_feed_incident_manager.handler"
-  memory_size                    = 512
-  timeout                        = 60
-  reserved_concurrent_executions = 2
-
-  core_shared_services_id = local.environment_management.account_ids[
-    "core-shared-services-production"
-  ]
-
-  production_dev = local.is-production ? "prod" : (
-    local.is-preproduction ? "preprod" : (
-      local.is-test ? "test" : "dev"
-    )
-  )
-
-  environment_variables = {
-    ENVIRONMENT             = local.environment_shorthand
-    POWERTOOLS_LOG_LEVEL    = "INFO"
-    POWERTOOLS_SERVICE_NAME = "live-feed-incident-manager"
-  }
-}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1112,3 +1112,47 @@ module "write_to_sharepoint" {
     SECRET_AZURE_CLIENT_SECRET = jsondecode(data.aws_secretsmanager_secret_version.entra_app_details[0].secret_string)["client_secret"]
   }
 }
+
+# ------------------------------------------------------------------------------
+# Live-feed incident manager
+# ------------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "live_feed_github_app" {
+  name = "live-feed-github-app-${local.environment_shorthand}"
+
+  description = (
+    "GitHub App credentials for live-feed incident automation"
+  )
+
+  recovery_window_in_days = 7
+
+  tags = local.tags
+}
+
+module "live_feed_incident_manager" {
+  source                         = "./modules/lambdas"
+  is_image                       = true
+  function_name                  = "live_feed_incident_manager"
+  role_name                      = aws_iam_role.live_feed_incident_manager.name
+  role_arn                       = aws_iam_role.live_feed_incident_manager.arn
+  handler                        = "live_feed_incident_manager.handler"
+  memory_size                    = 512
+  timeout                        = 60
+  reserved_concurrent_executions = 2
+
+  core_shared_services_id = local.environment_management.account_ids[
+    "core-shared-services-production"
+  ]
+
+  production_dev = local.is-production ? "prod" : (
+    local.is-preproduction ? "preprod" : (
+      local.is-test ? "test" : "dev"
+    )
+  )
+
+  environment_variables = {
+    ENVIRONMENT             = local.environment_shorthand
+    POWERTOOLS_LOG_LEVEL    = "INFO"
+    POWERTOOLS_SERVICE_NAME = "live-feed-incident-manager"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1139,3 +1139,31 @@ moved {
   from = aws_secretsmanager_secret.live_feed_github_app
   to   = module.live_feed_github_app.aws_secretsmanager_secret.this[0]
 }
+
+module "live_feed_incident_manager" {
+  source                         = "./modules/lambdas"
+  is_image                       = true
+  function_name                  = "live_feed_incident_manager"
+  role_name                      = aws_iam_role.live_feed_incident_manager.name
+  role_arn                       = aws_iam_role.live_feed_incident_manager.arn
+  handler                        = "live_feed_incident_manager.handler"
+  memory_size                    = 512
+  timeout                        = 60
+  reserved_concurrent_executions = 2
+
+  core_shared_services_id = local.environment_management.account_ids[
+    "core-shared-services-production"
+  ]
+
+  production_dev = local.is-production ? "prod" : (
+    local.is-preproduction ? "preprod" : (
+      local.is-test ? "test" : "dev"
+    )
+  )
+
+  environment_variables = {
+    ENVIRONMENT             = local.environment_shorthand
+    POWERTOOLS_LOG_LEVEL    = "INFO"
+    POWERTOOLS_SERVICE_NAME = "live-feed-incident-manager"
+  }
+}


### PR DESCRIPTION
Adds the AWS infrastructure required to receive live-feed incident events here https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/956