### PR TITLE
Route landing redrive through alarm threader

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -1825,6 +1825,16 @@ data "aws_iam_policy_document" "cloudwatch_alarm_threader_policy_document" {
   }
 
   statement {
+    sid    = "AllowStartLandingDlqRedriverWorkflow"
+    effect = "Allow"
+    actions = [
+      "states:StartExecution",
+    ]
+    resources = [
+      aws_sfn_state_machine.landing_dlq_redriver.arn,
+    ]
+  }
+  statement {
     sid    = "AllowSendIncidentEvents"
     effect = "Allow"
     actions = [

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -678,11 +678,19 @@ module "cloudwatch_alarm_threader" {
     INCLUDE_REASON        = "true"
     ENABLE_CUSTOM_ACTIONS = "false"
     INCIDENT_QUEUE_URL    = aws_sqs_queue.live_feed_incident_events.id
+
     GLUE_DB_JANITOR_STATE_MACHINE_ARN = (
       aws_sfn_state_machine.staging_db_janitor.arn
     )
     GLUE_DB_JANITOR_STALE_MINUTES = "60"
     GLUE_DB_JANITOR_BATCH_SIZE    = "2000"
+
+    LANDING_DLQ_REDRIVER_STATE_MACHINE_ARN = (
+      aws_sfn_state_machine.landing_dlq_redriver.arn
+    )
+    LANDING_DLQ_ALARM_NAMES = jsonencode(
+      keys(local.landing_dlq_redriver_config)
+    )
   }
 }
 

--- a/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_iam.tf
@@ -281,43 +281,6 @@ resource "aws_iam_role_policy" "landing_dlq_redriver_state_machine_invoke" {
   })
 }
 
-data "aws_iam_policy_document" "landing_dlq_redriver_eventbridge_assume" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "landing_dlq_redriver_eventbridge" {
-  name               = "landing_dlq_redriver_eventbridge_role"
-  assume_role_policy = data.aws_iam_policy_document.landing_dlq_redriver_eventbridge_assume.json
-}
-
-resource "aws_iam_role_policy" "landing_dlq_redriver_eventbridge_start" {
-  name = "landing_dlq_redriver_eventbridge_start_policy"
-  role = aws_iam_role.landing_dlq_redriver_eventbridge.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowStartLandingDlqRedriverWorkflow"
-        Effect = "Allow"
-        Action = [
-          "states:StartExecution",
-        ]
-        Resource = [
-          aws_sfn_state_machine.landing_dlq_redriver.arn,
-        ]
-      }
-    ]
-  })
-}
 
 # ------------------------------------------------------------------------------
 # cadt trigger policy

--- a/terraform/environments/electronic-monitoring-data/step_functions_main.tf
+++ b/terraform/environments/electronic-monitoring-data/step_functions_main.tf
@@ -391,13 +391,6 @@ resource "aws_sfn_state_machine" "landing_dlq_redriver" {
   })
 }
 
-resource "aws_cloudwatch_event_target" "landing_dlq_redriver" {
-  rule     = aws_cloudwatch_event_rule.alarm_state_change_threader.name
-  arn      = aws_sfn_state_machine.landing_dlq_redriver.arn
-  role_arn = aws_iam_role.landing_dlq_redriver_eventbridge.arn
-}
-
-
 # ------------------------------------------
 # Trigger cadt Step funtion
 # ------------------------------------------


### PR DESCRIPTION
Bug Fix: Routes landing DLQ redrive through cloudwatch_alarm_threader so the existing incident thread ID is passed directly to the workflow. See here for more context https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/969