### PR TITLE
Fix default value for budgets

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-teams.tf
@@ -3,7 +3,7 @@ resource "litellm_team" "teams" {
 
   team_alias      = try(each.value.alias, each.key)
   organization_id = litellm_organization.organisations[each.value.organisation].id
-  budget_duration = try(each.value.budget_duration, 30)
+  budget_duration = try(each.value.budget_duration, "monthly")
   max_budget      = try(each.value.max_budget, 500)
   models          = try(each.value.models, null)
   model_aliases = try(


### PR DESCRIPTION
This pull request makes a small change to the default value for the `budget_duration` property in the `litellm_team` resource. The default was changed from `30` to `"monthly"` to likely improve clarity or compatibility.

- Changed the default value of `budget_duration` in the `litellm_team` resource from `30` to `"monthly"` in `ai-gateway-teams.tf`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>