### PR TITLE
enabling PD contact point

### DIFF
--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# ------------------------------------------------------------------------------
-# PAGERDUTY CONTACT POINT
-# Creates a Grafana contact point that sends alerts to PagerDuty Event
-# Orchestrator. The routing key is read from Secrets Manager.
-# ------------------------------------------------------------------------------
-resource "grafana_contact_point" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # PAGERDUTY CONTACT POINT
+# # Creates a Grafana contact point that sends alerts to PagerDuty Event
+# # Orchestrator. The routing key is read from Secrets Manager.
+# # ------------------------------------------------------------------------------
+# resource "grafana_contact_point" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-  name = "pagerduty"
+#   name = "pagerduty"
 
-  pagerduty {
-    integration_key = local.pagerduty_routing_key
-    severity        = "{{ .CommonLabels.severity }}"
-    component       = "{{ .CommonLabels.component }}"
-    group           = "{{ .CommonLabels.environment }}"
+#   pagerduty {
+#     integration_key = local.pagerduty_routing_key
+#     severity        = "{{ .CommonLabels.severity }}"
+#     component       = "{{ .CommonLabels.component }}"
+#     group           = "{{ .CommonLabels.environment }}"
 
-    # Include all labels as custom details in the PagerDuty payload
-    details = {
-      environment = "{{ .CommonLabels.environment }}"
-      severity    = "{{ .CommonLabels.severity }}"
-      component   = "{{ .CommonLabels.component }}"
-      metric      = "{{ .CommonLabels.metric }}"
-      alertname   = "{{ .CommonLabels.alertname }}"
-      summary     = "{{ .CommonAnnotations.summary }}"
-      description = "{{ .CommonAnnotations.description }}"
-    }
-  }
+#     # Include all labels as custom details in the PagerDuty payload
+#     details = {
+#       environment = "{{ .CommonLabels.environment }}"
+#       severity    = "{{ .CommonLabels.severity }}"
+#       component   = "{{ .CommonLabels.component }}"
+#       metric      = "{{ .CommonLabels.metric }}"
+#       alertname   = "{{ .CommonLabels.alertname }}"
+#       summary     = "{{ .CommonAnnotations.summary }}"
+#       description = "{{ .CommonAnnotations.description }}"
+#     }
+#   }
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }
 
-# ------------------------------------------------------------------------------
-# NOTIFICATION POLICY
-# Routes alerts to the PagerDuty contact point. Each alert fires individually
-# without grouping.
-# ------------------------------------------------------------------------------
-resource "grafana_notification_policy" "pagerduty" {
-  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# # ------------------------------------------------------------------------------
+# # NOTIFICATION POLICY
+# # Routes alerts to the PagerDuty contact point. Each alert fires individually
+# # without grouping.
+# # ------------------------------------------------------------------------------
+# resource "grafana_notification_policy" "pagerduty" {
+#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-  contact_point   = grafana_contact_point.pagerduty[0].name
-  group_by        = ["..."]
-  group_wait      = "0s"
-  group_interval  = "1m"
-  repeat_interval = "4h"
+#   contact_point   = grafana_contact_point.pagerduty[0].name
+#   group_by        = ["..."]
+#   group_wait      = "0s"
+#   group_interval  = "1m"
+#   repeat_interval = "4h"
 
-  depends_on = [helm_release.grafana]
-}
+#   depends_on = [helm_release.grafana]
+# }

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# # ------------------------------------------------------------------------------
-# # PAGERDUTY CONTACT POINT
-# # Creates a Grafana contact point that sends alerts to PagerDuty Event
-# # Orchestrator. The routing key is read from Secrets Manager.
-# # ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.is-production && local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_routing_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_routing_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# # ------------------------------------------------------------------------------
-# # NOTIFICATION POLICY
-# # Routes alerts to the PagerDuty contact point. Each alert fires individually
-# # without grouping.
-# # ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.is-production && local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# # ------------------------------------------------------------------------------
-# # PAGERDUTY CONTACT POINT
-# # Creates a Grafana contact point that sends alerts to PagerDuty Event
-# # Orchestrator. The routing key is read from Secrets Manager.
-# # ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_routing_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_routing_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# # ------------------------------------------------------------------------------
-# # NOTIFICATION POLICY
-# # Routes alerts to the PagerDuty contact point. Each alert fires individually
-# # without grouping.
-# # ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -51,7 +51,7 @@ module "cloud_platform_live_namespace_secret" {
 }
 
 module "pagerduty_orchestrator_integration_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+  count = terraform.workspace == "data-platform-production" ? 1 : 0
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
 
@@ -67,7 +67,7 @@ module "pagerduty_orchestrator_integration_key_secret" {
 }
 
 module "pagerduty_slack_connection_api_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+  count = terraform.workspace == "data-platform-production" ? 1 : 0
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
 


### PR DESCRIPTION
This pull request enables the PagerDuty alerting integration for Grafana in the data platform's monitoring environment by uncommenting and activating the relevant Terraform resources. This change ensures that alerts can now be routed to PagerDuty via the specified contact point and notification policy.

**PagerDuty alerting integration:**

* Uncommented and activated the `grafana_contact_point.pagerduty` resource, which configures Grafana to send alerts to PagerDuty using a routing key from Secrets Manager.
* Uncommented and activated the `grafana_notification_policy.pagerduty` resource, which routes alerts to the PagerDuty contact point with specific grouping and timing settings.