### PR TITLE
🐛 Implement CORS for the Integration Hub Transfer web app

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/s3.tf
+++ b/terraform/environments/integration-hub-file-transfer/s3.tf
@@ -58,6 +58,28 @@ module "s3_bucket" {
   attach_deny_insecure_transport_policy = true
   bucket                                = each.value.bucket
 
+  cors_rule = each.key == "incoming" ? [
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+      allowed_origins = [aws_transfer_web_app.this.access_endpoint]
+      expose_headers = [
+        "last-modified",
+        "content-length",
+        "etag",
+        "x-amz-version-id",
+        "content-type",
+        "x-amz-request-id",
+        "x-amz-id-2",
+        "date",
+        "x-amz-cf-id",
+        "x-amz-storage-class",
+        "access-control-expose-headers",
+      ]
+      max_age_seconds = 3000
+    }
+  ] : []
+
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

Adds the missing CORS policy to the Integration Hub file-transfer incoming bucket so the AWS Transfer Family web app can access the group-assigned S3 location and upload files.

The rule permits the native Transfer web app endpoint, required object operations, and response headers. It is applied only to the incoming bucket.

## Investigation

CloudTrail confirmed the user's group grant is discovered and that `GetDataAccess` successfully returns `READWRITE` access for `group/integration-hub/*`. This pointed to the missing bucket CORS policy as the cause of the web app's generic network and upload errors.

## Validation

- `terraform fmt -check -diff terraform/environments/integration-hub-file-transfer/s3.tf`
- Terraform diagnostics for `s3.tf`
- `git diff --check`
- Development environment CI/apply is pending; this PR is required to run that validation.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>