### PR TITLE
Switch to Prod App SG and remove temp SSM only

### DIFF
--- a/terraform/environments/cica-tariff/tariff_ec2_app_clone_prod.tf
+++ b/terraform/environments/cica-tariff/tariff_ec2_app_clone_prod.tf
@@ -13,8 +13,8 @@ resource "aws_instance" "tariff_app_prod_clone" {
   key_name               = aws_key_pair.key_pair_app.key_name
   monitoring             = true
   subnet_id              = data.aws_subnet.private_subnets_a.id
-  #vpc_security_group_ids = [module.tariff_app_security_group[0].security_group_id]
-  vpc_security_group_ids = [aws_security_group.temp_prod_ssm_only[0].id] # TEMPORARY ASSIGNMENT FOR NO NETWORK (except SSM)
+  vpc_security_group_ids = [module.tariff_app_prod_security_group[0].security_group_id]
+  #vpc_security_group_ids = [aws_security_group.temp_prod_ssm_only[0].id] # TEMPORARY ASSIGNMENT FOR NO NETWORK (except SSM)
 
   # private_ip = ""
 
@@ -24,8 +24,8 @@ resource "aws_instance" "tariff_app_prod_clone" {
     }), local.tags, local.environment != "test" ? tomap({ "backup" = "true" }) : tomap({})
   )
 }
-
 # Temporary SG to restrict access to/from Clone above during configuration phase
+/*
 resource "aws_security_group" "temp_prod_ssm_only" {
   count       = local.environment == "production" ? 1 : 0
   name        = "temp-ssm-only"
@@ -50,3 +50,4 @@ resource "aws_security_group_rule" "temp_prod_ssm_only_egress" {
   protocol                 = "TCP"
   source_security_group_id = data.aws_security_group.core_vpc_protected.id
 }
+*/


### PR DESCRIPTION
This pull request updates the network security configuration for the `tariff_app_prod_clone` EC2 instance in the production environment. The main change is switching from a temporary, highly restrictive security group to the intended production security group, and commenting out the temporary security group resources.

**Security Group Assignment:**
* The `vpc_security_group_ids` for `aws_instance.tariff_app_prod_clone` is now set to use the production security group from `module.tariff_app_prod_security_group`, instead of the temporary SSM-only security group.

**Temporary Security Group Decommissioning:**
* The resource definition for `aws_security_group.temp_prod_ssm_only` and its associated rules are commented out, indicating they are no longer in use. [[1]](diffhunk://#diff-e827f55ca75da4d49950959ebb34dd07db23f948dfffa45c3aeccca8d4f70fddL27-R28) [[2]](diffhunk://#diff-e827f55ca75da4d49950959ebb34dd07db23f948dfffa45c3aeccca8d4f70fddR53)