### PR TITLE
Data Platform: Cluster maintenance for preproduction

### DIFF
--- a/terraform/environments/data-platform/cluster/configuration/cluster.yml
+++ b/terraform/environments/data-platform/cluster/configuration/cluster.yml
@@ -113,8 +113,8 @@ environment:
     node_update_config:
       max_unavailable: 1
     addon_versions:
-      aws_ebs_csi_driver: "v1.63.1-eksbuild.1"
-      aws_efs_csi_driver: "v3.4.1-eksbuild.1"
+      aws_ebs_csi_driver: "v1.64.0-eksbuild.1"
+      aws_efs_csi_driver: "v3.4.2-eksbuild.1"
       aws_guardduty_agent: "v1.16.0-eksbuild.2"
       aws_network_flow_monitoring_agent: "v1.1.6-eksbuild.1"
       eks_node_monitoring_agent: "v1.7.0-eksbuild.1"
@@ -122,23 +122,23 @@ environment:
     crd_versions:
       aws_load_balancer_controller: "v0.0.242"
       gateway_api: "v1.6.1"
-      karpenter: "1.14.0"
-      prometheus: "v0.93.0"
+      karpenter: "1.14.1"
+      prometheus: "v0.93.1"
     helm_chart_versions:
       aws_cloudwatch_observability: "5.4.0"
       aws_load_balancer_controller: "v3.5.0"
       cert_manager: "1.21.1"
-      cilium: "1.20.0"
+      cilium: "1.20.1"
       cluster_autoscaler: "9.59.0"
       coredns: "1.47.0"
       external_dns: "1.21.1"
       external_secrets: "2.9.0"
       fluent_bit: "0.2.0"
-      karpenter: "1.14.0"
+      karpenter: "1.14.1"
       keda: "2.20.2"
-      kube_prometheus_stack: "88.3.0"
-      kyverno: "3.8.2"
-      metrics_server: "3.13.1"
+      kube_prometheus_stack: "88.5.4"
+      kyverno: "3.9.0"
+      metrics_server: "3.14.0"
     kyverno_policies:
       validation_action: "Audit"
       excluded_namespaces:


### PR DESCRIPTION
## Summary

Update the Data Platform EKS cluster component versions for the preproduction environment, bringing it in line with the already-maintained development and test environments.

## Changes

Preproduction updates:

- Update the AWS EBS CSI Driver add-on from `v1.63.1-eksbuild.1` to `v1.64.0-eksbuild.1`.
- Update the AWS EFS CSI Driver add-on from `v3.4.1-eksbuild.1` to `v3.4.2-eksbuild.1`.
- Update the Karpenter CRD and Helm chart from `1.14.0` to `1.14.1`.
- Update the Prometheus Operator CRD from `v0.93.0` to `v0.93.1`.
- Update Cilium from `1.20.0` to `1.20.1`.
- Update kube-prometheus-stack from `88.3.0` to `88.5.4`.
- Update Kyverno from `3.8.2` to `3.9.0`.
- Update Metrics Server from `3.13.1` to `3.14.0`.

The Karpenter CRD and Helm chart versions are updated together. The Prometheus Operator CRD and kube-prometheus-stack versions are also kept aligned.

## Scope

- Development: unchanged by this PR
- Test: unchanged by this PR
- Preproduction: updated
- Production: unchanged by this PR
- Kubernetes version: unchanged at `1.36`
- Bottlerocket AMI version: unchanged at `1.64.0-ad9d4847`
- Kyverno validation action: unchanged at `Audit`

## Validation

- [x] Validate the YAML configuration.
- [x] Run Checkov and TFLint.
- [x] Deploy the changes to preproduction.
- [x] Confirm all updated add-ons, CRDs, and Helm releases become healthy.
- [x] Confirm production configuration remains unchanged.

## Files Changed

- `terraform/environments/data-platform/cluster/configuration/cluster.yml`