### PR TITLE
feat(monitoring): connect Grafana to Google Cloud Monitoring via workload identity federation

### DIFF
--- a/terraform/environments/data-platform/monitoring/data.tf
+++ b/terraform/environments/data-platform/monitoring/data.tf
@@ -45,5 +45,11 @@ data "aws_secretsmanager_secret_version" "pagerduty_orchestrator_integration_key
 data "aws_secretsmanager_secret_version" "grafana_azure_monitor" {
   count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
 
-  secret_id = "${local.component_name}/grafana-azure-monitor"
+  secret_id = module.grafana_azure_monitor_secret[0].secret_id
+}
+
+data "aws_secretsmanager_secret_version" "google_cloud_monitoring" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  secret_id = module.google_cloud_monitoring_secret[0].secret_id
 }

--- a/terraform/environments/data-platform/monitoring/environment-configuration.tf
+++ b/terraform/environments/data-platform/monitoring/environment-configuration.tf
@@ -5,7 +5,7 @@ locals {
       monitoring_stack_enabled = true
       monitoring_hostname      = "monitoring.development.data-platform.service.justice.gov.uk"
       grafana_namespace        = "data-platform-monitoring-development"
-      grafana_chart_version    = "12.4.8"
+      grafana_chart_version    = "12.11.0"
 
       # Enable dashboard management in grafana-dashboards.tf (keep false until monitoring/grafana-api-token is populated).
       grafana_dashboards_enabled = true
@@ -33,9 +33,9 @@ locals {
 
       # Alert routing by account: enabled groups, scoped namespaces, and overrides.
       alerts_configured_accounts = [
-        { name = "data-platform-development", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] },
-        { name = "data-platform-test", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] },
-        { name = "data-platform-preproduction", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] }
+        { name = "data-platform-development", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] },
+        { name = "data-platform-test", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] },
+        { name = "data-platform-preproduction", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] }
       ]
     }
     test = {
@@ -48,7 +48,7 @@ locals {
       monitoring_stack_enabled = true
       monitoring_hostname      = "monitoring.data-platform.service.justice.gov.uk"
       grafana_namespace        = "data-platform-monitoring-production"
-      grafana_chart_version    = "12.4.8"
+      grafana_chart_version    = "12.11.0"
 
       # Enable dashboard management in grafana-dashboards.tf (keep false until monitoring/grafana-api-token is populated).
       grafana_dashboards_enabled = true
@@ -74,10 +74,10 @@ locals {
       ]
       # Alert routing by account: enabled groups, scoped namespaces, and overrides.
       alerts_configured_accounts = [
-        { name = "data-platform-development", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] },
-        { name = "data-platform-test", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] },
-        { name = "data-platform-preproduction", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] },
-        { name = "data-platform-production", enabled_groups = ["AI Gateway","Bedrock"], namespaces = ["ai-gateway"] }
+        { name = "data-platform-development", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] },
+        { name = "data-platform-test", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] },
+        { name = "data-platform-preproduction", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] },
+        { name = "data-platform-production", enabled_groups = ["AI Gateway", "Bedrock"], namespaces = ["ai-gateway"] }
       ]
     }
   }

--- a/terraform/environments/data-platform/monitoring/google-cloud.tf
+++ b/terraform/environments/data-platform/monitoring/google-cloud.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_config_map_v1" "google_application_credentials" {
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  metadata {
+    namespace = local.environment_configuration.grafana_namespace
+    name      = "google-application-credentials"
+  }
+
+  data = {
+    "credentials.json" = local.google_application_credentials
+  }
+}

--- a/terraform/environments/data-platform/monitoring/helm-charts.tf
+++ b/terraform/environments/data-platform/monitoring/helm-charts.tf
@@ -15,6 +15,11 @@ resource "helm_release" "grafana" {
       azure_monitor_workload_identity_subscription_id = jsondecode(data.aws_secretsmanager_secret_version.grafana_azure_monitor[0].secret_string).subscription_id
       azure_monitor_workload_identity_tenant_id       = jsondecode(data.aws_secretsmanager_secret_version.grafana_azure_monitor[0].secret_string).tenant_id
 
+      # Google
+      googleWorkloadIdentityAudience        = local.google_workload_identity_audience
+      googleApplicationCredentialsConfigMap = kubernetes_config_map_v1.google_application_credentials[0].metadata[0].name
+      googleCloudProjectName                = local.google_cloud_project_name
+
       hostname           = local.environment_configuration.monitoring_hostname
       entra_id_tenant_id = local.grafana_entra_id.tenant_id
       # Cloud Platform requires a unique external-dns set-identifier per ingress:

--- a/terraform/environments/data-platform/monitoring/locals.tf
+++ b/terraform/environments/data-platform/monitoring/locals.tf
@@ -8,6 +8,28 @@ locals {
   # try() keeps this resolvable when monitoring is disabled.
   grafana_api_token = try(jsondecode(data.aws_secretsmanager_secret_version.grafana_api_token[0].secret_string)["token"], "")
 
+  # Google workload identity federation (used by Grafana's Google Cloud Monitoring
+  # datasource; same GCP project and pattern as the ai-gateway component).
+  # try() keeps these resolvable when monitoring is disabled.
+  google_cloud_project_name = try(jsondecode(data.aws_secretsmanager_secret_version.google_cloud_monitoring[0].secret_string)["project_name"], "")
+  google_cloud_project_id   = try(jsondecode(data.aws_secretsmanager_secret_version.google_cloud_monitoring[0].secret_string)["project_id"], "")
+
+  grafana_service_account_email     = "grafana@${local.google_cloud_project_name}.iam.gserviceaccount.com"
+  google_workload_identity_audience = "//iam.googleapis.com/projects/${local.google_cloud_project_id}/locations/global/workloadIdentityPools/amazon-eks/providers/data-platform-monitoring"
+
+  # No secret material here; external_account credentials only describe how to exchange the projected token, so a ConfigMap is fine
+  google_application_credentials = jsonencode({
+    type                              = "external_account"
+    audience                          = local.google_workload_identity_audience
+    subject_token_type                = "urn:ietf:params:oauth:token-type:jwt"
+    token_url                         = "https://sts.googleapis.com/v1/token"
+    service_account_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${local.grafana_service_account_email}:generateAccessToken"
+    quota_project_id                  = local.google_cloud_project_name
+    credential_source = {
+      file = "/var/run/secrets/sts.googleapis.com/google-identity-token"
+    }
+  })
+
   pagerduty_routing_key = try(data.aws_secretsmanager_secret_version.pagerduty_orchestrator_integration_key_secret[0].secret_string, null)
   # Dashboards as code: each src/helm/dashboards subdirectory maps to one Grafana folder.
   grafana_dashboard_root = "${path.module}/src/helm/dashboards"

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -97,3 +97,20 @@ module "grafana_azure_monitor_secret" {
 
   ignore_secret_changes = true
 }
+
+# Google Cloud project used for Grafana's Google Cloud Monitoring datasource via
+# workload identity federation (see the ai-gateway component for the same pattern).
+module "google_cloud_monitoring_secret" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=d03382d3ec9c12b849fbbe35b770eaa047f7bbea" # v2.1.0
+
+  count = local.environment_configuration.monitoring_stack_enabled ? 1 : 0
+
+  name = "${local.component_name}/google-cloud-platform/moj-gcp-ai-gateway"
+
+  secret_string = jsonencode({
+    project_name = "CHANGEME"
+    project_id   = "CHANGEME"
+  })
+
+  ignore_secret_changes = true
+}

--- a/terraform/environments/data-platform/monitoring/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/environments/data-platform/monitoring/src/helm/values/grafana/values.yml.tftpl
@@ -66,6 +66,30 @@ extraSecretMounts:
             path: azure-identity-token
             audience: api://AzureADTokenExchange
             expirationSeconds: 3600
+  # Mount Google Workload Identity Federation token for service authentication.
+  - name: google-workload-identity-token
+    mountPath: /var/run/secrets/sts.googleapis.com
+    readOnly: true
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            path: google-identity-token
+            audience: ${googleWorkloadIdentityAudience}
+            expirationSeconds: 3600
+
+extraVolumes:
+  - name: google-application-default-credentials
+    configMap:
+      name: ${googleApplicationCredentialsConfigMap}
+      items:
+        - key: credentials.json
+          path: application_default_credentials.json
+
+extraVolumeMounts:
+  - name: google-application-default-credentials
+    mountPath: /home/grafana/.config/gcloud
+    readOnly: true
 
 # RDS connection values come from the grafana-rds secret; sensitive values are
 # not stored in this file.
@@ -141,6 +165,15 @@ datasources:
         jsonData:
           azureAuthType: workloadidentity
           subscriptionId: ${azure_monitor_workload_identity_subscription_id}
+      - name: google-cloud-monitoring-moj-gcp-ai-gateway
+        type: stackdriver
+        access: proxy
+        uid: google-cloud-monitoring
+        isDefault: false
+        jsonData:
+          authenticationType: gce
+          defaultProject: ${googleCloudProjectName}
+          universeDomain: googleapis.com
 %{ for account in monitored_accounts ~}
       - name: ${account.name}-cloudwatch
         type: cloudwatch


### PR DESCRIPTION
Do not merge until https://github.com/ministryofjustice/gcp-management/pull/7 is in

## What

Adds a Google Cloud Monitoring (Stackdriver) datasource to the `data-platform-monitoring` Grafana instance, authenticated via keyless Workload Identity Federation (WIF) — following the same pattern already used for AI Gateway's Google integration and for Azure Monitor's WIF setup in this component.

## Why

Lets Grafana query Google Cloud Monitoring metrics (e.g. for `moj-gcp-ai-gateway-development`) alongside the existing CloudWatch, X-Ray, Amazon Managed Prometheus and Azure Monitor datasources, without needing any long-lived GCP service account keys.

## How it works

- **secrets.tf / data.tf / locals.tf**: stores the GCP project name/number in Secrets Manager (same field convention as AI Gateway: `project_id` = numeric project number used for the WIF audience, `project_name` = the actual project ID string), and builds the `external_account` credentials JSON used to exchange the pod's projected Kubernetes service account token for a Google access token, impersonating a dedicated `grafana` GCP service account.
- **google-cloud.tf**: a ConfigMap holding the `external_account` credentials (no secret material — it only describes *how* to exchange the projected token, not a static key).
- **helm-charts.tf / values.yml.tftpl**: projects the WIF token into the pod, mounts the credentials at Google's well-known Application Default Credentials path (`~/.config/gcloud/application_default_credentials.json`) — required because Grafana's Google Cloud Monitoring plugin runs as a separate backend subprocess that does not inherit `GOOGLE_APPLICATION_CREDENTIALS` from the main Grafana process — and provisions the datasource itself (`authenticationType: gce`, which is the correct type for ADC-based auth regardless of platform).
- **environment-configuration.tf**: bumps the Grafana chart to `12.11.0` (Grafana `13.2.0`).

## Dependencies

Requires the corresponding [gcp-management](https://github.com/ministryofjustice/gcp-management) change (PR #7) that creates the `data-platform-monitoring` workload identity pool provider and the `grafana` GCP service account (granted `roles/monitoring.viewer`), and the `monitoring.googleapis.com` API enabled on the target GCP project.

## Testing

Verified end-to-end in the development environment:
- WIF token exchange, service account impersonation, and direct Cloud Monitoring API calls all confirmed working manually.
- Confirmed real Google Cloud Monitoring metrics are queryable from Grafana's Explore page.

Note: the datasource's "Save & Test" button currently shows a generic `400 Bad Request` despite the plugin's own health check reporting success internally (`status=ok`) — this looks like a cosmetic bug in the `stackdriver` plugin/Grafana 13.2.0 response handling, not a functional issue (queries work correctly).

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>