### PR TITLE
Add Azure token and secret references

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/secrets.tf
+++ b/terraform/environments/data-platform/ai-gateway/secrets.tf
@@ -43,8 +43,12 @@ module "microsoft_foundry_jedi_gateway_secret" {
   name = "${local.component_name}/microsoft-foundry/jedi-gateway"
 
   secret_string = jsonencode({
+    # Legacy API key mechanism
     api_key  = "CHANGEME"
     endpoint = "CHANGEME"
+    # New OIDC mechanism
+    client_id = "CHANGEME"
+    tenant_id = "CHANGEME"
   })
   ignore_secret_changes = true
 }

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -121,6 +121,14 @@ volumes:
   - name: migrations
     emptyDir:
       sizeLimit: 64Mi
+  - name: azure-workload-identity-token
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            path: azure-identity-token
+            audience: api://AzureADTokenExchange
+            expirationSeconds: 3600
 
 volumeMounts:
   - name: ui
@@ -131,6 +139,9 @@ volumeMounts:
     mountPath: /app/cache
   - name: migrations
     mountPath: /app/migrations
+  - name: azure-workload-identity-token
+    mountPath: /var/run/secrets/sts.windows.net
+    readOnly: true
 
 extraInitContainers:
   - name: setup-ui

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -120,12 +120,23 @@ volumes:
   - name: migrations
     emptyDir:
       sizeLimit: 64Mi
+  - name: azure-workload-identity-token
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            path: azure-identity-token
+            audience: api://AzureADTokenExchange
+            expirationSeconds: 3600
 
 volumeMounts:
   - name: app-cache
     mountPath: /app/cache
   - name: migrations
     mountPath: /app/migrations
+  - name: azure-workload-identity-token
+    mountPath: /var/run/secrets/sts.windows.net
+    readOnly: true
 
 migrationJob:
   enabled: false


### PR DESCRIPTION
This pull request introduces support for Azure Workload Identity authentication in the AI Gateway deployment. It does so by updating both the secret management and the Helm chart values to provision and mount the necessary identity tokens into the relevant pods. The most important changes are grouped below:

**Azure Workload Identity Integration:**

* Added a projected volume named `azure-workload-identity-token` in both `litellm` and `litellm-admin` Helm chart values files, which provides a service account token for Azure AD token exchange. This enables pods to authenticate using Azure Workload Identity instead of legacy secrets. [[1]](diffhunk://#diff-641c6c0fec455ed16113420bf0aeadb5d5a0bea428683c08276ca3116d6b6884R123-R139) [[2]](diffhunk://#diff-d9448a589697cdaf56021f3bcb1bf40bff4d74e4e57c348a45dc4dfce1bcf2aaR124-R131)
* Mounted the `azure-workload-identity-token` volume into the containers at `/var/run/secrets/sts.windows.net` as read-only, making the identity token available to applications running in the pods. [[1]](diffhunk://#diff-641c6c0fec455ed16113420bf0aeadb5d5a0bea428683c08276ca3116d6b6884R123-R139) [[2]](diffhunk://#diff-d9448a589697cdaf56021f3bcb1bf40bff4d74e4e57c348a45dc4dfce1bcf2aaR142-R144)

**Secret Management Updates:**

* Updated the `microsoft_foundry_jedi_gateway_secret` Terraform resource to include new fields for OIDC-based authentication (`client_id` and `tenant_id`) alongside the legacy `api_key` and `endpoint`, supporting a transition to modern authentication methods.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>