### PR TITLE
fix(argocd): Register hub capability role on spokes

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -200,6 +200,7 @@ resource "aws_eks_access_entry" "argocd_spoke_capability" {
 # Cluster-wide read: required by Argo CD for resource discovery, health
 # assessment and diffing desired vs live state.
 resource "kubernetes_cluster_role_v1" "argocd_hub_read" {
+  # checkov:skip=CKV_K8S_49:Cluster-wide read (get/list/watch) on all kinds is required by Argo CD for resource discovery, health and drift detection, including CRDs added later. This matches AWS's documented argocd-read-all ClusterRole for the managed Argo CD capability. Write access is scoped to specific kinds in argocd_hub_deploy; this role grants no write verbs.
   count = local.is_argocd_spoke ? 1 : 0
 
   metadata {

--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -95,10 +95,15 @@ locals {
     "-argocd-capability"
   )
 
-  # Access entries expose the principal to Kubernetes RBAC as a group named
-  # "eks-access-entry:<principal-arn>". Binding custom RBAC to this group is
-  # how we avoid attaching AmazonEKSClusterAdminPolicy (= system:masters).
-  argocd_hub_capability_rbac_group = "eks-access-entry:${local.resolved_hub_capability_role_arn}"
+  # Kubernetes RBAC group that the hub capability role is placed into on this spoke.
+  # The access entry declares this group explicitly via kubernetes_groups (EKS
+  # does NOT auto-create an "eks-access-entry:<arn>" group), and the custom
+  # ClusterRoles below bind to it. This is how we grant scoped access without
+  # attaching AmazonEKSClusterAdminPolicy.
+  #
+  # Must be a valid Kubernetes group name (<= 63 chars), so it is a short fixed
+  # label rather than anything derived from the role ARN.
+  argocd_hub_capability_rbac_group = "argocd-hub"
 
   # A cluster never self-identifies as both hub and spoke.
   is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
@@ -173,6 +178,11 @@ resource "aws_eks_access_entry" "argocd_spoke_capability" {
   cluster_name  = module.eks.cluster_name
   principal_arn = local.resolved_hub_capability_role_arn
   type          = "STANDARD"
+
+  # Place the capability role into the RBAC group the ClusterRoleBindings below
+  # bind to. Without this the principal is mapped to a username only, in no
+  # group, and the scoped RBAC never applies (every API call is forbidden).
+  kubernetes_groups = [local.argocd_hub_capability_rbac_group]
 
   tags = merge(local.tags, {
     Name    = "${module.eks.cluster_name}-argocd-capability-access"

--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -80,6 +80,26 @@ locals {
     : local.argocd_hub_convention_role_arn
   )
 
+  # Hub's ArgoCD Capability role ARN. The EKS-managed Argo CD authenticates to
+  # spoke clusters as its capability role, so the spoke must grant that role
+  # access — without it, API calls from the hub fail with Unauthorized and
+  # Applications sit in Unknown sync state.
+  #
+  # Both hub roles follow the module naming "<hub-cluster>-argocd-<suffix>"
+  # (see modules/argo-cd), so the capability ARN is derived from the resolved
+  # spoke-access ARN. This holds for convention-based permanent hubs and for
+  # explicit ephemeral-hub overrides, since both roles live in the hub account.
+  resolved_hub_capability_role_arn = replace(
+    local.resolved_hub_spoke_access_role_arn,
+    "-argocd-spoke-access",
+    "-argocd-capability"
+  )
+
+  # Access entries expose the principal to Kubernetes RBAC as a group named
+  # "eks-access-entry:<principal-arn>". Binding custom RBAC to this group is
+  # how we avoid attaching AmazonEKSClusterAdminPolicy (= system:masters).
+  argocd_hub_capability_rbac_group = "eks-access-entry:${local.resolved_hub_capability_role_arn}"
+
   # A cluster never self-identifies as both hub and spoke.
   is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
 
@@ -126,4 +146,208 @@ resource "aws_eks_access_policy_association" "argocd_spoke" {
   }
 
   depends_on = [aws_eks_access_entry.argocd_spoke]
+}
+
+#------------------------------------------------------------------------------
+# Spoke: Register the hub's ArgoCD Capability role (least privilege)
+#
+# The EKS-managed Argo CD reaches spoke clusters as the hub's capability role,
+# so that role needs its own access entry here. Deliberately NO access policy
+# association: AmazonEKSClusterAdminPolicy is equivalent to system:masters and
+# AWS documents it as unsuitable for production. Authorisation instead comes
+# from the scoped ClusterRoles below, bound to the access entry's group.
+#
+# Scope rationale — Argo CD needs cluster-wide READ for discovery, health and
+# drift detection, plus WRITE limited to the resource kinds our Applications
+# actually manage (see cluster-core/argocd-gitops.tf AppProjects and the
+# app-baseline chart: Namespace + RoleBinding + NetworkPolicy).
+#
+# Intentionally withheld from the hub: ClusterRole/ClusterRoleBinding writes,
+# CustomResourceDefinitions, admission webhooks and node access. A compromised
+# hub therefore cannot escalate cluster RBAC, install CRDs or tamper with
+# admission control on a spoke (threat T-0011).
+#------------------------------------------------------------------------------
+resource "aws_eks_access_entry" "argocd_spoke_capability" {
+  count = local.is_argocd_spoke ? 1 : 0
+
+  cluster_name  = module.eks.cluster_name
+  principal_arn = local.resolved_hub_capability_role_arn
+  type          = "STANDARD"
+
+  tags = merge(local.tags, {
+    Name    = "${module.eks.cluster_name}-argocd-capability-access"
+    Purpose = "argocd-hub-spoke-registration"
+  })
+
+  lifecycle {
+    precondition {
+      condition     = local.resolved_hub_capability_role_arn != ""
+      error_message = "Could not resolve the hub capability role ARN. Ensure the spoke's tier has a hub in local.argocd_hubs, or pass TF_VAR_argocd_hub_spoke_access_role_arn."
+    }
+  }
+}
+
+# Cluster-wide read: required by Argo CD for resource discovery, health
+# assessment and diffing desired vs live state.
+resource "kubernetes_cluster_role_v1" "argocd_hub_read" {
+  count = local.is_argocd_spoke ? 1 : 0
+
+  metadata {
+    name = "argocd-hub-read-all"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "container-platform/purpose"   = "argocd-hub-spoke-access"
+    }
+  }
+
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+# Write access, limited to the resource kinds Argo CD Applications manage.
+resource "kubernetes_cluster_role_v1" "argocd_hub_deploy" {
+  count = local.is_argocd_spoke ? 1 : 0
+
+  metadata {
+    name = "argocd-hub-deploy"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "container-platform/purpose"   = "argocd-hub-spoke-access"
+    }
+  }
+
+  # Namespace lifecycle — the app-baseline chart creates one namespace per
+  # product environment. Note "finalize" is withheld.
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces"]
+    verbs      = ["create", "update", "patch", "delete"]
+  }
+
+  # Core workload resources.
+  rule {
+    api_groups = [""]
+    resources = [
+      "configmaps",
+      "secrets",
+      "services",
+      "serviceaccounts",
+      "persistentvolumeclaims",
+    ]
+    verbs = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  # Workload controllers.
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  rule {
+    api_groups = ["autoscaling"]
+    resources  = ["horizontalpodautoscalers"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  rule {
+    api_groups = ["policy"]
+    resources  = ["poddisruptionbudgets"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  # Ingress and network policy (incl. the baseline default-deny-ingress).
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "networkpolicies"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  # Gateway API routes used by product workloads.
+  rule {
+    api_groups = ["gateway.networking.k8s.io"]
+    resources  = ["httproutes", "grpcroutes"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  # Namespace-scoped RBAC only — the baseline grants team access per namespace.
+  # ClusterRole/ClusterRoleBinding writes are deliberately excluded.
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["roles", "rolebindings"]
+    verbs      = ["create", "update", "patch", "delete", "deletecollection"]
+  }
+
+  # Kubernetes privilege-escalation prevention requires "bind" on a referenced
+  # ClusterRole when the creator lacks those permissions itself. The baseline
+  # RoleBindings reference the built-in view/edit/admin roles, so allow bind on
+  # exactly those and nothing else.
+  rule {
+    api_groups     = ["rbac.authorization.k8s.io"]
+    resources      = ["clusterroles"]
+    resource_names = ["view", "edit", "admin"]
+    verbs          = ["bind"]
+  }
+}
+
+# Bind both ClusterRoles to the access entry's auto-generated group.
+resource "kubernetes_cluster_role_binding_v1" "argocd_hub_read" {
+  count = local.is_argocd_spoke ? 1 : 0
+
+  metadata {
+    name = "argocd-hub-read-all"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "container-platform/purpose"   = "argocd-hub-spoke-access"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.argocd_hub_read[0].metadata[0].name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = local.argocd_hub_capability_rbac_group
+  }
+
+  depends_on = [aws_eks_access_entry.argocd_spoke_capability]
+}
+
+resource "kubernetes_cluster_role_binding_v1" "argocd_hub_deploy" {
+  count = local.is_argocd_spoke ? 1 : 0
+
+  metadata {
+    name = "argocd-hub-deploy"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "container-platform/purpose"   = "argocd-hub-spoke-access"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.argocd_hub_deploy[0].metadata[0].name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = local.argocd_hub_capability_rbac_group
+  }
+
+  depends_on = [aws_eks_access_entry.argocd_spoke_capability]
 }

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -4,11 +4,6 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
-      /* ArgoCD — TEST ONLY: register ephemeral spoke(s) with an ephemeral hub.
-         Revert before merging this PR. The -hub/-spoke convention proposed for
-         step 2 will remove the need for this list on dev clusters. */
-      argocd_registered_spokes = ["cp-1408-1705-spoke"]
-
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -4,6 +4,11 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
+      /* ArgoCD — TEST ONLY: register ephemeral spoke(s) with an ephemeral hub.
+         Revert before merging this PR. The -hub/-spoke convention proposed for
+         step 2 will remove the need for this list on dev clusters. */
+      argocd_registered_spokes = ["cp-1408-1705-spoke"]
+
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"


### PR DESCRIPTION
## What

Register the hub's Argo CD **capability role** as an EKS access entry on spoke clusters, authorised by scoped Kubernetes RBAC rather than `AmazonEKSClusterAdminPolicy`.

## Why

The EKS-managed Argo CD authenticates to spoke clusters as its **capability role** (`<hub>-argocd-capability`), but our Terraform only registered the
**spoke-access role** (`<hub>-argocd-spoke-access`). As a result the hub cannot verify an access entry for itself on the spoke and every reconcile fails.

Confirmed live on the `cloud-platform-nonlive` hub — all six Argo CD Applications targeting `container-platform-octo-nonlive` are stuck in
`Sync: Unknown` / `phase: Error`:
`ComparisonError: Failed to load live state: ... error getting cluster RESTConfig: failed to verify the access entry`


The spoke-access entry is present and the cluster Secret references it via `roleARN`, yet it still fails — so the capability role needs its own access entry regardless. The PoC hub/spoke pair only ever worked because that entry
had been added there by hand, which is why the gap was invisible in code.

## What changed

`terraform/environments/cloud-platform/cluster/argocd.tf` (additive, gated on the existing `is_argocd_spoke`):

- `aws_eks_access_entry.argocd_spoke_capability` — registers the hub capability role on the spoke, **with no access policy association**.
- `kubernetes_cluster_role_v1.argocd_hub_read` — cluster-wide `get/list/watch` for Argo CD discovery, health and drift detection.
- `kubernetes_cluster_role_v1.argocd_hub_deploy` — write access limited to the kinds our Applications manage (namespaces; core workload resources; `apps`, `batch`, `autoscaling`, `policy`; `networking.k8s.io`;
  `gateway.networking.k8s.io`; namespaced `roles`/`rolebindings`; and `bind` on only the `view`/`edit`/`admin` ClusterRoles the baseline RoleBindings  reference).
- Two `kubernetes_cluster_role_binding_v1` — bind both to the access entry's RBAC group (see below).

The capability role ARN is derived from the resolved spoke-access ARN (both follow the `<hub-cluster>-argocd-<suffix>` module naming), so it works for convention-based permanent hubs and explicit ephemeral-hub overrides alike.

## Security

Deliberately avoids `AmazonEKSClusterAdminPolicy` (= `system:masters`), which AWS documents as unsuitable for production. Withheld from the hub:
ClusterRole/ClusterRoleBinding writes, CRDs, admission webhooks, node access.
A compromised hub therefore cannot escalate cluster RBAC or tamper with admission control on a spoke (threat T-0011).

> Note: this PR does not yet reduce the existing spoke-access `system:masters`
> grant — that role is retired in follow-up work. This change is additive and
> does not alter the spoke-access registration.

## Testing

- `terraform fmt` + `terraform validate`: pass.
- Root cause reproduced and diagnosed on the live `cloud-platform-nonlive` hub.
- Verified end-to-end on a fresh ephemeral hub/spoke pair deployed purely from this branch (no manual steps): the capability role access entry is created with no access policy, is placed in the `argocd-hub` Kubernetes group via `kubernetes_groups`, the scoped ClusterRoles/bindings are created and bound to that group, and Argo CD authenticated as the capability role and successfully synced a real workload (Deployment + Service) onto the spoke.
- Checkov `CKV_K8S_49` on the wildcard read ClusterRole is suppressed with a documented justification; the write ClusterRole passes the check unmodified.

## Blast radius

Only affects workspaces where `is_argocd_spoke` is true (registered spokes).
Hubs and non-spoke clusters see no change. Review the plan for a spoke workspace (e.g. `container-platform-octo-nonlive`) before merge.

## Ticket

Relates to ministryofjustice/cloud-platform#8438 (Deploy ArgoCD to nonlive) — this fix was found while debugging a failed spoke registration during that rollout.
