### PR TITLE
 Add shared configuration access AWS provider

### DIFF
--- a/terraform/environments/analytical-platform-common/platform_providers.tf
+++ b/terraform/environments/analytical-platform-common/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/actions-runner/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/actions-runner/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/airflow/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/central-digital-bedrock/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/central-digital-bedrock/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/cluster/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/dashboard-service/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/dashboard-service/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/lakeformation/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/lakeformation/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/mlflow/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/mlflow/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/network/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/network/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/next/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/next/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/quicksight/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/quicksight/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-compute/sagemaker-ai/platform_providers.tf
+++ b/terraform/environments/analytical-platform-compute/sagemaker-ai/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/dms/platform_providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/dms/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/platform_providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-ingestion/transfer-family/platform_providers.tf
+++ b/terraform/environments/analytical-platform-ingestion/transfer-family/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-next-poc-hub/platform_providers.tf
+++ b/terraform/environments/analytical-platform-next-poc-hub/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/analytical-platform-next-poc-producer/platform_providers.tf
+++ b/terraform/environments/analytical-platform-next-poc-producer/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/apex/platform_providers.tf
+++ b/terraform/environments/apex/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs-ai/platform_providers.tf
+++ b/terraform/environments/ccms-ebs-ai/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs-upgrade/anonymisation/platform_providers.tf
+++ b/terraform/environments/ccms-ebs-upgrade/anonymisation/platform_providers.tf
@@ -47,3 +47,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs-upgrade/platform_providers.tf
+++ b/terraform/environments/ccms-ebs-upgrade/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs-upgrade/sandbox/platform_providers.tf
+++ b/terraform/environments/ccms-ebs-upgrade/sandbox/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs/ccms-ebs-ssogen/platform_providers.tf
+++ b/terraform/environments/ccms-ebs/ccms-ebs-ssogen/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs/ccms-file-transfer/platform_providers.tf
+++ b/terraform/environments/ccms-ebs/ccms-file-transfer/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs/platform_providers.tf
+++ b/terraform/environments/ccms-ebs/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-ebs/workspaces-secure-browser/platform_providers.tf
+++ b/terraform/environments/ccms-ebs/workspaces-secure-browser/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-edrms/platform_providers.tf
+++ b/terraform/environments/ccms-edrms/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/ccms-ebs/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/ccms-ebs/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/ccms-edrms/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/ccms-edrms/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/ccms-oia/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/ccms-oia/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/ccms-pui/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/ccms-pui/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/ccms-soa/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/ccms-soa/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-feasibility/platform_providers.tf
+++ b/terraform/environments/ccms-feasibility/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-oia/platform_providers.tf
+++ b/terraform/environments/ccms-oia/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-pui-internal/platform_providers.tf
+++ b/terraform/environments/ccms-pui-internal/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-pui-internal/workspaces-secure-browser/platform_providers.tf
+++ b/terraform/environments/ccms-pui-internal/workspaces-secure-browser/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ccms-pui/platform_providers.tf
+++ b/terraform/environments/ccms-pui/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cdpt-chaps/platform_providers.tf
+++ b/terraform/environments/cdpt-chaps/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cdpt-ifs/platform_providers.tf
+++ b/terraform/environments/cdpt-ifs/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cfo-data-management-system/platform_providers.tf
+++ b/terraform/environments/cfo-data-management-system/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cica-sandbox/platform_providers.tf
+++ b/terraform/environments/cica-sandbox/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cica-tariff/platform_providers.tf
+++ b/terraform/environments/cica-tariff/platform_providers.tf
@@ -67,3 +67,13 @@ provider "aws" {
 provider "random" {
 
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-live/cluster-components/platform_providers.tf
+++ b/terraform/environments/cloud-platform-live/cluster-components/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-live/cluster-core/platform_providers.tf
+++ b/terraform/environments/cloud-platform-live/cluster-core/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-live/cluster/platform_providers.tf
+++ b/terraform/environments/cloud-platform-live/cluster/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-live/network/platform_providers.tf
+++ b/terraform/environments/cloud-platform-live/network/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-live/platform_providers.tf
+++ b/terraform/environments/cloud-platform-live/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-non-live/cluster-components/platform_providers.tf
+++ b/terraform/environments/cloud-platform-non-live/cluster-components/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-non-live/cluster-core/platform_providers.tf
+++ b/terraform/environments/cloud-platform-non-live/cluster-core/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-non-live/cluster/platform_providers.tf
+++ b/terraform/environments/cloud-platform-non-live/cluster/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-non-live/network/platform_providers.tf
+++ b/terraform/environments/cloud-platform-non-live/network/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform-non-live/platform_providers.tf
+++ b/terraform/environments/cloud-platform-non-live/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/cluster-base/platform_providers.tf
+++ b/terraform/environments/cloud-platform/cluster-base/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/cluster-components/platform_providers.tf
+++ b/terraform/environments/cloud-platform/cluster-components/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/cluster-core/platform_providers.tf
+++ b/terraform/environments/cloud-platform/cluster-core/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/cluster/platform_providers.tf
+++ b/terraform/environments/cloud-platform/cluster/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/network/platform_providers.tf
+++ b/terraform/environments/cloud-platform/network/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cloud-platform/platform_providers.tf
+++ b/terraform/environments/cloud-platform/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/coat/platform_providers.tf
+++ b/terraform/environments/coat/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/container-platform-cd/platform_providers.tf
+++ b/terraform/environments/container-platform-cd/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/container-platform-hmpps/platform_providers.tf
+++ b/terraform/environments/container-platform-hmpps/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/container-platform-laa/platform_providers.tf
+++ b/terraform/environments/container-platform-laa/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/container-platform-octo/platform_providers.tf
+++ b/terraform/environments/container-platform-octo/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/contract-work-administration/platform_providers.tf
+++ b/terraform/environments/contract-work-administration/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/cooker/platform_providers.tf
+++ b/terraform/environments/cooker/platform_providers.tf
@@ -74,3 +74,13 @@ provider "aws" {
   default_tags { tags = local.tags }
 }
 
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/corporate-staff-rostering/platform_providers.tf
+++ b/terraform/environments/corporate-staff-rostering/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/dacp/platform_providers.tf
+++ b/terraform/environments/dacp/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-corporate/commercial/platform_providers.tf
+++ b/terraform/environments/data-factory-corporate/commercial/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-corporate/finance/platform_providers.tf
+++ b/terraform/environments/data-factory-corporate/finance/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-corporate/people/platform_providers.tf
+++ b/terraform/environments/data-factory-corporate/people/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-corporate/platform_providers.tf
+++ b/terraform/environments/data-factory-corporate/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-laa/platform_providers.tf
+++ b/terraform/environments/data-factory-laa/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc-devops/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc-devops/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc-maf/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc-maf/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc-msk/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc-msk/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc-opensearch-config/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc-opensearch-config/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc-opensearch/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc-opensearch/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-factory-moj/streaming-poc/platform_providers.tf
+++ b/terraform/environments/data-factory-moj/streaming-poc/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform-governance/lakeformation/platform_providers.tf
+++ b/terraform/environments/data-platform-governance/lakeformation/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform-governance/platform_providers.tf
+++ b/terraform/environments/data-platform-governance/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/ai-gateway/platform_providers.tf
+++ b/terraform/environments/data-platform/ai-gateway/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/app/platform_providers.tf
+++ b/terraform/environments/data-platform/app/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/cluster/platform_providers.tf
+++ b/terraform/environments/data-platform/cluster/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/dns/platform_providers.tf
+++ b/terraform/environments/data-platform/dns/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/iac/platform_providers.tf
+++ b/terraform/environments/data-platform/iac/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/llm-gateway/platform_providers.tf
+++ b/terraform/environments/data-platform/llm-gateway/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/monitoring/platform_providers.tf
+++ b/terraform/environments/data-platform/monitoring/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/network/platform_providers.tf
+++ b/terraform/environments/data-platform/network/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/platform_providers.tf
+++ b/terraform/environments/data-platform/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/data-platform/sagemaker/platform_providers.tf
+++ b/terraform/environments/data-platform/sagemaker/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-alfresco/platform_providers.tf
+++ b/terraform/environments/delius-alfresco/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-core-training/platform_providers.tf
+++ b/terraform/environments/delius-core-training/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-core/platform_providers.tf
+++ b/terraform/environments/delius-core/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-iaps/platform_providers.tf
+++ b/terraform/environments/delius-iaps/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-jitbit/platform_providers.tf
+++ b/terraform/environments/delius-jitbit/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/delius-mis/platform_providers.tf
+++ b/terraform/environments/delius-mis/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/digital-prison-reporting/platform_providers.tf
+++ b/terraform/environments/digital-prison-reporting/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/platform_providers.tf
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/edw-19c/platform_providers.tf
+++ b/terraform/environments/edw-19c/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/platform_providers.tf
+++ b/terraform/environments/electronic-monitoring-data/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/equip/platform_providers.tf
+++ b/terraform/environments/equip/platform_providers.tf
@@ -64,3 +64,13 @@ provider "aws" {
   default_tags { tags = local.tags }
 }
 
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/eucs-appstream/platform_providers.tf
+++ b/terraform/environments/eucs-appstream/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/example/platform_providers.tf
+++ b/terraform/environments/example/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/genesys-call-centre-data/platform_providers.tf
+++ b/terraform/environments/genesys-call-centre-data/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/hmcts-claude-provider/platform_providers.tf
+++ b/terraform/environments/hmcts-claude-provider/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/hmpps-court-data-ingestion-api/platform_providers.tf
+++ b/terraform/environments/hmpps-court-data-ingestion-api/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/hmpps-domain-services/platform_providers.tf
+++ b/terraform/environments/hmpps-domain-services/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/hmpps-esupervision/platform_providers.tf
+++ b/terraform/environments/hmpps-esupervision/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/hmpps-oem/platform_providers.tf
+++ b/terraform/environments/hmpps-oem/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub-api/platform_providers.tf
+++ b/terraform/environments/integration-hub-api/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/platform_providers.tf
+++ b/terraform/environments/integration-hub-file-transfer/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub/api-platform/platform_providers.tf
+++ b/terraform/environments/integration-hub/api-platform/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub/events-platform/platform_providers.tf
+++ b/terraform/environments/integration-hub/events-platform/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub/managed-file-transfer/platform_providers.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub/platform_providers.tf
+++ b/terraform/environments/integration-hub/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-ccms-soa/ccms-soa-sandbox/platform_providers.tf
+++ b/terraform/environments/laa-ccms-soa/ccms-soa-sandbox/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-ccms-soa/platform_providers.tf
+++ b/terraform/environments/laa-ccms-soa/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-cis/platform_providers.tf
+++ b/terraform/environments/laa-cis/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-enterprise-service-bus/lambda-files/platform_providers.tf
+++ b/terraform/environments/laa-enterprise-service-bus/lambda-files/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-enterprise-service-bus/platform_providers.tf
+++ b/terraform/environments/laa-enterprise-service-bus/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-mail-relay/platform_providers.tf
+++ b/terraform/environments/laa-mail-relay/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-new-workspaces/ad-radius-mfa-config/platform_providers.tf
+++ b/terraform/environments/laa-new-workspaces/ad-radius-mfa-config/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-new-workspaces/platform_providers.tf
+++ b/terraform/environments/laa-new-workspaces/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-new-workspaces/workspace-components/platform_providers.tf
+++ b/terraform/environments/laa-new-workspaces/workspace-components/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-oem/platform_providers.tf
+++ b/terraform/environments/laa-oem/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-pui-secure-browser/networking/platform_providers.tf
+++ b/terraform/environments/laa-pui-secure-browser/networking/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-pui-secure-browser/platform_providers.tf
+++ b/terraform/environments/laa-pui-secure-browser/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-pui-secure-browser/workspaces-secure-browser/platform_providers.tf
+++ b/terraform/environments/laa-pui-secure-browser/workspaces-secure-browser/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-stabilisation-cdc-poc/platform_providers.tf
+++ b/terraform/environments/laa-stabilisation-cdc-poc/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-workspaces/platform_providers.tf
+++ b/terraform/environments/laa-workspaces/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/laa-workspaces/workspace-components/platform_providers.tf
+++ b/terraform/environments/laa-workspaces/workspace-components/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/london-unpaid-work/platform_providers.tf
+++ b/terraform/environments/london-unpaid-work/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/long-term-storage/platform_providers.tf
+++ b/terraform/environments/long-term-storage/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/maat/platform_providers.tf
+++ b/terraform/environments/maat/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/maatdb/platform_providers.tf
+++ b/terraform/environments/maatdb/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/mlra/platform_providers.tf
+++ b/terraform/environments/mlra/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/mojfin/platform_providers.tf
+++ b/terraform/environments/mojfin/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ncas/platform_providers.tf
+++ b/terraform/environments/ncas/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/nomis-combined-reporting/platform_providers.tf
+++ b/terraform/environments/nomis-combined-reporting/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/nomis-data-hub/platform_providers.tf
+++ b/terraform/environments/nomis-data-hub/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/nomis/platform_providers.tf
+++ b/terraform/environments/nomis/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/oas/platform_providers.tf
+++ b/terraform/environments/oas/platform_providers.tf
@@ -69,3 +69,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/oasys-national-reporting/platform_providers.tf
+++ b/terraform/environments/oasys-national-reporting/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/oasys/platform_providers.tf
+++ b/terraform/environments/oasys/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/observability-platform/platform_providers.tf
+++ b/terraform/environments/observability-platform/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/platform_providers.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/octo-engineering-ai-enablement/platform_providers.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/octo/platform_providers.tf
+++ b/terraform/environments/octo/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/panda-cyber-appsec-lab/platform_providers.tf
+++ b/terraform/environments/panda-cyber-appsec-lab/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/performance-hub/platform_providers.tf
+++ b/terraform/environments/performance-hub/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/planetfm/platform_providers.tf
+++ b/terraform/environments/planetfm/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/ppud/platform_providers.tf
+++ b/terraform/environments/ppud/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/pra-register/platform_providers.tf
+++ b/terraform/environments/pra-register/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/prison-retail/platform_providers.tf
+++ b/terraform/environments/prison-retail/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/property-cafm-data-migration/platform_providers.tf
+++ b/terraform/environments/property-cafm-data-migration/platform_providers.tf
@@ -47,3 +47,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/refer-monitor/platform_providers.tf
+++ b/terraform/environments/refer-monitor/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/sprinkler/platform_providers.tf
+++ b/terraform/environments/sprinkler/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/sprinkler/playground/platform_providers.tf
+++ b/terraform/environments/sprinkler/playground/platform_providers.tf
@@ -53,3 +53,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/sprinkler/testbed/platform_providers.tf
+++ b/terraform/environments/sprinkler/testbed/platform_providers.tf
@@ -53,3 +53,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/tipstaff/platform_providers.tf
+++ b/terraform/environments/tipstaff/platform_providers.tf
@@ -63,3 +63,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/tribunals/platform_providers.tf
+++ b/terraform/environments/tribunals/platform_providers.tf
@@ -63,3 +63,12 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/vcms/platform_providers.tf
+++ b/terraform/environments/vcms/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/wardship/platform_providers.tf
+++ b/terraform/environments/wardship/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/xhibit-portal/platform_providers.tf
+++ b/terraform/environments/xhibit-portal/platform_providers.tf
@@ -56,3 +56,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/youth-justice-app-framework/platform_providers.tf
+++ b/terraform/environments/youth-justice-app-framework/platform_providers.tf
@@ -63,3 +63,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/youth-justice-networking/platform_providers.tf
+++ b/terraform/environments/youth-justice-networking/platform_providers.tf
@@ -53,3 +53,13 @@ provider "aws" {
   }
   default_tags { tags = local.tags }
 }
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}


### PR DESCRIPTION
This provider is used to manage Business Unit secrets and parameters in the `core-shared-services-production` account. It assumes the shared configuration access IAM role, allowing Terraform to securely access and manage shared configuration resources. [#13169](https://github.com/ministryofjustice/modernisation-platform/issues/13169)