### PR TITLE
Resolve issues with missing providers for `integration-hub/managed-file-transfer`

### DIFF
--- a/terraform/environments/integration-hub/managed-file-transfer/versions.tf
+++ b/terraform/environments/integration-hub/managed-file-transfer/versions.tf
@@ -16,6 +16,18 @@ terraform {
       version = "~> 3.0"
       source  = "hashicorp/http"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.9"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9"
+    }
   }
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
After removing the content for `integration-hub/managed-file-transfer` a small set of providers are still required as they are present in state.