### PR TITLE
Add benefit checker API hosting platform infrastructure

### DIFF
--- a/terraform/environments/integration-hub/api-hosting-platform/README.md
+++ b/terraform/environments/integration-hub/api-hosting-platform/README.md
@@ -1,0 +1,27 @@
+# Integration Hub API Hosting Platform
+
+Development-only MVP infrastructure for the benefit-checker orchestration API.
+This is a separate Modernisation Platform component so it cannot modify the
+legacy API platform state used by the file-transfer API.
+
+The stack creates an HTTP API Gateway, request-authorizer and orchestration
+Lambdas, DynamoDB authentication mappings, Secrets Manager client credentials,
+access and application logs, throttling, CloudWatch alarms, and a narrowly
+scoped GitHub OIDC deployment role.
+
+The public health route is `GET /health`. The authenticated client route is
+`POST /v1/benefit-checks/assessments`. Application code and OpenAPI are owned by
+`ministryofjustice/integration-hub-api-platform`.
+
+Resources are gated by `local.is-development`. The downstream mock API and its
+credential secret must exist before applying this stack.
+
+## Deployment sequence
+
+1. Merge the Modernisation Platform component registration PR.
+2. Merge main into this branch to receive the automatically generated platform files.
+3. Plan and apply workspace `integration-hub-development`.
+4. Set repository environment `integration-hub-api-hosting-platform-development`
+   variable `AWS_DEPLOY_ROLE_ARN` to the `app_deploy_role_arn` output.
+5. Replace the generated client credential placeholder in Secrets Manager.
+6. Merge the application PR to deploy both Lambda packages.

--- a/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
@@ -60,6 +60,7 @@ resource "aws_apigatewayv2_route" "assessment" {
 }
 
 resource "aws_apigatewayv2_route" "health" {
+  #checkov:skip=CKV_AWS_309:The health endpoint is intentionally public and returns no sensitive data
   count = local.create_service ? 1 : 0
 
   api_id             = aws_apigatewayv2_api.benefit_checker[0].id

--- a/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
@@ -2,7 +2,8 @@ resource "aws_cloudwatch_log_group" "api_access" {
   count = local.create_service ? 1 : 0
 
   name              = "/aws/apigateway/${local.application_name}-${local.component_name}"
-  retention_in_days = 30
+  kms_key_id        = module.kms_cloudwatch_logs[0].key_arn
+  retention_in_days = 365
   tags              = local.tags
 }
 
@@ -61,9 +62,10 @@ resource "aws_apigatewayv2_route" "assessment" {
 resource "aws_apigatewayv2_route" "health" {
   count = local.create_service ? 1 : 0
 
-  api_id    = aws_apigatewayv2_api.benefit_checker[0].id
-  route_key = "GET /health"
-  target    = "integrations/${aws_apigatewayv2_integration.benefit_orchestrator[0].id}"
+  api_id             = aws_apigatewayv2_api.benefit_checker[0].id
+  route_key          = "GET /health"
+  target             = "integrations/${aws_apigatewayv2_integration.benefit_orchestrator[0].id}"
+  authorization_type = "NONE"
 }
 
 resource "aws_apigatewayv2_stage" "default" {

--- a/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/api-gateway.tf
@@ -1,0 +1,112 @@
+resource "aws_cloudwatch_log_group" "api_access" {
+  count = local.create_service ? 1 : 0
+
+  name              = "/aws/apigateway/${local.application_name}-${local.component_name}"
+  retention_in_days = 30
+  tags              = local.tags
+}
+
+resource "aws_apigatewayv2_api" "benefit_checker" {
+  count = local.create_service ? 1 : 0
+
+  name          = "${local.application_name}-${local.component_name}"
+  protocol_type = "HTTP"
+  dynamic "cors_configuration" {
+    for_each = length(local.cors_allowed_origins) > 0 ? [1] : []
+    content {
+      allow_headers  = ["authorization", "content-type", "x-correlation-id"]
+      allow_methods  = ["GET", "OPTIONS", "POST"]
+      allow_origins  = local.cors_allowed_origins
+      expose_headers = ["content-type", "x-correlation-id"]
+      max_age        = 300
+    }
+  }
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_integration" "benefit_orchestrator" {
+  count = local.create_service ? 1 : 0
+
+  api_id                 = aws_apigatewayv2_api.benefit_checker[0].id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = module.lambda_benefit_orchestrator[0].lambda_function_invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 10000
+}
+
+resource "aws_apigatewayv2_authorizer" "request" {
+  count = local.create_service ? 1 : 0
+
+  api_id                            = aws_apigatewayv2_api.benefit_checker[0].id
+  authorizer_type                   = "REQUEST"
+  name                              = "${local.application_name}-${local.component_name}-authorizer"
+  authorizer_uri                    = module.lambda_api_authorizer[0].lambda_function_invoke_arn
+  authorizer_payload_format_version = "2.0"
+  authorizer_result_ttl_in_seconds  = 0
+  enable_simple_responses           = true
+  identity_sources                  = ["$request.header.Authorization"]
+}
+
+resource "aws_apigatewayv2_route" "assessment" {
+  count = local.create_service ? 1 : 0
+
+  api_id             = aws_apigatewayv2_api.benefit_checker[0].id
+  route_key          = "POST /v1/benefit-checks/assessments"
+  target             = "integrations/${aws_apigatewayv2_integration.benefit_orchestrator[0].id}"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.request[0].id
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  count = local.create_service ? 1 : 0
+
+  api_id    = aws_apigatewayv2_api.benefit_checker[0].id
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.benefit_orchestrator[0].id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  count = local.create_service ? 1 : 0
+
+  api_id      = aws_apigatewayv2_api.benefit_checker[0].id
+  name        = "$default"
+  auto_deploy = true
+  default_route_settings {
+    throttling_burst_limit = local.api_configuration.burst_limit
+    throttling_rate_limit  = local.api_configuration.rate_limit
+  }
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access[0].arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      sourceIp       = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
+  tags = local.tags
+}
+
+resource "aws_lambda_permission" "api_gateway_orchestrator" {
+  count = local.create_service ? 1 : 0
+
+  statement_id  = "AllowExecutionFromApiGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_benefit_orchestrator[0].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.benefit_checker[0].execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "api_gateway_authorizer" {
+  count = local.create_service ? 1 : 0
+
+  statement_id  = "AllowExecutionFromApiGatewayAuthorizer"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_api_authorizer[0].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.benefit_checker[0].execution_arn}/authorizers/${aws_apigatewayv2_authorizer.request[0].id}"
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/app-deploy.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/app-deploy.tf
@@ -1,0 +1,55 @@
+data "aws_iam_policy_document" "app_deploy_assume_role" {
+  count = local.create_service ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:ministryofjustice/integration-hub-api-platform:environment:integration-hub-api-hosting-platform-${local.environment}*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "app_deploy" {
+  count = local.create_service ? 1 : 0
+
+  name               = "${local.application_name}-${local.component_name}-${local.environment}-app-deploy"
+  assume_role_policy = data.aws_iam_policy_document.app_deploy_assume_role[0].json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "app_deploy" {
+  count = local.create_service ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+      "lambda:UpdateFunctionCode",
+    ]
+    resources = [
+      module.lambda_benefit_orchestrator[0].lambda_function_arn,
+      module.lambda_api_authorizer[0].lambda_function_arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "app_deploy" {
+  count = local.create_service ? 1 : 0
+
+  name   = "${local.application_name}-${local.component_name}-${local.environment}-app-deploy"
+  role   = aws_iam_role.app_deploy[0].id
+  policy = data.aws_iam_policy_document.app_deploy[0].json
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/application_variables.json
+++ b/terraform/environments/integration-hub/api-hosting-platform/application_variables.json
@@ -1,0 +1,42 @@
+{
+  "accounts": {
+    "development": {
+      "api_configuration": {
+        "cors_allowed_origins": [],
+        "downstream_benefit_checker_url": "https://kic2y0kswe.execute-api.eu-west-2.amazonaws.com",
+        "downstream_basic_auth_secret_id": "integration-hub-downstream-mock-api-development-basic-auth",
+        "rate_limit": 20,
+        "burst_limit": 10
+      },
+      "auth_configuration": {
+        "roles": {
+          "benefit-checker-consumer": {}
+        },
+        "users": {
+          "benefit-checker-demo-user": {
+            "enabled": true,
+            "role_name": "benefit-checker-consumer"
+          }
+        },
+        "system_principals": {
+          "benefit-checker-demo-client": {
+            "enabled": true,
+            "role_name": "benefit-checker-consumer"
+          }
+        }
+      }
+    },
+    "test": {
+      "api_configuration": {},
+      "auth_configuration": { "roles": {}, "users": {}, "system_principals": {} }
+    },
+    "preproduction": {
+      "api_configuration": {},
+      "auth_configuration": { "roles": {}, "users": {}, "system_principals": {} }
+    },
+    "production": {
+      "api_configuration": {},
+      "auth_configuration": { "roles": {}, "users": {}, "system_principals": {} }
+    }
+  }
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/auth.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/auth.tf
@@ -1,8 +1,7 @@
 module "api_user_credentials_secret" {
   for_each = local.create_service ? local.auth_users : {}
 
-  source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.1.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=d03382d3ec9c12b849fbbe35b770eaa047f7bbea" # v2.1.0
 
   name                    = "${local.application_name}-${local.component_name}-${local.environment}-user-${each.key}"
   description             = "API platform Basic authentication credentials for ${each.key}"
@@ -21,8 +20,7 @@ module "api_user_credentials_secret" {
 module "api_system_bearer_token_secret" {
   for_each = local.create_service ? local.auth_system_principals : {}
 
-  source  = "terraform-aws-modules/secrets-manager/aws"
-  version = "2.1.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=d03382d3ec9c12b849fbbe35b770eaa047f7bbea" # v2.1.0
 
   name                    = "${local.application_name}-${local.component_name}-${local.environment}-system-${each.key}"
   description             = "API platform bearer token for ${each.key}"

--- a/terraform/environments/integration-hub/api-hosting-platform/auth.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/auth.tf
@@ -1,0 +1,39 @@
+module "api_user_credentials_secret" {
+  for_each = local.create_service ? local.auth_users : {}
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-${local.component_name}-${local.environment}-user-${each.key}"
+  description             = "API platform Basic authentication credentials for ${each.key}"
+  recovery_window_in_days = 7
+  create_policy           = false
+  block_public_policy     = true
+  ignore_secret_changes   = true
+  secret_string = jsonencode({
+    username = each.key
+    password = "replace-me"
+    roleName = each.value.role_name
+  })
+  tags = local.tags
+}
+
+module "api_system_bearer_token_secret" {
+  for_each = local.create_service ? local.auth_system_principals : {}
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.1.0"
+
+  name                    = "${local.application_name}-${local.component_name}-${local.environment}-system-${each.key}"
+  description             = "API platform bearer token for ${each.key}"
+  recovery_window_in_days = 7
+  create_policy           = false
+  block_public_policy     = true
+  ignore_secret_changes   = true
+  secret_string = jsonencode({
+    tokenId     = each.key
+    bearerToken = "replace-me"
+    roleName    = each.value.role_name
+  })
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/bootstrap-lambdas/benefit-orchestrator/lambda_function.py
+++ b/terraform/environments/integration-hub/api-hosting-platform/bootstrap-lambdas/benefit-orchestrator/lambda_function.py
@@ -1,0 +1,16 @@
+import json
+
+
+def lambda_handler(event, context):
+    request_id = event.get("requestContext", {}).get("requestId") or context.aws_request_id
+    return {
+        "statusCode": 503,
+        "headers": {"content-type": "application/json", "x-correlation-id": request_id},
+        "body": json.dumps({
+            "requestId": request_id,
+            "error": {
+                "code": "application_not_deployed",
+                "message": "Deploy application code from integration-hub-api-platform",
+            },
+        }),
+    }

--- a/terraform/environments/integration-hub/api-hosting-platform/bootstrap-lambdas/request-authorizer/lambda_function.py
+++ b/terraform/environments/integration-hub/api-hosting-platform/bootstrap-lambdas/request-authorizer/lambda_function.py
@@ -1,0 +1,5 @@
+def lambda_handler(_event, _context):
+    return {
+        "isAuthorized": False,
+        "context": {"reason": "Application code has not been deployed yet."},
+    }

--- a/terraform/environments/integration-hub/api-hosting-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/dynamo-db.tf
@@ -1,8 +1,7 @@
 module "dynamodb_auth_roles" {
   count = local.create_service ? 1 : 0
 
-  source  = "terraform-aws-modules/dynamodb-table/aws"
-  version = "5.5.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table.git?ref=45c9cb10c2f6209e7362bba92cadd5ab3c9e2003" # v5.5.0
 
   name         = "${local.application_name}-${local.component_name}-auth-roles"
   billing_mode = "PAY_PER_REQUEST"
@@ -17,8 +16,7 @@ module "dynamodb_auth_roles" {
 module "dynamodb_auth_principals" {
   count = local.create_service ? 1 : 0
 
-  source  = "terraform-aws-modules/dynamodb-table/aws"
-  version = "5.5.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table.git?ref=45c9cb10c2f6209e7362bba92cadd5ab3c9e2003" # v5.5.0
 
   name         = "${local.application_name}-${local.component_name}-auth-principals"
   billing_mode = "PAY_PER_REQUEST"

--- a/terraform/environments/integration-hub/api-hosting-platform/dynamo-db.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/dynamo-db.tf
@@ -1,0 +1,69 @@
+module "dynamodb_auth_roles" {
+  count = local.create_service ? 1 : 0
+
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-auth-roles"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "role_name"
+  attributes = [{
+    name = "role_name"
+    type = "S"
+  }]
+  tags = local.tags
+}
+
+module "dynamodb_auth_principals" {
+  count = local.create_service ? 1 : 0
+
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "5.5.0"
+
+  name         = "${local.application_name}-${local.component_name}-auth-principals"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "auth_lookup_key"
+  attributes = [{
+    name = "auth_lookup_key"
+    type = "S"
+  }]
+  tags = local.tags
+}
+
+resource "aws_dynamodb_table_item" "auth_role" {
+  for_each = local.create_service ? local.auth_roles : {}
+
+  table_name = module.dynamodb_auth_roles[0].dynamodb_table_id
+  hash_key   = "role_name"
+  item       = jsonencode({ role_name = { S = each.key } })
+}
+
+resource "aws_dynamodb_table_item" "auth_user_principal" {
+  for_each = local.create_service ? local.auth_users : {}
+
+  table_name = module.dynamodb_auth_principals[0].dynamodb_table_id
+  hash_key   = "auth_lookup_key"
+  item = jsonencode({
+    auth_lookup_key = { S = "basic#${each.key}" }
+    principal_id    = { S = each.key }
+    auth_type       = { S = "basic" }
+    enabled         = { BOOL = try(each.value.enabled, true) }
+    role_name       = { S = each.value.role_name }
+    secret_name     = { S = module.api_user_credentials_secret[each.key].secret_name }
+  })
+}
+
+resource "aws_dynamodb_table_item" "auth_system_principal" {
+  for_each = local.create_service ? local.auth_system_principals : {}
+
+  table_name = module.dynamodb_auth_principals[0].dynamodb_table_id
+  hash_key   = "auth_lookup_key"
+  item = jsonencode({
+    auth_lookup_key = { S = "bearer#${each.key}" }
+    principal_id    = { S = each.key }
+    auth_type       = { S = "bearer" }
+    enabled         = { BOOL = try(each.value.enabled, true) }
+    role_name       = { S = each.value.role_name }
+    secret_name     = { S = module.api_system_bearer_token_secret[each.key].secret_name }
+  })
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/kms.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/kms.tf
@@ -1,0 +1,33 @@
+module "kms_cloudwatch_logs" {
+  count = local.create_service ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
+
+  aliases                 = ["${local.application_name}/${local.component_name}/logs"]
+  description             = "KMS key for API hosting platform CloudWatch logs"
+  enable_default_policy   = true
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  key_administrators      = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+  key_statements = [{
+    sid = "AllowCloudWatchLogsService"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+    ]
+    resources = ["*"]
+    principals = [{
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
+    }]
+    condition = [{
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/${local.application_name}-${local.component_name}"]
+    }]
+  }]
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/lambda.tf
@@ -6,8 +6,7 @@ data "aws_secretsmanager_secret" "downstream_basic_auth" {
 module "lambda_benefit_orchestrator" {
   count = local.create_service ? 1 : 0
 
-  source  = "terraform-aws-modules/lambda/aws"
-  version = "8.8.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git?ref=b842374147fc07731d79028517223e9e0cbaab6d" # v8.8.0
 
   function_name                = "${local.application_name}-${local.component_name}-benefit-orchestrator"
   description                  = "Orchestrates requests to the downstream mock benefit checker"
@@ -38,8 +37,7 @@ module "lambda_benefit_orchestrator" {
 module "lambda_api_authorizer" {
   count = local.create_service ? 1 : 0
 
-  source  = "terraform-aws-modules/lambda/aws"
-  version = "8.8.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git?ref=b842374147fc07731d79028517223e9e0cbaab6d" # v8.8.0
 
   function_name                = "${local.application_name}-${local.component_name}-authorizer"
   description                  = "Authenticates API hosting platform clients"

--- a/terraform/environments/integration-hub/api-hosting-platform/lambda.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/lambda.tf
@@ -1,0 +1,75 @@
+data "aws_secretsmanager_secret" "downstream_basic_auth" {
+  count = local.create_service ? 1 : 0
+  name  = local.api_configuration.downstream_basic_auth_secret_id
+}
+
+module "lambda_benefit_orchestrator" {
+  count = local.create_service ? 1 : 0
+
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-${local.component_name}-benefit-orchestrator"
+  description                  = "Orchestrates requests to the downstream mock benefit checker"
+  handler                      = "lambda_function.lambda_handler"
+  runtime                      = "python3.13"
+  timeout                      = 15
+  memory_size                  = 256
+  source_path                  = "${local.bootstrap_code_root}/benefit-orchestrator"
+  trigger_on_package_timestamp = false
+  environment_variables = {
+    DOWNSTREAM_BENEFIT_CHECKER_URL  = local.api_configuration.downstream_benefit_checker_url
+    DOWNSTREAM_BASIC_AUTH_SECRET_ID = data.aws_secretsmanager_secret.downstream_basic_auth[0].name
+    DOWNSTREAM_TIMEOUT_SECONDS      = "5"
+    SECRET_CACHE_TTL_SECONDS        = "300"
+  }
+  attach_policy_statements = true
+  policy_statements = {
+    downstream_secret_read = {
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [data.aws_secretsmanager_secret.downstream_basic_auth[0].arn]
+    }
+  }
+  cloudwatch_logs_retention_in_days = 30
+  tags                              = local.tags
+}
+
+module "lambda_api_authorizer" {
+  count = local.create_service ? 1 : 0
+
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name                = "${local.application_name}-${local.component_name}-authorizer"
+  description                  = "Authenticates API hosting platform clients"
+  handler                      = "lambda_function.lambda_handler"
+  runtime                      = "python3.13"
+  source_path                  = "${local.bootstrap_code_root}/request-authorizer"
+  trigger_on_package_timestamp = false
+  environment_variables = {
+    AUTH_PRINCIPALS_TABLE = module.dynamodb_auth_principals[0].dynamodb_table_id
+    AUTH_ROLES_TABLE      = module.dynamodb_auth_roles[0].dynamodb_table_id
+  }
+  attach_policy_statements = true
+  policy_statements = {
+    auth_tables_read = {
+      effect  = "Allow"
+      actions = ["dynamodb:GetItem"]
+      resources = [
+        module.dynamodb_auth_principals[0].dynamodb_table_arn,
+        module.dynamodb_auth_roles[0].dynamodb_table_arn,
+      ]
+    }
+    auth_secrets_read = {
+      effect  = "Allow"
+      actions = ["secretsmanager:GetSecretValue"]
+      resources = concat(
+        [for secret in values(module.api_user_credentials_secret) : secret.secret_arn],
+        [for secret in values(module.api_system_bearer_token_secret) : secret.secret_arn],
+      )
+    }
+  }
+  cloudwatch_logs_retention_in_days = 30
+  tags                              = local.tags
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/locals.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  api_configuration      = try(local.application_data.accounts[local.environment].api_configuration, {})
+  auth_configuration     = try(local.application_data.accounts[local.environment].auth_configuration, {})
+  auth_roles             = try(local.auth_configuration.roles, {})
+  auth_users             = try(local.auth_configuration.users, {})
+  auth_system_principals = try(local.auth_configuration.system_principals, {})
+  cors_allowed_origins   = try(local.api_configuration.cors_allowed_origins, [])
+  create_service         = local.is-development
+  bootstrap_code_root    = "${path.module}/bootstrap-lambdas"
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/monitoring.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/monitoring.tf
@@ -1,0 +1,37 @@
+resource "aws_cloudwatch_metric_alarm" "orchestrator_errors" {
+  count = local.create_service ? 1 : 0
+
+  alarm_name          = "${local.application_name}-${local.component_name}-orchestrator-errors"
+  alarm_description   = "Benefit orchestrator Lambda errors in a five-minute window"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    FunctionName = module.lambda_benefit_orchestrator[0].lambda_function_name
+  }
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  count = local.create_service ? 1 : 0
+
+  alarm_name          = "${local.application_name}-${local.component_name}-api-5xx"
+  alarm_description   = "API Gateway server errors in a five-minute window"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "5xx"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.benefit_checker[0].id
+  }
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/networking.auto.tfvars.json
+++ b/terraform/environments/integration-hub/api-hosting-platform/networking.auto.tfvars.json
@@ -1,0 +1,9 @@
+{
+  "networking": [
+    {
+      "business-unit": "platforms",
+      "set": "general",
+      "application": "integration-hub"
+    }
+  ]
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/outputs.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/outputs.tf
@@ -1,0 +1,29 @@
+output "benefit_checker_api_endpoint" {
+  description = "Client-facing orchestration API endpoint"
+  value       = try(aws_apigatewayv2_api.benefit_checker[0].api_endpoint, null)
+}
+
+output "benefit_orchestrator_function_name" {
+  description = "Lambda function deployed by the application repository"
+  value       = try(module.lambda_benefit_orchestrator[0].lambda_function_name, null)
+}
+
+output "request_authorizer_function_name" {
+  description = "Request authorizer Lambda deployed by the application repository"
+  value       = try(module.lambda_api_authorizer[0].lambda_function_name, null)
+}
+
+output "app_deploy_role_arn" {
+  description = "GitHub Actions role for scoped application deployment"
+  value       = try(aws_iam_role.app_deploy[0].arn, null)
+}
+
+output "user_auth_secret_names" {
+  description = "Basic authentication secret names keyed by username"
+  value       = { for username, secret in module.api_user_credentials_secret : username => secret.secret_name }
+}
+
+output "system_auth_secret_names" {
+  description = "Bearer token secret names keyed by system principal"
+  value       = { for principal, secret in module.api_system_bearer_token_secret : principal => secret.secret_name }
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_backend.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_backend.tf
@@ -1,0 +1,14 @@
+# Backend
+terraform {
+  # `backend` blocks do not support variables, so the following are hard-coded here:
+  # - S3 bucket name, which is created in modernisation-platform-account/s3.tf
+  backend "s3" {
+    acl                  = "bucket-owner-full-control"
+    bucket               = "modernisation-platform-terraform-state"
+    encrypt              = true
+    key                  = "terraform.tfstate"
+    region               = "eu-west-2"
+    use_lockfile         = true
+    workspace_key_prefix = "environments/members/integration-hub/api-hosting-platform" # This will store the object as environments/members/<application>/<component>/${workspace}/terraform.tfstate
+  }
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_base_variables.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_base_variables.tf
@@ -1,0 +1,9 @@
+variable "networking" {
+  type = list(any)
+}
+
+variable "collaborator_access" {
+  type        = string
+  default     = "developer"
+  description = "Collaborators must specify which access level they are using, eg set an environment variable of export TF_VAR_collaborator_access=migration"
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_data.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_data.tf
@@ -1,0 +1,173 @@
+# Current account data
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+# VPC and subnet data
+data "aws_vpc" "shared" {
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}"
+  }
+}
+
+data "aws_subnets" "shared-data" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data*"
+  }
+}
+
+data "aws_subnets" "shared-private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private*"
+  }
+}
+
+data "aws_subnets" "shared-public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.shared.id]
+  }
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public*"
+  }
+}
+
+data "aws_subnet" "data_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}a"
+  }
+}
+
+data "aws_subnet" "data_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}b"
+  }
+}
+
+data "aws_subnet" "data_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}c"
+  }
+}
+
+data "aws_subnet" "private_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}a"
+  }
+}
+
+data "aws_subnet" "private_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}b"
+  }
+}
+
+data "aws_subnet" "private_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}c"
+  }
+}
+
+data "aws_subnet" "public_subnets_a" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}a"
+  }
+}
+
+data "aws_subnet" "public_subnets_b" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}b"
+  }
+}
+
+data "aws_subnet" "public_subnets_c" {
+  vpc_id = data.aws_vpc.shared.id
+  tags = {
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}c"
+  }
+}
+
+# Route53 DNS data
+data "aws_route53_zone" "external" {
+  provider = aws.core-vpc
+
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
+
+data "aws_route53_zone" "inner" {
+  provider = aws.core-vpc
+
+  name         = "${var.networking[0].business-unit}-${local.environment}.modernisation-platform.internal."
+  private_zone = true
+}
+
+data "aws_route53_zone" "network-services" {
+  provider = aws.core-network-services
+
+  name         = "modernisation-platform.service.justice.gov.uk."
+  private_zone = false
+}
+
+# Shared KMS keys (per business unit)
+data "aws_kms_key" "general_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/general-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "ebs_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/ebs-${var.networking[0].business-unit}"
+}
+
+data "aws_kms_key" "rds_shared" {
+  key_id = "arn:aws:kms:eu-west-2:${local.environment_management.account_ids["core-shared-services-production"]}:alias/rds-${var.networking[0].business-unit}"
+}
+
+# State for core-network-services resource information
+data "terraform_remote_state" "core_network_services" {
+  backend = "s3"
+  config = {
+    acl     = "bucket-owner-full-control"
+    bucket  = "modernisation-platform-terraform-state"
+    key     = "environments/accounts/core-network-services/core-network-services-production/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = "true"
+  }
+}
+
+data "aws_organizations_organization" "root_account" {}
+
+# Retrieve information about the modernisation platform account
+data "aws_caller_identity" "modernisation_platform" {
+  provider = aws.modernisation-platform
+}
+
+# caller account information to instantiate aws.oidc provider
+data "aws_caller_identity" "original_session" {
+  provider = aws.original-session
+}
+
+data "aws_iam_session_context" "whoami" {
+  provider = aws.original-session
+  arn      = data.aws_caller_identity.original_session.arn
+}
+
+# Get the environments file from the main repository
+data "http" "environments_file" {
+  url = "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform/main/environments/${local.application_name}.json"
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_locals.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_locals.tf
@@ -1,0 +1,39 @@
+locals {
+
+  application_name = "integration-hub"
+  component_name   = "api-hosting-platform"
+
+  environment_management = jsondecode(data.aws_secretsmanager_secret_version.environment_management.secret_string)
+
+  # Stores modernisation platform account id for setting up the modernisation-platform provider
+  modernisation_platform_account_id = data.aws_ssm_parameter.modernisation_platform_account_id.value
+
+  # This takes the name of the Terraform workspace (e.g. core-vpc-production), strips out the application name (e.g. core-vpc), and checks if
+  # the string leftover is `-production`, if it isn't (e.g. core-vpc-non-production => -non-production) then it sets the var to false.
+  is-production    = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production"
+  is-preproduction = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction"
+  is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
+  is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
+
+  # Merge tags from the environment json file with additional ones
+  tags = merge(
+    jsondecode(data.http.environments_file.response_body).tags,
+    { "is-production" = local.is-production },
+    { "environment-name" = terraform.workspace },
+    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform-environments" }
+  )
+
+  environment     = trimprefix(terraform.workspace, "${var.networking[0].application}-")
+  vpc_name        = var.networking[0].business-unit
+  subnet_set      = var.networking[0].set
+  vpc_all         = "${local.vpc_name}-${local.environment}"
+  subnet_set_name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}"
+
+  is_live       = [substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-production" || substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-preproduction" ? "live" : "non-live"]
+  provider_name = "core-vpc-${local.environment}"
+
+  # environment specfic variables
+  # example usage:
+  # example_data = local.application_data.accounts[local.environment].example_var
+  application_data = fileexists("./application_variables.json") ? jsondecode(file("./application_variables.json")) : null
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_providers.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_providers.tf
@@ -1,0 +1,75 @@
+# AWS provider for the original session which you connect with
+provider "aws" {
+  alias  = "original-session"
+  region = "eu-west-2"
+  default_tags { tags = local.tags }
+}
+
+# AWS provider for the workspace you're working in (every resource will default to using this, unless otherwise specified)
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccess"
+  }
+  default_tags { tags = local.tags }
+}
+
+# AWS provider for the Modernisation Platform, to get things from there if required
+provider "aws" {
+  alias  = "modernisation-platform"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.modernisation_platform_account_id}:role/modernisation-account-limited-read-member-access"
+  }
+  default_tags { tags = local.tags }
+}
+
+# AWS provider for core-vpc-<environment>, to access resources in the core-vpc accounts
+provider "aws" {
+  alias  = "core-vpc"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-read-only" : "arn:aws:iam::${local.environment_management.account_ids[local.provider_name]}:role/member-delegation-${local.vpc_name}-${local.environment}"
+  }
+  default_tags { tags = local.tags }
+}
+
+# AWS provider for network services to enable dns entries for certificate validation to be created
+provider "aws" {
+  alias  = "core-network-services"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/read-log-records" : "arn:aws:iam::${local.environment_management.account_ids["core-network-services-production"]}:role/modify-dns-records"
+  }
+  default_tags { tags = local.tags }
+}
+
+# Provider for creating resources in us-east-1, eg ACM resources for CloudFront
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  assume_role {
+    role_arn = !can(regex("githubactionsrolesession|AdministratorAccess|user", data.aws_caller_identity.original_session.arn)) ? null : can(regex("user", data.aws_caller_identity.original_session.arn)) ? "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/${var.collaborator_access}" : "arn:aws:iam::${data.aws_caller_identity.original_session.id}:role/MemberInfrastructureAccessUSEast"
+  }
+  default_tags { tags = local.tags }
+}
+
+# Provider for reading resources from root account IdentityStore
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "sso-readonly"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.aws_organizations_root_account_id}:role/ModernisationPlatformSSOReadOnly"
+  }
+  default_tags { tags = local.tags }
+}
+
+# AWS provider for managing Business Unit secrets and parameters
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "shared-configuration-access"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids["core-shared-services-production"]}:role/${local.vpc_name}-shared-configuration-access"
+  }
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/platform_secrets.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/platform_secrets.tf
@@ -1,0 +1,17 @@
+# Get modernisation account id from ssm parameter
+data "aws_ssm_parameter" "modernisation_platform_account_id" {
+  provider = aws.original-session
+  name     = "modernisation_platform_account_id"
+}
+
+# Get secret by arn for environment management
+data "aws_secretsmanager_secret" "environment_management" {
+  provider = aws.modernisation-platform
+  name     = "environment_management"
+}
+
+# Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
+data "aws_secretsmanager_secret_version" "environment_management" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.environment_management.id
+}

--- a/terraform/environments/integration-hub/api-hosting-platform/versions.tf
+++ b/terraform/environments/integration-hub/api-hosting-platform/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 6.0"
+      source  = "hashicorp/aws"
+    }
+    dns = {
+      version = "~> 3.0"
+      source  = "hashicorp/dns"
+    }
+    external = {
+      version = "~> 2.0"
+      source  = "hashicorp/external"
+    }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
## Summary

- add a development-only API hosting platform component for benefit-checker orchestration
- expose public health and authenticated assessment routes through HTTP API Gateway
- provision Basic and Bearer client authentication, Secrets Manager credentials and DynamoDB mappings
- give the orchestrator least-privilege access to the downstream credential
- add access logs, Lambda logs, throttling, CloudWatch alarms and a scoped GitHub OIDC deployment role
- install safe bootstrap Lambdas until application code is deployed

## Safety and component boundary

This uses the new integration-hub/api-hosting-platform component. It intentionally does not modify the legacy integration-hub/api-platform folder because that backend is currently shared with the migrated file-transfer stack and would produce a destructive plan.

## Verification

- terraform fmt passes
- custom Terraform validates with zero errors and warnings when combined with the standard generated Modernisation Platform component files
- no generated platform files are committed, following the component workflow

## Dependency

Draft until ministryofjustice/modernisation-platform#13851 is merged and automation generates the component platform files. After that, merge main into this branch and run the development plan.