### PR TITLE
🪟 Add Azure Monitor integration

### DIFF
--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -42,3 +42,8 @@ data "aws_secretsmanager_secret_version" "pagerduty_orchestrator_integration_key
   secret_id = "pagerduty/orchestrator-integration-key"
 }
 
+data "aws_secretsmanager_secret_version" "grafana_azure_monitor" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  secret_id = "${local.component_name}/grafana-azure-monitor"
+}

--- a/terraform/environments/data-platform/monitoring/helm-charts.tf
+++ b/terraform/environments/data-platform/monitoring/helm-charts.tf
@@ -10,6 +10,11 @@ resource "helm_release" "grafana" {
 
   values = [
     templatefile("${path.module}/src/helm/values/grafana/values.yml.tftpl", {
+
+      azure_monitor_workload_identity_client_id       = jsondecode(data.aws_secretsmanager_secret_version.grafana_azure_monitor[0].secret_string).client_id
+      azure_monitor_workload_identity_subscription_id = jsondecode(data.aws_secretsmanager_secret_version.grafana_azure_monitor[0].secret_string).subscription_id
+      azure_monitor_workload_identity_tenant_id       = jsondecode(data.aws_secretsmanager_secret_version.grafana_azure_monitor[0].secret_string).tenant_id
+
       hostname           = local.environment_configuration.monitoring_hostname
       entra_id_tenant_id = local.grafana_entra_id.tenant_id
       # Cloud Platform requires a unique external-dns set-identifier per ingress:

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -81,3 +81,19 @@ module "pagerduty_slack_connection_api_key_secret" {
     { "credential-expiration" = "none" }
   )
 }
+
+module "grafana_azure_monitor_secret" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=d03382d3ec9c12b849fbbe35b770eaa047f7bbea" # v2.1.0
+
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  name = "${local.component_name}/grafana-azure-monitor"
+
+  secret_string = jsonencode({
+    client_id       = "CHANGEME"
+    subscription_id = "CHANGEME"
+    tenant_id       = "CHANGEME"
+  })
+
+  ignore_secret_changes = true
+}

--- a/terraform/environments/data-platform/monitoring/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/environments/data-platform/monitoring/src/helm/values/grafana/values.yml.tftpl
@@ -53,6 +53,20 @@ persistence:
   # Grafana state is stored in external RDS Postgres, so no PV is required.
   enabled: false
 
+# Mount Azure Workload Identity Federation token for service authentication.
+# ref: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
+extraSecretMounts:
+  - name: azure-workload-identity-token
+    mountPath: /var/run/secrets/sts.windows.net
+    readOnly: true
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            path: azure-identity-token
+            audience: api://AzureADTokenExchange
+            expirationSeconds: 3600
+
 # RDS connection values come from the grafana-rds secret; sensitive values are
 # not stored in this file.
 envValueFrom:
@@ -99,6 +113,12 @@ grafana.ini:
     # Unmapped users default to Viewer; GrafanaAdmin can grant server admin.
     role_attribute_strict: false
     allow_assign_grafana_admin: true
+  # Azure Workload Identity Federation
+  azure:
+    workload_identity_enabled: true
+    workload_identity_tenant_id: ${azure_monitor_workload_identity_tenant_id}
+    workload_identity_client_id: ${azure_monitor_workload_identity_client_id}
+    workload_identity_token_file: /var/run/secrets/sts.windows.net/azure-identity-token
 
   # Plugins for X-Ray and Amazon Managed Prometheus (CloudWatch is built in).
 plugins:
@@ -113,6 +133,14 @@ datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
+      - name: azure-monitor-ai-foundry
+        type: grafana-azure-monitor-datasource
+        access: proxy
+        uid: azure-monitor-ai-foundry
+        isDefault: false
+        jsonData:
+          azureAuthType: workloadidentity
+          subscriptionId: ${azure_monitor_workload_identity_subscription_id}
 %{ for account in monitored_accounts ~}
       - name: ${account.name}-cloudwatch
         type: cloudwatch


### PR DESCRIPTION
This pull request introduces Azure Workload Identity Federation support to the Grafana deployment in the data platform monitoring stack. It adds a new secret for Azure Monitor credentials, configures the Helm chart to mount the necessary identity token, and updates Grafana's configuration to enable Azure Monitor as a data source using workload identity authentication.

Key changes include:

**Azure Workload Identity Federation Integration**

* Added a new secret (`grafana_azure_monitor_secret`) for storing Azure Monitor Workload Identity credentials (`client_id`, `subscription_id`, `tenant_id`) using the `terraform-aws-secrets-manager` module.
* Updated Terraform data sources to retrieve the Azure Monitor secret and expose its values to the Grafana Helm chart. [[1]](diffhunk://#diff-c9932d92c9ad1e269e6b3d67e361381f242e7613172d6a34467cea4f2ca9370dR45-R49) [[2]](diffhunk://#diff-881a998b1cfb7c16fc12d4e7002fca8685618fb05ea71b70fffb8cd86b4cf58aR13-R17)
* Modified the Grafana Helm values template to mount the Azure Workload Identity Federation token as a projected service account token in the container.

**Grafana Configuration Updates**

* Enabled Azure Workload Identity Federation in `grafana.ini`, referencing the secret values and the mounted token file for authentication.
* Added a new Azure Monitor data source (`azure-monitor-ai-foundry`) to Grafana, configured to use workload identity authentication.