### PR TITLE
fix(argocd): Retire the spoke-access IAM role

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -13,7 +13,9 @@
 #       → Never register as a spoke
 #
 #     NO → Is this workspace in argocd_registered_spokes (environment config)?
-#       YES → Register with the hub (create EKS Access Entry for hub role)
+#       YES → Register with the hub (create EKS Access Entry for the hub's
+#             Argo CD Capability role, the identity the EKS-managed Argo CD
+#             actually authenticates as)
 #       NO  → Do nothing (cluster is neither hub nor spoke)
 #
 # WHERE TO MAKE CHANGES:
@@ -21,7 +23,7 @@
 #   - To register a spoke: add its workspace name to argocd_registered_spokes
 #     in environment-configuration.tf (under the nonlive or live block)
 #   - For ephemeral test hubs: pass TF_VAR_enable_argocd=true at deploy time
-#   - For ephemeral test spokes: pass TF_VAR_argocd_hub_spoke_access_role_arn
+#   - For ephemeral test spokes: pass TF_VAR_argocd_hub_capability_role_arn
 #
 # References:
 #   - ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
@@ -44,7 +46,6 @@ module "argocd" {
   count  = local.enable_argocd ? 1 : 0
 
   cluster_name = module.eks.cluster_name
-  cluster_arn  = module.eks.cluster_arn
 
   idc_instance_arn = var.argocd_idc_instance_arn
   idc_region       = var.argocd_idc_region
@@ -66,33 +67,27 @@ module "argocd" {
 #------------------------------------------------------------------------------
 # Spoke: Register with the hub's ArgoCD
 #
-# A spoke grants the hub's spoke-access role an EKS Access Entry with
-# AmazonEKSClusterAdminPolicy. This allows the hub's managed ArgoCD to deploy
-# workloads to this cluster without VPC peering or TGW. Cross-account access
-# is native to EKS Access Entries.
+# A spoke grants the hub's Argo CD Capability role an EKS Access Entry,
+# authorised by the scoped Kubernetes RBAC below (no AmazonEKSClusterAdminPolicy
+# access policy — see the access entry resource for the security rationale).
+# This is the only principal a spoke needs to register: the EKS-managed Argo
+# CD authenticates to spoke clusters as its capability role, not a separate
+# cross-account role. Cross-account access is native to EKS Access Entries, so
+# no VPC peering or TGW is required.
 #------------------------------------------------------------------------------
 
 locals {
-  # Hub's spoke-access role ARN — resolved by convention or explicit override.
-  resolved_hub_spoke_access_role_arn = (
-    var.argocd_hub_spoke_access_role_arn != ""
-    ? var.argocd_hub_spoke_access_role_arn
-    : local.argocd_hub_convention_role_arn
-  )
-
-  # Hub's ArgoCD Capability role ARN. The EKS-managed Argo CD authenticates to
-  # spoke clusters as its capability role, so the spoke must grant that role
-  # access — without it, API calls from the hub fail with Unauthorized and
-  # Applications sit in Unknown sync state.
-  #
-  # Both hub roles follow the module naming "<hub-cluster>-argocd-<suffix>"
-  # (see modules/argo-cd), so the capability ARN is derived from the resolved
-  # spoke-access ARN. This holds for convention-based permanent hubs and for
-  # explicit ephemeral-hub overrides, since both roles live in the hub account.
-  resolved_hub_capability_role_arn = replace(
-    local.resolved_hub_spoke_access_role_arn,
-    "-argocd-spoke-access",
-    "-argocd-capability"
+  # Hub's Argo CD Capability role ARN — resolved by convention or explicit
+  # override. Permanent hubs (nonlive/live) follow the module naming
+  # "<hub-cluster>-argocd-capability" (see modules/argo-cd), so the ARN is
+  # constructed directly for the spoke's tier via local.argocd_hubs. Ephemeral
+  # hubs are NOT covered by that convention — for those, the engineer passes
+  # the ARN explicitly as a workflow input, which arrives as
+  # var.argocd_hub_capability_role_arn and takes precedence.
+  resolved_hub_capability_role_arn = (
+    var.argocd_hub_capability_role_arn != ""
+    ? var.argocd_hub_capability_role_arn
+    : local.argocd_hub_capability_convention_role_arn
   )
 
   # Kubernetes RBAC group that the hub capability role is placed into on this spoke.
@@ -115,42 +110,8 @@ locals {
     lookup(local.environment_configuration, "argocd_registered_spokes", []),
     terraform.workspace
     ) && !local.enable_argocd && !local.is_argocd_hub_cluster && (
-    contains(local.mp_environments, terraform.workspace) || var.argocd_hub_spoke_access_role_arn != ""
+    contains(local.mp_environments, terraform.workspace) || var.argocd_hub_capability_role_arn != ""
   )
-}
-
-resource "aws_eks_access_entry" "argocd_spoke" {
-  count = local.is_argocd_spoke ? 1 : 0
-
-  cluster_name  = module.eks.cluster_name
-  principal_arn = local.resolved_hub_spoke_access_role_arn
-  type          = "STANDARD"
-
-  tags = merge(local.tags, {
-    Name    = "${module.eks.cluster_name}-argocd-spoke-access"
-    Purpose = "argocd-hub-spoke-registration"
-  })
-
-  lifecycle {
-    precondition {
-      condition     = local.resolved_hub_spoke_access_role_arn != ""
-      error_message = "Could not resolve the hub spoke-access role ARN. Ensure the spoke's tier has a hub in local.argocd_hubs, or pass TF_VAR_argocd_hub_spoke_access_role_arn."
-    }
-  }
-}
-
-resource "aws_eks_access_policy_association" "argocd_spoke" {
-  count = local.is_argocd_spoke ? 1 : 0
-
-  cluster_name  = module.eks.cluster_name
-  principal_arn = local.resolved_hub_spoke_access_role_arn
-  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-
-  access_scope {
-    type = "cluster"
-  }
-
-  depends_on = [aws_eks_access_entry.argocd_spoke]
 }
 
 #------------------------------------------------------------------------------
@@ -192,7 +153,7 @@ resource "aws_eks_access_entry" "argocd_spoke_capability" {
   lifecycle {
     precondition {
       condition     = local.resolved_hub_capability_role_arn != ""
-      error_message = "Could not resolve the hub capability role ARN. Ensure the spoke's tier has a hub in local.argocd_hubs, or pass TF_VAR_argocd_hub_spoke_access_role_arn."
+      error_message = "Could not resolve the hub capability role ARN. Ensure the spoke's tier has a hub in local.argocd_hubs, or pass TF_VAR_argocd_hub_capability_role_arn."
     }
   }
 }

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -4,11 +4,6 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
-      /* ArgoCD — TEST ONLY: register ephemeral spoke(s) with an ephemeral hub
-         to verify the spoke-access role retirement. Revert before merging
-         this PR. */
-      argocd_registered_spokes = ["cp-1708-1513-spoke"]
-
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"

--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -4,6 +4,11 @@ locals {
       /* EKS */
       eks_cluster_version = "1.35"
 
+      /* ArgoCD — TEST ONLY: register ephemeral spoke(s) with an ephemeral hub
+         to verify the spoke-access role retirement. Revert before merging
+         this PR. */
+      argocd_registered_spokes = ["cp-1708-1513-spoke"]
+
       /* Addons */
       eks_cluster_addon_versions = {
         kube_proxy             = "v1.34.2-eksbuild.1"

--- a/terraform/environments/cloud-platform/cluster/locals.tf
+++ b/terraform/environments/cloud-platform/cluster/locals.tf
@@ -24,16 +24,16 @@ locals {
   # ArgoCD Hub Configuration (ADR-002 — dual-hub model)
   #
   # Permanent hubs (development + production) are located by convention: spokes
-  # construct the hub's spoke-access role ARN from the hub identity for their
-  # environment tier. No manual input is needed for these.
+  # construct the hub's Argo CD Capability role ARN from the hub identity for
+  # their environment tier. No manual input is needed for these.
   #
   # Ephemeral/test hubs are NOT covered by the convention — for those, the
   # engineer passes the hub role ARN explicitly as a workflow input, which
-  # arrives as var.argocd_hub_spoke_access_role_arn and takes precedence.
+  # arrives as var.argocd_hub_capability_role_arn and takes precedence.
   #
   # IMPORTANT: cluster_name MUST equal the hub cluster's Terraform workspace
-  # name, because the hub's role is created as "<workspace>-argocd-spoke-access"
-  # (see modules/argo-cd — aws_iam_role.argocd_spoke_access).
+  # name, because the hub's role is created as "<workspace>-argocd-capability"
+  # (see modules/argo-cd — aws_iam_role.argocd_capability).
   #-----------------------------------------------------------------------------
   argocd_hubs = {
     nonlive = {
@@ -49,6 +49,6 @@ locals {
   # Environment tier of this spoke (last segment of the workspace name).
   argocd_spoke_tier = local.workspace_environment == "live" ? "live" : "nonlive"
 
-  # Convention-based hub role ARN for this spoke's tier.
-  argocd_hub_convention_role_arn = "arn:aws:iam::${local.argocd_hubs[local.argocd_spoke_tier].account_id}:role/${local.argocd_hubs[local.argocd_spoke_tier].cluster_name}-argocd-spoke-access"
+  # Convention-based hub Argo CD Capability role ARN for this spoke's tier.
+  argocd_hub_capability_convention_role_arn = "arn:aws:iam::${local.argocd_hubs[local.argocd_spoke_tier].account_id}:role/${local.argocd_hubs[local.argocd_spoke_tier].cluster_name}-argocd-capability"
 }

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
@@ -32,12 +32,9 @@ terraform {
   }
 }
 
-data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-
   # Flatten the role -> identities map into a flat list for the dynamic block
   # Input:  { ADMIN = [{id, type}], EDITOR = [{id, type}] }
   # Output: [{role, id, type}, {role, id, type}, ...]
@@ -240,44 +237,6 @@ resource "null_resource" "argocd_destroy_cleanup" {
 }
 
 #------------------------------------------------------------------------------
-# Argo CD Cross-Account Spoke Access Role
-#
-# This role is assumed by the Argo CD Capability to deploy to spoke clusters.
-# Each spoke cluster registers this role as an EKS Access Entry with
-# AmazonEKSClusterAdminPolicy for GitOps deployments.
-#------------------------------------------------------------------------------
-resource "aws_iam_role" "argocd_spoke_access" {
-  name        = "${var.cluster_name}-argocd-spoke-access"
-  description = "Allows Argo CD Capability to access spoke EKS clusters"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "eks.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-        Condition = {
-          StringEquals = {
-            "aws:SourceAccount" = local.account_id
-          }
-          ArnEquals = {
-            "aws:SourceArn" = var.cluster_arn
-          }
-        }
-      }
-    ]
-  })
-
-  tags = merge(var.tags, {
-    Name    = "${var.cluster_name}-argocd-spoke-access"
-    Purpose = "cross-account-gitops"
-  })
-}
-
-#------------------------------------------------------------------------------
 # CodeConnections for GitHub repository access
 #
 # The EKS-managed Argo CD reposerver runs under the capability role
@@ -308,27 +267,4 @@ resource "aws_iam_role_policy" "argocd_codeconnection" {
   })
 }
 
-#------------------------------------------------------------------------------
-# Register Argo CD IAM role as Access Entry on the hub cluster
-#------------------------------------------------------------------------------
-resource "aws_eks_access_entry" "argocd_hub" {
-  cluster_name  = var.cluster_name
-  principal_arn = aws_iam_role.argocd_spoke_access.arn
-  type          = "STANDARD"
 
-  tags = merge(var.tags, {
-    Name = "${var.cluster_name}-argocd-hub-access"
-  })
-}
-
-resource "aws_eks_access_policy_association" "argocd_hub" {
-  cluster_name  = var.cluster_name
-  principal_arn = aws_iam_role.argocd_spoke_access.arn
-  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-
-  access_scope {
-    type = "cluster"
-  }
-
-  depends_on = [aws_eks_access_entry.argocd_hub]
-}

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/outputs.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/outputs.tf
@@ -8,16 +8,6 @@ output "capability_arn" {
 }
 
 output "capability_role_arn" {
-  description = "ARN of the IAM role used by the Argo CD Capability"
+  description = "ARN of the IAM role used by the Argo CD Capability. Spokes register this role directly as their EKS Access Entry."
   value       = aws_iam_role.argocd_capability.arn
-}
-
-output "spoke_access_role_arn" {
-  description = "ARN of the IAM role for cross-account spoke cluster access"
-  value       = aws_iam_role.argocd_spoke_access.arn
-}
-
-output "spoke_access_role_name" {
-  description = "Name of the IAM role for cross-account spoke cluster access"
-  value       = aws_iam_role.argocd_spoke_access.name
 }

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/variables.tf
@@ -10,11 +10,6 @@ variable "cluster_name" {
   type        = string
 }
 
-variable "cluster_arn" {
-  description = "ARN of the hub EKS cluster"
-  type        = string
-}
-
 #------------------------------------------------------------------------------
 # Identity Center (required for Argo CD authentication)
 #------------------------------------------------------------------------------

--- a/terraform/environments/cloud-platform/cluster/outputs.tf
+++ b/terraform/environments/cloud-platform/cluster/outputs.tf
@@ -25,9 +25,9 @@ output "argocd_capability_arn" {
   value       = local.enable_argocd ? module.argocd[0].capability_arn : ""
 }
 
-output "argocd_spoke_access_role_arn" {
-  description = "ARN of the IAM role for spoke cluster access (register this in spoke Access Entries)"
-  value       = local.enable_argocd ? module.argocd[0].spoke_access_role_arn : ""
+output "argocd_capability_role_arn" {
+  description = "ARN of the Argo CD Capability role (register this in spoke Access Entries)"
+  value       = local.enable_argocd ? module.argocd[0].capability_role_arn : ""
 }
 
 output "argocd_spoke_registered" {

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -48,10 +48,10 @@ variable "argocd_rbac_role_mappings" {
 #------------------------------------------------------------------------------
 # Argo CD Spoke Registration (ADR-002 — Spoke-Driven Model)
 
-variable "argocd_hub_spoke_access_role_arn" {
+variable "argocd_hub_capability_role_arn" {
   type        = string
   default     = ""
-  description = "Override for the hub cluster's ArgoCD spoke-access IAM role ARN. Leave empty for permanent hubs (development/production) — the ARN is resolved by convention from local.argocd_hubs. Set this only for ephemeral/test hubs, passed as a workflow input when launching the cluster."
+  description = "Override for the hub cluster's ArgoCD Capability IAM role ARN. Leave empty for permanent hubs (development/production) — the ARN is resolved by convention from local.argocd_hubs. Set this only for ephemeral/test hubs, passed as a workflow input when launching the cluster."
 }
 
 resource "null_resource" "created_by_tag" {


### PR DESCRIPTION
## What

Remove the `<hub>-argocd-spoke-access` IAM role, its access entries, and the code that registers it on every spoke — leaving the hub's ArgoCD **capability** role as the only principal a spoke needs to grant.

## Why

Every registered spoke carried two hub principals:
- the original `<hub>-argocd-spoke-access` role with `AmazonEKSClusterAdminPolicy` (`system:masters`)
- the capability role with scoped, least-privilege RBAC (added to fix spoke registration — the EKS-managed Argo CD authenticates as the **capability** role, not the spoke-access role)

That addition was deliberately additive and never removed the first grant. The capability-role path is now verified end-to-end, so the spoke-access role is redundant — it's pure attack surface. A compromised or misconfigured hub could obtain full cluster-admin on every spoke via that role, with no corresponding benefit.

## What changed

- `cluster/argocd.tf` — removed `aws_eks_access_entry.argocd_spoke` and `aws_eks_access_policy_association.argocd_spoke` (the `system:masters` grant on spokes). The capability role ARN is now resolved directly by convention instead of derived from the spoke-access ARN via string replace.
- `modules/argo-cd/main.tf` — removed `aws_iam_role.argocd_spoke_access`, its hub-side access entry/policy association, and the now-dead `aws_caller_identity` data source / `account_id` local it alone used.
- `modules/argo-cd/variables.tf` / `outputs.tf` — removed the now-unused `cluster_arn` input and the `spoke_access_role_arn` / `spoke_access_role_name` outputs.
- `cluster/locals.tf` / `variables.tf` / `outputs.tf` — renamed the convention local and the override variable from spoke-access to capability-centric naming (`argocd_hub_spoke_access_role_arn` → `argocd_hub_capability_role_arn`); the top-level output is now `argocd_capability_role_arn`.

## Testing

- `terraform fmt` + `terraform validate`: pass.
- Verified end-to-end on a fresh ephemeral hub/spoke pair (`cp-1708-1513-hub` / `cp-1708-1513-spoke`) deployed purely from this branch (paired with ministryofjustice/cloud-platform-github-workflows#75):
  - The spoke has **only** the capability role registered — no `spoke-access` principal exists at all (`ResourceNotFoundException`).
  - That access entry has **no** associated access policy (confirmed empty via `list-associated-access-policies`).
  - The scoped `argocd-hub-read-all` / `argocd-hub-deploy` ClusterRoles and bindings are created and correctly bound to the `argocd-hub` group.
  - Registered the spoke in the hub's Argo CD with the minimal cluster Secret (`name` + `server` only, no `roleARN`) and synced a real workload (Deployment + Service) onto the spoke successfully — first attempt, no manual patching required.

## Blast radius

Applies to every registered spoke on next apply — each will show a **destroy** of `aws_eks_access_entry.argocd_spoke` and `aws_eks_access_policy_association.argocd_spoke`, removing the `system:masters` grant. Review the plan for a spoke workspace (e.g. `container-platform-octo-nonlive`) before merge to confirm only those two resources are destroyed.

## Ticket

Closes ministryofjustice/cloud-platform#8454.
