### PR TITLE
upgrading apc-dev and test cluster 1.36 and addons

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -15,7 +15,7 @@ locals {
         aws_network_flow_monitoring_agent = "v1.1.6-eksbuild.1"
         eks_node_monitoring_agent         = "v1.7.0-eksbuild.1"
         coredns                           = "v1.14.3-eksbuild.3"
-        eks_pod_identity_agent            = "v1.3.10-eksbuild.3"
+        eks_pod_identity_agent            = "v1.4.0-eksbuild.1"
         aws_guardduty_agent               = "v1.16.0-eksbuild.2"
         aws_ebs_csi_driver                = "v1.63.1-eksbuild.1"
         vpc_cni                           = "v1.22.4-eksbuild.3"

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -8,7 +8,7 @@ locals {
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
       eks_cluster_version = "1.36"
-      eks_node_version    = "1.57.0-beaadc52"
+      eks_node_version    = "1.64.0-ad9d4847"
       eks_cluster_addon_versions = {
         kube_proxy                        = "v1.36.0-eksbuild.14"
         aws_efs_csi_driver                = "v3.4.1-eksbuild.1"

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -18,7 +18,7 @@ locals {
         eks_pod_identity_agent            = "v1.4.0-eksbuild.1"
         aws_guardduty_agent               = "v1.16.0-eksbuild.2"
         aws_ebs_csi_driver                = "v1.63.1-eksbuild.1"
-        vpc_cni                           = "v1.22.4-eksbuild.3"
+        vpc_cni                           = "v1.23.0-eksbuild.1"
       }
 
       helm_chart_version = {
@@ -53,18 +53,18 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-developer"
-      eks_cluster_version = "1.35"
-      eks_node_version    = "1.57.0-beaadc52"
+      eks_cluster_version = "1.36"
+      eks_node_version    = "1.64.0-ad9d4847"
       eks_cluster_addon_versions = {
-        kube_proxy                        = "v1.35.2-eksbuild.4"
+        kube_proxy                        = "v1.36.0-eksbuild.14"
         aws_efs_csi_driver                = "v3.4.1-eksbuild.1"
-        aws_network_flow_monitoring_agent = "v1.1.3-eksbuild.2"
-        eks_node_monitoring_agent         = "v1.6.2-eksbuild.1"
-        coredns                           = "v1.13.2-eksbuild.4"
-        eks_pod_identity_agent            = "v1.3.10-eksbuild.2"
+        aws_network_flow_monitoring_agent = "v1.1.6-eksbuild.1"
+        eks_node_monitoring_agent         = "v1.7.0-eksbuild.1"
+        coredns                           = "v1.14.3-eksbuild.3"
+        eks_pod_identity_agent            = "v1.4.0-eksbuild.1"
         aws_guardduty_agent               = "v1.16.0-eksbuild.2"
-        aws_ebs_csi_driver                = "v1.57.1-eksbuild.1"
-        vpc_cni                           = "v1.21.1-eksbuild.5"
+        aws_ebs_csi_driver                = "v1.63.1-eksbuild.1"
+        vpc_cni                           = "v1.23.0-eksbuild.1"
       }
 
       helm_chart_version = {

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -24,23 +24,23 @@ locals {
       helm_chart_version = {
         aws_cloudwatch_metrics = "0.0.11"
         aws_for_fluent_bit     = "0.2.0"
-        cert_manager           = "v1.19.2"
-        cluster_autoscaler     = "9.56.0"
-        external_dns           = "1.20.0"
-        external_secrets       = "2.2.0"
+        cert_manager           = "v1.20.2"
+        cluster_autoscaler     = "9.59.0"
+        external_dns           = "1.21.1"
+        external_secrets       = "2.7.0"
         ingress_nginx          = "4.15.0"
-        karpenter              = "1.10.0"
-        keda                   = "2.18.3"
-        kube_prometheus_stack  = "82.16.0"
-        kyverno                = "3.6.2"
-        velero                 = "12.0.0"
+        karpenter              = "1.14.0"
+        keda                   = "2.20.2"
+        kube_prometheus_stack  = "88.3.0"
+        kyverno                = "3.8.1"
+        velero                 = "12.1.0"
       }
 
       /* Velero */
       velero_aws_plugin_version = "v1.14.0"
 
       /* Kube Prometheus Stack */
-      prometheus_operator_crd_version = "v0.89.0"
+      prometheus_operator_crd_version = "v0.93.0"
 
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-dev-execution-role"

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -70,23 +70,23 @@ locals {
       helm_chart_version = {
         aws_cloudwatch_metrics = "0.0.11"
         aws_for_fluent_bit     = "0.2.0"
-        cert_manager           = "v1.19.2"
-        cluster_autoscaler     = "9.56.0"
-        external_dns           = "1.20.0"
-        external_secrets       = "2.2.0"
+        cert_manager           = "v1.20.2"
+        cluster_autoscaler     = "9.59.0"
+        external_dns           = "1.21.1"
+        external_secrets       = "2.7.0"
         ingress_nginx          = "4.15.0"
-        karpenter              = "1.10.0"
-        keda                   = "2.18.3"
-        kube_prometheus_stack  = "82.16.0"
-        kyverno                = "3.6.2"
-        velero                 = "12.0.0"
+        karpenter              = "1.14.0"
+        keda                   = "2.20.2"
+        kube_prometheus_stack  = "88.3.0"
+        kyverno                = "3.8.1"
+        velero                 = "12.1.0"
       }
 
       /* Velero */
       velero_aws_plugin_version = "v1.14.0"
 
       /* Kube Prometheus Stack */
-      prometheus_operator_crd_version = "v0.89.0"
+      prometheus_operator_crd_version = "v0.93.0"
 
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-dev-execution-role"

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -7,18 +7,18 @@ locals {
 
       /* EKS */
       eks_sso_access_role = "modernisation-platform-sandbox"
-      eks_cluster_version = "1.35"
+      eks_cluster_version = "1.36"
       eks_node_version    = "1.57.0-beaadc52"
       eks_cluster_addon_versions = {
-        kube_proxy                        = "v1.35.2-eksbuild.4"
+        kube_proxy                        = "v1.36.0-eksbuild.14"
         aws_efs_csi_driver                = "v3.4.1-eksbuild.1"
-        aws_network_flow_monitoring_agent = "v1.1.3-eksbuild.2"
-        eks_node_monitoring_agent         = "v1.6.2-eksbuild.1"
-        coredns                           = "v1.13.2-eksbuild.4"
-        eks_pod_identity_agent            = "v1.3.10-eksbuild.2"
+        aws_network_flow_monitoring_agent = "v1.1.6-eksbuild.1"
+        eks_node_monitoring_agent         = "v1.7.0-eksbuild.1"
+        coredns                           = "v1.14.3-eksbuild.3"
+        eks_pod_identity_agent            = "v1.3.10-eksbuild.3"
         aws_guardduty_agent               = "v1.16.0-eksbuild.2"
-        aws_ebs_csi_driver                = "v1.57.1-eksbuild.1"
-        vpc_cni                           = "v1.21.1-eksbuild.5"
+        aws_ebs_csi_driver                = "v1.63.1-eksbuild.1"
+        vpc_cni                           = "v1.22.4-eksbuild.3"
       }
 
       helm_chart_version = {

--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -57,12 +57,12 @@ locals {
       eks_node_version    = "1.57.0-beaadc52"
       eks_cluster_addon_versions = {
         kube_proxy                        = "v1.35.2-eksbuild.4"
-        aws_efs_csi_driver                = "v2.3.1-eksbuild.1"
+        aws_efs_csi_driver                = "v3.4.1-eksbuild.1"
         aws_network_flow_monitoring_agent = "v1.1.3-eksbuild.2"
         eks_node_monitoring_agent         = "v1.6.2-eksbuild.1"
         coredns                           = "v1.13.2-eksbuild.4"
         eks_pod_identity_agent            = "v1.3.10-eksbuild.2"
-        aws_guardduty_agent               = "v1.12.1-eksbuild.2"
+        aws_guardduty_agent               = "v1.16.0-eksbuild.2"
         aws_ebs_csi_driver                = "v1.57.1-eksbuild.1"
         vpc_cni                           = "v1.21.1-eksbuild.5"
       }


### PR DESCRIPTION
PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/627) ticket.

#### Upgrading `apc-dev` and `apc-test` cluster to 1.36 and addons

#### EKS Cluster
- `eks_cluster_version` from `1.35` to `1.36`
- `eks_node_version` from `1.57.0-beaadc52` to `1.64.0-ad9d4847`

#### EKS Addons
- `kube_proxy` from `v1.35.2-eksbuild.4` to `v1.36.0-eksbuild.14`
- `aws_efs_csi_driver` from `v2.3.1-eksbuild.1` to `v3.4.1-eksbuild.1`
- `aws_network_flow_monitoring_agent` from `v1.1.3-eksbuild.2` to `v1.1.6-eksbuild.1`
- `eks_node_monitoring_agent` from `v1.6.2-eksbuild.1` to `v1.7.0-eksbuild.1`
- `coredns` from `v1.13.2-eksbuild.4` to `v1.14.3-eksbuild.3`
- `eks_pod_identity_agent` from `v1.3.10-eksbuild.2` to `v1.4.0-eksbuild.1`
- `aws_guardduty_agent` from `v1.12.1-eksbuild.2` to `v1.16.0-eksbuild.2`
- `aws_ebs_csi_driver` from `v1.57.1-eksbuild.1` to `v1.63.1-eksbuild.1`
- `vpc_cni` from `v1.21.1-eksbuild.5` to `v1.23.0-eksbuild.1`

#### Helm Charts
- `cert_manager` from `v1.19.2` to `v1.20.2`
- `cluster_autoscaler` from `9.56.0` to `9.59.0`
- `external_dns` from `1.20.0` to `1.21.1`
- `external_secrets` from `2.2.0` to `2.7.0`
- `karpenter` from `1.10.0` to `1.14.0`
- `keda` from `2.18.3` to `2.20.2`
- `kube_prometheus_stack` from `82.16.0` to `88.3.0`
- `kyverno` from `3.6.2` to `3.8.1`
- `velero` from `12.0.0` to `12.1.0`

#### Kube Prometheus Stack
- `prometheus_operator_crd_version` from `v0.89.0` to `v0.93.0`
