### PR TITLE
upgrading the apc-prod helm charts

### DIFF
--- a/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/cluster/environment-configuration.tf
@@ -116,23 +116,23 @@ locals {
       helm_chart_version = {
         aws_cloudwatch_metrics = "0.0.11"
         aws_for_fluent_bit     = "0.2.0"
-        cert_manager           = "v1.19.2"
-        cluster_autoscaler     = "9.56.0"
-        external_dns           = "1.20.0"
-        external_secrets       = "2.2.0"
+        cert_manager           = "v1.20.2"
+        cluster_autoscaler     = "9.59.0"
+        external_dns           = "1.21.1"
+        external_secrets       = "2.7.0"
         ingress_nginx          = "4.15.0"
-        karpenter              = "1.10.0"
-        keda                   = "2.18.3"
-        kube_prometheus_stack  = "82.16.0"
-        kyverno                = "3.6.2"
-        velero                 = "12.0.0"
+        karpenter              = "1.14.0"
+        keda                   = "2.20.2"
+        kube_prometheus_stack  = "88.3.0"
+        kyverno                = "3.8.1"
+        velero                 = "12.1.0"
       }
 
       /* Velero */
       velero_aws_plugin_version = "v1.14.0"
 
       /* Kube Prometheus Stack */
-      prometheus_operator_crd_version = "v0.89.0"
+      prometheus_operator_crd_version = "v0.93.0"
 
       /* Data Engineering Airflow */
       data_engineering_airflow_execution_role_arn = "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/airflow-prod-execution-role"


### PR DESCRIPTION
PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/627) ticket.

#### Upgrading `apc-prod` helm charts

- `cert_manager` from `v1.19.2` to `v1.20.2`
- `cluster_autoscaler` from `9.56.0` to `9.59.0`
- `external_dns` from `1.20.0` to `1.21.1`
- `external_secrets` from `2.2.0` to `2.7.0`
- `karpenter` from `1.10.0` to `1.14.0`
- `keda` from `2.18.3` to `2.20.2`
- `kube_prometheus_stack` from `82.16.0` to `88.3.0`
- `kyverno` from `3.6.2` to `3.8.1`
- `velero` from `12.0.0` to `12.1.0`

#### Kube Prometheus Stack
- `prometheus_operator_crd_version` from `v0.89.0` to `v0.93.0`