### PR TITLE
Fix NFW routing issues

### DIFF
--- a/terraform/environments/data-platform/network/routes.tf
+++ b/terraform/environments/data-platform/network/routes.tf
@@ -69,8 +69,8 @@ resource "aws_route" "transit_gateway_to_network_firewall" {
         for subnet_key, subnet in local.subnets : {
           key              = "${attachment_key}-${subnet_key}"
           attachment_key   = attachment_key
-          attachment_az    = attachment.az
           destination_cidr = subnet.cidr_block
+          destination_az   = subnet.az
         } if subnet.type == "private"
       ]
     ]) : route.key => route
@@ -78,7 +78,7 @@ resource "aws_route" "transit_gateway_to_network_firewall" {
 
   route_table_id         = aws_route_table.additional[each.value.attachment_key].id
   destination_cidr_block = each.value.destination_cidr
-  vpc_endpoint_id        = data.aws_vpc_endpoint.network_firewall[each.value.attachment_az].id
+  vpc_endpoint_id        = data.aws_vpc_endpoint.network_firewall[each.value.destination_az].id
 
   depends_on = [aws_networkfirewall_firewall.main]
 }


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/data-platform/issues/651

This pull request updates the way routes to the Network Firewall are defined in the Terraform configuration, specifically improving how availability zones are referenced for VPC endpoints. The main focus is on making the code more consistent and less error-prone by switching from using the attachment's AZ to the subnet's AZ.

**Terraform configuration improvements:**

* Changed the key used to look up the Network Firewall VPC endpoint from `attachment.az` to `subnet.az` by introducing a new `destination_az` attribute, ensuring the correct endpoint is used for each subnet's availability zone (`terraform/environments/data-platform/network/routes.tf`).
* Removed the now-unnecessary `attachment_az` attribute from the route map, simplifying the local variable structure (`terraform/environments/data-platform/network/routes.tf`).

## Justification

Traffic from Cloud Platform (`172.20.0.0/16`), via the Transit Gateway, to `data-platform-production` private subnets was intermittently unreachable depending on destination AZ. Confirmed via testing that connections to an AZ-b target succeeded, while connections to AZ-a and AZ-c targets consistently timed out at the TCP handshake stage from the same source pod/node.

Root cause: `transit_gateway_to_network_firewall` routed TGW-ingress traffic to the Network Firewall endpoint in the **TGW attachment's own AZ** (`attachment_az`), regardless of the destination subnet's AZ. The return path (`private_to_network_firewall`) already routed based on the **destination subnet's own AZ**. Since the TGW attachment has Appliance Mode enabled, a given flow consistently enters via one attachment AZ, which may differ from the destination instance's AZ.

This meant, for a flow crossing AZs:
- The forward SYN was inspected and passed by the Network Firewall endpoint matching the attachment's AZ.
- The return SYN-ACK was sent to the Network Firewall endpoint matching the destination subnet's AZ instead — a different, independent stateful (Suricata) engine that never saw the initial SYN, so it dropped the packet as unrecognised/asymmetric traffic.

This was confirmed by:
- VPC Flow Logs showing `ACCEPT` egress packets leaving the destination ENI toward the source, which never arrived back at the client (`curl` hung at TCP connect until timeout).
- Network Firewall flow logs showing only SYN (`tcp_flags: 02`) events for the failing destinations, in the AZ matching the TGW attachment rather than the destination.

The fix routes `transit_gateway_to_network_firewall` traffic to the firewall endpoint matching the **destination subnet's AZ** (via the new `destination_az` attribute), so both the forward and return legs of any flow always traverse the same firewall endpoint, regardless of which TGW attachment AZ the traffic entered through.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>