### PR TITLE
bump envoy-gateway and gateway-api module

### DIFF
--- a/terraform/environments/cloud-platform/cluster-components/gateway-api.tf
+++ b/terraform/environments/cloud-platform/cluster-components/gateway-api.tf
@@ -1,6 +1,6 @@
 # Gateway resources (Gateway, GatewayClass, ListenerSet, etc)
 module "gateway_api" {
-  source = "github.com/ministryofjustice/container-platform-terraform-gateway-api?ref=33be8f18154b51efcbcc2493020ac74384f80462" #1.0.0
+  source = "github.com/ministryofjustice/container-platform-terraform-gateway-api?ref=085b885fb01575f92ffeee742f11e27116d027b3" #1.1.0
 
   lb_name_prefix      = local.workspace_slug
   cluster_base_domain = local.cluster_domain

--- a/terraform/environments/cloud-platform/cluster-core/envoy-gateway.tf
+++ b/terraform/environments/cloud-platform/cluster-core/envoy-gateway.tf
@@ -1,6 +1,6 @@
 # Base envoy installation, includes gateway api CRDs
 module "envoy_gateway" {
-  source = "github.com/ministryofjustice/container-platform-terraform-envoy-gateway?ref=d3bea0e86de00c0ca463084a0e7921fb776fa26e" #1.0.0
+  source = "github.com/ministryofjustice/container-platform-terraform-envoy-gateway?ref=54df47381507b0998f397d4d5a64d1245320c6a1" #1.1.0
 
   depends_on = [module.gatekeeper]
 }


### PR DESCRIPTION
Bumping two modules to the roll out latest Envoy Gateway helm chart and latest composer container (which has the Coraza WAF extension)

Changelog:
https://github.com/ministryofjustice/container-platform-terraform-envoy-gateway/releases/tag/1.1.0
https://github.com/ministryofjustice/container-platform-terraform-gateway-api/releases/tag/1.1.0

Related to https://github.com/ministryofjustice/cloud-platform/issues/8368

