### PR TITLE
fix(data-platform): promote litellm 1.98.0 to pre-production and production

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.98.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -121,7 +121,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.98.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Promotes `litellm_version` from `1.97.0` to `1.98.0` for preproduction and production in [`environment-configuration.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/fix/promote-litellm-1.98.0-to-production/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L84-L124), completing the staged rollout.
- Development and test have been running `1.98.0` since #18566 merged and were verified aligned before this change.
- This is stage two of the staged rollout started in #18566 (development/test) and paired with [data-platform-app#227](https://github.com/ministryofjustice/data-platform-app/pull/227), which shipped the same `1.98.0` image for local Compose.
- Validation completed: `terraform fmt -check -diff` passed with no changes required, and `git diff --check` passed; the diff contains only the two intended version changes (preproduction and production).

## Data Platform client compatibility

Compatibility evidence was established and verified in the first-stage PR #18566 (merged, development/test) and remains valid for this promotion since no code or configuration changes are introduced here beyond the version bump — only the previously-validated `1.98.0` image is now applied to preproduction and production.

- No breaking changes affecting the Data Platform AI Gateway client were identified between `1.97.0` and `1.98.0`. The full analysis of access-group/organisation, teams, virtual-keys, models/activity, and authentication/error-handling endpoints against the `AIGatewayClient` is documented in #18566 and is reused unchanged here. See the [complete v1.97.0...v1.98.0 upstream comparison](https://github.com/BerriAI/litellm/compare/v1.97.0...v1.98.0).
- Re-checked for new evidence prior to this promotion: the two LiteLLM security advisories published since #18566 was authored — [GHSA-3cv6-jpf6-8222](https://github.com/BerriAI/litellm/security/advisories/GHSA-3cv6-jpf6-8222) (fixed `<1.94.0`) and [GHSA-hx8v-g79f-8w5f](https://github.com/BerriAI/litellm/security/advisories/GHSA-hx8v-g79f-8w5f) (fixed `<=1.83.8`) — are both already resolved in `1.98.0` and do not affect this promotion. No new LiteLLM release superseding `1.98.0` was found to warrant re-targeting.

## Other breaking changes

- No breaking-change entry applicable to this deployment was identified in the [v1.98.0 release notes](https://github.com/BerriAI/litellm/releases/tag/v1.98.0); this analysis was completed in #18566 and is unchanged for preproduction/production.
- The Prisma schema and migration-job behaviour reviewed in #18566 apply identically here, since preproduction and production use the same [Helm values](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl) configuration already validated for development and test.

## Release notes

- [LiteLLM 1.98.0 release notes](https://github.com/BerriAI/litellm/releases/tag/v1.98.0)
- [Full upstream comparison](https://github.com/BerriAI/litellm/compare/v1.97.0...v1.98.0)

## Related

- First stage (development/test): #18566
- Paired Data Platform App PR: ministryofjustice/data-platform-app#227
