### PR TITLE
🔒 Route mismatched malware tags to investigation

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/lambda/file-mover/mft_file_mover/model.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-mover/mft_file_mover/model.py
@@ -54,9 +54,11 @@ def plan_multipart_copy(size_bytes, part_size_bytes, maximum_parts):
     ]
 
 
-def select_route(scan_result_status):
+def select_route(scan_result_status, scan_result_status_matches_tag):
     if scan_result_status not in SUPPORTED_SCAN_RESULTS:
         raise ValueError(f"Unsupported scan result status: {scan_result_status}")
+    if not scan_result_status_matches_tag:
+        return "investigation"
     if scan_result_status == "NO_THREATS_FOUND":
         return "clean"
     if scan_result_status == "THREATS_FOUND":

--- a/terraform/environments/integration-hub-file-transfer/lambda/file-mover/mft_file_mover/service.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-mover/mft_file_mover/service.py
@@ -150,7 +150,10 @@ class FileMoverService:
             return self.config.destinations["processing"], item
         if "route" in item:
             return self.config.destinations[item["route"]], item
-        route = select_route(operation_event.scan_result_status)
+        route = select_route(
+            operation_event.scan_result_status,
+            operation_event.scan_result_status_matches_tag,
+        )
         item = self.store.update_fields(
             item,
             owner,

--- a/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_model.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_model.py
@@ -29,15 +29,20 @@ class MultipartCopyPlanTest(unittest.TestCase):
 
 class RouteSelectionTest(unittest.TestCase):
     def test_selects_clean_for_a_clean_event_result(self):
-        self.assertEqual(select_route("NO_THREATS_FOUND"), "clean")
+        self.assertEqual(select_route("NO_THREATS_FOUND", True), "clean")
 
     def test_selects_quarantine_for_a_threat_event_result(self):
-        self.assertEqual(select_route("THREATS_FOUND"), "quarantine")
+        self.assertEqual(select_route("THREATS_FOUND", True), "quarantine")
 
     def test_selects_investigation_for_non_terminal_routes(self):
         for status in ["UNSUPPORTED", "ACCESS_DENIED", "FAILED"]:
             with self.subTest(status=status):
-                self.assertEqual(select_route(status), "investigation")
+                self.assertEqual(select_route(status, True), "investigation")
+
+    def test_selects_investigation_when_the_scan_result_does_not_match_the_tag(self):
+        for status in ["NO_THREATS_FOUND", "THREATS_FOUND"]:
+            with self.subTest(status=status):
+                self.assertEqual(select_route(status, False), "investigation")
 
 
 if __name__ == "__main__":

--- a/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_schema_contracts.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_schema_contracts.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from jsonschema import Draft4Validator, FormatChecker
+from jsonschema import Draft4Validator, FormatChecker, ValidationError
 
 from mft_file_mover.config import Destination
 from mft_file_mover.service import EVENT_SOURCE, FileMoverService
@@ -26,9 +26,11 @@ class CompletionEventSchemaTest(unittest.TestCase):
 
     def test_route_completion_events_match_all_schema_branches(self):
         cases = [
-            ("clean", "NO_THREATS_FOUND", False),
-            ("quarantine", "THREATS_FOUND", False),
+            ("clean", "NO_THREATS_FOUND", True),
+            ("quarantine", "THREATS_FOUND", True),
             ("investigation", "FAILED", True),
+            ("investigation", "NO_THREATS_FOUND", False),
+            ("investigation", "THREATS_FOUND", False),
         ]
         service = self._service("ROUTE")
         for route, status, matches_tag in cases:
@@ -46,6 +48,28 @@ class CompletionEventSchemaTest(unittest.TestCase):
                 detail, detail_type, _ = service._completion_event(item)
 
                 self._validate(detail_type, detail)
+
+    def test_route_completion_rejects_a_tag_mismatch_outside_investigation(self):
+        cases = [
+            ("clean", "NO_THREATS_FOUND"),
+            ("quarantine", "THREATS_FOUND"),
+        ]
+        service = self._service("ROUTE")
+        for route, status in cases:
+            with self.subTest(route=route, status=status):
+                item = self._item(
+                    operation="ROUTE",
+                    source_bucket="processing",
+                    destination_bucket=route,
+                    destination_version_id=f"{route}-version",
+                    route=route,
+                    scan_result_status=status,
+                    scan_result_status_matches_tag=False,
+                )
+                detail, detail_type, _ = service._completion_event(item)
+
+                with self.assertRaises(ValidationError):
+                    self._validate(detail_type, detail)
 
     def _validate(self, detail_type, detail):
         schema = json.loads((SCHEMA_DIRECTORY / f"{detail_type}.json").read_text())

--- a/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_service.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-mover/test_service.py
@@ -77,7 +77,7 @@ class FileMoverServiceTest(unittest.TestCase):
         self.assertEqual(completed_fields["processing_version_id"], "destination-version")
         self.assertEqual(completed_fields["staged_event_id"], "completion-event-id")
 
-    def test_route_uses_the_event_status_and_preserves_the_tag_match_flag(self):
+    def test_route_sends_a_tag_mismatch_to_investigation(self):
         route_event = {
             **self.event,
             "detail-type": "FileScanResultRecorded.v1",
@@ -114,8 +114,8 @@ class FileMoverServiceTest(unittest.TestCase):
         self.copy_engine.copy.side_effect = lambda item, *_args: {
             **item,
             "status": "COPIED",
-            "destination_bucket": "clean",
-            "destination_version_id": "clean-version",
+            "destination_bucket": "investigation",
+            "destination_version_id": "investigation-version",
             "copy_token": "copy-token",
         }
         service = self._route_service()
@@ -126,7 +126,7 @@ class FileMoverServiceTest(unittest.TestCase):
         published = json.loads(
             self.eventbridge.put_events.call_args.kwargs["Entries"][0]["Detail"]
         )
-        self.assertEqual(published["data"]["route"], "clean")
+        self.assertEqual(published["data"]["route"], "investigation")
         self.assertFalse(published["data"]["scanResultStatusMatchesTag"])
         self.copy_engine.delete_source.assert_called_once()
 

--- a/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
+++ b/terraform/environments/integration-hub-file-transfer/schemas/FileRouted.v1.json
@@ -49,13 +49,21 @@
             {
               "properties": {
                 "route": { "enum": ["clean"] },
-                "scanResultStatus": { "enum": ["NO_THREATS_FOUND"] }
+                "scanResultStatus": { "enum": ["NO_THREATS_FOUND"] },
+                "scanResultStatusMatchesTag": { "enum": [true] }
               }
             },
             {
               "properties": {
                 "route": { "enum": ["quarantine"] },
-                "scanResultStatus": { "enum": ["THREATS_FOUND"] }
+                "scanResultStatus": { "enum": ["THREATS_FOUND"] },
+                "scanResultStatusMatchesTag": { "enum": [true] }
+              }
+            },
+            {
+              "properties": {
+                "route": { "enum": ["investigation"] },
+                "scanResultStatusMatchesTag": { "enum": [false] }
               }
             },
             {
@@ -63,7 +71,8 @@
                 "route": { "enum": ["investigation"] },
                 "scanResultStatus": {
                   "enum": ["UNSUPPORTED", "ACCESS_DENIED", "FAILED"]
-                }
+                },
+                "scanResultStatusMatchesTag": { "enum": [true] }
               }
             }
           ],
@@ -91,7 +100,7 @@
             },
             "scanResultStatusMatchesTag": {
               "type": "boolean",
-              "description": "Diagnostic value copied from FileScanResultRecorded.v1; it does not select the route."
+              "description": "Whether scanResultStatus matched the exact object's GuardDutyMalwareScanStatus tag. A mismatch routes the object to investigation."
             },
             "sourceDeleted": { "type": "boolean", "enum": [true] }
           }


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed

- Route files to `investigation` whenever the native GuardDuty result does not match the exact-version S3 tag
- Keep the original GuardDuty status and mismatch flag in the routed event, preserving the evidence responders need
- Update the `FileRouted.v1` routing constraints and add unit and contract coverage for both mismatch outcomes

## Why

A mismatch means two security signals disagree. Sending the file to its normal clean or quarantine destination could put it somewhere people do not expect, so the mover now fails closed and gives the team a safe place to investigate. 🔎

This does not change event fields or GuardDuty status values.

## Testing

- 41 file-mover tests passed
- 9 GuardDuty adapter tests passed
- Editor diagnostics and `git diff --check` passed

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>