### PR TITLE
Sherlock test writer role

### DIFF
--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -1,0 +1,19 @@
+module "sherlock_landing_bucket" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=d349d84388ff71e70a2bf7e3076b1d31795ecc23"
+
+  bucket_prefix = "landing-sherlock"
+  kms_key_arn   = module.sherlock_kms_key.key_arn
+  enable_malware_protection = true
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "sherlock-landing-bucket"
+  }
+}
+
+module "sherlock_kms_key" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git//?ref=496d8bd559afebb43b78af0034ec74d8b32378ca"
+
+  aliases = ["sherlock-landing"]
+}

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -137,11 +137,7 @@ module "assume_iam_role" {
     "glue:UpdateTable"
   ]
 
-  tags = {
-    Application = "data-factory-corporate"
-    Component   = "people"
-    Infrastructure = "assume-iam-role"
-  }
+
 
   }
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -16,7 +16,7 @@ data "aws_secretsmanager_secret" "external_account_id" {
   name = "external-aws-account"
 }
 
-data "aws_secretsmanager_secret_version" "external_ account_id" {
+data "aws_secretsmanager_secret_version" "external_account_id" {
   secret_id = data.aws_secretsmanager_secret.external_account_id.id
 }
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -82,7 +82,7 @@ resource "aws_secretsmanager_secret" "external_account" {
 }
 
 module "sherlock_glue_database" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=dccbc7b4e67e60e5c80e0ea163d1e98a0d386245"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=75a5fd1ccb6c1858508b98651030cc4c919b9d03"
   
   database_name = "sherlock_glue_database"
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -16,7 +16,7 @@ data "aws_secretsmanager_secret" "external_account_id" {
   name = "external-aws-account"
 }
 
-data "aws_secretsmanager_secret_version" "external_account_id" {
+data "aws_secretsmanager_secret_version" "external_ account_id" {
   secret_id = data.aws_secretsmanager_secret.external_account_id.id
 }
 
@@ -138,7 +138,6 @@ module "assume_iam_role" {
   ]
 
   tags = {
-    Environment = terraform.workspace
     Application = "data-factory-corporate"
     Component   = "people"
     Infrastructure = "assume-iam-role"

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -12,13 +12,13 @@ module "sherlock_landing_bucket" {
   }
 }
 
-# data "aws_secretsmanager_secret" "external_account_id" {
-#   name = "external-aws-account"
-# }
+data "aws_secretsmanager_secret" "external_account_id" {
+  name = "external-aws-account"
+}
 
-# data "aws_secretsmanager_secret_version" "external_account_id" {
-#   secret_id = data.aws_secretsmanager_secret.external_account_id.id
-# }
+data "aws_secretsmanager_secret_version" "external_account_id" {
+  secret_id = data.aws_secretsmanager_secret.external_account_id.id
+}
 
 locals {
   glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
@@ -89,60 +89,60 @@ module "sherlock_glue_database" {
   storage = {
     bucket_name = module.sherlock_landing_bucket_test.bucket.bucket
 
-    #currently the prefix is not optional, but should be.
+    #currently the prefix is not optional
     prefix      = "avature-sherlock"
     kms_key_arn = module.sherlock_kms_key.key_arn
   }
 
 }
 
-# module "assume_iam_role" {
-#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
+module "assume_iam_role" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
   
-#   role_name = "datafactory_dev_assume_role"
+  role_name = "datafactory_dev_assume_role"
 
-#   trusted_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
+  trusted_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
 
-#   bucket_arn = module.sherlock_landing_bucket_test.bucket.arn
+  bucket_arn = module.sherlock_landing_bucket_test.bucket.arn
 
-#   s3_prefix = "avature-sherlock"
+  s3_prefix = "avature-sherlock"
 
-#   s3_object_actions = [
-#     "s3:GetObject",
-#     "s3:PutObject",
-#     "s3:ListBucket"
-#   ]
+  s3_object_actions = [
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:ListBucket"
+  ]
 
-#   kms_key_arn = module.sherlock_kms_key.key_arn
+  kms_key_arn = module.sherlock_kms_key.key_arn
 
-#   kms_actions = [
-#     "kms:Decrypt",
-#     "kms:Encrypt",
-#     "kms:GenerateDataKey",
-#     "kms:DescribeKey",
-#     "kms:ReEncryptFrom",
-#     "kms:ReEncryptTo"
-#   ]
+  kms_actions = [
+    "kms:Decrypt",
+    "kms:Encrypt",
+    "kms:GenerateDataKey",
+    "kms:DescribeKey",
+    "kms:ReEncryptFrom",
+    "kms:ReEncryptTo"
+  ]
 
-#   glue_database_arn = module.sherlock_glue_database.glue_database_arn
-#   glue_catalog_arn = local.glue_catalog_arn
-#   glue_table_name = "*"
+  glue_database_arn = module.sherlock_glue_database.glue_database_arn
+  glue_catalog_arn = local.glue_catalog_arn
+  glue_table_name = "*"
 
-#   glue_actions =[
-#     "glue:GetDatabase",
-#     "glue:GetTable",
-#     "glue:SearchTables",
-#     "glue:DeleteTable",
-#     "glue:CreateTable",
-#     "glue:UpdateTable"
-#   ]
+  glue_actions =[
+    "glue:GetDatabase",
+    "glue:GetTable",
+    "glue:SearchTables",
+    "glue:DeleteTable",
+    "glue:CreateTable",
+    "glue:UpdateTable"
+  ]
 
-#   tags = {
-#     Environment = terraform.workspace
-#     Application = "data-factory-corporate"
-#     Component   = "people"
-#     Infrastructure = "assume-iam-role"
-#   }
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "assume-iam-role"
+  }
 
-#   }
+  }
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "sherlock_landing_bucket_test" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v11.1.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=66bd5c6aa0d0396442f0d4a63642029ff38d2a8a"
 
   bucket_prefix      = "landing-sherlock-test"
   bucket_namespace   = "account-regional"
@@ -60,6 +60,7 @@ module "sherlock_kms_key" {
 resource "aws_secretsmanager_secret" "external_account" {
   name        = "external-aws-account"
   description = "AWS account permitted to assume the external role"
+  kms_key_id = module.sherlock_kms_key.key_arn
 
   tags = {
     Environment = terraform.workspace

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -1,22 +1,22 @@
-# module "sherlock_landing_bucket" {
-#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=313b46a604dc6aaee1d7309990388c6687272b6e"
+module "sherlock_landing_bucket" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=313b46a604dc6aaee1d7309990388c6687272b6e"
 
-#   bucket_prefix = "landing-sherlock"
-#   kms_key_arn   = module.sherlock_kms_key.key_arn
-#   enable_malware_protection = true
-#   tags = {
-#     Environment = terraform.workspace
-#     Application = "data-factory-corporate"
-#     Component   = "people"
-#     Infrastructure = "sherlock-landing-bucket"
-#   }
-# }
+  bucket_prefix = "landing-sherlock"
+  kms_key_arn   = module.sherlock_kms_key.key_arn
+  enable_malware_protection = true
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "sherlock-landing-bucket"
+  }
+}
 
 locals {
   glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
 }
 
-module "sherlock_landing_bucket" {
+module "sherlock_landing_bucket_test" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v11.1.0"
 
   bucket_prefix      = "landing-sherlock-test"
@@ -47,7 +47,7 @@ module "sherlock_landing_bucket" {
     Environment = terraform.workspace
     Application = "data-factory-corporate"
     Component   = "people"
-    Infrastructure = "sherlock-landing-bucket"
+    Infrastructure = "sherlock-landing-bucket-test"
   }
 }
 
@@ -57,73 +57,85 @@ module "sherlock_kms_key" {
   aliases = ["sherlock-landing"]
 }
 
-module "sherlock_glue_database" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
-  
-  database_name = "sherlock_glue_database"
+resource "aws_secretsmanager_secret" "external_account" {
+  name        = "external-aws-account"
+  description = "AWS account permitted to assume the external role"
 
-  storage = {
-    bucket_name = module.sherlock_landing_bucket.bucket.bucket
-
-    #currently the prefix is not optional, but should be.
-    prefix      = "avature-sherlock"
-    kms_key_arn = module.sherlock_kms_key.key_arn
-  }
   tags = {
     Environment = terraform.workspace
     Application = "data-factory-corporate"
     Component   = "people"
-    Infrastructure = "sherlock-glue-database"
+    Infrastructure = "sherlock-secret-id"
   }
 }
 
-module "assume_iam_role" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
+# module "sherlock_glue_database" {
+#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
   
-  role_name = "datafactory_dev_assume_role"
+#   database_name = "sherlock_glue_database"
 
-  trusted_account_id = ""
+#   storage = {
+#     bucket_name = module.sherlock_landing_bucket_test.bucket.bucket
 
-  bucket_arn = module.sherlock_landing_bucket.bucket.arn
+#     #currently the prefix is not optional, but should be.
+#     prefix      = "avature-sherlock"
+#     kms_key_arn = module.sherlock_kms_key.key_arn
+#   }
+#   tags = {
+#     Environment = terraform.workspace
+#     Application = "data-factory-corporate"
+#     Component   = "people"
+#     Infrastructure = "sherlock-glue-database"
+#   }
+# }
 
-  s3_prefix = "avature-sherlock"
+# module "assume_iam_role" {
+#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
+  
+#   role_name = "datafactory_dev_assume_role"
 
-  s3_object_actions = [
-    "s3:GetObject",
-    "s3:PutObject",
-    "s3:ListBucket"
-  ]
+#   trusted_account_id = ""
 
-  kms_key_arn = module.sherlock_kms_key.key_arn
+#   bucket_arn = module.sherlock_landing_bucket_test.bucket.arn
 
-  kms_actions = [
-    "kms:Decrypt",
-    "kms:Encrypt",
-    "kms:GenerateDataKey",
-    "kms:DescribeKey",
-    "kms:ReEncryptFrom",
-    "kms:ReEncryptTo"
-  ]
+#   s3_prefix = "avature-sherlock"
 
-  glue_database_arn = module.sherlock_glue_database.glue_database_arn
-  glue_catalog_arn = local.glue_catalog_arn
-  glue_table_name = "*"
+#   s3_object_actions = [
+#     "s3:GetObject",
+#     "s3:PutObject",
+#     "s3:ListBucket"
+#   ]
 
-  glue_actions =[
-    "glue:GetDatabase",
-    "glue:GetTable",
-    "glue:SearchTables",
-    "glue:DeleteTable",
-    "glue:CreateTable",
-    "glue:UpdateTable"
-  ]
+#   kms_key_arn = module.sherlock_kms_key.key_arn
 
-  tags = {
-    Environment = terraform.workspace
-    Application = "data-factory-corporate"
-    Component   = "people"
-    Infrastructure = "assume-iam-role"
-  }
+#   kms_actions = [
+#     "kms:Decrypt",
+#     "kms:Encrypt",
+#     "kms:GenerateDataKey",
+#     "kms:DescribeKey",
+#     "kms:ReEncryptFrom",
+#     "kms:ReEncryptTo"
+#   ]
 
-  }
+#   glue_database_arn = module.sherlock_glue_database.glue_database_arn
+#   glue_catalog_arn = local.glue_catalog_arn
+#   glue_table_name = "*"
+
+#   glue_actions =[
+#     "glue:GetDatabase",
+#     "glue:GetTable",
+#     "glue:SearchTables",
+#     "glue:DeleteTable",
+#     "glue:CreateTable",
+#     "glue:UpdateTable"
+#   ]
+
+#   tags = {
+#     Environment = terraform.workspace
+#     Application = "data-factory-corporate"
+#     Component   = "people"
+#     Infrastructure = "assume-iam-role"
+#   }
+
+#   }
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -1,5 +1,5 @@
 module "sherlock_landing_bucket" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=d349d84388ff71e70a2bf7e3076b1d31795ecc23"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=313b46a604dc6aaee1d7309990388c6687272b6e"
 
   bucket_prefix = "landing-sherlock"
   kms_key_arn   = module.sherlock_kms_key.key_arn

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -97,7 +97,7 @@ module "sherlock_glue_database" {
 }
 
 module "assume_iam_role" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=5a63095dcff8fceeac1b28e7ec4e8c8753345ed7"
   
   role_name = "datafactory_dev_assume_role"
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -58,6 +58,7 @@ module "sherlock_kms_key" {
 }
 
 resource "aws_secretsmanager_secret" "external_account" {
+  #checkov:skip=CKV2_AWS_57: "Secret holds a static external AWS account ID — rotation not applicable"
   name        = "external-aws-account"
   description = "AWS account permitted to assume the external role"
   kms_key_id = module.sherlock_kms_key.key_arn

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -82,7 +82,7 @@ module "assume_iam_role" {
   
   role_name = "datafactory_dev_assume_role"
 
-  trusted_account_id = "446677926185"
+  trusted_account_id = ""
 
   bucket_arn = module.sherlock_landing_bucket.bucket.arn
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -93,12 +93,7 @@ module "sherlock_glue_database" {
     prefix      = "avature-sherlock"
     kms_key_arn = module.sherlock_kms_key.key_arn
   }
-  tags = {
-    Environment = terraform.workspace
-    Application = "data-factory-corporate"
-    Component   = "people"
-    Infrastructure = "sherlock-glue-database"
-  }
+
 }
 
 # module "assume_iam_role" {

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -12,8 +12,18 @@ module "sherlock_landing_bucket" {
   }
 }
 
+data "aws_secretsmanager_secret" "external_account_id" {
+  name = "external-aws-account"
+}
+
+data "aws_secretsmanager_secret_version" "external_account_id" {
+  secret_id = data.aws_secretsmanager_secret.external_account_id.id
+}
+
 locals {
-  glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+  glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
+
+  external_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
 }
 
 module "sherlock_landing_bucket_test" {
@@ -71,32 +81,32 @@ resource "aws_secretsmanager_secret" "external_account" {
   }
 }
 
-# module "sherlock_glue_database" {
-#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
+module "sherlock_glue_database" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
   
-#   database_name = "sherlock_glue_database"
+  database_name = "sherlock_glue_database"
 
-#   storage = {
-#     bucket_name = module.sherlock_landing_bucket_test.bucket.bucket
+  storage = {
+    bucket_name = module.sherlock_landing_bucket_test.bucket.bucket
 
-#     #currently the prefix is not optional, but should be.
-#     prefix      = "avature-sherlock"
-#     kms_key_arn = module.sherlock_kms_key.key_arn
-#   }
-#   tags = {
-#     Environment = terraform.workspace
-#     Application = "data-factory-corporate"
-#     Component   = "people"
-#     Infrastructure = "sherlock-glue-database"
-#   }
-# }
+    #currently the prefix is not optional, but should be.
+    prefix      = "avature-sherlock"
+    kms_key_arn = module.sherlock_kms_key.key_arn
+  }
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "sherlock-glue-database"
+  }
+}
 
 # module "assume_iam_role" {
 #   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
   
 #   role_name = "datafactory_dev_assume_role"
 
-#   trusted_account_id = ""
+#   trusted_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
 
 #   bucket_arn = module.sherlock_landing_bucket_test.bucket.arn
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -82,7 +82,7 @@ resource "aws_secretsmanager_secret" "external_account" {
 }
 
 module "sherlock_glue_database" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=dccbc7b4e67e60e5c80e0ea163d1e98a0d386245"
   
   database_name = "sherlock_glue_database"
 

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -1,9 +1,48 @@
-module "sherlock_landing_bucket" {
-  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=313b46a604dc6aaee1d7309990388c6687272b6e"
+# module "sherlock_landing_bucket" {
+#   source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/s3-bucket?ref=313b46a604dc6aaee1d7309990388c6687272b6e"
 
-  bucket_prefix = "landing-sherlock"
-  kms_key_arn   = module.sherlock_kms_key.key_arn
-  enable_malware_protection = true
+#   bucket_prefix = "landing-sherlock"
+#   kms_key_arn   = module.sherlock_kms_key.key_arn
+#   enable_malware_protection = true
+#   tags = {
+#     Environment = terraform.workspace
+#     Application = "data-factory-corporate"
+#     Component   = "people"
+#     Infrastructure = "sherlock-landing-bucket"
+#   }
+# }
+
+locals {
+  glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+}
+
+module "sherlock_landing_bucket" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v11.1.0"
+
+  bucket_prefix      = "landing-sherlock-test"
+  bucket_namespace   = "account-regional"
+  versioning_enabled = true
+
+  ownership_controls = "BucketOwnerEnforced"
+
+  replication_enabled = false
+  # Below variable and providers configuration is only relevant if 'replication_enabled' is set to true
+  # replication_region  = "eu-west-2"
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  # Default/recommended encryption mode
+  sse_algorithm  = "aws:kms"
+  custom_kms_key = module.sherlock_kms_key.key_arn
+
+  # Optional compatibility mode for uploaders that rely on bucket default
+  # SSE-KMS encryption and do not send explicit SSE-KMS request headers.
+  # enforce_kms_request_headers = false
+
+  # Optional compatibility mode for services that cannot use SSE-KMS
+  # sse_algorithm = "AES256"
+
   tags = {
     Environment = terraform.workspace
     Application = "data-factory-corporate"
@@ -17,3 +56,74 @@ module "sherlock_kms_key" {
 
   aliases = ["sherlock-landing"]
 }
+
+module "sherlock_glue_database" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/data-factory-glue-database?ref=glue_outputs"
+  
+  database_name = "sherlock_glue_database"
+
+  storage = {
+    bucket_name = module.sherlock_landing_bucket.bucket.bucket
+
+    #currently the prefix is not optional, but should be.
+    prefix      = "avature-sherlock"
+    kms_key_arn = module.sherlock_kms_key.key_arn
+  }
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "sherlock-glue-database"
+  }
+}
+
+module "assume_iam_role" {
+  source = "git::https://github.com/ministryofjustice/terraform-aws-moj-data-factory-modules.git//modules/external-i-am-role?ref=external-iam-dev"
+  
+  role_name = "datafactory_dev_assume_role"
+
+  trusted_account_id = "446677926185"
+
+  bucket_arn = module.sherlock_landing_bucket.bucket.arn
+
+  s3_prefix = "avature-sherlock"
+
+  s3_object_actions = [
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:ListBucket"
+  ]
+
+  kms_key_arn = module.sherlock_kms_key.key_arn
+
+  kms_actions = [
+    "kms:Decrypt",
+    "kms:Encrypt",
+    "kms:GenerateDataKey",
+    "kms:DescribeKey",
+    "kms:ReEncryptFrom",
+    "kms:ReEncryptTo"
+  ]
+
+  glue_database_arn = module.sherlock_glue_database.glue_database_arn
+  glue_catalog_arn = local.glue_catalog_arn
+  glue_table_name = "*"
+
+  glue_actions =[
+    "glue:GetDatabase",
+    "glue:GetTable",
+    "glue:SearchTables",
+    "glue:DeleteTable",
+    "glue:CreateTable",
+    "glue:UpdateTable"
+  ]
+
+  tags = {
+    Environment = terraform.workspace
+    Application = "data-factory-corporate"
+    Component   = "people"
+    Infrastructure = "assume-iam-role"
+  }
+
+  }
+

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -12,18 +12,18 @@ module "sherlock_landing_bucket" {
   }
 }
 
-data "aws_secretsmanager_secret" "external_account_id" {
-  name = "external-aws-account"
-}
+# data "aws_secretsmanager_secret" "external_account_id" {
+#   name = "external-aws-account"
+# }
 
-data "aws_secretsmanager_secret_version" "external_account_id" {
-  secret_id = data.aws_secretsmanager_secret.external_account_id.id
-}
+# data "aws_secretsmanager_secret_version" "external_account_id" {
+#   secret_id = data.aws_secretsmanager_secret.external_account_id.id
+# }
 
 locals {
   glue_catalog_arn = "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
 
-  external_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
+  #external_account_id = data.aws_secretsmanager_secret_version.external_account_id.secret_string
 }
 
 module "sherlock_landing_bucket_test" {

--- a/terraform/environments/data-factory-corporate/people/main.tf
+++ b/terraform/environments/data-factory-corporate/people/main.tf
@@ -137,7 +137,9 @@ module "assume_iam_role" {
     "glue:UpdateTable"
   ]
 
+  tags = {
 
+  }
 
   }
 

--- a/terraform/environments/data-factory-corporate/people/sherlock_test_writer.tf
+++ b/terraform/environments/data-factory-corporate/people/sherlock_test_writer.tf
@@ -1,0 +1,84 @@
+# -----------------------------------------------------------------------------
+# Sherlock test writer role (TEST WORKSPACE ONLY)
+# -----------------------------------------------------------------------------
+# Temporary, same-account IAM role used to validate the Sherlock S3/KMS write
+# path in the corp test account. This mirrors the Avature spec's same-account
+# resource-access model (rather than the throwaway cross-account dev->corp
+# assume-role config), so a successful KMS-encrypted write here validates the
+# policy shape that the production Avature role will use.
+#
+# Gated with `count = local.is-test ? 1 : 0` so it ONLY exists in the -test
+# workspace and can never be created in dev/preprod/prod. Delete this file once
+# testing is complete.
+#
+# NOTE ON PREFIX: the S3 object statement below is scoped to
+# `<bucket>/avature-sherlock/*` to match the `s3_prefix` used by the production
+# `assume_iam_role` module in main.tf. If that prefix changes (e.g. to the
+# spec's `data/*`), update BOTH together so the test remains meaningful.
+#
+# NOTE ON KMS: the identity-side kms:* permissions here are not sufficient on
+# their own. The `sherlock_kms_key` key policy must also allow this role (or
+# delegate to IAM via a default key policy), otherwise writes fail AccessDenied.
+
+data "aws_iam_policy_document" "sherlock_test_writer_trust" {
+  count = local.is-test ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    # Restrict to the collaborator/SSO principals in this account. Adjust the
+    # ArnLike value to the specific SSO permission set or role you will assume
+    # from when running the write test.
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/MemberInfrastructureAccess"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "sherlock_test_writer" {
+  count              = local.is-test ? 1 : 0
+  name               = "sherlock_test_writer"
+  assume_role_policy = data.aws_iam_policy_document.sherlock_test_writer_trust[0].json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy" "sherlock_test_writer_s3_kms" {
+  count = local.is-test ? 1 : 0
+  name  = "sherlock-test-writer-s3-kms"
+  role  = aws_iam_role.sherlock_test_writer[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = module.sherlock_landing_bucket_test.bucket.arn
+      },
+      {
+        Sid      = "ObjectReadWrite"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "${module.sherlock_landing_bucket_test.bucket.arn}/avature-sherlock/*"
+      },
+      {
+        Sid      = "KmsEncryptDecrypt"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:ReEncrypt*"]
+        Resource = module.sherlock_kms_key.key_arn
+      }
+    ]
+  })
+}


### PR DESCRIPTION
This pull request introduces new infrastructure for the Sherlock data pipeline in the `data-factory-corporate/people` environment. The main changes add secure S3 buckets, a KMS key, Glue database, IAM roles, and supporting resources for both production and test scenarios. It also includes a temporary, test-only IAM role to validate S3/KMS integration in the test workspace.

**Infrastructure provisioning:**

* Added `sherlock_landing_bucket` and `sherlock_landing_bucket_test` S3 buckets with KMS encryption and malware protection, using shared Terraform modules.
* Provisioned a dedicated KMS key (`sherlock_kms_key`) for bucket encryption and access control.
* Created a Glue database (`sherlock_glue_database`) for cataloging data in the Sherlock landing bucket.

**IAM and access control:**

* Added the `assume_iam_role` module to create an external IAM role for cross-account access, with permissions scoped to S3, KMS, and Glue resources.
* Created a temporary, test-only IAM role (`sherlock_test_writer`) and policy to allow same-account users to validate S3/KMS write access in the test workspace, ensuring the production policy shape is correct. This role is only provisioned in the `-test` workspace and should be removed after testing.

**Secrets management:**

* Added an `aws_secretsmanager_secret` resource to securely store the external AWS account ID permitted to assume the cross-account role.