### PR TITLE
Add Justice Engineering AI Enablement Bedrock

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
@@ -7,7 +7,7 @@ resource "litellm_model" "amazon_bedrock" {
   tier                = "paid"
 
   aws_region_name = each.value.region
-  aws_role_name   = try(each.value.role_name, module.iam_role.arn)
+  aws_role_name   = can(each.value.aws_role_name) ? "arn:aws:iam::${local.environment_management.account_ids[each.value.aws_account_name]}:role/${each.value.aws_role_name}" : module.iam_role.arn
 
   additional_litellm_params = {
     ai_model_provider            = "Amazon Bedrock"

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -196,6 +196,15 @@ models:
       model_name: "OpenAI GPT OSS Safeguard 120B"
       region: eu-west-2
       generally_available: true
+    # Justice Engineering AI Enablement
+    jeaie-claude-haiku-4-5:
+      model_id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+      model_family: "Anthropic Claude"
+      model_name: "Anthropic Claude Haiku 4.5 (EU)"
+      region: eu-west-2
+      aws_account_name: octo-engineering-ai-enablement-production
+      aws_role_name: ai-gateway
+      generally_available: false
   google_gemini_enterprise_agent_platform: {}
   microsoft_foundry:
     # Anthropic

--- a/terraform/environments/data-platform/ai-gateway/iam-policies.tf
+++ b/terraform/environments/data-platform/ai-gateway/iam-policies.tf
@@ -50,6 +50,16 @@ data "aws_iam_policy_document" "ai_gateway" {
       "arn:aws:rds-db:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:dbuser:*/litellm"
     ]
   }
+
+  # DEBUG
+  statement {
+    sid     = "AssumeOCTOEngineeringAIEnablementRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::${local.environment_management.account_ids["octo-engineering-ai-enablement-production"]}:role/ai-gateway"
+    ]
+  }
 }
 
 module "ai_gateway_iam_policy" {

--- a/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
+++ b/terraform/environments/octo-engineering-ai-enablement/ai-gateway/iam-roles.tf
@@ -10,8 +10,13 @@ module "iam_role" {
         "sts:TagSession",
       ]
       principals = [{
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${local.environment_management.account_ids["data-platform-production"]}:role/ai-gateway"]
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${local.environment_management.account_ids["data-platform-development"]}:role/ai-gateway",
+          "arn:aws:iam::${local.environment_management.account_ids["data-platform-test"]}:role/ai-gateway",
+          "arn:aws:iam::${local.environment_management.account_ids["data-platform-preproduction"]}:role/ai-gateway",
+          "arn:aws:iam::${local.environment_management.account_ids["data-platform-production"]}:role/ai-gateway",
+        ]
       }]
     }
   }


### PR DESCRIPTION
This pull request introduces support for the new Anthropic Claude Haiku 4.5 model in the AI Gateway, updates IAM roles and policies to enable cross-account access for the Justice Engineering AI Enablement account, and improves the flexibility of role assignment for Bedrock models. The main changes are grouped below:

**New Model Integration:**

* Added configuration for the `jeaie-claude-haiku-4-5` model (Anthropic Claude Haiku 4.5, EU region) under the Justice Engineering AI Enablement account in `configuration.yml`.

**IAM Role and Policy Updates for Cross-Account Access:**

* Updated the AI Gateway IAM policy to allow assuming the `ai-gateway` role in the `octo-engineering-ai-enablement-production` account.
* Expanded the list of principals allowed to assume the `ai-gateway` role in the Justice Engineering AI Enablement environment to include all data platform environments (development, test, preproduction, production).

**Terraform Resource Improvements:**

* Enhanced the `aws_role_name` assignment for Bedrock models to dynamically construct the role ARN if provided, otherwise defaulting to the existing module output.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>