### PR TITLE
feat(ai-gateway): add opt-in cost-based routing across providers

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
@@ -22,7 +22,8 @@ resource "litellm_unified_access_group" "microsoft_foundry" {
 resource "litellm_unified_access_group" "generally_available_models" {
   access_group_name = "generally-available-models"
 
-  access_model_names = concat(
+  # distinct(): a shared_model_name can make a model appear in more than one provider loop below.
+  access_model_names = distinct(concat(
     [
       for key in sort(keys(litellm_model.amazon_bedrock)) :
       litellm_model.amazon_bedrock[key].model_name
@@ -38,5 +39,5 @@ resource "litellm_unified_access_group" "generally_available_models" {
       litellm_model.microsoft_foundry[key].model_name
       if try(local.ai_gateway_models_filtered.microsoft_foundry[key].generally_available, false)
     ]
-  )
+  ))
 }

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
@@ -22,7 +22,7 @@ resource "litellm_unified_access_group" "microsoft_foundry" {
 resource "litellm_unified_access_group" "generally_available_models" {
   access_group_name = "generally-available-models"
 
-  # distinct(): a shared_model_name can make a model appear in more than one provider loop below.
+  # distinct(): a model can have both a provider-specific and a shared-alias deployment.
   access_model_names = distinct(concat(
     [
       for key in sort(keys(litellm_model.amazon_bedrock)) :
@@ -37,6 +37,16 @@ resource "litellm_unified_access_group" "generally_available_models" {
     [
       for key in sort(keys(litellm_model.microsoft_foundry)) :
       litellm_model.microsoft_foundry[key].model_name
+      if try(local.ai_gateway_models_filtered.microsoft_foundry[key].generally_available, false)
+    ],
+    [
+      for key in sort(keys(litellm_model.amazon_bedrock_shared)) :
+      litellm_model.amazon_bedrock_shared[key].model_name
+      if try(local.ai_gateway_models_filtered.amazon_bedrock[key].generally_available, false)
+    ],
+    [
+      for key in sort(keys(litellm_model.microsoft_foundry_shared)) :
+      litellm_model.microsoft_foundry_shared[key].model_name
       if try(local.ai_gateway_models_filtered.microsoft_foundry[key].generally_available, false)
     ]
   ))

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
@@ -2,7 +2,7 @@ resource "litellm_model" "amazon_bedrock" {
   for_each = try(local.ai_gateway_models_filtered.amazon_bedrock, {})
 
   custom_llm_provider = "bedrock"
-  model_name          = try(each.value.shared_model_name, "bedrock-${each.key}")
+  model_name          = "bedrock-${each.key}"
   base_model          = each.value.model_id
   tier                = "paid"
 
@@ -57,7 +57,61 @@ resource "litellm_model" "microsoft_foundry" {
   for_each = try(local.ai_gateway_models_filtered.microsoft_foundry, {})
 
   custom_llm_provider = each.value.model_provider
-  model_name          = try(each.value.shared_model_name, "azure-${each.key}")
+  model_name          = "azure-${each.key}"
+  base_model          = each.value.model_id
+  tier                = "paid"
+
+  model_api_base = can(each.value.model_endpoint) ? "${jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["endpoint"]}/${each.value.model_endpoint}" : jsondecode(data.aws_secretsmanager_secret_version.microsoft_foundry_jedi_gateway.secret_string)["endpoint"]
+  api_version    = try(each.value.model_api_version, each.value.model_provider == "azure" ? "v1" : null)
+
+  additional_litellm_params = {
+    ai_model_provider            = "Microsoft Foundry"
+    ai_model_family              = each.value.model_family
+    ai_model_name                = each.value.model_name
+    ai_model_generally_available = each.value.generally_available
+    additional_drop_params       = "[\"ai_model_provider\",\"ai_model_family\",\"ai_model_name\",\"ai_model_generally_available\"]"
+  }
+
+  depends_on = [
+    helm_release.ai_gateway_configuration,
+    helm_release.litellm,
+    helm_release.litellm_admin
+  ]
+}
+
+# Opt-in second registration of the same deployment under a shared public alias, so LiteLLM's
+# cost-based router can pick between providers. The provider-specific model above is untouched.
+resource "litellm_model" "amazon_bedrock_shared" {
+  for_each = { for key, model in try(local.ai_gateway_models_filtered.amazon_bedrock, {}) : key => model if can(model.shared_model_name) }
+
+  custom_llm_provider = "bedrock"
+  model_name          = each.value.shared_model_name
+  base_model          = each.value.model_id
+  tier                = "paid"
+
+  aws_region_name = each.value.region
+  aws_role_name   = can(each.value.aws_role_name) ? "arn:aws:iam::${local.environment_management.account_ids[each.value.aws_account_name]}:role/${each.value.aws_role_name}" : module.iam_role.arn
+
+  additional_litellm_params = {
+    ai_model_provider            = try(each.value.model_provider, "Amazon Bedrock")
+    ai_model_family              = each.value.model_family
+    ai_model_name                = each.value.model_name
+    ai_model_generally_available = each.value.generally_available
+    additional_drop_params       = "[\"ai_model_provider\",\"ai_model_family\",\"ai_model_name\",\"ai_model_generally_available\"]"
+  }
+
+  depends_on = [
+    helm_release.ai_gateway_configuration,
+    helm_release.litellm,
+    helm_release.litellm_admin
+  ]
+}
+
+resource "litellm_model" "microsoft_foundry_shared" {
+  for_each = { for key, model in try(local.ai_gateway_models_filtered.microsoft_foundry, {}) : key => model if can(model.shared_model_name) }
+
+  custom_llm_provider = each.value.model_provider
+  model_name          = each.value.shared_model_name
   base_model          = each.value.model_id
   tier                = "paid"
 

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
@@ -2,7 +2,7 @@ resource "litellm_model" "amazon_bedrock" {
   for_each = try(local.ai_gateway_models_filtered.amazon_bedrock, {})
 
   custom_llm_provider = "bedrock"
-  model_name          = "bedrock-${each.key}"
+  model_name          = try(each.value.shared_model_name, "bedrock-${each.key}")
   base_model          = each.value.model_id
   tier                = "paid"
 
@@ -57,7 +57,7 @@ resource "litellm_model" "microsoft_foundry" {
   for_each = try(local.ai_gateway_models_filtered.microsoft_foundry, {})
 
   custom_llm_provider = each.value.model_provider
-  model_name          = "azure-${each.key}"
+  model_name          = try(each.value.shared_model_name, "azure-${each.key}")
   base_model          = each.value.model_id
   tier                = "paid"
 

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -98,6 +98,8 @@ models:
       model_name: "Anthropic Claude Opus 4.8 (EU)"
       region: eu-west-2
       generally_available: true
+      # Opt-in: shares a public model_name with the Azure claude-opus-4-8 deployment for cost-based routing.
+      shared_model_name: "claude-opus-4-8"
     claude-opus-5:
       model_id: eu.anthropic.claude-opus-5
       model_family: "Anthropic Claude"
@@ -344,6 +346,8 @@ models:
       model_endpoint: "anthropic"
       generally_available: false
       environments_available: ["development", "test", "preproduction"]
+      # Opt-in: shares a public model_name with the Bedrock claude-opus-4-8 deployment for cost-based routing.
+      shared_model_name: "claude-opus-4-8"
     claude-opus-5:
       model_id: "claude-opus-5"
       model_family: "Anthropic Claude"

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl
@@ -83,7 +83,7 @@ proxy_config:
       port: 6379
       password: os.environ/auth_token
   router_settings:
-    routing_strategy: simple-shuffle
+    routing_strategy: cost-based-routing
     redis_host: os.environ/primary_endpoint_address
     redis_port: 6379
     redis_password: os.environ/auth_token

--- a/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
+++ b/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl
@@ -88,7 +88,7 @@ proxy_config:
       budget_duration: 30d
       models: []
   router_settings:
-    routing_strategy: simple-shuffle
+    routing_strategy: cost-based-routing
     redis_host: os.environ/primary_endpoint_address
     redis_port: 6379
     redis_password: os.environ/auth_token


### PR DESCRIPTION
## What
Adds an **opt-in** way to expose a single model alias backed by multiple provider deployments, letting LiteLLM's `cost-based-routing` router strategy pick the cheapest eligible one automatically. No existing model, alias, team, or access-group configuration changes behaviour unless explicitly opted in.

## Why
The same underlying model (e.g. Claude Opus 4.8) is available from both AWS Bedrock and Microsoft Foundry (Azure) at different prices. Previously every model was registered under a provider-prefixed name (`bedrock-<key>` / `azure-<key>`), so no two deployments could ever share a LiteLLM "model group" — cost comparison never had anything to compare.

## Changes
- `configuration/configuration.yml`: new optional per-model field `shared_model_name`. When set on a model, that deployment additionally registers under a shared public alias for cost-based routing. Set on `amazon_bedrock.claude-opus-4-8` and `microsoft_foundry.claude-opus-4-8` (both → `claude-opus-4-8`) as the initial test case.
- `ai-gateway-models.tf`: the existing `litellm_model.amazon_bedrock` / `litellm_model.microsoft_foundry` resources are **unchanged** — they keep registering every model under `bedrock-<key>` / `azure-<key>` exactly as before. Two new resources, `litellm_model.amazon_bedrock_shared` and `litellm_model.microsoft_foundry_shared`, register a **second** deployment row (same credentials/base model) under `shared_model_name` only for models that opt in — currently just the two Opus 4.8 entries.
- `ai-gateway-access-groups.tf`: `generally-available-models` gains two additional list entries pulling in the new shared-alias deployments (still gated on `generally_available`), wrapped in `distinct(...)` for safety. Existing entries and the per-provider `bedrock-<key>` / `azure-<key>` access groups are untouched.
- `src/helm/values/litellm/values.yml.tftpl` and `src/helm/values/litellm-admin/values.yml.tftpl`: `router_settings.routing_strategy` changed from `simple-shuffle` to `cost-based-routing`. Only changes behaviour where two or more deployments share a `model_name` — today that's only the new `claude-opus-4-8` group.
- No prices are hardcoded anywhere: cost comparison relies entirely on LiteLLM's own bundled/auto-updating cost map (resolved from `custom_llm_provider` + `base_model`), the same mechanism every model in this repo already relies on implicitly.

## Behaviour after this change
- `bedrock-claude-opus-4-8` and `azure-claude-opus-4-8` keep working exactly as before, for callers who want to pin to a specific provider — same resources, same access groups, no plan diff on them.
- `claude-opus-4-8` is now also callable, and LiteLLM routes it to whichever of the two deployments it currently prices cheaper; if the cheaper one is unhealthy, the built-in health checks let it fail over to the other automatically.
- Access control is unaffected for existing models/aliases: whichever access group/team already grants access to a model's underlying `model_name` continues to apply. The new shared alias is additive to `generally-available-models`, not a replacement of any entry.

## Caveat / follow-up
Cost-based routing only produces a genuine cheapest-wins decision if LiteLLM's bundled pricing map recognises `bedrock/eu.anthropic.claude-opus-4-8` and `azure_ai/claude-opus-4-8`. If either is unrecognised, LiteLLM treats it as zero/tied cost and the choice between the two becomes arbitrary until LiteLLM's map is updated. Recommend verifying this via `/model/info` (or `litellm.get_model_info()`) after deploying, before relying on this for real cost optimisation.

## Things to watch if more models adopt `shared_model_name` later
- Unpriced deployments look "free" to the router: if a deployment's `custom_llm_provider`/`base_model` isn't in LiteLLM's bundled cost map, its cost defaults to near-zero/untracked, so it'll always "win" the comparison regardless of real price.
- Tie-breaking is close to random when two deployments report identical or both-missing costs — behaves like `simple-shuffle` in that case, so no regression, just no real benefit either.
- `tpm`/`rpm` limits are still respected — cost-based routing filters out deployments over their configured rate limits first, same as before.

## Verification
- [ ] `terraform plan` in the ai-gateway environment(s) — confirm **only new resources** (`litellm_model.amazon_bedrock_shared["claude-opus-4-8"]`, `litellm_model.microsoft_foundry_shared["claude-opus-4-8"]`, and the `generally-available-models` access group gaining entries) are planned; no existing resource should show an in-place `~` update.
- [ ] After apply: confirm LiteLLM recognises pricing for both deployments (`/model/info`).
- [ ] Call `POST /chat/completions` with `"model": "claude-opus-4-8"` and confirm the cheaper deployment is selected (check spend logs / hidden params for actual provider used).
- [ ] Temporarily break one deployment and confirm the alias still succeeds via the other (failover).
- [ ] Confirm existing team/key access-group checks still gate the shared alias correctly, and that `bedrock-claude-opus-4-8` / `azure-claude-opus-4-8` are unaffected.
