### PR TITLE
Use existing Apex Secrets Manager secrets

### DIFF
--- a/terraform/environments/apex/locals.tf
+++ b/terraform/environments/apex/locals.tf
@@ -74,7 +74,7 @@ locals {
   })
 
   # ECS task definition consumes this ARN via task_definition.json.
-  db_secret_arn = local.environment == "test" ? data.aws_secretsmanager_secret.app_apex_dbpassword_tad[0].arn : aws_secretsmanager_secret.app_apex_dbpassword_tad[0].arn
+  db_secret_arn = data.aws_secretsmanager_secret.app_apex_dbpassword_tad.arn
 
   env_account_id       = local.environment_management.account_ids[terraform.workspace]
   app_db_password_name = "APP_APEX_DBPASSWORD_TAD"

--- a/terraform/environments/apex/secrets.tf
+++ b/terraform/environments/apex/secrets.tf
@@ -1,53 +1,38 @@
 #### This file can be used to store secrets specific to the member account ####
 data "aws_secretsmanager_secret" "app_apex_dbpassword_tad" {
-  count = local.environment == "test" ? 1 : 0
-  name  = "APP_APEX_DBPASSWORD_TAD"
-}
-resource "aws_secretsmanager_secret" "app_apex_dbpassword_tad" {
-  count = local.environment == "test" ? 0 : 1
-  name  = "APP_APEX_DBPASSWORD_TAD"
-}
-data "aws_secretsmanager_secret_version" "app_apex_dbpassword_tad" {
-  secret_id = local.environment == "test" ? data.aws_secretsmanager_secret.app_apex_dbpassword_tad[0].id : aws_secretsmanager_secret.app_apex_dbpassword_tad[0].id
-}
-resource "aws_secretsmanager_secret_version" "app_apex_dbpassword_tad" {
-  count         = local.environment == "test" ? 0 : 1
-  secret_id     = local.environment == "test" ? data.aws_secretsmanager_secret.app_apex_dbpassword_tad[0].id : aws_secretsmanager_secret.app_apex_dbpassword_tad[0].id
-  secret_string = data.aws_secretsmanager_secret_version.app_apex_dbpassword_tad.secret_string
+  name = "APP_APEX_DBPASSWORD_TAD"
 }
 
 data "aws_secretsmanager_secret" "ec2_ssh_key" {
-  count = local.environment == "test" ? 1 : 0
-  name  = "EC2_SSH_KEY"
-}
-resource "aws_secretsmanager_secret" "ec2_ssh_key" {
-  count = local.environment == "test" ? 0 : 1
-  name  = "EC2_SSH_KEY"
-}
-data "aws_secretsmanager_secret_version" "ec2_ssh_key" {
-  secret_id = local.environment == "test" ? data.aws_secretsmanager_secret.ec2_ssh_key[0].id : aws_secretsmanager_secret.ec2_ssh_key[0].id
-}
-resource "aws_secretsmanager_secret_version" "ec2_ssh_key" {
-  count         = local.environment == "test" ? 0 : 1
-  secret_id     = local.environment == "test" ? data.aws_secretsmanager_secret.ec2_ssh_key[0].id : aws_secretsmanager_secret.ec2_ssh_key[0].id
-  secret_string = data.aws_secretsmanager_secret_version.ec2_ssh_key.secret_string
+  name = "EC2_SSH_KEY"
 }
 
-resource "aws_secretsmanager_secret" "app_apex_dbpassword_admin" {
-  count = local.environment == "preproduction" ? 1 : 0
-  name  = "APP_APEX_DBPASSWORD_ADMIN"
-}
 data "aws_secretsmanager_secret" "app_apex_dbpassword_admin" {
-  count = local.environment == "test" ? 1 : 0
+  count = contains(["test", "preproduction"], local.environment) ? 1 : 0
   name  = "APP_APEX_DBPASSWORD_ADMIN"
 }
-data "aws_secretsmanager_secret_version" "app_apex_dbpassword_admin" {
-  count     = contains(["test", "preproduction"], local.environment) ? 1 : 0
-  secret_id = local.environment == "test" ? data.aws_secretsmanager_secret.app_apex_dbpassword_admin[0].id : aws_secretsmanager_secret.app_apex_dbpassword_admin[0].id
+
+removed {
+  from = aws_secretsmanager_secret.app_apex_dbpassword_tad
+
+  lifecycle {
+    destroy = false
+  }
 }
-resource "aws_secretsmanager_secret_version" "app_apex_dbpassword_admin" {
-  count         = local.environment == "preproduction" ? 1 : 0
-  secret_id     = local.environment == "test" ? data.aws_secretsmanager_secret.app_apex_dbpassword_admin[0].id : aws_secretsmanager_secret.app_apex_dbpassword_admin[0].id
-  secret_string = data.aws_secretsmanager_secret_version.app_apex_dbpassword_admin[0].secret_string
+
+removed {
+  from = aws_secretsmanager_secret.ec2_ssh_key
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_secretsmanager_secret.app_apex_dbpassword_admin
+
+  lifecycle {
+    destroy = false
+  }
 }
 


### PR DESCRIPTION
This change simplifies Apex secret handling by using existing AWS Secrets Manager secrets as data sources across all environments.

It removes Terraform management of the secret resources and secret versions, preventing Terraform from recreating, deleting, or replacing existing secrets.