### PR TITLE
[cloud-platform] Auto-register ephemeral Argo CD spokes + fresh-deploy fixes

### DIFF
--- a/terraform/environments/cloud-platform/cluster/argocd.tf
+++ b/terraform/environments/cloud-platform/cluster/argocd.tf
@@ -12,18 +12,25 @@
 #       → Create ArgoCD Capability, CodeConnection IAM policy, hub tag
 #       → Never register as a spoke
 #
-#     NO → Is this workspace in argocd_registered_spokes (environment config)?
-#       YES → Register with the hub (create EKS Access Entry for the hub's
-#             Argo CD Capability role, the identity the EKS-managed Argo CD
-#             actually authenticates as)
-#       NO  → Do nothing (cluster is neither hub nor spoke)
+#     NO → Should this cluster register as a spoke?
+#       Permanent cluster listed in argocd_registered_spokes (environment config)?
+#         YES → Register with its tier's permanent hub
+#       OR ephemeral dev cluster whose workspace ends in "-spoke"?
+#         YES → Register with its convention-paired "<prefix>-hub" in the same
+#               account (mirrors the hub side — see cluster-core/argocd-gitops.tf)
+#       Registration creates an EKS Access Entry for the hub's Argo CD Capability
+#       role (the identity the EKS-managed Argo CD authenticates as) plus the
+#       scoped RBAC below. Otherwise: do nothing.
 #
 # WHERE TO MAKE CHANGES:
 #   - To add/remove a hub: edit argocd_hubs in locals.tf
-#   - To register a spoke: add its workspace name to argocd_registered_spokes
-#     in environment-configuration.tf (under the nonlive or live block)
-#   - For ephemeral test hubs: pass TF_VAR_enable_argocd=true at deploy time
-#   - For ephemeral test spokes: pass TF_VAR_argocd_hub_capability_role_arn
+#   - To register a permanent spoke: add its workspace name to
+#     argocd_registered_spokes in environment-configuration.tf (nonlive/live block)
+#   - For ephemeral test hubs: name the workspace "<prefix>-hub" (or pass
+#     TF_VAR_enable_argocd=true) at deploy time
+#   - For ephemeral test spokes: name the workspace "<prefix>-spoke" — it
+#     self-registers with "<prefix>-hub"; no allowlist edit or ARN input needed
+#     (TF_VAR_argocd_hub_capability_role_arn remains an optional override)
 #
 # References:
 #   - ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
@@ -80,17 +87,54 @@ module "argocd" {
 #------------------------------------------------------------------------------
 
 locals {
-  # Hub's Argo CD Capability role ARN — resolved by convention or explicit
-  # override. Permanent hubs (nonlive/live) follow the module naming
-  # "<hub-cluster>-argocd-capability" (see modules/argo-cd), so the ARN is
-  # constructed directly for the spoke's tier via local.argocd_hubs. Ephemeral
-  # hubs are NOT covered by that convention — for those, the engineer passes
-  # the ARN explicitly as a workflow input, which arrives as
-  # var.argocd_hub_capability_role_arn and takes precedence.
+  # A cluster never self-identifies as both hub and spoke.
+  is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
+
+  # Ephemeral dev spoke — self-identifies by the "-spoke" suffix, strictly
+  # scoped to development_cluster. This mirrors the hub side (cluster-core/
+  # argocd-gitops.tf, issue #8457), where an ephemeral hub derives its paired
+  # spoke from the "-hub"/"-spoke" convention. No argocd_registered_spokes entry
+  # and no hub-ARN workflow input are required: an ephemeral hub/spoke pair
+  # shares a prefix and an account, so each partner is derivable from the
+  # workspace name. Confined to development_cluster so it can never affect a
+  # permanent cluster.
+  is_argocd_ephemeral_spoke = (
+    local.cluster_environment == "development_cluster" &&
+    endswith(terraform.workspace, "-spoke")
+  )
+
+  # Permanent spoke — must be explicitly listed in argocd_registered_spokes for
+  # its tier AND be a known permanent cluster. The allowlist is a deliberate,
+  # reviewed opt-in: a permanent cluster does not grant a hub elevated access to
+  # itself just because the hub exists, and it also gates phased BU onboarding.
+  is_argocd_permanent_spoke = contains(
+    lookup(local.environment_configuration, "argocd_registered_spokes", []),
+    terraform.workspace
+  ) && contains(local.mp_environments, terraform.workspace)
+
+  # This cluster registers with a hub if it is either a permanent registered
+  # spoke or an ephemeral convention spoke, and is not itself a hub.
+  is_argocd_spoke = (
+    (local.is_argocd_permanent_spoke || local.is_argocd_ephemeral_spoke) &&
+    !local.enable_argocd &&
+    !local.is_argocd_hub_cluster
+  )
+
+  # Ephemeral hub paired with this ephemeral spoke: "<prefix>-hub" in the SAME
+  # account. Its Argo CD Capability role follows the module naming convention
+  # "<hub-workspace>-argocd-capability" (see modules/argo-cd).
+  argocd_ephemeral_hub_workspace           = replace(terraform.workspace, "-spoke", "-hub")
+  argocd_ephemeral_hub_capability_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.argocd_ephemeral_hub_workspace}-argocd-capability"
+
+  # Hub's Argo CD Capability role ARN, resolved in precedence order:
+  #   1. Explicit override (var.argocd_hub_capability_role_arn) — escape hatch,
+  #      e.g. an ephemeral spoke pairing with a non-convention hub.
+  #   2. Ephemeral convention — the paired "<prefix>-hub" in this account.
+  #   3. Permanent convention — the tier hub (nonlive/live) from local.argocd_hubs.
   resolved_hub_capability_role_arn = (
-    var.argocd_hub_capability_role_arn != ""
-    ? var.argocd_hub_capability_role_arn
-    : local.argocd_hub_capability_convention_role_arn
+    var.argocd_hub_capability_role_arn != "" ? var.argocd_hub_capability_role_arn :
+    local.is_argocd_ephemeral_spoke ? local.argocd_ephemeral_hub_capability_role_arn :
+    local.argocd_hub_capability_convention_role_arn
   )
 
   # Kubernetes RBAC group that the hub capability role is placed into on this spoke.
@@ -102,19 +146,6 @@ locals {
   # Must be a valid Kubernetes group name (<= 63 chars), so it is a short fixed
   # label rather than anything derived from the role ARN.
   argocd_hub_capability_rbac_group = "argocd-hub"
-
-  # A cluster never self-identifies as both hub and spoke.
-  is_argocd_hub_cluster = contains(values(local.argocd_hubs)[*].cluster_name, terraform.workspace)
-
-  # Spoke registration: workspace must appear in the argocd_registered_spokes
-  # allowlist AND must not be a hub AND must be a known permanent cluster (or
-  # have an explicit hub ARN for ephemeral spokes).
-  is_argocd_spoke = contains(
-    lookup(local.environment_configuration, "argocd_registered_spokes", []),
-    terraform.workspace
-    ) && !local.enable_argocd && !local.is_argocd_hub_cluster && (
-    contains(local.mp_environments, terraform.workspace) || var.argocd_hub_capability_role_arn != ""
-  )
 }
 
 #------------------------------------------------------------------------------

--- a/terraform/environments/cloud-platform/cluster/data.tf
+++ b/terraform/environments/cloud-platform/cluster/data.tf
@@ -55,17 +55,18 @@ locals {
   container_platform_aws_group_id   = "7682a204-00f1-7031-257e-713bb28289c6"
 }
 
-# NOTE: do NOT add `depends_on = [module.eks]` to these EKS data sources. The
-# `name` reference already creates an implicit dependency on the cluster, so
-# they read only after it exists. An explicit depends_on additionally forces
-# Terraform to DEFER the read whenever module.eks shows any planned change,
-# making endpoint/token unknown at plan time. The kubernetes/helm providers
-# (providers.tf) then fall back to localhost, breaking plan-time refresh of the
-# kubernetes_* resources in this component (e.g. the ArgoCD spoke RBAC).
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_name
-}
-
+# Auth token for the kubernetes/helm providers (providers.tf).
+# aws_eks_cluster_auth generates a token from the cluster name and the caller's
+# credentials; it does NOT call the EKS API to look the cluster up, so it is
+# safe on a brand-new cluster that does not exist yet.
+#
+# NOTE: the cluster endpoint and CA are read from module.eks outputs in
+# providers.tf, NOT from a data.aws_eks_cluster lookup. A data source performs
+# an eager API read at plan and fails on a first-time deploy ("reading EKS
+# Cluster: couldn't find resource") because the cluster does not exist yet.
+# Module outputs are known from state for existing clusters (so the providers
+# reach the API at plan — preserving the #8462 plan-time refresh fix) and are
+# known-after-apply on create.
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_name
 }

--- a/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
+++ b/terraform/environments/cloud-platform/cluster/modules/argo-cd/main.tf
@@ -34,21 +34,6 @@ terraform {
 
 data "aws_region" "current" {}
 
-locals {
-  # Flatten the role -> identities map into a flat list for the dynamic block
-  # Input:  { ADMIN = [{id, type}], EDITOR = [{id, type}] }
-  # Output: [{role, id, type}, {role, id, type}, ...]
-  flattened_rbac_mappings = flatten([
-    for role, identities in var.rbac_role_mappings : [
-      for identity in identities : {
-        role = role
-        id   = identity.id
-        type = identity.type
-      }
-    ]
-  ])
-}
-
 #------------------------------------------------------------------------------
 # IAM Role for Argo CD Capability
 #
@@ -118,13 +103,22 @@ resource "aws_eks_capability" "argocd" {
 
       namespace = "argocd"
 
+      # One rbac_role_mapping block per role, with all of that role's identities
+      # nested as identity sub-blocks. AWS coalesces identities for a given role
+      # into a single rbac_role_mapping element; emitting one block per
+      # (role, identity) pair instead makes the applied result diverge from the
+      # plan whenever a role has more than one identity ("Provider produced
+      # inconsistent result after apply").
       dynamic "rbac_role_mapping" {
-        for_each = local.flattened_rbac_mappings
+        for_each = var.rbac_role_mappings
         content {
-          role = rbac_role_mapping.value.role
-          identity {
-            id   = rbac_role_mapping.value.id
-            type = rbac_role_mapping.value.type
+          role = rbac_role_mapping.key
+          dynamic "identity" {
+            for_each = rbac_role_mapping.value
+            content {
+              id   = identity.value.id
+              type = identity.value.type
+            }
           }
         }
       }

--- a/terraform/environments/cloud-platform/cluster/providers.tf
+++ b/terraform/environments/cloud-platform/cluster/providers.tf
@@ -1,13 +1,27 @@
+# Kubernetes/Helm providers are configured from module.eks outputs rather than a
+# data.aws_eks_cluster lookup.
+#
+# Module outputs resolve from state for an existing cluster (endpoint/CA known at
+# plan, so the providers reach the real API server and plan-time refresh of
+# existing kubernetes_* resources — e.g. the ArgoCD spoke RBAC — works; this
+# preserves the #8462 fix), and are known-after-apply on a fresh create (the
+# providers fall back to localhost only at plan, when there are no existing k8s
+# objects to refresh; at apply the cluster exists and the endpoint resolves, so
+# new resources are created against the real cluster).
+#
+# A data.aws_eks_cluster read would instead do an eager API lookup at plan and
+# fail on a brand-new cluster ("reading EKS Cluster: couldn't find resource"),
+# which blocked first-time ephemeral deploys.
 provider "kubernetes" {
-  host                   = try(data.aws_eks_cluster.cluster.endpoint, null)
-  cluster_ca_certificate = try(base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data), null)
+  host                   = try(module.eks.cluster_endpoint, null)
+  cluster_ca_certificate = try(base64decode(module.eks.cluster_certificate_authority_data), null)
   token                  = try(data.aws_eks_cluster_auth.cluster.token, null)
 }
 
 provider "helm" {
   kubernetes = {
-    host                   = try(data.aws_eks_cluster.cluster.endpoint, null)
-    cluster_ca_certificate = try(base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data), null)
+    host                   = try(module.eks.cluster_endpoint, null)
+    cluster_ca_certificate = try(base64decode(module.eks.cluster_certificate_authority_data), null)
     token                  = try(data.aws_eks_cluster_auth.cluster.token, null)
   }
 }

--- a/terraform/environments/cloud-platform/cluster/variables.tf
+++ b/terraform/environments/cloud-platform/cluster/variables.tf
@@ -51,7 +51,7 @@ variable "argocd_rbac_role_mappings" {
 variable "argocd_hub_capability_role_arn" {
   type        = string
   default     = ""
-  description = "Override for the hub cluster's ArgoCD Capability IAM role ARN. Leave empty for permanent hubs (development/production) — the ARN is resolved by convention from local.argocd_hubs. Set this only for ephemeral/test hubs, passed as a workflow input when launching the cluster."
+  description = "Optional override for the hub cluster's ArgoCD Capability IAM role ARN. Leave empty in the normal cases: permanent spokes resolve the ARN by convention from local.argocd_hubs (their tier hub), and ephemeral '-spoke' dev clusters resolve it from their convention-paired '<prefix>-hub' in the same account. Set this only to pair an ephemeral spoke with a hub that does not follow the naming convention."
 }
 
 resource "null_resource" "created_by_tag" {


### PR DESCRIPTION
## Summary

Implements Option 1 from ministryofjustice/cloud-platform#8458 (agreed with Dave Elliot): ephemeral dev spokes self-register with their hub by naming convention, removing the manual `argocd_registered_spokes` edit from the test loop. Validating this on a real ephemeral pair surfaced two pre-existing blockers on `main` for fresh cluster creation, fixed here so the change could be verified end-to-end.

Three distinct commits (kept separate for review):

### 1. feat(argocd): auto-register ephemeral spokes  (#8458)
- `cluster/argocd.tf`: split the spoke gate into `is_argocd_permanent_spoke` (unchanged allowlist behaviour) and `is_argocd_ephemeral_spoke` (new: `development_cluster` **and** workspace ends in `-spoke`). An ephemeral spoke derives its hub capability role ARN from its convention-paired `<prefix>-hub` in the same account, so **no allowlist edit and no `TF_VAR` input** are needed.
- `cluster/variables.tf`: `argocd_hub_capability_role_arn` reworded as an optional override.
- Mirrors the hub side (#8457). Permanent-spoke guardrail is unchanged and the new path is hard-scoped to `development_cluster`.

### 2. fix(cloud-platform): use module outputs for k8s/helm provider config  (#8462-adjacent)
- On a first-time (fresh) deploy, `data.aws_eks_cluster.cluster` failed at plan with "couldn't find resource" because the cluster does not exist yet. This blocked all fresh ephemeral creates after #8462 removed the `depends_on` that had deferred the read.
- `cluster/providers.tf` / `cluster/data.tf`: configure the kubernetes/helm providers from `module.eks` outputs and drop the `data.aws_eks_cluster` lookup. Outputs are known from state for existing clusters (preserving the #8462 plan-time refresh fix) and known-after-apply on create, so plan no longer does an eager read of an absent cluster. `data.aws_eks_cluster_auth` is retained for the token (it does no existence lookup).

### 3. fix(argocd): group capability RBAC identities per role
- `aws_eks_capability` coalesces all identities for a role into one `rbac_role_mapping` element. The module emitted one block per (role, identity) pair, so once ADMIN gained a second SSO group (#18275) apply failed with "Provider produced inconsistent result after apply".
- `modules/argo-cd/main.tf`: emit one `rbac_role_mapping` per role with identities as nested `identity` sub-blocks, matching AWS's returned shape.

## Testing

`terraform fmt` + `terraform validate` pass. Validated end-to-end on a fresh ephemeral pair (`cp-2008-1135-hub` / `cp-2008-1135-spoke`) in the dev account, with the spoke deployed zero-touch (`enable_argocd=false`, no ARN input, no allowlist edit):

- Spoke access entry present for `role/cp-2008-1135-hub-argocd-capability` — the convention-derived hub role, never supplied.
- No access policy bound to that principal (scoped RBAC only, no admin policy).
- Spoke ClusterRoles `argocd-hub-read-all` + `argocd-hub-deploy` bound to group `argocd-hub`.
- Hub auto-created the spoke registration Secret `cp-2008-1135-spoke`.

Fresh-create `terraform plan` passed on both hub and spoke (fix 2), and the hub `aws_eks_capability` applied cleanly (fix 3).

Refs: ministryofjustice/cloud-platform#8458, ministryofjustice/cloud-platform#8462