### PR TITLE
PLAT-176: oasys: use ARN instead of ID so cross-account access works

### DIFF
--- a/terraform/environments/oasys/arns_integration.tf
+++ b/terraform/environments/oasys/arns_integration.tf
@@ -131,7 +131,7 @@ resource "aws_secretsmanager_secret" "arns_integration_cloud_platform_config" {
 
   name                    = "/postgres/database/${local.arns_integration.database_hostname}/cloud-platform-config"
   description             = "Database configuration and passwords populated by Cloud Platform terraform"
-  kms_key_id              = aws_kms_key.arns_integration[0].key_id
+  kms_key_id              = aws_kms_key.arns_integration[0].arn
   policy                  = local.arns_cross_account_config != null ? data.aws_iam_policy_document.arns_integration_secret_policy[0].json : null
   recovery_window_in_days = 0
 

--- a/terraform/environments/oasys/locals_preproduction.tf
+++ b/terraform/environments/oasys/locals_preproduction.tf
@@ -1,6 +1,10 @@
 locals {
 
   locals_preproduction = {
+    arns_integration = {
+      cross_account_secret_configured = false
+      database_hostname               = "hmpps-arns-assessment-view-db-preprod"
+    }
     delius_oasys_queues = {
       "pp" = {
         sns_topic_arn_configured = true # set to true when sns_topic_arn has been populated in config secret

--- a/terraform/environments/oasys/locals_production.tf
+++ b/terraform/environments/oasys/locals_production.tf
@@ -3,6 +3,10 @@ locals {
   web_live_side = "b"
 
   locals_production = {
+    arns_integration = {
+      cross_account_secret_configured = false
+      database_hostname               = "hmpps-arns-assessment-view-db-prod"
+    }
     delius_oasys_queues = {
       "pd" = {
         sns_topic_arn_configured = true # set to true when sns_topic_arn has been populated in config secret


### PR DESCRIPTION
Fix + configure preprod + prod part 1.