### PR TITLE
✨ Add Route 53 records for file-transfer accounts

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/README.md
+++ b/terraform/environments/integration-hub-file-transfer/README.md
@@ -17,7 +17,9 @@ A one-way managed file transfer service, provided by the Integration Hub, to all
 
 ### **Service URLs:**
 
-> *.managed-file-transfer.service.justice.gov.uk
+> ftps.file-transfer.service.justice.gov.uk
+> sftp.file-transfer.service.justice.gov.uk
+> web.file-transfer.service.justice.gov.uk
 
 ### **Incident response hours:**
 

--- a/terraform/environments/integration-hub-file-transfer/route53.tf
+++ b/terraform/environments/integration-hub-file-transfer/route53.tf
@@ -1,0 +1,30 @@
+module "r53_managed_file_transfer" {
+  providers = { aws = aws.core-network-services }
+  source    = "terraform-aws-modules/route53/aws"
+  version   = "6.5.1"
+
+  name        = local.is-production == false ? "${local.environment}.file-transfer.service.justice.gov.uk" : "file-transfer.service.justice.gov.uk"
+  comment     = "Managed by Terraform"
+  create_zone = false
+
+  records = {
+    ftps = {
+      name    = "ftps"
+      type    = "A"
+      ttl     = 300
+      records = [for key, value in aws_eip.this : value.public_ip]
+    }
+    sftp = {
+      name    = "sftp"
+      type    = "A"
+      ttl     = 300
+      records = [for key, value in aws_eip.this : value.public_ip]
+    }
+    web = {
+      name    = "web"
+      type    = "CNAME"
+      ttl     = 300
+      records = [trimprefix(aws_transfer_web_app.this.access_endpoint, "https://")]
+    }
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/route53.tf
+++ b/terraform/environments/integration-hub-file-transfer/route53.tf
@@ -1,4 +1,5 @@
-module "r53_managed_file_transfer" {
+module "r53_file_transfer" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   providers = { aws = aws.core-network-services }
   source    = "terraform-aws-modules/route53/aws"
   version   = "6.5.1"


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

Adds standard Route 53 records for the managed file-transfer accounts:

- `ftps` and `sftp` A records targeting the file-transfer Elastic IP addresses
- `web` CNAME record targeting the AWS Transfer Family web app endpoint

The records use the existing file-transfer hosted zone and environment-specific naming.

## Testing

- Local validation completed by the author.

## Risk

- No known breaking changes or additional security or operational caveats.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>