### PR TITLE
Data Platform: Remove ai-gateway and app namespaces from Kyverno exclusion

### DIFF
--- a/terraform/environments/data-platform/cluster/configuration/cluster.yml
+++ b/terraform/environments/data-platform/cluster/configuration/cluster.yml
@@ -34,10 +34,8 @@ environment:
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:
-        - ai-gateway
         - amazon-guardduty
         - amazon-network-flow-monitor
-        - app
         - aws-cloudwatch-observability
         - cert-manager
         - cilium-secrets
@@ -90,10 +88,8 @@ environment:
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:
-        - ai-gateway
         - amazon-guardduty
         - amazon-network-flow-monitor
-        - app
         - aws-cloudwatch-observability
         - cert-manager
         - cilium-secrets
@@ -146,10 +142,8 @@ environment:
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:
-        - ai-gateway
         - amazon-guardduty
         - amazon-network-flow-monitor
-        - app
         - aws-cloudwatch-observability
         - cert-manager
         - cilium-secrets
@@ -202,10 +196,8 @@ environment:
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:
-        - ai-gateway
         - amazon-guardduty
         - amazon-network-flow-monitor
-        - app
         - aws-cloudwatch-observability
         - cert-manager
         - cilium-secrets


### PR DESCRIPTION
## Summary

Remove the `ai-gateway` and `app` namespaces from the Kyverno exclusion lists so their workloads are evaluated by the configured validation policies.

## Changes

The following namespaces are removed from `kyverno_policies.excluded_namespaces` in all environments:

- `ai-gateway`
- `app`

The existing Kyverno validation action and all other namespace exclusions remain unchanged.

## Scope

- Development: updated
- Test: updated
- Preproduction: updated
- Production: updated

This change affects policy evaluation only. It does not modify the Kyverno policy definitions or change the validation action.

## Expected Behaviour

Workloads deployed to the `ai-gateway` and `app` namespaces will now be subject to the configured Kyverno policies, including checks for:

- Required resource requests and limits
- Required team ownership labels
- Explicit non-default ServiceAccounts
- Non-mutable image tags

Existing excluded platform namespaces remain excluded to avoid blocking platform-managed controllers and agents.

## Validation

- [x] YAML configuration parsed successfully.
- [x] Confirmed `ai-gateway` and `app` are absent from every Kyverno exclusion list.
- [x] Deploy to a non-production environment.
- [x] Verify compliant workloads continue to deploy successfully.
- [x] Verify non-compliant workloads in `ai-gateway` and `app` are handled according to the configured validation action.

## Files Changed

- `terraform/environments/data-platform/cluster/configuration/cluster.yml`