### PR TITLE
🔄 Switch Justice Engineering AI Enablment teams to dedicated Bedrock backend

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -22,12 +22,12 @@ teams:
       - bedrock-jeaie-claude-opus-5
       - bedrock-jeaie-claude-sonnet-5
     model_aliases:
-        - alias: "claude-haiku-4.5"
-          model: "bedrock-jeaie-claude-haiku-4-5"
-        - alias: "claude-opus-5"
-          model: "bedrock-jeaie-claude-opus-5"
-        - alias: "claude-sonnet-5"
-          model: "bedrock-jeaie-claude-sonnet-5"
+      - alias: "claude-haiku-4.5"
+        model: "bedrock-jeaie-claude-haiku-4-5"
+      - alias: "claude-opus-5"
+        model: "bedrock-jeaie-claude-opus-5"
+      - alias: "claude-sonnet-5"
+        model: "bedrock-jeaie-claude-sonnet-5"
   pom-e-supervision:
     alias: POM Phased Implementation - E-Supervision
     organisation: ministryofjustice
@@ -39,12 +39,12 @@ teams:
       - bedrock-jeaie-claude-opus-5
       - bedrock-jeaie-claude-sonnet-5
     model_aliases:
-        - alias: "claude-haiku-4.5"
-          model: "bedrock-jeaie-claude-haiku-4-5"
-        - alias: "claude-opus-5"
-          model: "bedrock-jeaie-claude-opus-5"
-        - alias: "claude-sonnet-5"
-          model: "bedrock-jeaie-claude-sonnet-5"
+      - alias: "claude-haiku-4.5"
+        model: "bedrock-jeaie-claude-haiku-4-5"
+      - alias: "claude-opus-5"
+        model: "bedrock-jeaie-claude-opus-5"
+      - alias: "claude-sonnet-5"
+        model: "bedrock-jeaie-claude-sonnet-5"
 
 models:
   amazon_bedrock:

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -9,33 +9,42 @@ teams:
     organisation: ministryofjustice
     max_budget: 10000
     models: ["no-default-models"]
-    unified_access_groups: ["generally-available-models"]
+    unified_access_groups:
+      - generally-available-models
   justice-engineering-ai-enablement:
     alias: Justice Engineering AI Enablement
     organisation: ministryofjustice
     max_budget: 10000
     models: ["no-default-models"]
-    unified_access_groups: ["generally-available-models"]
+    unified_access_groups:
+      - generally-available-models
+      - bedrock-jeaie-claude-haiku-4-5
+      - bedrock-jeaie-claude-opus-5
+      - bedrock-jeaie-claude-sonnet-5
     model_aliases:
         - alias: "claude-haiku-4.5"
-          model: "bedrock-claude-haiku-4-5"
+          model: "bedrock-jeaie-claude-haiku-4-5"
         - alias: "claude-opus-5"
-          model: "bedrock-claude-opus-5"
+          model: "bedrock-jeaie-claude-opus-5"
         - alias: "claude-sonnet-5"
-          model: "bedrock-claude-sonnet-5"
+          model: "bedrock-jeaie-claude-sonnet-5"
   pom-e-supervision:
     alias: POM Phased Implementation - E-Supervision
     organisation: ministryofjustice
     max_budget: 2000
     models: ["no-default-models"]
-    unified_access_groups: ["generally-available-models"]
+    unified_access_groups:
+      - generally-available-models
+      - bedrock-jeaie-claude-haiku-4-5
+      - bedrock-jeaie-claude-opus-5
+      - bedrock-jeaie-claude-sonnet-5
     model_aliases:
-      - alias: "claude-haiku-4.5"
-        model: "bedrock-claude-haiku-4-5"
-      - alias: "claude-opus-5"
-        model: "bedrock-claude-opus-5"
-      - alias: "claude-sonnet-5"
-        model: "bedrock-claude-sonnet-5"
+        - alias: "claude-haiku-4.5"
+          model: "bedrock-jeaie-claude-haiku-4-5"
+        - alias: "claude-opus-5"
+          model: "bedrock-jeaie-claude-opus-5"
+        - alias: "claude-sonnet-5"
+          model: "bedrock-jeaie-claude-sonnet-5"
 
 models:
   amazon_bedrock:


### PR DESCRIPTION
## Proposed Changes

- Switches the Justice Engineering AI Enablement teams to use the dedicated backend

## Notes

- As `unified_access_groups` still doesn't work, I've manually added that in the admin interface

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>