### PR TITLE
:octocat: Add resources for DevX's GitHub Management Terraform

### DIFF
--- a/terraform/environments/developer-experience/github-management/iam-roles.tf
+++ b/terraform/environments/developer-experience/github-management/iam-roles.tf
@@ -1,0 +1,48 @@
+module "iam_role" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role?ref=d6e381ccfa95b944149c8b14ba4087e517c57ac7" # v6.8.0
+
+  name            = local.component_name
+  use_name_prefix = false
+
+  enable_github_oidc = true
+
+  oidc_wildcard_subjects = ["ministryofjustice@2203574/developer-experience-github-management@1333267581:*"]
+
+  create_inline_policy = true
+  inline_policy_permissions = {
+    KMSAccess = {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = [module.kms_key[0].key_arn]
+    }
+    S3BucketAccess = {
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketVersions"
+      ]
+      resources = [module.s3_bucket[0].s3_bucket_arn]
+    }
+    S3ObjectAccess = {
+      effect = "Allow"
+      actions = [
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:PutObject"
+      ]
+      resources = ["${module.s3_bucket[0].s3_bucket_arn}/*"]
+    }
+    SecretsManagerReadAccess = {
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [module.github_app_secret[0].secret_arn]
+    }
+  }
+}

--- a/terraform/environments/developer-experience/github-management/kms-keys.tf
+++ b/terraform/environments/developer-experience/github-management/kms-keys.tf
@@ -1,0 +1,7 @@
+module "kms_key" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=af1d45558a6073c017a732d2273efcc733b34d0f" # v4.2.1
+
+  aliases = [local.component_name]
+}

--- a/terraform/environments/developer-experience/github-management/locals.tf
+++ b/terraform/environments/developer-experience/github-management/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  bucket_name = "mojdevx-${local.environment}-${local.component_name}"
+}

--- a/terraform/environments/developer-experience/github-management/s3-buckets.tf
+++ b/terraform/environments/developer-experience/github-management/s3-buckets.tf
@@ -1,0 +1,60 @@
+data "aws_iam_policy_document" "s3_bucket" {
+  count = local.is-production ? 1 : 0
+
+  statement {
+    sid    = "AllowBucketActions"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucketVersions"
+    ]
+    resources = ["arn:aws:s3:::${local.bucket_name}"]
+    principals {
+      type        = "AWS"
+      identifiers = [module.iam_role[0].arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowObjectActions"
+    effect = "Allow"
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [module.iam_role[0].arn]
+    }
+  }
+}
+
+module "s3_bucket" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=dd0c434de5e74d8864e249ee020d917b076b6e32" # v5.14.4
+
+  bucket = local.bucket_name
+
+  attach_policy                         = true
+  policy                                = data.aws_iam_policy_document.s3_bucket[0].json
+  attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = true
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.kms_key[0].key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  versioning = {
+    status = "Enabled"
+  }
+}

--- a/terraform/environments/developer-experience/github-management/secrets-manager.tf
+++ b/terraform/environments/developer-experience/github-management/secrets-manager.tf
@@ -1,0 +1,23 @@
+module "github_app_secret" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=d03382d3ec9c12b849fbbe35b770eaa047f7bbea" # v2.1.0
+
+  name = "${local.component_name}/github-app"
+
+  kms_key_id = module.kms_key[0].kms_key_arn
+
+  secret_string = jsonencode({
+    app_id          = "CHANGEME"
+    client_id       = "CHANGEME"
+    installation_id = "CHANGEME"
+    private_key     = "CHANGEME"
+  })
+
+  ignore_secret_changes = true
+
+  tags = merge(
+    local.tags,
+    { "credential-expiration" = "none" }
+  )
+}

--- a/terraform/environments/developer-experience/github-management/secrets-manager.tf
+++ b/terraform/environments/developer-experience/github-management/secrets-manager.tf
@@ -5,7 +5,7 @@ module "github_app_secret" {
 
   name = "${local.component_name}/github-app"
 
-  kms_key_id = module.kms_key[0].kms_key_arn
+  kms_key_id = module.kms_key[0].key_arn
 
   secret_string = jsonencode({
     app_id          = "CHANGEME"


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/70

## Proposed Changes

- Adds KMS key, S3 bucket, IAM role and Secrets Manager secret for GitHub Management backend

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>