### PR TITLE
fix(workflows): don't let skipped fetch-secrets cascade-skip plan/apply

### DIFF
--- a/.github/workflows/cloud-platform.yml
+++ b/.github/workflows/cloud-platform.yml
@@ -16,6 +16,7 @@ on:
       - 'terraform/environments/cloud-platform/**'
       - '.github/workflows/cloud-platform.yml'
       - '.github/workflows/cloud-platform-reusable.yml'
+      - '.github/workflows/reusable_terraform_components_plan_apply.yml'
 
 permissions:
   id-token: write  # This is required for requesting the JWT

--- a/.github/workflows/container-platform.yml
+++ b/.github/workflows/container-platform.yml
@@ -18,6 +18,7 @@ on:
       - 'terraform/environments/cloud-platform/accounts.json'
       - '.github/workflows/container-platform.yml'
       - '.github/workflows/cloud-platform-reusable.yml'
+      - '.github/workflows/reusable_terraform_components_plan_apply.yml'
 
 permissions:
   id-token: write  # This is required for requesting the JWT

--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -82,7 +82,7 @@
       # Skipped when a caller has already fetched secrets and passed them in (inputs.secrets_prefetched)
       fetch-secrets:
         if: ${{ inputs.secrets_prefetched != true }}
-        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
+        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
         secrets:
           MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -115,7 +115,7 @@
               echo "SKIP_PLAN_EVALUATOR=${SKIP_PLAN_EVALUATOR}" >> $GITHUB_ENV
 
           - name: Decrypt Secrets
-            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
+            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
             with:
               environment_management: ${{ needs.fetch-secrets.outputs.environment_management || secrets.ENVIRONMENT_MANAGEMENT }}
               github_ci_user_environments_repo_pat: ${{ needs.fetch-secrets.outputs.github_ci_user_environments_repo_pat || secrets.GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT }}
@@ -324,7 +324,7 @@
             uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           
           - name: Decrypt Secrets
-            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
+            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
             with:
               environment_management: ${{ needs.fetch-secrets.outputs.environment_management || secrets.ENVIRONMENT_MANAGEMENT }}
               PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/reusable_terraform_components_plan_apply.yml
+++ b/.github/workflows/reusable_terraform_components_plan_apply.yml
@@ -82,7 +82,7 @@
       # Skipped when a caller has already fetched secrets and passed them in (inputs.secrets_prefetched)
       fetch-secrets:
         if: ${{ inputs.secrets_prefetched != true }}
-        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+        uses: ministryofjustice/modernisation-platform-github-actions/.github/workflows/aws-secrets-management.yml@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
         secrets:
           MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -90,6 +90,8 @@
         name: "plan ${{ inputs.component}}"
         runs-on: ${{ inputs.runner }}
         needs: fetch-secrets
+        # fetch-secrets is intentionally skipped when secrets_prefetched is true, so don't rely on the default success() check
+        if: ${{ !cancelled() && !failure() }}
         outputs:
           plan_exitcode: "${{ steps.plan.outputs.exitcode }}"
         steps:
@@ -113,7 +115,7 @@
               echo "SKIP_PLAN_EVALUATOR=${SKIP_PLAN_EVALUATOR}" >> $GITHUB_ENV
 
           - name: Decrypt Secrets
-            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
             with:
               environment_management: ${{ needs.fetch-secrets.outputs.environment_management || secrets.ENVIRONMENT_MANAGEMENT }}
               github_ci_user_environments_repo_pat: ${{ needs.fetch-secrets.outputs.github_ci_user_environments_repo_pat || secrets.GITHUB_CI_USER_ENVIRONMENTS_REPO_PAT }}
@@ -313,7 +315,8 @@
       apply:
         name: "apply"
         needs: [plan, fetch-secrets]
-        if: inputs.action == 'plan_apply' && needs.plan.outputs.plan_exitcode == '2'
+        # fetch-secrets is intentionally skipped when secrets_prefetched is true, so don't rely on the default success() check
+        if: ${{ !cancelled() && !failure() && inputs.action == 'plan_apply' && needs.plan.outputs.plan_exitcode == '2' }}
         runs-on: ${{ inputs.runner }}
         environment: ${{ inputs.account_name && (inputs.component != 'root' && format('{0}-{1}', inputs.account_name, inputs.component) || inputs.account_name) || (inputs.component != 'root' && format('{0}-{1}-{2}', inputs.application, inputs.environment, inputs.component) || format('{0}-{1}', inputs.application, inputs.environment)) }}
         steps:
@@ -321,7 +324,7 @@
             uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           
           - name: Decrypt Secrets
-            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@2988728879704953e739f82ac926d37931c6d01b # v6.1.9
+            uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
             with:
               environment_management: ${{ needs.fetch-secrets.outputs.environment_management || secrets.ENVIRONMENT_MANAGEMENT }}
               PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'terraform/environments/sprinkler/**'
       - '.github/workflows/sprinkler.yml'
+      - '.github/workflows/reusable_terraform_components_plan_apply.yml'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sprinkler.yml
+++ b/.github/workflows/sprinkler.yml
@@ -14,7 +14,6 @@ on:
     paths:
       - 'terraform/environments/sprinkler/**'
       - '.github/workflows/sprinkler.yml'
-      - '.github/workflows/reusable_terraform_components_plan_apply.yml'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
A job with no explicit `if` implicitly requires all `needs` to succeed (GitHub's default `success()` check). Since fetch-secrets is deliberately skipped when secrets_prefetched is true, plan (and apply, which needs plan) were also being skipped instead of running, so development-root-terraform et al never actually planned or applied.

Add `if: ${{ !cancelled() && !failure() }}` to plan and apply so a skipped fetch-secrets no longer blocks them, while still skipping on a genuine fetch-secrets failure.