### PR TITLE
typo of workspace name

### DIFF
--- a/terraform/environments/eucs-appstream/application_variables.json
+++ b/terraform/environments/eucs-appstream/application_variables.json
@@ -67,7 +67,7 @@
         "judith-adams": "JudithAdamsNPS",
         "oluwaseun-ajiboye": "Oluwaseun.Ajiboye",
         "rajesh-gupta": "Rajesh.Gupta",
-        "workspaces-imagebuild": "workspaces.imagebuild",
+        "workspaces-imagebuild": "workspaces.imagebuil",
         "workspace-user": "workspace.user",
         "michelle-reed": "michelle.reed",
         "sarah-lumsdon": "sarah.lumsdon",


### PR DESCRIPTION
Note, that this fixes a typo for an assigned workspace - simple letter removal for production