### PR TITLE
DHS-833: ingestion pipelines versions table and policy to give step function access

### DIFF
--- a/terraform/environments/digital-prison-reporting/locals.tf
+++ b/terraform/environments/digital-prison-reporting/locals.tf
@@ -90,8 +90,9 @@ locals {
   secretsmanager_read_policy = "${local.project}_secretsmanager_read_policy"
 
 
-  trigger_glue_job_policy = "${local.project}_start_glue_job_policy"
-  start_dms_task_policy   = "${local.project}_start_dms_task_policy"
+  trigger_glue_job_policy                          = "${local.project}_start_glue_job_policy"
+  start_dms_task_policy                            = "${local.project}_start_dms_task_policy"
+  update_ingestion_pipeline_versions_dynamo_policy = "${local.project}_access_ingestion_version_dynamodb_table_policy"
 
   s3_all_object_actions_policy = "${local.project}_s3_all_object_actions_policy"
   all_state_machine_policy     = "${local.project}_all_state_machine_policy"

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -490,6 +490,11 @@ module "s3_glue_job_bucket" {
 }
 
 # S3 Raw Archive
+# Superseded by the Versioned Raw Archive bucket and will be decommissioned in the future.
+# See epic DHS-693 and associated solution design document.
+# This bucket is retained for the duration of the migration to the Versioned Raw Archive bucket.
+# Once all data is migrated to the Versioned Raw Archive bucket, and AP give the go ahead, then
+# this bucket can be deleted.
 module "s3_raw_archive_bucket" {
   source                    = "./modules/s3_bucket"
   create_s3                 = local.setup_buckets
@@ -504,6 +509,29 @@ module "s3_raw_archive_bucket" {
       dpr-name          = "${local.project}-raw-archive-${local.env}"
       dpr-resource-type = "S3 Bucket"
       dpr-jira          = "DPR2-209"
+    }
+  )
+}
+
+# S3 Versioned Raw Archive
+# Versioning was introduced to the Raw Archive, which required the old Raw archive
+# data to be migrated to this new Versioned Raw Archive bucket.
+# Once all data is migrated this will be the canonical Raw Archive.
+# See epic DHS-693 and associated solution design document.
+module "s3_raw_archive_versioned_bucket" {
+  source                    = "./modules/s3_bucket"
+  create_s3                 = local.setup_buckets
+  name                      = "${local.project}-raw-archive-versioned-${local.env}"
+  custom_kms_key            = local.s3_kms_arn
+  create_notification_queue = false # For SQS Queue
+  enable_lifecycle          = true
+
+  tags = merge(
+    local.all_tags,
+    {
+      dpr-name          = "${local.project}-raw-archive-versioned-${local.env}"
+      dpr-resource-type = "S3 Bucket"
+      dpr-jira          = "DHS-833"
     }
   )
 }

--- a/terraform/environments/digital-prison-reporting/main.tf
+++ b/terraform/environments/digital-prison-reporting/main.tf
@@ -1080,6 +1080,35 @@ module "dynamo_table_step_functions_token" {
   )
 }
 
+# Dynamo table for Ingestion pipeline versions
+# An ingestion version is a run of the ingestion pipeline.
+# The table is keyed by the ingestion_domain.
+module "dynamo_table_ingestion_pipeline_versions" {
+  source              = "./modules/dynamo_tables"
+  create_table        = true
+  autoscaling_enabled = false
+  name                = "${local.project}-ingestion-pipeline-versions-${local.environment}"
+
+  hash_key    = "ingestion_domain"
+  table_class = "STANDARD"
+
+  attributes = [
+    {
+      name = "ingestion_domain"
+      type = "S"
+    }
+  ]
+
+  tags = merge(
+    local.all_tags,
+    {
+      dpr-name          = "${local.project}-ingestion-pipeline-versions-${local.environment}"
+      dpr-resource-type = "Dynamo Table"
+      dpr-jira          = "DHS-833"
+    }
+  )
+}
+
 ##########################
 # Application Backend TF # 
 ##########################

--- a/terraform/environments/digital-prison-reporting/policy.tf
+++ b/terraform/environments/digital-prison-reporting/policy.tf
@@ -185,6 +185,24 @@ resource "aws_iam_policy" "start_dms_task_policy" {
   })
 }
 
+# DynamoDB
+resource "aws_iam_policy" "update_ingestion_pipeline_versions_dynamo_policy" {
+  name        = local.update_ingestion_pipeline_versions_dynamo_policy
+  description = "Allows access to update the ingestion pipeline versions DynamoDB table, E.g. allows the ingestion pipeline Step Function execution role to atomically update the ingestion_version counter for the given pipeline"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowIngestionVersionCounterAtomicUpdateAndGet"
+        Effect   = "Allow"
+        Action   = ["dynamodb:UpdateItem"]
+        Resource = module.dynamo_table_ingestion_pipeline_versions.dynamodb_table_arn
+      }
+    ]
+  })
+}
+
 # Trigger Glue Job Policy
 resource "aws_iam_policy" "trigger_glue_job_policy" {
   name = local.trigger_glue_job_policy
@@ -1147,6 +1165,11 @@ resource "aws_iam_role_policy_attachment" "step_function_role_policy_attachment"
 resource "aws_iam_role_policy_attachment" "step_function_role_dms_policy_attachment" {
   role       = aws_iam_role.step_function_execution_role.id
   policy_arn = aws_iam_policy.start_dms_task_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "step_function_role_ingestion_version_dynamo_policy_attachment" {
+  role       = aws_iam_role.step_function_execution_role.id
+  policy_arn = aws_iam_policy.update_ingestion_pipeline_versions_dynamo_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "step_function_role_glue_policy_attachment" {


### PR DESCRIPTION
- The ingestion pipelines versions DyanmoDB table is used by the step function pipeline and associated jobs to know which ingestion version we are using, which is then used to version the raw archive.
- The ingestion pipeline requires Update access so it can atomically increment and retrieve the value, which is why the step function role requires this access. It is also purposely a much more restricted policy than reusing the pre-existing dynamo policy.