### PR TITLE
Bump OIDC module and rework secret management

### DIFF
--- a/terraform/environments/data-platform/iam-oidc-providers.tf
+++ b/terraform/environments/data-platform/iam-oidc-providers.tf
@@ -1,5 +1,5 @@
 module "cloud_platform_live_iam_oidc_provider" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-oidc-provider?ref=5b962b1163790398605f2b17447cf5b6cc512237" # v6.6.1
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-oidc-provider?ref=d6e381ccfa95b944149c8b14ba4087e517c57ac7" # v6.8.0
 
   url = jsondecode(data.aws_secretsmanager_secret_version.cloud_platform_live.secret_string)["oidc_provider"]
 
@@ -12,7 +12,7 @@ module "cloud_platform_live_iam_oidc_provider" {
 }
 
 module "justiceuk_entra_iam_oidc_provider" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-oidc-provider?ref=5b962b1163790398605f2b17447cf5b6cc512237" # v6.6.1
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-oidc-provider?ref=d6e381ccfa95b944149c8b14ba4087e517c57ac7" # v6.8.0
 
   url = "https://sts.windows.net/${jsondecode(data.aws_secretsmanager_secret_version.justiceuk_entra.secret_string)["tenant_id"]}/"
   client_id_list = distinct(concat(

--- a/terraform/environments/data-platform/sagemaker/iam-roles.tf
+++ b/terraform/environments/data-platform/sagemaker/iam-roles.tf
@@ -88,12 +88,12 @@ module "justice_transcribe_backend_iam_role" {
         {
           test     = "StringEquals"
           variable = "sts.windows.net/${jsondecode(data.aws_secretsmanager_secret_version.justiceuk_entra_secret[0].secret_string)["tenant_id"]}/:aud"
-          values   = [jsondecode(data.aws_secretsmanager_secret_version.justice_transcribe_backend_secret[0].secret_string)["audience"]]
+          values   = [for client in values(tomap(jsondecode(data.aws_secretsmanager_secret_version.justice_transcribe_backend_secret[0].secret_string)["client_map"])) : client["audience"]]
         },
         {
           test     = "StringEquals"
           variable = "sts.windows.net/${jsondecode(data.aws_secretsmanager_secret_version.justiceuk_entra_secret[0].secret_string)["tenant_id"]}/:sub"
-          values   = [jsondecode(data.aws_secretsmanager_secret_version.justice_transcribe_backend_secret[0].secret_string)["subject"]]
+          values   = compact([for client in values(tomap(jsondecode(data.aws_secretsmanager_secret_version.justice_transcribe_backend_secret[0].secret_string)["client_map"])) : try(client["subject"], null)])
         }
       ]
     }

--- a/terraform/environments/data-platform/sagemaker/secrets.tf
+++ b/terraform/environments/data-platform/sagemaker/secrets.tf
@@ -21,8 +21,20 @@ module "justice_transcribe_backend_secret" {
   name = "${local.component_name}/justice-transcribe-backend"
 
   secret_string = jsonencode({
-    audience = "CHANGEME"
-    subject  = "CHANGEME"
+    client_map = {
+      client_1 = {
+        audience = "api://8d3d0f97-25a3-402b-ae46-606dbbc5e3f4"
+        subject  = "9aec1350-e7bc-4f16-98fe-f3ac411bbff4"
+      }
+      client_2 = {
+        audience = "api://22e1db50-b952-4c8d-9d29-c52c5ac89ba4"
+        subject  = "0f166e21-97df-4cbe-8d53-6d9a3aaf30fe"
+      }
+      client_3 = {
+        audience = "api://9467c0f9-8b85-4d03-b13b-5be5b0a7ad77"
+        subject  = "1d77e7c4-d80d-4c28-8380-d7a3d086e478"
+      }
+    }
   })
   ignore_secret_changes = true
 }

--- a/terraform/environments/data-platform/sagemaker/secrets.tf
+++ b/terraform/environments/data-platform/sagemaker/secrets.tf
@@ -21,20 +21,7 @@ module "justice_transcribe_backend_secret" {
   name = "${local.component_name}/justice-transcribe-backend"
 
   secret_string = jsonencode({
-    client_map = {
-      client_1 = {
-        audience = "api://8d3d0f97-25a3-402b-ae46-606dbbc5e3f4"
-        subject  = "9aec1350-e7bc-4f16-98fe-f3ac411bbff4"
-      }
-      client_2 = {
-        audience = "api://22e1db50-b952-4c8d-9d29-c52c5ac89ba4"
-        subject  = "0f166e21-97df-4cbe-8d53-6d9a3aaf30fe"
-      }
-      client_3 = {
-        audience = "api://9467c0f9-8b85-4d03-b13b-5be5b0a7ad77"
-        subject  = "1d77e7c4-d80d-4c28-8380-d7a3d086e478"
-      }
-    }
+    client_map = {}
   })
   ignore_secret_changes = true
 }


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/data-platform/issues/98

This pull request updates the configuration for OIDC providers and IAM roles in the data platform environment, primarily focusing on supporting multiple clients for the Justice Transcribe backend and updating Terraform module versions. The most significant changes are grouped below:

**OIDC Provider Module Updates:**

* Updated the `terraform-aws-iam` module source and version for both `cloud_platform_live_iam_oidc_provider` and `justiceuk_entra_iam_oidc_provider` modules from v6.6.1 to v6.8.0, ensuring the latest features and fixes are included. [[1]](diffhunk://#diff-5332ebecebe7db2b9c559e1690e5531b1857f2fa69eeeea290da875483908854L2-R2) [[2]](diffhunk://#diff-5332ebecebe7db2b9c559e1690e5531b1857f2fa69eeeea290da875483908854L15-R15)

**Justice Transcribe Backend IAM Role and Secret Refactor:**

* Changed the `justice_transcribe_backend_secret` structure to use a `client_map` object instead of individual `audience` and `subject` fields, allowing for multiple clients to be supported.
* Updated the `justice_transcribe_backend_iam_role` policy to extract `audience` and `subject` values from the `client_map`, supporting multiple client entries and handling missing subjects gracefully.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>