### PR TITLE
Allow ArgoCD hub deploy role to manage ListenerSets on spokes

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -250,7 +250,7 @@ resource "kubernetes_cluster_role_v1" "argocd_hub_deploy" {
   # Gateway API routes used by product workloads.
   rule {
     api_groups = ["gateway.networking.k8s.io"]
-    resources  = ["httproutes", "grpcroutes"]
+    resources  = ["httproutes", "grpcroutes", "listenersets"]
     verbs      = ["create", "update", "patch", "delete", "deletecollection"]
   }
 


### PR DESCRIPTION
## What

Adds `listenersets` to the `gateway.networking.k8s.io` write rule in the `argocd-hub-deploy` ClusterRole (`cluster/argocd.tf`), granting the hub's ArgoCD capability role permission to create/manage `ListenerSet` resources on registered spoke clusters.

## Why

Teams delivering custom-domain TLS create a namespaced `ListenerSet` via GitOps. This requires authorization at two independent layers:

1. **ArgoCD AppProject whitelist** (hub, `cluster-core`): "the project may create ListenerSets." Done in #18265 (applied).
2. **Kubernetes RBAC on the spoke** (this change): "the ArgoCD user may create ListenerSets on this cluster."

With only layer 1 in place, sync fails on the spoke with:

```
listenersets.gateway.networking.k8s.io is forbidden: User "arn:aws:sts::--redacted--:assumed-role/cloud-platform-nonlive-argocd-capability/aws-go-sdk--redacted--" cannot create resource "listenersets" in API group "gateway.networking.k8s.io" in the namespace "dns-testapp-dev"
```

`HTTPRoute` synced fine because it was already in the rule; `ListenerSet` was not. This change closes that gap.

## Scope

- The ClusterRole is created on spokes (`local.is_argocd_spoke`), so this applies to all registered spokes (currently `container-platform-octo-nonlive`).
- `ListenerSet` is namespaced, so this does not touch the deliberately-withheld cluster-scoped permissions. Least-privilege posture is preserved, it extends the existing namespaced Gateway API write permission that already covers `httproutes`/`grpcroutes`.
- Hostname hijacking is constrained separately by the Gatekeeper hostname guardrail (fast-follow), not by this grant.

## Testing

Unblocks the `dns-testapp` custom-TLS smoke test on `container-platform-octo-nonlive`: once applied to the spoke, the hub can create the team-owned `ListenerSet`, cert-manager issues a staging certificate, and traffic is served over HTTPS.
