### PR TITLE
fix: upgrade ebs upgrade test ftp server

### DIFF
--- a/terraform/environments/ccms-ebs-upgrade/application_variables.json
+++ b/terraform/environments/ccms-ebs-upgrade/application_variables.json
@@ -158,7 +158,7 @@
       "ec2_oracle_instance_threads_accessgate": "2",
       "ami_owner": "self",
       "ec2_instance_type_ftp": "c5d.large",
-      "ftp_ami_id": "ami-08cd358d745620807",
+      "ftp_ami_id": "ami-0841b1152f02fa85e",
       "ec2_instance_type_clamav": "c5d.large",
       "clamav_ami_id": "ami-02cb9c4732e6429dd",
       "ebsdb_ami_id": "ami-014b2ba6362f16b1e",


### PR DESCRIPTION
ftp server upgraded to amazon linux 2023 in ebs upgrade test environment