### PR TITLE
PLAT-54: delius-mis: prod build v6

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -348,6 +348,12 @@ locals {
     throughtput_capacity = 16
   }
 
+  acm_certificate_dev = {
+    domain_name                         = "modernisation-platform.service.justice.gov.uk"
+    external_validation_records_created = true
+    additional_subject_alternate_names  = []
+  }
+
   lb_config_dev = {
     bucket_policy_enabled = true
     maintenance_message   = "NDMIS Reporting Dev is currently unavailable due to planned maintenance or out-of-hours shutdown (7pm-7am)."

--- a/terraform/environments/delius-mis/locals_preproduction.tf
+++ b/terraform/environments/delius-mis/locals_preproduction.tf
@@ -430,6 +430,11 @@ locals {
 
   dfi_report_bucket_config_preprod = null
 
+  acm_certificate_preprod = {
+    domain_name                         = "modernisation-platform.service.justice.gov.uk"
+    external_validation_records_created = true
+  }
+
   lb_config_preprod = {
     bucket_policy_enabled = true
     maintenance_message   = "NDMIS Reporting Pre-Production is currently unavailable due to planned maintenance or out-of-hours shutdown (7pm-7am)."

--- a/terraform/environments/delius-mis/locals_production.tf
+++ b/terraform/environments/delius-mis/locals_production.tf
@@ -427,6 +427,13 @@ locals {
     bucket_policy_enabled = true
   }
 
+  acm_certificate_production = null
+
+  # acm_certificate_production = {
+  #   domain_name                         = "reporting.probation.service.justice.gov.uk"
+  #   external_validation_records_created = false
+  # }
+
   lb_config_production = {
     bucket_policy_enabled = true
   }

--- a/terraform/environments/delius-mis/locals_stage.tf
+++ b/terraform/environments/delius-mis/locals_stage.tf
@@ -461,6 +461,11 @@ locals {
     bucket_policy_enabled = true
   }
 
+  acm_certificate_stage = {
+    domain_name                         = "modernisation-platform.service.justice.gov.uk"
+    external_validation_records_created = true
+  }
+
   lb_config_stage = {
     bucket_policy_enabled = true
     maintenance_message   = "NDMIS Reporting Stage is currently unavailable due to planned maintenance or out-of-hours shutdown (7pm-7am)."

--- a/terraform/environments/delius-mis/main_development.tf
+++ b/terraform/environments/delius-mis/main_development.tf
@@ -39,6 +39,7 @@ module "environment_dev" {
   boe_db_config = local.boe_db_config_dev
   mis_db_config = local.mis_db_config_dev
 
+  acm_certificate          = local.acm_certificate_dev
   fsx_config               = local.fsx_config_dev
   dfi_report_bucket_config = local.dfi_report_bucket_config_dev
   lb_config                = local.lb_config_dev

--- a/terraform/environments/delius-mis/main_preproduction.tf
+++ b/terraform/environments/delius-mis/main_preproduction.tf
@@ -39,6 +39,7 @@ module "environment_stage" {
   boe_db_config = local.boe_db_config_stage
   mis_db_config = local.mis_db_config_stage
 
+  acm_certificate          = local.acm_certificate_stage
   fsx_config               = local.fsx_config_stage
   dfi_report_bucket_config = local.dfi_report_bucket_config_stage
   lb_config                = local.lb_config_stage
@@ -92,6 +93,7 @@ module "environment_preproduction" {
   boe_db_config = local.boe_db_config_preprod
   mis_db_config = local.mis_db_config_preprod
 
+  acm_certificate          = local.acm_certificate_preprod
   fsx_config               = local.fsx_config_preprod
   dfi_report_bucket_config = local.dfi_report_bucket_config_preprod
   lb_config                = local.lb_config_preprod

--- a/terraform/environments/delius-mis/main_production.tf
+++ b/terraform/environments/delius-mis/main_production.tf
@@ -40,6 +40,7 @@ module "environment_production" {
   boe_db_config = local.boe_db_config_production
   mis_db_config = local.mis_db_config_production
 
+  acm_certificate          = local.acm_certificate_production
   fsx_config               = local.fsx_config_production
   dfi_report_bucket_config = local.dfi_report_bucket_config_production
   lb_config                = local.lb_config_production

--- a/terraform/environments/delius-mis/modules/mis_environment/lb.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/lb.tf
@@ -465,7 +465,7 @@ resource "aws_lb_listener" "mis_http" {
 
 # HTTPS Listener (port 443) - default action is HTTP 501 if no rules are matched
 resource "aws_lb_listener" "mis_https" {
-  count = var.lb_config != null ? 1 : 0
+  count = var.lb_config != null && var.acm_certificate != null ? 1 : 0
 
   load_balancer_arn = aws_lb.mis[0].arn
   port              = "443"
@@ -487,7 +487,7 @@ resource "aws_lb_listener" "mis_https" {
 }
 
 resource "aws_lb_listener_rule" "dfi_https" {
-  count        = local.dfi_enabled ? 1 : 0
+  count        = length(aws_lb_listener.mis_https) == 1 && local.dfi_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 100
 
@@ -506,7 +506,7 @@ resource "aws_lb_listener_rule" "dfi_https" {
 }
 
 resource "aws_lb_listener_rule" "dis_https" {
-  count        = local.dis_enabled ? 1 : 0
+  count        = length(aws_lb_listener.mis_https) == 1 && local.dis_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 200
 
@@ -525,7 +525,7 @@ resource "aws_lb_listener_rule" "dis_https" {
 }
 
 resource "aws_lb_listener_rule" "bws_https" {
-  count        = local.bws_enabled ? 1 : 0
+  count        = length(aws_lb_listener.mis_https) == 1 && local.bws_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 300
 
@@ -547,7 +547,7 @@ resource "aws_lb_listener_rule" "bws_https" {
 }
 
 resource "aws_lb_listener_rule" "bws_sso_https" {
-  count        = local.bws_sso_enabled ? 1 : 0
+  count        = length(aws_lb_listener.mis_https) == 1 && local.bws_sso_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 350
 
@@ -566,7 +566,7 @@ resource "aws_lb_listener_rule" "bws_sso_https" {
 }
 
 resource "aws_lb_listener_rule" "bcs_win_https" {
-  count        = local.bcs_win_enabled ? 1 : 0
+  count        = length(aws_lb_listener.mis_https) == 1 && local.bcs_win_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 400
 
@@ -585,7 +585,7 @@ resource "aws_lb_listener_rule" "bcs_win_https" {
 }
 
 resource "aws_lb_listener_rule" "maintenance" {
-  count = local.maintenance_rule_enabled ? 1 : 0
+  count = length(aws_lb_listener.mis_https) == 1 && local.maintenance_rule_enabled ? 1 : 0
 
   listener_arn = aws_lb_listener.mis_https[0].arn
   priority     = 999
@@ -618,7 +618,7 @@ resource "aws_lb_listener_rule" "maintenance" {
 
 # ACM certificate using the modernisation platform pattern - dynamically includes SANs based on enabled services
 module "acm_certificate" {
-  count  = var.lb_config != null ? 1 : 0
+  count  = var.acm_certificate != null ? 1 : 0
   source = "../../../../modules/acm_certificate"
 
   providers = {
@@ -627,11 +627,13 @@ module "acm_certificate" {
   }
 
   name        = "${local.lb_name}-cert"
-  domain_name = "modernisation-platform.service.justice.gov.uk"
+  domain_name = var.acm_certificate.domain_name
   subject_alternate_names = [
     "${var.env_name}.${var.account_config.dns_suffix}",
     "*.${var.env_name}.${var.account_config.dns_suffix}"
   ]
+
+  external_validation_records_created = var.acm_certificate.external_validation_records_created
 
   validation = {
     "modernisation-platform.service.justice.gov.uk" = {

--- a/terraform/environments/delius-mis/modules/mis_environment/outputs.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/outputs.tf
@@ -1,7 +1,17 @@
+output "acm_certificates_validation_records_external" {
+  description = "ACM validation records for external zones"
+  value       = length(module.acm_certificate) == 1 ? module.acm_certificate[0].validation_records_external : {}
+}
+
 # DataSync outputs
 output "datasync_task_arn" {
   description = "ARN of the DataSync task for S3 to FSX sync"
   value       = var.datasync_config != null ? aws_datasync_task.dfi_s3_to_fsx[0].arn : null
+}
+
+output "datasync_s3_role_arn" {
+  description = "ARN of the DataSync S3 role"
+  value       = var.datasync_config != null ? aws_iam_role.datasync_s3_role[0].arn : null
 }
 
 output "datasync_fsx_credentials_secret_arn" {

--- a/terraform/environments/delius-mis/modules/mis_environment/variables.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/variables.tf
@@ -19,6 +19,10 @@ variable "environment_config" {
   type = any
 }
 
+variable "acm_certificate" {
+  type = any
+}
+
 variable "bastion_config" {
   type = any
 }

--- a/terraform/environments/delius-mis/output.tf
+++ b/terraform/environments/delius-mis/output.tf
@@ -1,0 +1,4 @@
+output "acm_certificates_validation_records_external_prod" {
+  description = "ACM validation records for prod external zones"
+  value       = local.is-production ? module.environment_production[0].acm_certificates_validation_records_external : null
+}


### PR DESCRIPTION
Remove existing production ACM cert (it isn't used yet). It will be replaced with a production friendly domain, reporting.probation.service.justice.gov.uk in future PR.