### PR TITLE
Allow development user to access AWS Transfer server via SFTP

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -20,7 +20,7 @@ locals {
       environments          = ["development"]
       home_directory_target = "dms1981"
       server_id_allow_list  = []
-      cidr_blocks           = []
+      cidr_blocks           = ["139.28.208.0/22"]
       ssh_public_keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPE6XyQIDh5gt+7HOrUQymtsfl3+NZqUM5p7BQqi9uso"
       ]


### PR DESCRIPTION
* Adding a /32 for me gets uncomfortably close to becoming PII.
* Allows `dms1981` to SFTP/FTPS into the development transfer server