### PR TITLE
🚅 Add IAM resources for AI Gateway Integration

### DIFF
--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-policies.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-policies.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "ai_gateway" {
+  statement {
+    sid    = "AwsMarketplaceAccess"
+    effect = "Allow"
+    actions = [
+      "aws-marketplace:Subscribe",
+      "aws-marketplace:ViewSubscriptions"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "BedrockInferenceProfileAccess"
+    effect    = "Allow"
+    actions   = ["bedrock:InvokeModel*"]
+    resources = formatlist("arn:aws:bedrock:%s:${data.aws_caller_identity.current.account_id}:inference-profile/*", ["eu-west-1", "eu-west-2"])
+  }
+
+  statement {
+    sid       = "BedrockFoundationModelAccess"
+    effect    = "Allow"
+    actions   = ["bedrock:InvokeModel*"]
+    resources = ["arn:aws:bedrock:eu-*::foundation-model/*"]
+  }
+}
+
+module "iam_policy" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=d6e381ccfa95b944149c8b14ba4087e517c57ac7" # v6.8.0
+
+  name_prefix = local.component_name
+
+  policy = data.aws_iam_policy_document.ai_gateway.json
+}

--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
@@ -1,0 +1,22 @@
+module "iam_role" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role?ref=d6e381ccfa95b944149c8b14ba4087e517c57ac7" # v6.8.0
+
+  name = local.component_name
+
+  trust_policy_permissions = {
+    TrustRoleAndServiceToAssume = {
+      actions = [
+        "sts:AssumeRole",
+        "sts:TagSession",
+      ]
+      principals = [{
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${local.environment_management.account_ids["data-platform-production"]}:role/ai-gateway-20260501124346396300000007"]
+      }]
+    }
+  }
+
+  policies = {
+    ai-gateway = module.ai_gateway_iam_policy.arn
+  }
+}

--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
@@ -17,6 +17,6 @@ module "iam_role" {
   }
 
   policies = {
-    ai-gateway = module.ai_gateway_iam_policy.arn
+    ai-gateway = module.iam_policy.arn
   }
 }

--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
@@ -11,7 +11,7 @@ module "iam_role" {
       ]
       principals = [{
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${local.environment_management.account_ids["data-platform-production"]}:role/ai-gateway-20260501124346396300000007"]
+        identifiers = ["arn:aws:iam::${local.environment_management.account_ids["data-platform-production"]}:role/ai-gateway"]
       }]
     }
   }


### PR DESCRIPTION
This pull request introduces new IAM policy and role resources for the AI Gateway in the `octo-engineering-ai-enablement` environment. The main changes add fine-grained access controls for AWS Marketplace and Bedrock services, and define a new IAM role with explicit trust and policy attachments.

**IAM Policy Enhancements:**

* Added a new IAM policy (`data.aws_iam_policy_document.ai_gateway`) granting:
  * Access to AWS Marketplace subscription and view actions.
  * Permissions to invoke Bedrock inference profiles in `eu-west-1` and `eu-west-2` regions.
  * Permissions to invoke Bedrock foundation models across all EU regions.
* Created a new IAM policy resource using the `terraform-aws-iam` module, applying the above policy document.

**IAM Role Configuration:**

* Added a new IAM role using the `terraform-aws-iam` module, with:
  * Trust policy allowing a specific role in the `data-platform-production` account to assume this role.
  * Attachment of the newly created AI Gateway IAM policy to the role.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>