### PR TITLE
checkov lambda fixes + s3

### DIFF
--- a/terraform/environments/coat/chatbot-lambda.tf
+++ b/terraform/environments/coat/chatbot-lambda.tf
@@ -1,18 +1,17 @@
 # Lambda
 
 resource "aws_security_group" "rag_lambda" {
-  #checkov:skip=CKV_AWS_382:To be reviewed later
-  #checkov:skip=CKV2_AWS_5:To be reviewed later
+  #checkov:skip=CKV2_AWS_5:Attached to RAG Lambda via module.rag_lambda vpc_security_group_ids
 
   name        = "${local.application_name}-${local.environment}-rag-lambda-security-group"
   description = "RAG Lambda Security Group"
   vpc_id      = data.aws_vpc.shared.id
 
   egress {
-    description = "outbound access"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    description = "HTTPS to AWS APIs and LLM gateway"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
@@ -49,10 +48,6 @@ data "aws_iam_policy_document" "rag_lambda_function_assume_role" {
 }
 
 data "aws_iam_policy_document" "rag_lambda_function_role" {
-  #checkov:skip=CKV_AWS_111:To be reviewed later
-  #checkov:skip=CKV_AWS_356:To be reviewed later
-
-
   statement {
     sid    = "AllowToWriteCloudWatchLog"
     effect = "Allow"
@@ -77,7 +72,7 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
     ]
 
     resources = [
-      "arn:aws:s3:::coat-${local.environment}-cur-v2-hourly/",
+      "arn:aws:s3:::coat-${local.environment}-cur-v2-hourly",
       "arn:aws:s3:::coat-${local.environment}-cur-v2-hourly/*"
     ]
   }
@@ -93,7 +88,10 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
       "athena:StopQueryExecution"
     ]
 
-    resources = ["*"]
+    resources = [
+      "arn:aws:athena:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:workgroup/primary",
+      "arn:aws:athena:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:workgroup/${local.athena_workgroup}"
+    ]
   }
 
   statement {
@@ -109,7 +107,11 @@ data "aws_iam_policy_document" "rag_lambda_function_role" {
       "glue:GetPartitions"
     ]
 
-    resources = ["*"]
+    resources = [
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog",
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:database/${aws_glue_catalog_database.cur_v2_database.name}",
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_glue_catalog_database.cur_v2_database.name}/*"
+    ]
   }
 
   statement {

--- a/terraform/environments/coat/chatbot-lambda.tf
+++ b/terraform/environments/coat/chatbot-lambda.tf
@@ -172,7 +172,10 @@ module "rag_lambda" {
     ]
   }]
   artifacts_dir                = "${abspath(path.root)}/builds"
-  trigger_on_package_timestamp = false
+  # CI workspaces have no builds/ zip; ignore hash drift and allow missing packages to rebuild
+  ignore_source_code_hash      = true
+  recreate_missing_package     = true
+  trigger_on_package_timestamp = true
 
   reserved_concurrent_executions = 10
 

--- a/terraform/environments/coat/s3.tf
+++ b/terraform/environments/coat/s3.tf
@@ -441,8 +441,6 @@ resource "aws_s3_object" "pod_waste_reports" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly" {
-  #checkov:skip=CKV_AWS_300:To be reviewed later
-
   bucket = module.cur_v2_hourly.s3_bucket_id
 
   rule {
@@ -454,12 +452,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly" {
     noncurrent_version_expiration {
       noncurrent_days = 1
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "focus_reports" {
-  #checkov:skip=CKV_AWS_300:To be reviewed later
-
   bucket = module.focus_reports.s3_bucket_id
 
   rule {
@@ -471,12 +471,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "focus_reports" {
     noncurrent_version_expiration {
       noncurrent_days = 1
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "coat_reports" {
-  #checkov:skip=CKV_AWS_300:To be reviewed later
-
   bucket = module.coat_reports.s3_bucket_id
 
   rule {
@@ -488,12 +490,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "coat_reports" {
     noncurrent_version_expiration {
       noncurrent_days = 1
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly_enriched" {
-  #checkov:skip=CKV_AWS_300:To be reviewed later
-
   count  = local.is-development ? 0 : 1
   bucket = module.cur_v2_hourly_enriched[0].s3_bucket_id
 
@@ -505,6 +509,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "cur_v2_hourly_enriched" {
 
     noncurrent_version_expiration {
       noncurrent_days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
     }
   }
 }


### PR DESCRIPTION
Resolves coat Checkov findings in `terraform/environments/coat` and fixes the related Lambda package CI apply failure.

- Add S3 abort incomplete multipart upload rules (`CKV_AWS_300`)
- Restrict RAG Lambda SG egress to HTTPS 443 (`CKV_AWS_382`)
- Scope Athena/Glue IAM resources (remove `Resource = "*"`) (`CKV_AWS_111`, `CKV_AWS_356`)
- Keep `CKV2_AWS_5` skip: SG is attached via the Lambda module (Checkov false positive)
- Allow missing Lambda zips to rebuild on clean CI runners

https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1032
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1033
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1034
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1035
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1038

<img width="1604" height="439" alt="image" src="https://github.com/user-attachments/assets/71cf5530-3dbd-4b70-9911-3b8fd42626aa" />
