### PR TITLE
fix/coat-checkov-api-gateway

### DIFF
--- a/terraform/environments/coat/chatbot-api-gw.tf
+++ b/terraform/environments/coat/chatbot-api-gw.tf
@@ -128,7 +128,7 @@ resource "aws_cloudwatch_log_group" "chatbot_api_access_logs" {
   #checkov:skip=CKV_AWS_158:Default AWS encryption is sufficient for chatbot access logs
 
   name              = "/aws/apigateway/chatbot-${local.environment}"
-  retention_in_days = 120
+  retention_in_days = 365
 }
 
 resource "aws_iam_role" "chatbot_api_cloudwatch" {
@@ -163,6 +163,7 @@ resource "aws_api_gateway_client_certificate" "chatbot" {
 
 resource "aws_api_gateway_stage" "chatbot_api_stage" {
   #checkov:skip=CKV_AWS_120:Caching disabled - chatbot responses are dynamic per user question
+  #checkov:skip=CKV2_AWS_77:Log4j protection implemented via AWSManagedRulesKnownBadInputsRuleSet in associated WAF
 
   deployment_id         = aws_api_gateway_deployment.chatbot_api_deployment.id
   rest_api_id           = aws_api_gateway_rest_api.chatbot_api.id
@@ -191,6 +192,8 @@ resource "aws_api_gateway_stage" "chatbot_api_stage" {
 }
 
 resource "aws_api_gateway_method_settings" "chatbot_api_stage" {
+  #checkov:skip=CKV_AWS_225:Caching disabled - chatbot responses are dynamic per user question
+
   rest_api_id = aws_api_gateway_rest_api.chatbot_api.id
   stage_name  = aws_api_gateway_stage.chatbot_api_stage.stage_name
   method_path = "*/*"
@@ -272,7 +275,7 @@ resource "aws_cloudwatch_log_group" "chatbot_api_waf_logs" {
   #checkov:skip=CKV_AWS_158:Default AWS encryption is sufficient for WAF logs
 
   name              = "aws-waf-logs-chatbot-${local.environment}"
-  retention_in_days = 120
+  retention_in_days = 365
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "chatbot_api" {

--- a/terraform/environments/coat/chatbot-api-gw.tf
+++ b/terraform/environments/coat/chatbot-api-gw.tf
@@ -124,17 +124,160 @@ resource "aws_api_gateway_deployment" "chatbot_api_deployment" {
   ]
 }
 
-resource "aws_api_gateway_stage" "chatbot_api_stage" {
-  #checkov:skip=CKV_AWS_73:To be reviewed later
-  #checkov:skip=CKV_AWS_120:To be reviewed later
-  #checkov:skip=CKV_AWS_76:To be reviewed later
-  #checkov:skip=CKV2_AWS_4:To be reviewed later
-  #checkov:skip=CKV2_AWS_51:To be reviewed later
-  #checkov:skip=CKV2_AWS_29:To be reviewed later
+resource "aws_cloudwatch_log_group" "chatbot_api_access_logs" {
+  #checkov:skip=CKV_AWS_158:Default AWS encryption is sufficient for chatbot access logs
 
-  deployment_id = aws_api_gateway_deployment.chatbot_api_deployment.id
-  rest_api_id   = aws_api_gateway_rest_api.chatbot_api.id
-  stage_name    = local.environment
+  name              = "/aws/apigateway/chatbot-${local.environment}"
+  retention_in_days = 120
+}
+
+resource "aws_iam_role" "chatbot_api_cloudwatch" {
+  name = "chatbot-${local.environment}-apigw-cloudwatch"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "apigateway.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "chatbot_api_cloudwatch" {
+  role       = aws_iam_role.chatbot_api_cloudwatch.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+}
+
+resource "aws_api_gateway_account" "chatbot" {
+  cloudwatch_role_arn = aws_iam_role.chatbot_api_cloudwatch.arn
+
+  depends_on = [aws_iam_role_policy_attachment.chatbot_api_cloudwatch]
+}
+
+resource "aws_api_gateway_client_certificate" "chatbot" {
+  description = "Client certificate for chatbot-${local.environment} API Gateway"
+}
+
+resource "aws_api_gateway_stage" "chatbot_api_stage" {
+  #checkov:skip=CKV_AWS_120:Caching disabled - chatbot responses are dynamic per user question
+
+  deployment_id         = aws_api_gateway_deployment.chatbot_api_deployment.id
+  rest_api_id           = aws_api_gateway_rest_api.chatbot_api.id
+  stage_name            = local.environment
+  xray_tracing_enabled  = true
+  client_certificate_id = aws_api_gateway_client_certificate.chatbot.id
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.chatbot_api_access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+      apiKeyId       = "$context.identity.apiKeyId"
+    })
+  }
+
+  depends_on = [aws_api_gateway_account.chatbot]
+}
+
+resource "aws_api_gateway_method_settings" "chatbot_api_stage" {
+  rest_api_id = aws_api_gateway_rest_api.chatbot_api.id
+  stage_name  = aws_api_gateway_stage.chatbot_api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+  }
+
+  depends_on = [aws_api_gateway_account.chatbot]
+}
+
+resource "aws_wafv2_web_acl" "chatbot_api" {
+  name        = "chatbot-${local.environment}-api-waf"
+  description = "WAF for chatbot API Gateway"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "chatbot-${local.environment}-ip-reputation"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "chatbot-${local.environment}-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "chatbot-${local.environment}-api-waf"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "chatbot_api" {
+  resource_arn = aws_api_gateway_stage.chatbot_api_stage.arn
+  web_acl_arn  = aws_wafv2_web_acl.chatbot_api.arn
+}
+
+resource "aws_cloudwatch_log_group" "chatbot_api_waf_logs" {
+  #checkov:skip=CKV_AWS_158:Default AWS encryption is sufficient for WAF logs
+
+  name              = "aws-waf-logs-chatbot-${local.environment}"
+  retention_in_days = 120
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "chatbot_api" {
+  resource_arn            = aws_wafv2_web_acl.chatbot_api.arn
+  log_destination_configs = [aws_cloudwatch_log_group.chatbot_api_waf_logs.arn]
 }
 
 # Permissions


### PR DESCRIPTION
<img width="1049" height="621" alt="image" src="https://github.com/user-attachments/assets/27c13a0a-f1d5-4a49-b6b7-93aad678d1ec" />

https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1031
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1030
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1029
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1028
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1027
https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/1026

### **Summary** 
Resolves outstanding Checkov findings for the coat chatbot API Gateway in terraform/environments/coat/chatbot-api-gw.tf.

No change to how callers use the API — still POST /send-request with an API key to the RAG Lambda.

### **What's been added and why**

**Logging**

- CloudWatch log group (chatbot_api_access_logs) — API Gateway access logs (CKV_AWS_76, CKV_AWS_338)
- IAM role + policy attachment (chatbot_api_cloudwatch) — lets API Gateway write logs to CloudWatch
- aws_api_gateway_account — account-level CloudWatch role for execution logging (CKV2_AWS_4)
- aws_api_gateway_method_settings — INFO execution logging and metrics on all methods (CKV2_AWS_4)

**Security**
- aws_api_gateway_client_certificate — client certificate on the stage (CKV2_AWS_51)
- aws_wafv2_web_acl — regional WAF with AWS managed IP reputation and known bad inputs rules (CKV2_AWS_29)
- aws_wafv2_web_acl_association — attaches WAF to the API stage
- WAF log group + logging configuration — WAF request logging (365-day retention)

**Updates to existing resources**
- aws_api_gateway_stage — X-Ray tracing, access log settings, and client certificate (CKV_AWS_73)

### **Intentional Checkov skips**
- Caching (CKV_AWS_120, CKV_AWS_225) — chatbot responses are dynamic per user question; caching would return stale answers
- Log4j WAF graph check (CKV2_AWS_77) — WAF already includes AWSManagedRulesKnownBadInputsRuleSet; Checkov doesn't detect the stage↔WAF association
- KMS on log groups (CKV_AWS_158) — default AWS encryption is sufficient for these logs
