### PR TITLE
Add new non-live spokes to Argo CD

### DIFF
--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -358,6 +358,9 @@ locals {
       /* ArgoCD — spokes registered with the preproduction hub */
       argocd_registered_spokes = [
         "container-platform-octo-nonlive",
+        "container-platform-laa-nonlive",
+        "container-platform-cd-nonlive",
+        "container-platform-hmpps-nonlive"
       ]
 
       /* Addons */


### PR DESCRIPTION
This pull request updates the `environment-configuration.tf` file to register additional ArgoCD spokes with the preproduction hub. This ensures that new non-live environments are managed by ArgoCD.

ArgoCD configuration updates:

* Added `container-platform-laa-nonlive`, `container-platform-cd-nonlive`, and `container-platform-hmpps-nonlive` to the `argocd_registered_spokes` list in `environment-configuration.tf`, enabling ArgoCD management for these environments.