### PR TITLE
Data Platform: Cluster maintenance for development and test

### DIFF
--- a/terraform/environments/data-platform/cluster/configuration/cluster.yml
+++ b/terraform/environments/data-platform/cluster/configuration/cluster.yml
@@ -14,7 +14,7 @@ environment:
     crd_versions:
       aws_load_balancer_controller: "v0.0.242"
       gateway_api: "v1.6.1"
-      karpenter: "1.14.0"
+      karpenter: "1.14.1"
       prometheus: "v0.93.1"
     helm_chart_versions:
       aws_cloudwatch_observability: "5.4.0"
@@ -26,7 +26,7 @@ environment:
       external_dns: "1.21.1"
       external_secrets: "2.9.0"
       fluent_bit: "0.2.0"
-      karpenter: "1.14.0"
+      karpenter: "1.14.1"
       keda: "2.20.2"
       kube_prometheus_stack: "88.5.4"
       kyverno: "3.9.0"
@@ -70,7 +70,7 @@ environment:
     crd_versions:
       aws_load_balancer_controller: "v0.0.242"
       gateway_api: "v1.6.1"
-      karpenter: "1.14.0"
+      karpenter: "1.14.1"
       prometheus: "v0.93.1"
     helm_chart_versions:
       aws_cloudwatch_observability: "5.4.0"
@@ -82,7 +82,7 @@ environment:
       external_dns: "1.21.1"
       external_secrets: "2.9.0"
       fluent_bit: "0.2.0"
-      karpenter: "1.14.0"
+      karpenter: "1.14.1"
       keda: "2.20.2"
       kube_prometheus_stack: "88.5.4"
       kyverno: "3.9.0"

--- a/terraform/environments/data-platform/cluster/configuration/cluster.yml
+++ b/terraform/environments/data-platform/cluster/configuration/cluster.yml
@@ -5,8 +5,8 @@ environment:
     node_update_config:
       max_unavailable: 3
     addon_versions:
-      aws_ebs_csi_driver: "v1.63.1-eksbuild.1"
-      aws_efs_csi_driver: "v3.4.1-eksbuild.1"
+      aws_ebs_csi_driver: "v1.64.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.4.2-eksbuild.1"
       aws_guardduty_agent: "v1.16.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.6-eksbuild.1"
       eks_node_monitoring_agent: "v1.7.0-eksbuild.1"
@@ -15,12 +15,12 @@ environment:
       aws_load_balancer_controller: "v0.0.242"
       gateway_api: "v1.6.1"
       karpenter: "1.14.0"
-      prometheus: "v0.93.0"
+      prometheus: "v0.93.1"
     helm_chart_versions:
       aws_cloudwatch_observability: "5.4.0"
       aws_load_balancer_controller: "v3.5.0"
       cert_manager: "1.21.1"
-      cilium: "1.20.0"
+      cilium: "1.20.1"
       cluster_autoscaler: "9.59.0"
       coredns: "1.47.0"
       external_dns: "1.21.1"
@@ -28,9 +28,9 @@ environment:
       fluent_bit: "0.2.0"
       karpenter: "1.14.0"
       keda: "2.20.2"
-      kube_prometheus_stack: "88.3.0"
-      kyverno: "3.8.2"
-      metrics_server: "3.13.1"
+      kube_prometheus_stack: "88.5.4"
+      kyverno: "3.9.0"
+      metrics_server: "3.14.0"
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:
@@ -61,8 +61,8 @@ environment:
     node_update_config:
       max_unavailable: 3
     addon_versions:
-      aws_ebs_csi_driver: "v1.63.1-eksbuild.1"
-      aws_efs_csi_driver: "v3.4.1-eksbuild.1"
+      aws_ebs_csi_driver: "v1.64.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.4.2-eksbuild.1"
       aws_guardduty_agent: "v1.16.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.6-eksbuild.1"
       eks_node_monitoring_agent: "v1.7.0-eksbuild.1"
@@ -71,12 +71,12 @@ environment:
       aws_load_balancer_controller: "v0.0.242"
       gateway_api: "v1.6.1"
       karpenter: "1.14.0"
-      prometheus: "v0.93.0"
+      prometheus: "v0.93.1"
     helm_chart_versions:
       aws_cloudwatch_observability: "5.4.0"
       aws_load_balancer_controller: "v3.5.0"
       cert_manager: "1.21.1"
-      cilium: "1.20.0"
+      cilium: "1.20.1"
       cluster_autoscaler: "9.59.0"
       coredns: "1.47.0"
       external_dns: "1.21.1"
@@ -84,9 +84,9 @@ environment:
       fluent_bit: "0.2.0"
       karpenter: "1.14.0"
       keda: "2.20.2"
-      kube_prometheus_stack: "88.3.0"
-      kyverno: "3.8.2"
-      metrics_server: "3.13.1"
+      kube_prometheus_stack: "88.5.4"
+      kyverno: "3.9.0"
+      metrics_server: "3.14.0"
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:


### PR DESCRIPTION
## Summary

Update the Data Platform EKS cluster component versions for the development and test environments.

The changes refresh verified Kubernetes add-ons, CRDs, and Helm charts while keeping the preproduction and production environments unchanged.

## Changes

For both development and test:

- Update the AWS EBS CSI Driver add-on from `v1.63.1-eksbuild.1` to `v1.64.0-eksbuild.1`.
- Update the AWS EFS CSI Driver add-on from `v3.4.1-eksbuild.1` to `v3.4.2-eksbuild.1`.
- Update the Karpenter CRD version from `1.14.0` to `1.14.1`.
- Update the Karpenter Helm chart from `1.14.0` to `1.14.1`.
- Update the Prometheus Operator CRD version from `v0.93.0` to `v0.93.1`.
- Update Cilium from `1.20.0` to `1.20.1`.
- Update kube-prometheus-stack from `88.3.0` to `88.5.4`.
- Update Kyverno from `3.8.2` to `3.9.0`.
- Update Metrics Server from `3.13.1` to `3.14.0`.

The Karpenter CRD and Helm chart versions are updated together to keep the controller and its CRDs aligned. The Prometheus CRD and kube-prometheus-stack versions are also updated together to keep the monitoring components aligned.

## Scope

- Development: updated
- Test: updated
- Preproduction: unchanged
- Production: unchanged
- Bottlerocket AMI version: unchanged at `1.64.0`
- Other EKS add-ons and component versions: unchanged

## Validation

- [x] YAML configuration parsed successfully.
- [x] Checkov scan passed.
- [x] TFLint scan passed.
- [x] Deploy and verify the updates in development and test.
- [x] Confirm cluster add-ons and Helm releases become healthy after upgrade.

## Files Changed

- `terraform/environments/data-platform/cluster/configuration/cluster.yml`