### PR TITLE
Integration Hub cleanup

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
+++ b/terraform/environments/integration-hub-file-transfer/docs/event-lifecycle-identifiers.md
@@ -44,7 +44,7 @@ The ROUTE Lambda mover consumes that event and claims a separate `(correlationId
 - `THREATS_FOUND` routes to `quarantine`; and
 - `UNSUPPORTED`, `ACCESS_DENIED` or `FAILED` routes to `investigation`.
 
-`scanResultStatusMatchesTag` is retained as diagnostic provenance from the adapter, but it does not select or override the destination route.
+`scanResultStatusMatchesTag` is retained as diagnostic provenance from the adapter. A mismatch overrides the reported scan result and routes the object to `investigation`.
 
 ROUTE copies and verifies the exact processing version with destination SSE-KMS encryption before deleting that exact source version. It then publishes `FileRouted.v1` with an idempotency key of `route:{route}:{destinationBucket}:{key}:{destinationVersionId}`.
 

--- a/terraform/environments/integration-hub-file-transfer/iam-transfer.tf
+++ b/terraform/environments/integration-hub-file-transfer/iam-transfer.tf
@@ -118,6 +118,18 @@ module "iam_role_transfer_user" {
         type        = "Service"
         identifiers = ["transfer.amazonaws.com"]
       }]
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        },
+        {
+          test     = "ArnLike"
+          variable = "aws:SourceArn"
+          values   = ["arn:aws:transfer:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:server/*"]
+        },
+      ]
     }
   }
 
@@ -143,6 +155,18 @@ module "iam_role_transfer" {
         type        = "Service"
         identifiers = ["transfer.amazonaws.com"]
       }]
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        },
+        {
+          test     = "ArnLike"
+          variable = "aws:SourceArn"
+          values   = ["arn:aws:transfer:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:server/*"]
+        },
+      ]
     }
   }
 

--- a/terraform/environments/integration-hub-file-transfer/locals-s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-s3.tf
@@ -36,11 +36,11 @@ locals {
     production = {
       default = [
         {
-          id     = "expire-objects-after-7-days"
+          id     = "expire-objects-after-1-day"
           status = "Enabled"
           filter = {}
           expiration = {
-            days = 7
+            days = 1
           }
           abort_incomplete_multipart_upload_days = 1
           noncurrent_version_expiration = {
@@ -60,40 +60,6 @@ locals {
     production = {
       default = local.s3_bucket_lifecycle_defaults.production.default
       buckets = {
-        clean = [
-          {
-            id     = "expire-clean-after-7-days"
-            status = "Enabled"
-            filter = {
-              prefix = "clean/"
-            }
-            expiration = {
-              days = 7
-            }
-            noncurrent_version_expiration = {
-              days = 7
-            }
-          },
-          {
-            id     = "expire-example-after-3-days"
-            status = "Enabled"
-            filter = {
-              prefix = "example/"
-            }
-            expiration = {
-              days = 3
-            }
-            noncurrent_version_expiration = {
-              days = 3
-            }
-          },
-          {
-            id                                     = "abort-incomplete-multipart-uploads-after-1-day"
-            status                                 = "Enabled"
-            filter                                 = {}
-            abort_incomplete_multipart_upload_days = 1
-          },
-        ]
         quarantine = [
           {
             id     = "expire-objects-after-7-days"


### PR DESCRIPTION
* Drop the current lifecycle in the `clean` bucket to 1 day pending a better idea on how to occasionally hold interesting objects that warrant a longer expiration
* Add some account-level role assumption gates to the Transfer and Guard Duty roles; they're currently in-line with AWS docs but these don't hurt