### PR TITLE
🔄 Switch to suffixless role ARN

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/iam-roles.tf
+++ b/terraform/environments/data-platform/ai-gateway/iam-roles.tf
@@ -1,7 +1,8 @@
 module "iam_role" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role-for-service-accounts?ref=1d73bcb359419e1b41872ac5ccaf8808b8f1150e" # v6.6.0
 
-  name = local.component_name
+  name            = local.component_name
+  use_name_prefix = false
 
   policies = {
     ai-gateway = module.ai_gateway_iam_policy.arn


### PR DESCRIPTION
## Proposed Changes

- Switches from `ai-gateway-${suffix}` to `ai-gateway`, making cross account assumption easier 🙏 

## Notes

Once deployed, the following needs running

```bash
kubectl --namespace ai-gateway rollout restart deployment litellm-admin

kubectl --namespace ai-gateway rollout restart deployment litellm
```


Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>