### PR TITLE
updating generating-account-workspaces script to exclude `modules` subfolders

### DIFF
--- a/terraform/environments/cloud-platform/generate-account-workspaces.sh
+++ b/terraform/environments/cloud-platform/generate-account-workspaces.sh
@@ -65,7 +65,7 @@ while IFS= read -r -d '' dir; do
   if compgen -G "${dir}/*.tf" >/dev/null; then
     terraform_dirs+=("${dir}")
   fi
-done < <(find "${SCRIPT_DIR}" -mindepth 1 -type d ! -name ".terraform" ! -path "*/.terraform/*" -print0)
+done < <(find "${SCRIPT_DIR}" -mindepth 1 -type d ! -name ".terraform" ! -path "*/.terraform/*" ! -path "*/modules/*" -print0)
 
 if [ "${#terraform_dirs[@]}" -eq 0 ]; then
   echo "No Terraform folders found under ${SCRIPT_DIR}"


### PR DESCRIPTION
**Summary**
Updated `generate-account-workspaces.sh` to exclude `modules/` directories when creating Terraform workspaces.

**Problem**
The script was attempting to create workspaces in module directories (e.g. `cluster/modules/argo-cd/`) which don't have backend configurations. This caused failures since modules are reusable components that don't require their own workspaces.

**Changes**
- Added `! -path "*/modules/*"` to the find command
- Modules directories are now excluded alongside `.terraform` folders

**Testing**
Ran `./generate-account-workspaces.sh --dry-run` to verify:
- Module directories are now skipped
- Workspace creation still works for valid directories (network, cluster, cluster-core, root)

**Impact**
- Prevents errors when running the workspace generation script
- Maintains workspace creation for all legitimate Terraform layers