### PR TITLE
PLATOPS: acm: fix static analysis warning

### DIFF
--- a/terraform/modules/acm_certificate/main.tf
+++ b/terraform/modules/acm_certificate/main.tf
@@ -6,6 +6,7 @@ locals {
 }
 
 resource "aws_acm_certificate" "this" {
+  #checkov:skip=CKV_AWS_234: transparency logging enabled by default but can be disabled if there is a requirement to do so
   domain_name               = var.domain_name
   validation_method         = "DNS"
   subject_alternative_names = var.subject_alternate_names

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -26,6 +26,7 @@ variable "subject_alternate_names" {
   default     = []
 }
 
+# tflint-ignore: terraform_typed_variables
 variable "route53_zones" {
   description = "Provide a map of existing route53_zones that can be used for validation, e.g. from environment module route53_zones output.  Key is zone name and value must include zone_id and provider"
   default     = {}


### PR DESCRIPTION
Fix static analysis warning on ACM module used by DSO apps