### PR TITLE
🔐 Scope Transfer users to their home folders

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/custom-idp-lambda.tf
+++ b/terraform/environments/integration-hub-file-transfer/custom-idp-lambda.tf
@@ -36,8 +36,15 @@ module "lambda_custom_idp" {
   trigger_on_package_timestamp   = false
 
   environment_variables = {
-    LOGLEVEL      = local.custom_idp_configuration.log_level
-    SECRET_PREFIX = local.custom_idp_configuration.secret_prefix
+    LOGLEVEL                = local.custom_idp_configuration.log_level
+    SECRET_PREFIX           = local.custom_idp_configuration.secret_prefix
+    AWS_ACCOUNT_ID          = data.aws_caller_identity.current.account_id
+    TRANSFER_ROLE_ARN       = module.iam_role_transfer_user.arn
+    TRANSFER_SESSION_POLICY = data.aws_iam_policy_document.transfer_user_session.json
+    TRANSFER_HOME_DIRECTORY_DETAILS = jsonencode([{
+      Entry  = "/"
+      Target = "/${module.s3_bucket["incoming"].s3_bucket_id}/{{USERNAME}}"
+    }])
   }
 
   attach_policy_statements = true

--- a/terraform/environments/integration-hub-file-transfer/custom-idp-secrets.tf
+++ b/terraform/environments/integration-hub-file-transfer/custom-idp-secrets.tf
@@ -35,16 +35,9 @@ module "secrets_custom_idp_user" {
   # complete secret versions managed outside Terraform so that credentials
   # remain out of state.
   secret_string = jsonencode({
-    username          = each.key
-    password          = null
-    publicKeys        = each.value.ssh_public_keys
-    Role              = module.iam_role_transfer_user.arn
-    Policy            = data.aws_iam_policy_document.transfer_user_session[each.key].json
-    HomeDirectoryType = "LOGICAL"
-    HomeDirectoryDetails = [{
-      Entry  = "/"
-      Target = "/${module.s3_bucket["incoming"].s3_bucket_id}/${trimprefix(each.value.home_directory_target, "/")}"
-    }]
+    username             = each.key
+    password             = null
+    publicKeys           = each.value.ssh_public_keys
     ipv4_allow_list      = each.value.cidr_blocks
     server_id_allow_list = each.value.server_id_allow_list
   })

--- a/terraform/environments/integration-hub-file-transfer/docs/transfer-users.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/transfer-users.md
@@ -6,14 +6,18 @@ The Lambda lower-cases the supplied username and retrieves that secret once for
 both FTPS password authentication and SFTP public-key authentication.
 
 The current secret version must be a JSON object containing `username`,
-`password`, `publicKeys`, `Role`, `Policy`, `HomeDirectoryType`,
-`ipv4_allow_list`, and `server_id_allow_list`.
+`password`, `publicKeys`, `ipv4_allow_list`, and `server_id_allow_list`. The
+secret contains authentication and connection restriction data only.
 
-For `HomeDirectoryType = "LOGICAL"`, include `HomeDirectoryDetails` to map
-virtual paths, such as `/`, to specific S3 locations. This lets the user see a
-simple directory structure without exposing the underlying bucket path. For
-`HomeDirectoryType = "PATH"`, include `HomeDirectory` to place the user directly
-at that path. `PosixProfile` is optional.
+Terraform provides the shared Transfer role, session policy, and logical home
+directory configuration to the custom IdP Lambda. The Lambda returns these
+Terraform-managed values after authenticating the user. AWS Transfer assumes
+the role and applies the session policy, which restricts the user to the S3
+prefix matching their lower-cased username. The logical home directory maps:
+
+```text
+/ -> /<incoming-bucket>/<username>
+```
 
 Terraform creates the initial record with a null password. A user cannot use
 FTPS password authentication until an operator publishes a complete new secret
@@ -21,6 +25,7 @@ version with a non-null password.
 
 Terraform intentionally ignores later secret value changes so credentials do
 not enter Terraform state. Operators must publish a complete replacement JSON
-record when changing a password, public keys, home directory, restrictions,
-role, or policy; omitted fields are not preserved automatically. Deleting the
-user secret disables that user's authentication.
+record when changing a password, public keys, or restrictions; omitted fields
+are not preserved automatically. Role, policy, and home directory fields in a
+secret are ignored. Deleting the user secret disables that user's
+authentication.

--- a/terraform/environments/integration-hub-file-transfer/docs/transfer-users.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/transfer-users.md
@@ -12,8 +12,9 @@ secret contains authentication and connection restriction data only.
 Terraform provides the shared Transfer role, session policy, and logical home
 directory configuration to the custom IdP Lambda. The Lambda returns these
 Terraform-managed values after authenticating the user. AWS Transfer assumes
-the role and applies the session policy, which restricts the user to the S3
-prefix matching their lower-cased username. The logical home directory maps:
+the role and applies the session policy, which uses `${transfer:UserName}` to
+restrict the user to their S3 prefix. The Lambda uses the lower-cased username
+for the logical home directory mapping:
 
 ```text
 / -> /<incoming-bucket>/<username>

--- a/terraform/environments/integration-hub-file-transfer/iam-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/iam-transfer.tf
@@ -36,8 +36,6 @@ data "aws_iam_policy_document" "transfer_user" {
 }
 
 data "aws_iam_policy_document" "transfer_user_session" {
-  for_each = local.environment_transfer_server_users
-
   statement {
     sid    = "AllowKMS"
     effect = "Allow"
@@ -69,9 +67,9 @@ data "aws_iam_policy_document" "transfer_user_session" {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
-        trimprefix(each.value.home_directory_target, "/"),
-        "${trimprefix(each.value.home_directory_target, "/")}/",
-        "${trimprefix(each.value.home_directory_target, "/")}/*",
+        "$${transfer:UserName}",
+        "$${transfer:UserName}/",
+        "$${transfer:UserName}/*",
       ]
     }
   }
@@ -84,7 +82,7 @@ data "aws_iam_policy_document" "transfer_user_session" {
       "s3:PutObject",
     ]
     resources = [
-      "${module.s3_bucket["incoming"].s3_bucket_arn}/${trimprefix(each.value.home_directory_target, "/")}/*",
+      "${module.s3_bucket["incoming"].s3_bucket_arn}/$${transfer:UserName}/*",
     ]
   }
 }

--- a/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/idp_handler/app.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/idp_handler/app.py
@@ -15,13 +15,15 @@ from custom_idp_common import (
 
 LOG_LEVEL = os.environ.get("LOGLEVEL", "INFO")
 SECRET_PREFIX = os.environ["SECRET_PREFIX"]
+AWS_ACCOUNT_ID = os.environ["AWS_ACCOUNT_ID"]
+TRANSFER_ROLE_ARN = os.environ["TRANSFER_ROLE_ARN"]
+TRANSFER_SESSION_POLICY = os.environ["TRANSFER_SESSION_POLICY"]
+TRANSFER_HOME_DIRECTORY_DETAILS = os.environ["TRANSFER_HOME_DIRECTORY_DETAILS"]
 
 logger = logging.getLogger()
 logger.setLevel(LOG_LEVEL)
 
-sts_client = boto3.client("sts")
 secretsmanager_client = boto3.client("secretsmanager")
-account_id = sts_client.get_caller_identity()["Account"]
 
 
 class AuthenticationError(Exception):
@@ -41,7 +43,7 @@ def lambda_handler(event, context):
         user_record = get_user_record(username)
         validate_user_record(username, user_record)
         validate_request_context(event, username, user_record)
-        response_data = build_transfer_response(user_record)
+        response_data = build_transfer_response()
 
         password = event.get("password")
         if isinstance(password, str) and password.strip():
@@ -53,7 +55,7 @@ def lambda_handler(event, context):
             response_data["PublicKeys"] = public_keys
 
         response_data = normalise_home_directory_details(response_data)
-        response_data = replace_response_variables(response_data, username, account_id, event["serverId"])
+        response_data = replace_response_variables(response_data, username, AWS_ACCOUNT_ID, event["serverId"])
         logger.info("Authentication succeeded for user %s", username)
         return response_data
     except AuthenticationError as error:
@@ -104,12 +106,6 @@ def validate_user_record(username, user_record):
     if user_record.get("username") != username:
         raise AuthenticationError("User secret username does not match request")
 
-    if not isinstance(user_record.get("Role"), str) or not user_record["Role"]:
-        raise AuthenticationError("Transfer role is not configured")
-
-    if not isinstance(user_record.get("Policy"), str):
-        raise AuthenticationError("Transfer policy is invalid")
-
     password = user_record.get("password")
     if password is not None and not isinstance(password, str):
         raise AuthenticationError("User password is invalid")
@@ -118,28 +114,6 @@ def validate_user_record(username, user_record):
         field_value = user_record.get(field_name)
         if not isinstance(field_value, list) or not all(isinstance(value, str) for value in field_value):
             raise AuthenticationError(f"User {field_name} is invalid")
-
-    home_directory_type = user_record.get("HomeDirectoryType")
-    if home_directory_type == "LOGICAL":
-        home_directory_details = user_record.get("HomeDirectoryDetails")
-        if not isinstance(home_directory_details, list) or not home_directory_details:
-            raise AuthenticationError("Logical home directory is invalid")
-        for home_directory_detail in home_directory_details:
-            if (
-                not isinstance(home_directory_detail, dict)
-                or not isinstance(home_directory_detail.get("Entry"), str)
-                or not isinstance(home_directory_detail.get("Target"), str)
-            ):
-                raise AuthenticationError("Logical home directory is invalid")
-    elif home_directory_type == "PATH":
-        if not isinstance(user_record.get("HomeDirectory"), str) or not user_record["HomeDirectory"]:
-            raise AuthenticationError("Path home directory is invalid")
-    else:
-        raise AuthenticationError("Home directory type is invalid")
-
-    if "PosixProfile" in user_record and not isinstance(user_record["PosixProfile"], dict):
-        raise AuthenticationError("Posix profile is invalid")
-
 
 def validate_request_context(event, username, user_record):
     server_id = event["serverId"]
@@ -155,16 +129,21 @@ def validate_request_context(event, username, user_record):
         raise AuthenticationError("Source IP is not allowed for this user")
 
 
-def build_transfer_response(user_record):
-    response_fields = [
-        "Role",
-        "Policy",
-        "HomeDirectoryType",
-        "HomeDirectoryDetails",
-        "HomeDirectory",
-        "PosixProfile",
-    ]
-    return {field_name: user_record[field_name] for field_name in response_fields if field_name in user_record}
+def build_transfer_response():
+    try:
+        home_directory_details = json.loads(TRANSFER_HOME_DIRECTORY_DETAILS)
+    except json.JSONDecodeError as error:
+        raise AuthenticationError("Transfer home directory configuration is invalid") from error
+
+    if not isinstance(home_directory_details, list) or not home_directory_details:
+        raise AuthenticationError("Transfer home directory configuration is invalid")
+
+    return {
+        "Role": TRANSFER_ROLE_ARN,
+        "Policy": TRANSFER_SESSION_POLICY,
+        "HomeDirectoryType": "LOGICAL",
+        "HomeDirectoryDetails": home_directory_details,
+    }
 
 
 def authenticate_password(input_password, user_record):

--- a/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/idp_handler/app.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/idp_handler/app.py
@@ -115,6 +115,7 @@ def validate_user_record(username, user_record):
         if not isinstance(field_value, list) or not all(isinstance(value, str) for value in field_value):
             raise AuthenticationError(f"User {field_name} is invalid")
 
+
 def validate_request_context(event, username, user_record):
     server_id = event["serverId"]
     source_ip = event.get("sourceIp")
@@ -135,7 +136,16 @@ def build_transfer_response():
     except json.JSONDecodeError as error:
         raise AuthenticationError("Transfer home directory configuration is invalid") from error
 
-    if not isinstance(home_directory_details, list) or not home_directory_details:
+    if (
+        not isinstance(home_directory_details, list)
+        or not home_directory_details
+        or any(
+            not isinstance(detail, dict)
+            or not isinstance(detail.get("Entry"), str)
+            or not isinstance(detail.get("Target"), str)
+            for detail in home_directory_details
+        )
+    ):
         raise AuthenticationError("Transfer home directory configuration is invalid")
 
     return {

--- a/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/test_idp_handler.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/test_idp_handler.py
@@ -12,6 +12,12 @@ CUSTOM_IDP_DIRECTORY = Path(__file__).parent
 HANDLER_FILE = CUSTOM_IDP_DIRECTORY / "idp_handler" / "app.py"
 LAYER_DIRECTORY = CUSTOM_IDP_DIRECTORY / "layer" / "python"
 SECRET_PREFIX = "integration-hub-file-transfer/development/transfer-users/"
+AWS_ACCOUNT_ID = "123456789012"
+TRANSFER_ROLE_ARN = "arn:aws:iam::123456789012:role/transfer-user"
+TRANSFER_SESSION_POLICY = '{"Version":"2012-10-17","Statement":[]}'
+TRANSFER_HOME_DIRECTORY_DETAILS = (
+    '[{"Entry":"/","Target":"/integration-hub-file-transfer-development-incoming/{{USERNAME}}"}]'
+)
 
 
 class ResourceNotFoundException(Exception):
@@ -23,22 +29,22 @@ class CustomIdpTest(unittest.TestCase):
     def setUpClass(cls):
         sys.path.insert(0, str(LAYER_DIRECTORY))
 
-        sts_client = MagicMock()
-        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
         secretsmanager_client = MagicMock()
         secretsmanager_client.exceptions = SimpleNamespace(
             ResourceNotFoundException=ResourceNotFoundException
         )
 
         boto3 = ModuleType("boto3")
-        boto3.client = MagicMock(
-            side_effect=lambda service: sts_client if service == "sts" else secretsmanager_client
-        )
+        boto3.client = MagicMock(return_value=secretsmanager_client)
 
         cls.modules_patch = patch.dict(sys.modules, {"boto3": boto3})
         cls.modules_patch.start()
 
         os.environ["SECRET_PREFIX"] = SECRET_PREFIX
+        os.environ["AWS_ACCOUNT_ID"] = AWS_ACCOUNT_ID
+        os.environ["TRANSFER_ROLE_ARN"] = TRANSFER_ROLE_ARN
+        os.environ["TRANSFER_SESSION_POLICY"] = TRANSFER_SESSION_POLICY
+        os.environ["TRANSFER_HOME_DIRECTORY_DETAILS"] = TRANSFER_HOME_DIRECTORY_DETAILS
 
         spec = importlib.util.spec_from_file_location("custom_idp_handler", HANDLER_FILE)
         cls.handler = importlib.util.module_from_spec(spec)
@@ -64,10 +70,6 @@ class CustomIdpTest(unittest.TestCase):
             "username": "example-user",
             "password": "super-secret",
             "publicKeys": ["ssh-ed25519 AAAATEST"],
-            "Role": "arn:aws:iam::123456789012:role/transfer-user",
-            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[]}",
-            "HomeDirectoryType": "LOGICAL",
-            "HomeDirectoryDetails": [{"Entry": "/", "Target": "/bucket/example-user"}],
             "ipv4_allow_list": [],
             "server_id_allow_list": [],
         }
@@ -93,10 +95,11 @@ class CustomIdpTest(unittest.TestCase):
 
         response = self.handler.lambda_handler(self.event(), None)
 
-        self.assertEqual("arn:aws:iam::123456789012:role/transfer-user", response["Role"])
+        self.assertEqual(TRANSFER_ROLE_ARN, response["Role"])
+        self.assertEqual(TRANSFER_SESSION_POLICY, response["Policy"])
         self.assertEqual("LOGICAL", response["HomeDirectoryType"])
         self.assertEqual(
-            '[{"Entry": "/", "Target": "/bucket/example-user"}]',
+            '[{"Entry": "/", "Target": "/integration-hub-file-transfer-development-incoming/example-user"}]',
             response["HomeDirectoryDetails"],
         )
         self.assertEqual(1, self.handler.secretsmanager_client.get_secret_value.call_count)
@@ -105,6 +108,8 @@ class CustomIdpTest(unittest.TestCase):
         )
         self.assertNotIn("password", response)
         self.assertNotIn("ipv4_allow_list", response)
+        self.assertNotIn("Role", self.secrets[f"{SECRET_PREFIX}example-user"])
+        self.assertNotIn("Policy", self.secrets[f"{SECRET_PREFIX}example-user"])
 
     def test_ssh_authentication_returns_keys(self):
         self.add_user_secret()
@@ -112,6 +117,24 @@ class CustomIdpTest(unittest.TestCase):
         response = self.handler.lambda_handler(self.event(password=""), None)
 
         self.assertEqual(["ssh-ed25519 AAAATEST"], response["PublicKeys"])
+
+    def test_secret_cannot_override_terraform_authorisation(self):
+        self.add_user_secret(
+            self.user_record(
+                Role="arn:aws:iam::123456789012:role/untrusted",
+                Policy="untrusted-policy",
+                HomeDirectoryDetails=[{"Entry": "/", "Target": "/untrusted"}],
+            )
+        )
+
+        response = self.handler.lambda_handler(self.event(), None)
+
+        self.assertEqual(TRANSFER_ROLE_ARN, response["Role"])
+        self.assertEqual(TRANSFER_SESSION_POLICY, response["Policy"])
+        self.assertEqual(
+            '[{"Entry": "/", "Target": "/integration-hub-file-transfer-development-incoming/example-user"}]',
+            response["HomeDirectoryDetails"],
+        )
 
     def test_wrong_or_missing_password_is_denied(self):
         self.add_user_secret()
@@ -136,7 +159,7 @@ class CustomIdpTest(unittest.TestCase):
         self.assertEqual({}, self.handler.lambda_handler(self.event(), None))
         self.add_user_secret(self.user_record(username="another-user"))
         self.assertEqual({}, self.handler.lambda_handler(self.event(), None))
-        self.secrets[f"{SECRET_PREFIX}example-user"] = self.user_record(HomeDirectoryDetails=[])
+        self.secrets[f"{SECRET_PREFIX}example-user"] = self.user_record(publicKeys="not-a-list")
         self.assertEqual({}, self.handler.lambda_handler(self.event(), None))
 
     def test_rejects_request_without_source_ip(self):

--- a/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/test_idp_handler.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/custom-idp/test_idp_handler.py
@@ -136,6 +136,21 @@ class CustomIdpTest(unittest.TestCase):
             response["HomeDirectoryDetails"],
         )
 
+    def test_invalid_home_directory_configuration_is_denied(self):
+        self.add_user_secret()
+        invalid_configurations = [
+            "not-json",
+            "{}",
+            "[]",
+            '[{"Entry": "/"}]',
+            '[{"Entry": 1, "Target": "/bucket/example-user"}]',
+        ]
+
+        for configuration in invalid_configurations:
+            with self.subTest(configuration=configuration):
+                with patch.object(self.handler, "TRANSFER_HOME_DIRECTORY_DETAILS", configuration):
+                    self.assertEqual({}, self.handler.lambda_handler(self.event(), None))
+
     def test_wrong_or_missing_password_is_denied(self):
         self.add_user_secret()
 

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -4,10 +4,9 @@ locals {
 
   # Custom IdP user configuration. Add users by username and list every
   # environment in which they may authenticate. Terraform creates the initial
-  # complete user record in Secrets Manager.
+  # authentication record in Secrets Manager.
   #
   # environments          - environments in which Terraform creates the user
-  # home_directory_target - prefix in the incoming bucket mapped to logical "/"
   # server_id_allow_list  - Transfer server IDs permitted for the user; empty allows any
   # cidr_blocks           - source networks permitted by the security group and IdP;
   #                         empty creates no ingress rules
@@ -17,10 +16,9 @@ locals {
   # directly in the generated Secrets Manager secret when password access is needed.
   transfer_server_users = {
     dms1981 = {
-      environments          = ["development"]
-      home_directory_target = "dms1981"
-      server_id_allow_list  = []
-      cidr_blocks           = []
+      environments         = ["development"]
+      server_id_allow_list = []
+      cidr_blocks          = []
       ssh_public_keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPE6XyQIDh5gt+7HOrUQymtsfl3+NZqUM5p7BQqi9uso"
       ]

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -18,7 +18,7 @@ locals {
     dms1981 = {
       environments         = ["development"]
       server_id_allow_list = []
-      cidr_blocks          = []
+      cidr_blocks          = ["139.28.208.0/22"]
       ssh_public_keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPE6XyQIDh5gt+7HOrUQymtsfl3+NZqUM5p7BQqi9uso"
       ]

--- a/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-transfer.tf
@@ -26,7 +26,7 @@ locals {
   }
 
   environment_transfer_server_users = {
-    for username, user in local.transfer_server_users : username => user
+    for username, user in local.transfer_server_users : lower(username) => user
     if contains(user.environments, local.environment)
   }
 


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed

People connecting through AWS Transfer now receive Terraform-managed authorisation settings after the custom identity provider authenticates them.

- Keep credentials, SSH public keys, and connection restrictions in each person's Secrets Manager record.
- Keep the shared IAM role, session policy, and logical home-directory mapping in Terraform.
- Scope each Transfer session to the S3 prefix matching `${transfer:UserName}`.
- Canonicalise configured usernames to lower case before Terraform creates dependent resources.
- Restrict the example development user to the configured `139.28.208.0/22` network.
- Reject malformed Terraform-provided home-directory mappings with focused regression coverage.

## Why

This gives each part of the service one clear responsibility. Secrets Manager holds the details that people may need to rotate, Terraform owns access to AWS resources, and the Lambda authenticates a person before returning that deployment configuration to AWS Transfer.

It also prevents values stored in a user secret from replacing the role, policy, or home directory chosen by Terraform.

## Validation

- 12 custom identity provider unit tests pass.
- `terraform fmt -check` passes.
- `terraform validate` passes.
- TFLint passes in CI.
- The development Terraform plan and apply completed successfully.
- Copilot reviewed the current head successfully; all four earlier review threads are resolved.

## Rollout note

Terraform uses `ignore_secret_changes` for existing user secrets so that later credential changes do not enter Terraform state. The existing development secret therefore needs a complete replacement version using the authentication-only schema, including `ipv4_allow_list = ["139.28.208.0/22"]`.

## CI note

The Checkov job currently fails before scanning because its Python 3.9 runtime cannot import a dependency that uses Python 3.10 union type syntax. This is a runner compatibility failure rather than a finding against these changes.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>