### PR TITLE
feat(data-platform): allow bidirectional stream invocation of ElevenLabs endpoint

### DIFF
--- a/terraform/environments/data-platform/sagemaker/iam-roles.tf
+++ b/terraform/environments/data-platform/sagemaker/iam-roles.tf
@@ -107,6 +107,7 @@ module "justice_transcribe_backend_iam_role" {
       actions = [
         "sagemaker:InvokeEndpoint",
         "sagemaker:InvokeEndpointAsync",
+        "sagemaker:InvokeEndpointWithBidirectionalStream",
       ]
       resources = [aws_sagemaker_endpoint.elevenlabs_asr[0].arn]
     }


### PR DESCRIPTION
## Why

JusticeTranscribe is moving its transcription from Azure Speech to ElevenLabs Scribe V2 Turbo on the `elevenlabs-asr` SageMaker endpoint in the Data Platform accounts.

The `justice-transcribe-backend-execution-role` currently has `sagemaker:InvokeEndpoint` and `sagemaker:InvokeEndpointAsync`, so streaming calls are denied today.

## What

Adds `sagemaker:InvokeEndpointWithBidirectionalStream` to the `InvokeElevenLabsEndpoint` inline policy on `justice_transcribe_backend_iam_role`, scoped to the existing `aws_sagemaker_endpoint.elevenlabs_asr[0].arn` — same resource as the two actions already granted. No widening of resource scope.

## No other infrastructure change is required

Bidirectional streaming is a capability of the model container, not of the endpoint configuration — there is no flag to set on `aws_sagemaker_endpoint_configuration`. SageMaker bridges the client's HTTP/2 connection to the container's WebSocket listener. `enable_network_isolation = true` and the absence of `vpc_config` are both fine for this.

## Testing

- `terraform fmt -check` passes.
- Functionally verifiable once merged and applied: the JusticeTranscribe backend already federates into this role via Entra OIDC (`sts:AssumeRoleWithWebIdentity`) and has a diagnostic handshake probe that exercises `sagemaker:InvokeEndpoint` against this endpoint today.
