### PR TITLE
Add cloud-platform-nonlive environment

### DIFF
--- a/.github/workflows/cloud-platform.yml
+++ b/.github/workflows/cloud-platform.yml
@@ -55,6 +55,9 @@ jobs:
             environment: preproduction
             action: "plan"
           - application: cloud-platform
+            environment: nonlive
+            action: "plan"
+          - application: cloud-platform
             environment: live
             action: "plan"
     uses: ./.github/workflows/cloud-platform-reusable.yml
@@ -74,6 +77,9 @@ jobs:
         include:
           - application: cloud-platform
             environment: preproduction
+            action: "plan_apply"
+          - application: cloud-platform
+            environment: nonlive
             action: "plan_apply"
           - application: cloud-platform
             environment: live

--- a/terraform/environments/cloud-platform/cluster-core/external-dns.tf
+++ b/terraform/environments/cloud-platform/cluster-core/external-dns.tf
@@ -27,6 +27,12 @@ module "external_dns" {
       aws_zone_cache_duration = local.aws_zone_cache_duration.development
       log_level               = "info"
     }
+    cloud-platform-nonlive = {
+      domain_name_prefix      = "nonlive"
+      sync_interval           = local.sync_interval.production
+      aws_zone_cache_duration = local.aws_zone_cache_duration.production
+      log_level               = "info"
+    }
     cloud-platform-live = {
       domain_name_prefix      = "live"
       sync_interval           = local.sync_interval.production

--- a/terraform/environments/cloud-platform/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/environment-configuration.tf
@@ -6,6 +6,9 @@ locals {
     cloud-platform-preproduction = {
       account_subdomain_name = "preproduction.${local.base_domain}"
     }
+    cloud-platform-nonlive = {
+      account_subdomain_name = "nonlive.${local.base_domain}"
+    }
     cloud-platform-live = {
       account_subdomain_name = "live.${local.base_domain}"
     }

--- a/terraform/environments/cloud-platform/network/locals.tf
+++ b/terraform/environments/cloud-platform/network/locals.tf
@@ -5,6 +5,7 @@ locals {
     [
       "cloud-platform-development",
       "cloud-platform-preproduction",
+      "cloud-platform-nonlive",
       "cloud-platform-live"
     ],
     local.bu_accounts.accounts
@@ -22,6 +23,10 @@ locals {
     cloud-platform-preproduction = {
       primary   = "10.195.16.0/20"
       secondary = "100.65.0.0/16"
+    }
+    cloud-platform-nonlive = {
+      primary   = "10.195.192.0/20"
+      secondary = "100.67.0.0/16"
     }
     cloud-platform-live = {
       primary   = "10.195.0.0/20"

--- a/terraform/environments/cloud-platform/network/ssm-relay.tf
+++ b/terraform/environments/cloud-platform/network/ssm-relay.tf
@@ -5,26 +5,6 @@
 # endpoint without a public endpoint or VPN. Development account only.
 ###############################################################################
 
-# Look up the existing cluster VPC (spike uses local state, so not via module).
-data "aws_vpc" "cluster" {
-  filter {
-    name   = "tag:Name"
-    values = [local.cp_vpc_name]
-  }
-}
-
-# Look up the existing private (node) subnets in that VPC.
-data "aws_subnets" "private" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.cluster.id]
-  }
-  filter {
-    name   = "tag:SubnetType"
-    values = ["Private"]
-  }
-}
-
 # IAM role assumed by the SSM relay EC2 instance (dev account only).
 resource "aws_iam_role" "ssm_relay" {
   count = local.is-development ? 1 : 0
@@ -67,7 +47,7 @@ resource "aws_security_group" "ssm_relay" {
 
   name_prefix = "ssm-relay-"
   description = "SSM relay for private EKS API access - outbound HTTPS only"
-  vpc_id      = data.aws_vpc.cluster.id
+  vpc_id      = module.cluster_vpc.vpc_id
 
   egress {
     description = "HTTPS to SSM endpoints and EKS API"
@@ -115,7 +95,7 @@ resource "aws_instance" "ssm_relay" {
 
   ami                    = data.aws_ami.al2023.id
   instance_type          = "t3.micro"
-  subnet_id              = data.aws_subnets.private.ids[0]
+  subnet_id              = module.cluster_vpc.private_subnets[0]
   iam_instance_profile   = aws_iam_instance_profile.ssm_relay[0].name
   vpc_security_group_ids = [aws_security_group.ssm_relay[0].id]
 


### PR DESCRIPTION
Adding this environment back in so that we can have separate ArgoCD clusters for live and nonlive.