### PR TITLE
fix(argocd): Make cluster kubernetes provider configurable at plan time

### DIFF
--- a/terraform/environments/cloud-platform/cluster/data.tf
+++ b/terraform/environments/cloud-platform/cluster/data.tf
@@ -50,12 +50,17 @@ locals {
   cloud_platform_engineers_group_id = "664252b4-7021-701e-49b9-6c46ccc7899e"
 }
 
+# NOTE: do NOT add `depends_on = [module.eks]` to these EKS data sources. The
+# `name` reference already creates an implicit dependency on the cluster, so
+# they read only after it exists. An explicit depends_on additionally forces
+# Terraform to DEFER the read whenever module.eks shows any planned change,
+# making endpoint/token unknown at plan time. The kubernetes/helm providers
+# (providers.tf) then fall back to localhost, breaking plan-time refresh of the
+# kubernetes_* resources in this component (e.g. the ArgoCD spoke RBAC).
 data "aws_eks_cluster" "cluster" {
-  name       = module.eks.cluster_name
-  depends_on = [module.eks]
+  name = module.eks.cluster_name
 }
 
 data "aws_eks_cluster_auth" "cluster" {
-  name       = module.eks.cluster_name
-  depends_on = [module.eks]
+  name = module.eks.cluster_name
 }


### PR DESCRIPTION
## What

Remove the redundant `depends_on = [module.eks]` from the two EKS data sources (`data.aws_eks_cluster.cluster` and `data.aws_eks_cluster_auth.cluster`) in `cloud-platform/cluster/data.tf`.

## Why

The `cluster` component's kubernetes/helm providers are configured from those data sources:

```hcl
provider "kubernetes" {
  host = try(data.aws_eks_cluster.cluster.endpoint, null)
  ...
}
```

With `depends_on = [module.eks]`, Terraform defers reading the data sources whenever the module shows any planned change, so `endpoint`/`token` are unknown at plan time. `try(..., null)` collapses that to `null`, the providers fall back to their default host (`localhost:80`), and `terraform plan` fails while refreshing existing resources:

```
Error: Get "http://localhost/apis/rbac.authorization.k8s.io/v1/clusterroles/argocd-hub-read-all":
dial tcp [::1]:80: connect: connection refused
  with kubernetes_cluster_role_v1.argocd_hub_read[0]
```

This was latent until #8454 added the first kubernetes-provider-managed resources (the scoped ArgoCD spoke RBAC ClusterRoles/bindings) to this component. Once those exist in a registered spoke's state (`container-platform-octo-nonlive`), every plan must refresh them via the kube API and hits the localhost error. Because the PR pipeline plans **all** cloud-platform components, this blocks every container-platform deployment (E.g. https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/32143813006/job/95733232171#step:14:332). The post-merge apply succeeds (on apply the module resolves and the data source reads a real endpoint); only plan-time refresh breaks.

## The fix

The `name = module.eks.cluster_name` reference already creates an implicit dependency, so the data sources still read only after the cluster exists — but without the explicit `depends_on` they are no longer force-deferred when the module shows a change. `cluster_name` stays known at plan, the providers receive a real endpoint, and refresh succeeds. A comment is added to prevent the `depends_on` being reintroduced.

## Testing

- `terraform fmt` + `terraform validate` pass.
- **Reproduced and verified locally** against the real `container-platform-octo-nonlive` workspace (read-only `terraform plan -lock=false`):
  - The workspace has a pending `module.eks` change (`module.eks.module.kms.aws_kms_key.this[0]` in-place update) — exactly the condition that made the old `depends_on` defer the data sources.
  - With this fix, all four `kubernetes_cluster_role*`/`_binding*` resources **refreshed cleanly** (no `localhost`, no connection-refused) and the plan completed.

## Blast radius

Plan-time only; no change to applied infrastructure for hubs or spokes. Unblocks all cloud-platform PRs.

## Ticket

Closes ministryofjustice/cloud-platform#8462
