### PR TITLE
increase dagbag import timeout to prevent DAG import errors

### DIFF
--- a/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
@@ -12,6 +12,7 @@ locals {
       airflow_min_workers             = 2
       airflow_schedulers              = 2
       airflow_celery_worker_autoscale = "7,1"
+      airflow_dagbag_import_timeout   = 60
     }
     test = {
       /* Route53 */
@@ -25,6 +26,7 @@ locals {
       airflow_min_workers             = 2
       airflow_schedulers              = 2
       airflow_celery_worker_autoscale = "7,1"
+      airflow_dagbag_import_timeout   = 60
     }
     production = {
       /* Route53 */
@@ -38,6 +40,7 @@ locals {
       airflow_min_workers             = 2
       airflow_schedulers              = 2
       airflow_celery_worker_autoscale = "7,1"
+      airflow_dagbag_import_timeout   = 60
     }
   }
 }

--- a/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/environment-configuration.tf
@@ -40,7 +40,7 @@ locals {
       airflow_min_workers             = 2
       airflow_schedulers              = 2
       airflow_celery_worker_autoscale = "7,1"
-      airflow_dagbag_import_timeout   = 60
+      airflow_dagbag_import_timeout   = 90
     }
   }
 }

--- a/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/mwaa.tf
@@ -23,6 +23,7 @@ resource "aws_mwaa_environment" "main" {
 
   airflow_configuration_options = {
     "celery.worker_autoscale"            = local.environment_configuration.airflow_celery_worker_autoscale
+    "core.dagbag_import_timeout"         = local.environment_configuration.airflow_dagbag_import_timeout
     "secrets.backend"                    = "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend"
     "secrets.backend_kwargs"             = "{\"connections_prefix\": \"airflow/connections\", \"variables_prefix\": \"airflow/variables\"}"
     "smtp.smtp_host"                     = "email-smtp.${data.aws_region.current.region}.amazonaws.com"

--- a/terraform/environments/analytical-platform-compute/airflow/versions.tf
+++ b/terraform/environments/analytical-platform-compute/airflow/versions.tf
@@ -20,6 +20,14 @@ terraform {
       version = "~> 2.8"
       source  = "hashicorp/archive"
     }
+    kubernetes = {
+      version = "~> 3.1"
+      source  = "hashicorp/kubernetes"
+    }
+    helm = {
+      version = "~> 3.1"
+      source  = "hashicorp/helm"
+    }
   }
   required_version = "~> 1.15"
 }


### PR DESCRIPTION
`core.dagbag_import_timeout` was previously unset, defaulting to Airflow's `30s`. `dag_factory.py` loads ~50+ workflow.yml files in a single parse, and total parse time has grown to the point of intermittently exceeding `30s`, causing DagBag import timeouts and ImportErrors across all DAGs in production.

bug [ticket](https://github.com/ministryofjustice/data-platform/issues/655) 
