### PR TITLE
PLAT-143: delius-mis: dev powered up on demand

### DIFF
--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -356,6 +356,7 @@ locals {
 
   lb_config_dev = {
     bucket_policy_enabled = true
+    bws_lb_rule_priority  = 1300
     maintenance_message   = "NDMIS Reporting Dev is rarely used so is started on demand. Please contact <a href=\"https://moj.enterprise.slack.com/archives/C032BQQHJE5\">#ask-probation-hosting</a> slack channel if you need the environment starting."
   }
 

--- a/terraform/environments/delius-mis/locals_development.tf
+++ b/terraform/environments/delius-mis/locals_development.tf
@@ -356,7 +356,7 @@ locals {
 
   lb_config_dev = {
     bucket_policy_enabled = true
-    maintenance_message   = "NDMIS Reporting Dev is currently unavailable due to planned maintenance or out-of-hours shutdown (7pm-7am)."
+    maintenance_message   = "NDMIS Reporting Dev is rarely used so is started on demand. Please contact <a href=\"https://moj.enterprise.slack.com/archives/C032BQQHJE5\">#ask-probation-hosting</a> slack channel if you need the environment starting."
   }
 
   datasync_config_dev = {

--- a/terraform/environments/delius-mis/modules/mis_environment/lb.tf
+++ b/terraform/environments/delius-mis/modules/mis_environment/lb.tf
@@ -530,7 +530,7 @@ resource "aws_lb_listener_rule" "dis_https" {
 resource "aws_lb_listener_rule" "bws_https" {
   count        = length(aws_lb_listener.mis_https) == 1 && local.bws_enabled ? 1 : 0
   listener_arn = aws_lb_listener.mis_https[0].arn
-  priority     = 300
+  priority     = lookup(var.lb_config, "bws_lb_rule_priority", 300)
 
   action {
     type             = "forward"


### PR DESCRIPTION
Update maintenance mode message and LB rule priority to reflect that dev is permanently powered off and only powered up on-demand via a pipeline.