### PR TITLE
Wire GitHub operational notifications

### DIFF
--- a/terraform/environments/electronic-monitoring-data/chatbot.tf
+++ b/terraform/environments/electronic-monitoring-data/chatbot.tf
@@ -14,3 +14,17 @@ module "chatbot_alerts" {
   tags             = local.tags
   application_name = local.application_name
 }
+
+module "chatbot_operational_incidents" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=0ec33c7bfde5649af3c23d0834ea85c849edf3ac" # v3.0.0
+
+  slack_channel_id = "C069RF589V4"
+  slack_team_id    = "T02DYEB3A"
+
+  sns_topic_arns = [
+    aws_sns_topic.operational_incident_updates.arn,
+  ]
+
+  tags             = local.tags
+  application_name = "${local.application_name}-operational-incidents"
+}

--- a/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
+++ b/terraform/environments/electronic-monitoring-data/lambda_triggers.tf
@@ -460,6 +460,19 @@ resource "aws_lambda_permission" "update_p1_export_api_gw" {
 }
 
 # ------------------------------------------------------------------------------
+# GitHub Project webhook
+# ------------------------------------------------------------------------------
+
+resource "aws_lambda_permission" "live_feed_github_webhook" {
+  statement_id  = "AllowGitHubWebhookApiGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.live_feed_incident_manager.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+
+  source_arn = "${aws_apigatewayv2_api.live_feed_github_webhook.execution_arn}/*/POST/github/project-status"
+}
+
+# ------------------------------------------------------------------------------
 # Live-feed incident event queue
 # ------------------------------------------------------------------------------
 

--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -2877,16 +2877,16 @@ resource "aws_iam_policy" "trigger_cadt_iam_policy" {
 
 module "trigger_cadt_iam" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role"
-  
+
   name = "trigger-cadt-iam-role"
   trust_policy_permissions = {
-   LambdaAssume = { actions = [
+    LambdaAssume = { actions = [
       "sts:AssumeRole",
-    ]
-    principals = [{
-      type = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }]}
+      ]
+      principals = [{
+        type        = "Service"
+        identifiers = ["lambda.amazonaws.com"]
+    }] }
   }
 
   policies = {
@@ -2913,7 +2913,7 @@ data "aws_iam_policy_document" "poll_cadt_policy_document" {
     condition {
       test     = "ArnEquals"
       variable = "ecs:cluster"
-      values = [aws_ecs_cluster.cadt.arn]
+      values   = [aws_ecs_cluster.cadt.arn]
     }
   }
 }
@@ -2926,16 +2926,16 @@ resource "aws_iam_policy" "poll_cadt_iam_policy" {
 
 module "poll_cadt_iam" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role"
-  
+
   name = "poll-cadt-iam-role"
   trust_policy_permissions = {
-   LambdaAssume = { actions = [
+    LambdaAssume = { actions = [
       "sts:AssumeRole",
-    ]
-    principals = [{
-      type = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }]}
+      ]
+      principals = [{
+        type        = "Service"
+        identifiers = ["lambda.amazonaws.com"]
+    }] }
   }
 
   policies = {
@@ -3009,6 +3009,34 @@ data "aws_iam_policy_document" "live_feed_incident_manager_policy_document" {
 
     resources = [
       "${module.s3-logging-bucket.bucket.arn}/incident-automation/episodes/${local.environment_shorthand}/*"
+    ]
+  }
+
+  statement {
+    sid    = "PublishIncidentNotifications"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.emds_alerts.arn,
+      aws_sns_topic.operational_incident_updates.arn,
+    ]
+  }
+
+  statement {
+    sid    = "UseIncidentNotificationKmsKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+
+    resources = [
+      aws_kms_key.emds_alerts.arn,
     ]
   }
 }

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -1156,7 +1156,7 @@ module "poll_cadt" {
   production_dev          = local.is-production ? "prod" : local.is-preproduction ? "preprod" : local.is-test ? "test" : "dev"
 
   environment_variables = {
-    CLUSTER_NAME        = aws_ecs_cluster.cadt.name
+    CLUSTER_NAME = aws_ecs_cluster.cadt.name
   }
 }
 
@@ -1240,5 +1240,10 @@ module "live_feed_incident_manager" {
     INCIDENT_STATE_BUCKET = local.alarm_thread_state_bucket
     INCIDENT_STATE_PREFIX = "incident-automation/episodes"
     AWS_ACCOUNT_ID        = data.aws_caller_identity.current.account_id
+
+    ENVIRONMENT_SNS_TOPIC_ARN = aws_sns_topic.emds_alerts.arn
+    OPERATIONAL_SNS_TOPIC_ARN = (
+      aws_sns_topic.operational_incident_updates.arn
+    )
   }
 }

--- a/terraform/environments/electronic-monitoring-data/live_feed_github_webhook.tf
+++ b/terraform/environments/electronic-monitoring-data/live_feed_github_webhook.tf
@@ -1,0 +1,54 @@
+# ------------------------------------------------------------------------------
+# GitHub Project webhook
+# ------------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "live_feed_github_webhook" {
+  name          = "live-feed-github-webhook-${local.environment_shorthand}"
+  protocol_type = "HTTP"
+
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_integration" "live_feed_github_webhook" {
+  api_id = aws_apigatewayv2_api.live_feed_github_webhook.id
+
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+
+  integration_uri = format(
+    "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations",
+    data.aws_region.current.name,
+    module.live_feed_incident_manager.lambda_function_arn,
+  )
+
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 30000
+}
+
+resource "aws_apigatewayv2_route" "live_feed_github_project_status" {
+  api_id = aws_apigatewayv2_api.live_feed_github_webhook.id
+
+  route_key          = "POST /github/project-status"
+  authorization_type = "NONE"
+  target = (
+    "integrations/${aws_apigatewayv2_integration.live_feed_github_webhook.id}"
+  )
+}
+
+resource "aws_apigatewayv2_stage" "live_feed_github_webhook" {
+  api_id = aws_apigatewayv2_api.live_feed_github_webhook.id
+
+  name        = "$default"
+  auto_deploy = true
+
+  tags = local.tags
+}
+
+output "live_feed_github_webhook_url" {
+  description = "GitHub App webhook URL for live-feed Project status events"
+
+  value = format(
+    "%s/github/project-status",
+    aws_apigatewayv2_api.live_feed_github_webhook.api_endpoint,
+  )
+}

--- a/terraform/environments/electronic-monitoring-data/sns.tf
+++ b/terraform/environments/electronic-monitoring-data/sns.tf
@@ -7,6 +7,17 @@ resource "aws_sns_topic" "emds_alerts" {
   http_success_feedback_sample_rate = 0
 }
 
+resource "aws_sns_topic" "operational_incident_updates" {
+  name              = "operational-incident-updates-${local.environment_shorthand}"
+  kms_master_key_id = aws_kms_key.emds_alerts.arn
+
+  http_success_feedback_role_arn    = aws_iam_role.sns_delivery_logging.arn
+  http_failure_feedback_role_arn    = aws_iam_role.sns_delivery_logging.arn
+  http_success_feedback_sample_rate = 0
+
+  tags = local.tags
+}
+
 resource "aws_kms_key" "emds_alerts" {
   description         = "KMS key for EMDS SNS alerts"
   enable_key_rotation = true
@@ -108,7 +119,20 @@ data "aws_iam_policy_document" "emds_alerts_kms" {
       identifiers = [aws_iam_role.landing_dlq_redriver.arn]
     }
   }
+
+  statement {
+    sid       = "AllowLiveFeedIncidentManagerUseOfKey"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.live_feed_incident_manager.arn]
+    }
+  }
 }
+
 
 data "aws_iam_policy_document" "emds_alerts_topic_policy" {
   version = "2012-10-17"
@@ -196,6 +220,22 @@ data "aws_iam_policy_document" "emds_alerts_topic_policy" {
   }
 
   statement {
+    sid    = "AllowLiveFeedIncidentManagerLambdaToPublish"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [aws_sns_topic.emds_alerts.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.live_feed_incident_manager.arn]
+    }
+  }
+
+  statement {
     sid    = "AllowChatbotToConsume"
     effect = "Allow"
 
@@ -221,6 +261,55 @@ data "aws_iam_policy_document" "emds_alerts_topic_policy" {
 resource "aws_sns_topic_policy" "emds_alerts" {
   arn    = aws_sns_topic.emds_alerts.arn
   policy = data.aws_iam_policy_document.emds_alerts_topic_policy.json
+}
+data "aws_iam_policy_document" "operational_incident_updates_topic_policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "AllowLiveFeedIncidentManagerLambdaToPublish"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.operational_incident_updates.arn,
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.live_feed_incident_manager.arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowChatbotToConsume"
+    effect = "Allow"
+
+    actions = [
+      "sns:Subscribe",
+      "sns:Receive",
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.operational_incident_updates.arn,
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "sns.amazonaws.com",
+        "chatbot.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "operational_incident_updates" {
+  arn    = aws_sns_topic.operational_incident_updates.arn
+  policy = data.aws_iam_policy_document.operational_incident_updates_topic_policy.json
 }
 
 resource "aws_sqs_queue" "emds_alerts_dlq" {


### PR DESCRIPTION
Adds the infrastructure for GitHub Project status notifications.

## Changes

- Adds the GitHub webhook endpoint
- Adds central operational Slack routing
- Adds incident manager SNS permissions
- Passes notification topics to the Lambda

## Outcome

GitHub operational updates are routed centrally without changing existing environment alarm notifications. See https://github.com/ministryofjustice/electronic-monitoring-data-lambda-functions/pull/970