### PR TITLE
Update OIDC client ID list

### DIFF
--- a/terraform/environments/data-platform/iam-oidc-providers.tf
+++ b/terraform/environments/data-platform/iam-oidc-providers.tf
@@ -15,6 +15,10 @@ module "justiceuk_entra_iam_oidc_provider" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-oidc-provider?ref=5b962b1163790398605f2b17447cf5b6cc512237" # v6.6.1
 
   url = "https://sts.windows.net/${jsondecode(data.aws_secretsmanager_secret_version.justiceuk_entra.secret_string)["tenant_id"]}/"
+  client_id_list = distinct(concat(
+    ["sts.amazonaws.com"],
+    try(values(tomap(jsondecode(data.aws_secretsmanager_secret_version.justiceuk_entra.secret_string)["client_id_map"])), [])
+  ))
 
   tags = merge(
     local.tags,

--- a/terraform/environments/data-platform/secrets.tf
+++ b/terraform/environments/data-platform/secrets.tf
@@ -18,6 +18,9 @@ module "justiceuk_entra_secret" {
 
   secret_string = jsonencode({
     tenant_id = "CHANGEME"
+    client_id_map = {
+      amazon_sts = "sts.amazonaws.com"
+    }
   })
   ignore_secret_changes = true
 }


### PR DESCRIPTION
This pull request updates the OIDC provider and secret configuration for the data platform environment to support multiple client IDs. The main changes involve adding a `client_id_map` to the secret and updating the OIDC provider module to dynamically construct the `client_id_list` from this map.

**OIDC Provider Configuration:**

* Updated the `justiceuk_entra_iam_oidc_provider` module to set `client_id_list` by combining the default `sts.amazonaws.com` with any additional client IDs defined in the `client_id_map` from the secret, allowing for flexible client ID management.

**Secrets Management:**

* Modified the `justiceuk_entra_secret` module to include a new `client_id_map` field in the secret, initializing it with `amazon_sts = "sts.amazonaws.com"`, which enables storing and managing multiple client IDs for the OIDC provider.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>