### PR TITLE
🧹 Tidy up Integration Hub S3 lifecycle rules

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/eventbridge.tf
+++ b/terraform/environments/integration-hub-file-transfer/eventbridge.tf
@@ -1,7 +1,7 @@
 module "eventbridge_default_bus" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/eventbridge/aws"
-  version = "4.3.0"
+  version = "4.3.1"
 
   bus_name                   = "default"
   create_bus                 = false
@@ -20,7 +20,7 @@ module "eventbridge_default_bus" {
 module "eventbridge_file_transfer_bus" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/eventbridge/aws"
-  version = "4.3.0"
+  version = "4.3.1"
 
   bus_name            = local.application_name
   create_archives     = true

--- a/terraform/environments/integration-hub-file-transfer/locals-s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-s3.tf
@@ -99,6 +99,7 @@ locals {
             id     = "expire-objects-after-7-days"
             status = "Enabled"
             filter = {}
+            expiration = {
               days = 7
             }
             noncurrent_version_expiration = {

--- a/terraform/environments/integration-hub-file-transfer/locals-s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-s3.tf
@@ -27,7 +27,7 @@ locals {
           }
           abort_incomplete_multipart_upload_days = 1
           noncurrent_version_expiration = {
-            days = 1
+            noncurrent_days = 1
           }
         },
       ]
@@ -87,14 +87,18 @@ locals {
               days = 3
             }
           },
+          {
+            id                                     = "abort-incomplete-multipart-uploads-after-1-day"
+            status                                 = "Enabled"
+            filter                                 = {}
+            abort_incomplete_multipart_upload_days = 1
+          },
         ]
         quarantine = [
           {
             id     = "expire-objects-after-7-days"
             status = "Enabled"
-            filter = {
-            }
-            expiration = {
+            filter = {}
               days = 7
             }
             noncurrent_version_expiration = {

--- a/terraform/environments/integration-hub-file-transfer/locals-s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-s3.tf
@@ -26,6 +26,9 @@ locals {
             days = 1
           }
           abort_incomplete_multipart_upload_days = 1
+          noncurrent_version_expiration = {
+            days = 1
+          }
         },
       ]
     }
@@ -33,13 +36,16 @@ locals {
     production = {
       default = [
         {
-          id     = "expire-objects-after-1-day"
+          id     = "expire-objects-after-7-days"
           status = "Enabled"
           filter = {}
           expiration = {
-            days = 14
+            days = 7
           }
           abort_incomplete_multipart_upload_days = 1
+          noncurrent_version_expiration = {
+            days = 1
+          }
         },
       ]
     }
@@ -54,24 +60,18 @@ locals {
     production = {
       default = local.s3_bucket_lifecycle_defaults.production.default
       buckets = {
-        incoming = []
-        processing = [
-          {
-            id                                     = "abort-incomplete-multipart-uploads-after-1-day"
-            status                                 = "Enabled"
-            filter                                 = {}
-            abort_incomplete_multipart_upload_days = 1
-          },
-        ]
         clean = [
           {
-            id     = "expire-clean-after-14-days"
+            id     = "expire-clean-after-7-days"
             status = "Enabled"
             filter = {
               prefix = "clean/"
             }
             expiration = {
-              days = 14
+              days = 7
+            }
+            noncurrent_version_expiration = {
+              days = 7
             }
           },
           {
@@ -83,15 +83,24 @@ locals {
             expiration = {
               days = 3
             }
-          },
-          {
-            id                                     = "abort-incomplete-multipart-uploads-after-1-day"
-            status                                 = "Enabled"
-            filter                                 = {}
-            abort_incomplete_multipart_upload_days = 1
+            noncurrent_version_expiration = {
+              days = 3
+            }
           },
         ]
         quarantine = [
+          {
+            id     = "expire-objects-after-7-days"
+            status = "Enabled"
+            filter = {
+            }
+            expiration = {
+              days = 7
+            }
+            noncurrent_version_expiration = {
+              days = 7
+            }
+          },
           {
             id                                     = "abort-incomplete-multipart-uploads-after-1-day"
             status                                 = "Enabled"
@@ -100,6 +109,18 @@ locals {
           },
         ]
         investigation = [
+          {
+            id     = "expire-objects-after-7-days"
+            status = "Enabled"
+            filter = {
+            }
+            expiration = {
+              days = 7
+            }
+            noncurrent_version_expiration = {
+              days = 7
+            }
+          },
           {
             id                                     = "abort-incomplete-multipart-uploads-after-1-day"
             status                                 = "Enabled"

--- a/terraform/environments/integration-hub-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/s3.tf
@@ -1,7 +1,7 @@
 module "s3_audit_bucket" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.14.1"
+  version = "5.15.3"
 
   allowed_kms_key_arn                   = module.kms_s3_audit.key_arn
   attach_deny_insecure_transport_policy = true
@@ -52,7 +52,7 @@ module "s3_bucket" {
     for key, value in local.s3_bucket_configuration : key => value
   }
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.14.1"
+  version = "5.15.3"
 
   allowed_kms_key_arn                   = module.kms_s3_bucket[each.key].key_arn
   attach_deny_insecure_transport_policy = true


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Why

Keep the Integration Hub File Transfer buckets tidy and make retention more predictable, including for older object versions. 🧹

## What changed

- Bumped S3 module version to latest (5.14.1 > 5.15.3)
- Added expiry rules for non-current object versions.
- Updated the production default retention period from 14 days to 7 days.
- Added matching retention rules for the `clean/` and `example/` prefixes.
- Added seven-day expiry rules for the `quarantine/` and `investigation/` buckets.
- Removed the separate `incoming` and `processing` overrides so they use the shared production defaults.

## Checks

- [x] `terraform fmt -check terraform/environments/integration-hub-file-transfer/locals-s3.tf`
- [x] `git diff --check HEAD^ HEAD -- terraform/environments/integration-hub-file-transfer/locals-s3.tf`
- [ ] Full Terraform validation was not run locally; CI will run the environment-level validation and plan.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>