### PR TITLE
fix(iam): Grant IDC assignment perms for ArgoCD capability

### DIFF
--- a/terraform/environments/cloud-platform/oidc.tf
+++ b/terraform/environments/cloud-platform/oidc.tf
@@ -236,7 +236,10 @@ data "aws_iam_policy_document" "github_actions_development_cluster_oidc_policy" 
       "sso:DeleteApplicationAccessScope",
       "sso:DeleteApplicationAuthenticationMethod",
       "sso:DeleteApplicationGrant",
-      "sso:PutApplicationAssignmentConfiguration"
+      "sso:PutApplicationAssignmentConfiguration",
+      "sso:CreateApplicationAssignment",
+      "sso:DeleteApplicationAssignment",
+      "sso:ListApplicationAssignments"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## What
Add the Identity Center application-assignment permissions the `github-actions-development-cluster` role needs to create the EKS-managed Argo CD capability.

## Why
Creating the Argo CD capability with an RBAC role mapping assigns the mapped Identity Center group to the Argo CD IDC application, which calls `sso:CreateApplicationAssignment`. The `SSOForArgoCDCapability` statement
granted the application-*grant* actions but omitted the *assignment* actions, so ephemeral hub deploys failed:

    AccessDenied: Caller does not have permission to perform
    sso:CreateApplicationAssignment on arn:aws:sso:::instance/ssoins-.../apl-...

and the capability entered CREATE_FAILED (observed on cp-1408-1352).

Permanent hubs (nonlive/live) are unaffected — they deploy via the MP
github-actions-apply role, not this dev-cluster role.

## Change
`terraform/environments/cloud-platform/oidc.tf` — add to
`SSOForArgoCDCapability`:
- `sso:CreateApplicationAssignment` (required on create)
- `sso:DeleteApplicationAssignment` (destroy/update)
- `sso:ListApplicationAssignments` (read)

## Testing
- `terraform fmt`: pass.
- Root cause reproduced on cp-1408-1352 (capability CREATE_FAILED) and traced to
  the missing action in the deployed policy (v15).

## Rollout / dependency
Must merge and apply (root component) before ephemeral hub deploys via GitHub Actions will succeed. A CREATE_FAILED argocd capability left on cp-1408-1352 should be deleted (or the ephemeral hub destroyed) before re-deploying.


## Ticket
Relates to ministryofjustice/cloud-platform#8438 (Deploy ArgoCD to nonlive).
