### PR TITLE
bumping gateway module to enable OWASP CRS on Gateway by default

### DIFF
--- a/terraform/environments/cloud-platform/cluster-components/gateway-api.tf
+++ b/terraform/environments/cloud-platform/cluster-components/gateway-api.tf
@@ -1,10 +1,12 @@
 # Gateway resources (Gateway, GatewayClass, ListenerSet, etc)
 module "gateway_api" {
-  source = "github.com/ministryofjustice/container-platform-terraform-gateway-api?ref=085b885fb01575f92ffeee742f11e27116d027b3" #1.1.0
+  source = "github.com/ministryofjustice/container-platform-terraform-gateway-api?ref=843e089f33b6e7b922cd3ad434ea52e0d20ff721" #1.2.0
 
   lb_name_prefix      = local.workspace_slug
   cluster_base_domain = local.cluster_domain
 
   gateway_name         = "default"
   envoy_proxy_replicas = 3
+
+  enable_owasp = true
 }


### PR DESCRIPTION
[Changelog](https://github.com/ministryofjustice/container-platform-terraform-gateway-api/releases/tag/1.2.0)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/8368