### PR TITLE
added kms to dlq topic

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
+++ b/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
@@ -206,6 +206,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_sns_dlq_not_empty" {
 
 resource "aws_sns_topic" "notifier_dlq_alerts" {
   name  = "${local.application_name}-${local.environment}-notifier-dlq-alerts"
+  kms_master_key_id = aws_kms_key.cloudwatch_sns_alerts_key.id
   tags  = local.tags
 }
 

--- a/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
+++ b/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
@@ -213,5 +213,5 @@ resource "aws_sns_topic" "notifier_dlq_alerts" {
 resource "aws_sns_topic_subscription" "notifier_dlq_email" {
   topic_arn = aws_sns_topic.notifier_dlq_alerts.arn
   protocol  = "email"
-  endpoint  = "laa-sres@justice.gov.uk"
+  endpoint  = "ApplicationOperations@justice.gov.uk"
 }

--- a/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
+++ b/terraform/environments/ccms-ebs/ccms-lambda-cloudwatch-slack-integration-v2.tf
@@ -213,5 +213,5 @@ resource "aws_sns_topic" "notifier_dlq_alerts" {
 resource "aws_sns_topic_subscription" "notifier_dlq_email" {
   topic_arn = aws_sns_topic.notifier_dlq_alerts.arn
   protocol  = "email"
-  endpoint  = "ApplicationOperations@justice.gov.uk"
+  endpoint  = "laa-sres@justice.gov.uk"
 }


### PR DESCRIPTION
As part of KPMG audit , we are required to make all the SNS topics KMS encrypted. As part of this activity , KMS encryption is enabled for the dlq topic