### PR TITLE
DHS-682: Shorten dps-manage-offences to dps-offences

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -97,7 +97,8 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences"
+        "dps-manage-offences",
+        "dps-offences"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -331,7 +332,8 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences"
+        "dps-manage-offences",
+        "dps-offences"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -548,7 +550,8 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences"
+        "dps-manage-offences",
+        "dps-offences"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -777,7 +780,9 @@
         "dps-san",
         "dps-cvl",
         "dps-adjudications",
-        "dps-acc-pro-custody"
+        "dps-acc-pro-custody",
+        "dps-manage-offences",
+        "dps-offences"
       ],
       "alarms": {
         "setup_cw_alarms": true,


### PR DESCRIPTION
To allow the terraform apply successfully in pre-prod, the `dps-manage-offences` domain name is shortened to `dps-offences`.