### PR TITLE
DHS-671: Create secrets for dps-visits and dps-body-scans

### DIFF
--- a/terraform/environments/digital-prison-reporting/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/application_variables.json
@@ -97,8 +97,9 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences",
-        "dps-offences"
+        "dps-offences",
+        "dps-visits",
+        "dps-body-scans"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -332,8 +333,9 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences",
-        "dps-offences"
+        "dps-offences",
+        "dps-visits",
+        "dps-body-scans"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -550,8 +552,9 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences",
-        "dps-offences"
+        "dps-offences",
+        "dps-visits",
+        "dps-body-scans"
       ],
       "alarms": {
         "setup_cw_alarms": true,
@@ -781,8 +784,9 @@
         "dps-cvl",
         "dps-adjudications",
         "dps-acc-pro-custody",
-        "dps-manage-offences",
-        "dps-offences"
+        "dps-offences",
+        "dps-visits",
+        "dps-body-scans"
       ],
       "alarms": {
         "setup_cw_alarms": true,


### PR DESCRIPTION
This PR
- Removes secret `dps-manage-offences` which has been replaced by the shorter `dps-offences`
- Adds `dps-visits` and `dps-body-scans`