### PR TITLE
[cloud-platform] Grant container-platform-aws ArgoCD admin access on hub clusters

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -51,7 +51,10 @@ module "argocd" {
   idc_region       = var.argocd_idc_region
   rbac_role_mappings = merge(
     {
-      ADMIN = [{ id = local.cloud_platform_engineers_group_id, type = "SSO_GROUP" }]
+      ADMIN = [
+        { id = local.cloud_platform_engineers_group_id, type = "SSO_GROUP" },
+        { id = local.container_platform_aws_group_id, type = "SSO_GROUP" },
+      ]
     },
     var.argocd_rbac_role_mappings
   )

--- a/terraform/environments/cloud-platform/cluster/data.tf
+++ b/terraform/environments/cloud-platform/cluster/data.tf
@@ -39,15 +39,20 @@ data "aws_iam_roles" "platform_engineer_admin_sso_role" {
 # }
 
 #------------------------------------------------------------------------------
-# IAM Identity Center — cloud-platform-engineers group ID for ArgoCD RBAC
+# IAM Identity Center — group IDs for ArgoCD RBAC
 #
 # Hardcoded because the ModernisationPlatformSSOReadOnly role returns
 # ResourceNotFoundException when calling GetGroupId despite having the
 # identitystore:Get* permission. TODO: investigate and switch back to
 # data.aws_identitystore_group lookup.
+#
+# - cloud-platform-engineers: the platform team, granted ArgoCD admin.
+# - container-platform-aws: the AWS ProServe team working on the project,
+#   granted ArgoCD admin so they can access the ArgoCD portal on hub clusters.
 #------------------------------------------------------------------------------
 locals {
   cloud_platform_engineers_group_id = "664252b4-7021-701e-49b9-6c46ccc7899e"
+  container_platform_aws_group_id   = "7682a204-00f1-7031-257e-713bb28289c6"
 }
 
 # NOTE: do NOT add `depends_on = [module.eks]` to these EKS data sources. The


### PR DESCRIPTION
## Summary

Extends ArgoCD admin access on hub clusters to the `container-platform-aws` IAM Identity Center group, so the AWS ProServe team can access the ArgoCD portal. Previously only `cloud-platform-engineers` was mapped to the ArgoCD `ADMIN` role.

Closes ministryofjustice/cloud-platform#8465

## Changes

- **`cluster/data.tf`** — add `container_platform_aws_group_id` (`7682a204-00f1-7031-257e-713bb28289c6`) alongside the existing engineers group, following the same hardcoding pattern (the SSO read-only role can't resolve group IDs via `GetGroupId`). Comment updated to describe both groups.
- **`cluster/argocd.tf`** — add the group to the ArgoCD `ADMIN` RBAC mapping next to `cloud-platform-engineers`.

`var.argocd_rbac_role_mappings` still merges on top, so per-BU overrides are unaffected. The mapping only takes effect on hub clusters (where `module.argocd` is instantiated).

## Testing

- `terraform fmt -check` — clean
- `terraform validate` — passes

## Acceptance criteria

- [x] `container-platform-aws` mapped to the ArgoCD `ADMIN` role on hub clusters
- [x] `cloud-platform-engineers` retains its existing admin access
- [x] Members of `container-platform-aws` can authenticate to and use the ArgoCD portal (verify post-apply)
- [x] `terraform plan` shows the added identity with no unintended changes (verify in pipeline)