### PR TITLE
updated addon to support 1.36 upgrade

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -103,12 +103,12 @@ locals {
       eks_node_version    = "1.57.0-beaadc52"
       eks_cluster_addon_versions = {
         kube_proxy                        = "v1.35.2-eksbuild.4"
-        aws_efs_csi_driver                = "v2.3.1-eksbuild.1"
+        aws_efs_csi_driver                = "v3.4.1-eksbuild.1"
         aws_network_flow_monitoring_agent = "v1.1.3-eksbuild.2"
         eks_node_monitoring_agent         = "v1.6.2-eksbuild.1"
         coredns                           = "v1.13.2-eksbuild.4"
         eks_pod_identity_agent            = "v1.3.10-eksbuild.2"
-        aws_guardduty_agent               = "v1.12.1-eksbuild.2"
+        aws_guardduty_agent               = "v1.16.0-eksbuild.2"
         aws_ebs_csi_driver                = "v1.57.1-eksbuild.1"
         vpc_cni                           = "v1.21.1-eksbuild.5"
       }


### PR DESCRIPTION
PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/627) ticket.

`aws_efs_csi_driver` from `v2.3.1-eksbuild.1` to `v3.4.1-eksbuild.1`
`aws_guardduty_agent` from `v1.12.1-eksbuild.2` to `v1.16.0-eksbuild.2`