### PR TITLE
CC-4573: Add default tag blocks to maatdb platform_providers.tf

### DIFF
--- a/terraform/environments/maatdb/platform_providers.tf
+++ b/terraform/environments/maatdb/platform_providers.tf
@@ -2,6 +2,7 @@
 provider "aws" {
   alias  = "original-session"
   region = "eu-west-2"
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
@@ -10,6 +11,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for the Modernisation Platform, to get things from there if required
@@ -19,6 +21,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for core-vpc-<environment>, to access resources in the core-vpc accounts
@@ -28,6 +31,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for network services to enable dns entries for certificate validation to be created
@@ -37,6 +41,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for creating resources in us-east-1, eg ACM resources for CloudFront
@@ -46,6 +51,7 @@ provider "aws" {
   assume_role {
     role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
   }
+  default_tags { tags = local.tags }
 }
 
 # Provider for reading resources from root account IdentityStore
@@ -55,6 +61,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
   }
+  default_tags { tags = local.tags }
 }
 
 # AWS provider for managing Business Unit secrets and parameters


### PR DESCRIPTION
## Summary

CC-4573: reproduces the change from #16553 (closed unmerged) — adds `default_tags { tags = local.tags }` to each AWS provider block in `terraform/environments/maatdb/platform_providers.tf`.

## Why a fresh PR instead of reopening #16553

#16553 was closed without merging. The `maatdb` `platform_providers.tf` has since gained an additional provider block (`shared-configuration-access`) that wasn't present when #16553 was opened, so that PR's diff no longer applies cleanly. This PR carries the same 6 provider-block changes as #16553; the new 7th block is deliberately left untouched pending review.

## Also included: revert production engine_version to match live state

Production's `engine_version` in code was ahead of live state (commit `3aae48b8`, Saanchi Dubey) — pre-staged for a future Oracle patch whose apply pipeline was then cancelled. Reverted back to `19.0.0.0.ru-2026-01.rur-2026-01.r3` (the currently-running version) so the tags plan is clean on this resource too. The real bump can be reapplied on its own whenever that patch actually goes ahead — this PR doesn't touch or advance it.

## Status: still not ready to apply

Plans for all four environments carry unrelated pre-existing S3 bucket-policy drift that would ride along with any apply:

- `module.s3_bucket["inbound"/"outbound"].aws_s3_bucket_policy.default` adding TLS/encryption-enforcement statements — Sanjay Baranwal, merged late July, never applied.
- `aws_s3_bucket_policy.shared_bucket_policy` Sid/condition reordering — Nick-MoJ-Pro, merged 2026-07-20, never applied.
- **Test only**: `aws_iam_access_key.ftp_user_key[0]` / `smtp_user_key[0]` show `status: Inactive -> Active`. No code sets `status`; looks like a manual AWS-side deactivation with no git trail. Needs confirmation before Terraform is allowed to reactivate these.

Left for manual triage by their owners rather than routed around here. This PR stays in draft until those are cleared or explicitly accepted.

## Open question

Should `default_tags` also be added to the `shared-configuration-access` provider block, which postdates #16553? Not included here pending review.