### PR TITLE
Bump to 1.3.0 release of Gatekeeper

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/gatekeeper.tf
+++ b/terraform/environments/cloud-platform/cluster-core/gatekeeper.tf
@@ -1,5 +1,5 @@
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/container-platform-terraform-gatekeeper?ref=block-imds" #1.2.1
+  source = "github.com/ministryofjustice/container-platform-terraform-gatekeeper?ref=1e282d05902b17fa31f00e152aade64d86e7d181" #1.3.0
 
   # boolean expression for applying opa valid hostname for test clusters only.
   dryrun_map = {

--- a/terraform/environments/cloud-platform/cluster-core/gatekeeper.tf
+++ b/terraform/environments/cloud-platform/cluster-core/gatekeeper.tf
@@ -1,5 +1,5 @@
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/container-platform-terraform-gatekeeper?ref=ef17291131e00fecb747073f72fa5d3a5b374659" #1.2.1
+  source = "github.com/ministryofjustice/container-platform-terraform-gatekeeper?ref=block-imds" #1.2.1
 
   # boolean expression for applying opa valid hostname for test clusters only.
   dryrun_map = {
@@ -8,6 +8,7 @@ module "gatekeeper" {
     user_ns_requires_psa_label         = false,
     lock_priv_capabilities             = false,
     warn_kubectl_create_sa             = false,
+    block_host_network                 = false,
   }
 
   constraint_violations_max_to_display = 25


### PR DESCRIPTION
Bumping to latest release of Gatekeeper to block the pod creation of pods with HostNetwork: true label. This is a way of preventing user workloads from reaching IMDSv2.

From [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/automode-learn-instances.html#_instance_metadata_service):
- EKS Auto Mode enforces IMDSv2 with a hop limit of 1 by default, adhering to AWS security best practices.
- If a Pod absolutely requires IMDS access when running in Auto Mode, the Pod must be configured to run with hostNetwork: true. This allows the Pod to access the instance metadata service directly.

Namespace exemptions:
- `amazon-guardduty`
- `kube-system`
- `logging`
- `monitoring`
- `tigera-operator`

Gator tests have been created for the following:
- Allowed - Create a pod without HostNetwork label
- Allowed - Create a pod with HostNetwork: true label in an allowed namespace
- Violation - Create a pod with HostNetwork: true label

This has been tested on a CP3 test cluster.

This is being done as part of https://github.com/ministryofjustice/cloud-platform/issues/8285.