### PR TITLE
refactor(ai-gateway): remove dead cache_params configuration

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -76,11 +76,6 @@ proxy_config:
     service_callback: ["prometheus_system"]
     default_internal_user_params:
       user_role: proxy_admin
-    cache_params:
-      type: redis
-      host: os.environ/primary_endpoint_address
-      port: 6379
-      password: os.environ/auth_token
   router_settings:
     routing_strategy: simple-shuffle
     redis_host: os.environ/primary_endpoint_address

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -66,11 +66,6 @@ proxy_config:
     request_timeout: 600
     json_logs: true
     cache: false
-    cache_params:
-      type: redis
-      host: os.environ/primary_endpoint_address
-      port: 6379
-      password: os.environ/auth_token
     require_auth_for_metrics_endpoint: false
     callbacks: ["prometheus"]
     success_callback: ["prometheus"]


### PR DESCRIPTION
## Summary

Removes the unused `cache_params` block from the LiteLLM Helm values templates for both `litellm` and `litellm-admin`.

## Why

The `cache_params` key under `litellm_settings` is only read by LiteLLM when `cache: true`. With `cache: false` (the current setting), LiteLLM never initialises the Redis client for response caching, so this configuration block has no effect and is dead code.

This is confirmed in the [LiteLLM caching documentation](https://docs.litellm.ai/docs/proxy/caching):

> `litellm_settings.cache` must be `true` (Redis for the proxy is initialized during cache setup)