### PR TITLE
Allow ListenerSet in per-BU AppProject whitelist

### DIFF
--- a/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
+++ b/terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf
@@ -265,6 +265,7 @@ resource "kubectl_manifest" "argocd_project_bu" {
         { group = "networking.k8s.io", kind = "NetworkPolicy" },
         { group = "gateway.networking.k8s.io", kind = "HTTPRoute" },
         { group = "gateway.networking.k8s.io", kind = "GRPCRoute" },
+        { group = "gateway.networking.k8s.io", kind = "ListenerSet" },
       ]
       # BU projects cannot create cluster-scoped resources
       clusterResourceBlacklist = [


### PR DESCRIPTION
## What

Adds `gateway.networking.k8s.io/ListenerSet` to the per-BU AppProject `namespaceResourceWhitelist` in `argocd-gitops.tf`.

## Why

Teams delivering custom-domain TLS create a namespaced `ListenerSet` (attached to the shared Envoy Gateway, which already sets `allowedListeners.namespaces.from: All`). The per-BU workload AppProjects currently whitelist `HTTPRoute` and `GRPCRoute` but not `ListenerSet`, so ArgoCD rejects the resource with a project permission error and the Application never syncs.

## Scope

The `argocd_project_bu` resource is a `for_each` over all BUs and both tiers, so this enables team-owned ListenerSets across `octo`, `laa`, `hmpps` (nonlive and live). Platform projects already permit all namespaced kinds and are unaffected.

## Testing

Unblocks the [dns-testapp](https://github.com/ministryofjustice/container-platform-environments/pull/20) custom-TLS smoke test on `container-platform-octo-nonlive`: once applied, the team-owned ListenerSet syncs, cert-manager issues a staging certificate, and traffic is served over HTTPS.
