### PR TITLE
fix(data-platform): update litellm to 1.97.0

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,7 +1,7 @@
 locals {
   environment_configurations = {
     development = {
-      litellm_version     = "1.96.2"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -41,7 +41,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.96.2"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.96.2"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -121,7 +121,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.96.2"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN

--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.96.2"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -121,7 +121,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.96.2"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
> [!NOTE]  
> This PR only updates test and development. Another PR will follow to update pre-production and production tomorrow.

## Summary

Updates LiteLLM from `1.96.2` to `1.97.0` across all AI Gateway environments.

`1.97.0` is the latest published stable release as of 2026-08-20, so the target does not differ from latest stable. The intervening releases reviewed were [`1.97.0-dev.1`](https://github.com/BerriAI/litellm/releases/tag/v1.97.0-dev.1), [`1.97.0-dev.2`](https://github.com/BerriAI/litellm/releases/tag/v1.97.0-dev.2), [`1.97.0-rc.1`](https://github.com/BerriAI/litellm/releases/tag/v1.97.0-rc.1), and stable [`1.97.0`](https://github.com/BerriAI/litellm/releases/tag/v1.97.0). Newer `1.98.0-rc.1` and `1.99.0-dev.1` are prereleases and were excluded. Both referenced GHCR artifacts (`litellm-helm` and `litellm-non_root`) are published at `1.97.0`.

## Data Platform client compatibility

No breaking changes affecting the Data Platform AI Gateway client were identified between `1.96.2` and `1.97.0`

The authoritative [`AIGatewayClient`](https://github.com/ministryofjustice/data-platform-app/blob/c3d7c4f805af9a21c6adf83f90cbabd7fc371ca1/ai_gateway/client.py) and related code were checked against upstream endpoint handlers, request/response models, and fields across the complete range:

- `GET /v1/access_group`: no endpoint, method, authentication, or response-field break. `access_group_name`, `access_group_id`, and `access_model_names` remain available. [Upstream handler](https://github.com/BerriAI/litellm/blob/v1.97.0/litellm/proxy/management_endpoints/access_group_endpoints.py#L399). [#36230](https://github.com/BerriAI/litellm/pull/36230) changes model resolution and hides the `no-default-models` sentinel, but preserves the response shape; applicable only as corrected listing behavior, with no client mitigation required.
- `GET /organization/list?org_alias=...`: no endpoint, query-schema, or response-field break; `organization_alias` and `organization_id` remain available. [Upstream handler](https://github.com/BerriAI/litellm/blob/v1.97.0/litellm/proxy/management_endpoints/organization_endpoints.py#L957). No mitigation required.
- `GET /v1/model/info`: no endpoint, method, auth, or `data`/`models` contract break identified. No mitigation required.
- `POST /team/new`, `POST /team/delete`, `GET /team/info?team_id=...`, and `POST /team/update`: request bodies and `team_id`, `team_info`, organization, budget, access-group/model-access, and `access_group_ids` behavior used by the client remain compatible. No mitigation required.
- `POST /key/generate`, `POST /key/{key}/regenerate`, `POST /key/delete`, `GET /key/info?key=...`, and `POST /key/update`: virtual-key request bodies and `key`/`keys` response usage remain compatible. No mitigation required.
- `GET /key/list`: the client query contract (`team_id`, `return_full_object`, `size`, `page`) and pagination/response fields (`keys`, `total_pages`) remain intact. [Upstream handler](https://github.com/BerriAI/litellm/blob/v1.97.0/litellm/proxy/management_endpoints/key_management_endpoints.py#L5315). [#35840](https://github.com/BerriAI/litellm/pull/35840) refactors filtering while retaining the team filter and response shape; impact is consistent `key_alias`/`key_hash` filtering, with no mitigation required.
- Authentication, authorization, status, and error handling: the client continues to use master-key bearer authentication and raises on non-success responses. JWT error handling in [#35831](https://github.com/BerriAI/litellm/pull/35831) and the OAuth2 Enterprise gate in [#35838](https://github.com/BerriAI/litellm/pull/35838) do not apply to this deployment because its management calls authenticate with the master key.

The environments repository evidence shows `litellm_version` drives both the [`litellm-helm` chart](https://github.com/ministryofjustice/modernisation-platform-environments/blob/90007e2fd43270d1deffa9d004e03c848a1434b2/terraform/environments/data-platform/ai-gateway/helm-charts.tf#L24) and [`litellm-non_root` image](https://github.com/ministryofjustice/modernisation-platform-environments/blob/90007e2fd43270d1deffa9d004e03c848a1434b2/terraform/environments/data-platform/ai-gateway/helm-charts.tf#L34); the configured master-key authentication and relevant enabled AI Gateway features require no change for this upgrade.

Evidence limitation: all 555 intervening commit subjects and relevant endpoint source changes and linked PRs were reviewed, but not every changed file line-by-line because the GitHub comparison files API caps results at 300 files.

## Other breaking changes

None identified. The complete release sequence and relevant configuration, deployment, database-migration, API, Helm, and image changes were reviewed. The only identified auth changes are the non-applicable JWT/OAuth2 changes linked above; no required schema migration or deployment mitigation was found for the enabled configuration. The production ingress allowlist and other AI Gateway settings are unchanged.

## Release notes

- [LiteLLM 1.97.0 release notes](https://github.com/BerriAI/litellm/releases/tag/v1.97.0)
- [Full upstream comparison](https://github.com/BerriAI/litellm/compare/v1.96.2...v1.97.0)
