### PR TITLE
Integration Hub - store dispatch information in secretsmanager

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/locals-dispatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-dispatch.tf
@@ -1,0 +1,44 @@
+locals {
+  file_dispatch_prefixes = {
+    development = {
+      # synergy = {
+      #   "/" = {
+      #     action = null
+      #     notifications = {
+      #       email = null
+      #       slack = null
+      #       teams = null
+      #     }
+      #   }
+      #   "/pensions/" = {
+      #     action        = null
+      #     notifications = {}
+      #   }
+      #   "/routes/1/" = {
+      #     action        = null
+      #     notifications = {}
+      #   }
+      # }
+      #
+      # web_app = {
+      #   "/group/group-1/" = {
+      #     action        = null
+      #     notifications = {}
+      #   }
+      # }
+    }
+    test          = {}
+    preproduction = {}
+    production    = {}
+  }
+
+  environment_file_dispatch_prefixes = merge(
+    {},
+    [
+      for identity, prefixes in local.file_dispatch_prefixes[local.environment] : {
+        for prefix, configuration in prefixes :
+        "${identity}${prefix}" => configuration
+      }
+    ]...
+  )
+}

--- a/terraform/environments/integration-hub-file-transfer/locals-dispatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-dispatch.tf
@@ -1,27 +1,27 @@
 locals {
   file_dispatch_prefixes = {
     development = {
-      # synergy = {
+      # example-transfer-identity = {
       #   "/" = {
       #     action = null
       #     notifications = {
-      #       email = null
-      #       slack = null
-      #       teams = null
+      #       email = null # email address
+      #       slack = null # slack webhook URL
+      #       teams = null # teams webhook URL
       #     }
       #   }
-      #   "/pensions/" = {
+      #   "/app-1/" = {
       #     action        = null
       #     notifications = {}
       #   }
-      #   "/routes/1/" = {
+      #   "/app-2/1/" = {
       #     action        = null
       #     notifications = {}
       #   }
       # }
       #
-      # web_app = {
-      #   "/group/group-1/" = {
+      # example-web-app-group = {
+      #   "/group/group-name/" = {
       #     action        = null
       #     notifications = {}
       #   }
@@ -32,13 +32,10 @@ locals {
     production    = {}
   }
 
-  environment_file_dispatch_prefixes = merge(
-    {},
-    [
-      for identity, prefixes in local.file_dispatch_prefixes[local.environment] : {
-        for prefix, configuration in prefixes :
-        "${identity}${prefix}" => configuration
-      }
-    ]...
-  )
+  environment_file_dispatch_prefixes = [
+    for identity, prefixes in local.file_dispatch_prefixes[local.environment] : {
+      for prefix, configuration in prefixes :
+      "${identity}${prefix}" => configuration
+    }
+  ]
 }

--- a/terraform/environments/integration-hub-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub-file-transfer/secrets.tf
@@ -3,7 +3,7 @@ module "secrets_file_dispatch_prefix" {
   source  = "terraform-aws-modules/secrets-manager/aws"
   version = "2.1.0"
 
-  for_each = local.environment_file_dispatch_prefixes
+  for_each = merge(local.environment_file_dispatch_prefixes...)
 
   name                    = each.key
   description             = "File dispatch configuration for the ${each.key} object key prefix"

--- a/terraform/environments/integration-hub-file-transfer/secrets.tf
+++ b/terraform/environments/integration-hub-file-transfer/secrets.tf
@@ -1,1 +1,31 @@
-#### This file can be used to store secrets specific to the member account ####
+module "secrets_file_dispatch_prefix" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  for_each = local.environment_file_dispatch_prefixes
+
+  name                    = each.key
+  description             = "File dispatch configuration for the ${each.key} object key prefix"
+  recovery_window_in_days = 7
+  kms_key_id              = module.kms_secrets.key_arn
+  create_policy           = true
+  block_public_policy     = true
+  ignore_secret_changes   = true
+
+  policy_statements = {
+    read = {
+      sid = "AllowCIRolesToRead"
+      principals = [{
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+        ]
+      }]
+      actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      resources = ["*"]
+    }
+  }
+
+  secret_string = jsonencode(each.value)
+}


### PR DESCRIPTION
In order to generate a `FileActionExecutionRequested.v1` event we need to know what the requested action _is_. Our rough flow looks like this:
1. Object appears in `clean` bucket.
2. `FileRouted.v1` is placed on the file transfer bus.
3. `FileRouted.v1` is sent to an adapter lambda.
4. The lambda conducts a lookup for a relevant prefix in AWS Secretsmanager.
5. If a matching prefix is found, we create the `FileActionExecutionRequested.v1` event and place it on the file transfer bus.
6. EventBridge rules/targets put the event on the relevant SQS queue(s) and the dispatch events happen.

Before we do this, though, we need to create the relevant information and store it in AWS Secretsmanager. We don't want to put sensitive values (webhooks) into code, so these will need to be manually filled until we come up with a better answer. The local will create a secret per-prefix supplied that will hold the relevant notifications and actions. I'll likely need to expand out from this.