### PR TITLE
Update s3_replication.tf

### DIFF
--- a/terraform/environments/ppud/s3_replication.tf
+++ b/terraform/environments/ppud/s3_replication.tf
@@ -16,7 +16,7 @@ locals {
         replication_rule_id     = "ppud-database-replication-rule-dev"
         additional_replication_rules = [
           {
-            destination = "arn:aws:s3:::ppud-bak-replication-development-771283872747-eu-west-2-an"
+            destination = "arn:aws:s3:::ppud-bak-replication-development-${local.environment_management.account_ids["digital-prison-reporting-development"]}-eu-west-2-an"
             rule_id     = "ppud-database-replication-rule-dev-mp"
             priority    = 2
           }


### PR DESCRIPTION
This pull request updates the S3 replication rule configuration in the `ppud` environment to dynamically use the correct AWS account ID for the replication destination. This change improves flexibility and correctness across different environments.

**Infrastructure configuration update:**

* Updated the `destination` value in the `additional_replication_rules` block of `terraform/environments/ppud/s3_replication.tf` to use the `${local.environment_management.account_ids["digital-prison-reporting-development"]}` variable, ensuring the S3 bucket ARN references the correct account dynamically.