### PR TITLE
🚨 feat(integration-hub): route file-transfer alerts to PagerDuty

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/cloudwatch.tf
@@ -29,6 +29,7 @@ module "cloudwatch_metric_alarms" {
   statistic           = each.value.statistic
   threshold           = each.value.threshold
   treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cloudwatch_alarm_actions[each.key]
 
   tags = local.tags
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-cloudwatch.tf
@@ -584,5 +584,67 @@ locals {
     }
   })
 
+  high_priority_alarm_names = toset(concat(
+    [
+      "lambda-file-received-adapter-errors",
+      "lambda-file-received-adapter-dead-letter-errors",
+      "lambda-file-scan-result-recorded-adapter-errors",
+      "lambda-file-scan-result-recorded-adapter-dead-letter-errors",
+      "lambda-stage-errors",
+      "lambda-stage-dead-letter-errors",
+      "lambda-stage-async-events-dropped",
+      "lambda-route-errors",
+      "lambda-route-dead-letter-errors",
+      "lambda-route-async-events-dropped",
+      "lambda-file-action-execution-requested-adapter-errors",
+      "lambda-file-action-execution-requested-adapter-dead-letter-errors",
+      "lambda-file-action-execution-requested-adapter-async-events-dropped",
+      "eventbridge-default-rule-failed-invocations",
+      "eventbridge-default-dlq-visible-messages",
+      "eventbridge-guardduty-malware-scan-result-failed-invocations",
+      "eventbridge-file-transfer-workflow-failed-invocations",
+      "eventbridge-file-routing-workflow-failed-invocations",
+      "eventbridge-file-action-dispatch-workflow-failed-invocations",
+      "eventbridge-file-transfer-workflow-dlq-visible-messages",
+      "lambda-file-received-adapter-dlq-visible-messages",
+      "lambda-file-scan-result-recorded-adapter-dlq-visible-messages",
+      "lambda-stage-dlq-visible-messages",
+      "lambda-route-dlq-visible-messages",
+      "lambda-file-action-execution-requested-adapter-dlq-visible-messages",
+      "guardduty-failed-scans",
+      "guardduty-infected-scans",
+    ],
+    [
+      for index, eip in aws_eip.this : "shield-transfer-eip-${index + 1}-ddos-detected"
+    ],
+  ))
+
+  low_priority_alarm_names = toset([
+    "lambda-file-received-adapter-throttles",
+    "lambda-file-received-adapter-duration",
+    "lambda-file-scan-result-recorded-adapter-throttles",
+    "lambda-file-scan-result-recorded-adapter-duration",
+    "lambda-stage-throttles",
+    "lambda-stage-duration",
+    "lambda-route-throttles",
+    "lambda-route-duration",
+    "lambda-file-action-execution-requested-adapter-throttles",
+    "lambda-file-action-execution-requested-adapter-duration",
+    "dynamodb-file-transfer-workflow-idempotency-read-throttles",
+    "dynamodb-file-transfer-workflow-idempotency-write-throttles",
+    "dynamodb-idempotency-read-throttles",
+    "dynamodb-idempotency-write-throttles",
+    "guardduty-skipped-scans-missing-permissions",
+    "guardduty-skipped-scans-unsupported",
+  ])
+
+  high_priority_alarm_actions = local.is-production ? [module.sns_pagerduty_high_priority.topic_arn] : [module.sns_pagerduty_low_priority.topic_arn]
+  low_priority_alarm_actions  = local.is-production ? [module.sns_pagerduty_low_priority.topic_arn] : []
+
+  cloudwatch_alarm_actions = merge(
+    { for alarm_name in local.high_priority_alarm_names : alarm_name => local.high_priority_alarm_actions },
+    { for alarm_name in local.low_priority_alarm_names : alarm_name => local.low_priority_alarm_actions },
+  )
+
   cloudwatch_retention_days = local.is-production ? 400 : 30
 }

--- a/terraform/environments/integration-hub-file-transfer/locals-pagerduty.tf
+++ b/terraform/environments/integration-hub-file-transfer/locals-pagerduty.tf
@@ -1,0 +1,13 @@
+locals {
+  pagerduty_integration_keys = jsondecode(data.aws_secretsmanager_secret_version.pagerduty_integration_keys.secret_string)
+}
+
+data "aws_secretsmanager_secret" "pagerduty_integration_keys" {
+  provider = aws.modernisation-platform
+  name     = "pagerduty_integration_keys"
+}
+
+data "aws_secretsmanager_secret_version" "pagerduty_integration_keys" {
+  provider  = aws.modernisation-platform
+  secret_id = data.aws_secretsmanager_secret.pagerduty_integration_keys.id
+}

--- a/terraform/environments/integration-hub-file-transfer/sns.tf
+++ b/terraform/environments/integration-hub-file-transfer/sns.tf
@@ -1,0 +1,47 @@
+module "sns_pagerduty_high_priority" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "6.2.0"
+
+  name = "pagerduty-high-priority"
+  subscriptions = {
+    pagerduty = {
+      protocol = "https"
+      endpoint = "https://events.pagerduty.com/integration/${local.pagerduty_integration_keys["integration_hub_high_priority"]}/enqueue"
+    }
+  }
+  topic_policy_statements = {
+    allow_eventbridge_publish = {
+      actions = ["sns:Publish"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+    }
+  }
+}
+
+module "sns_pagerduty_low_priority" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "6.2.0"
+
+  name = "pagerduty-low-priority"
+  subscriptions = {
+    pagerduty = {
+      protocol = "https"
+      endpoint = "https://events.pagerduty.com/integration/${local.pagerduty_integration_keys["integration_hub_low_priority"]}/enqueue"
+    }
+  }
+  topic_policy_statements = {
+    allow_eventbridge_publish = {
+      actions = ["sns:Publish"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+    }
+  }
+}

--- a/terraform/environments/integration-hub-file-transfer/sns.tf
+++ b/terraform/environments/integration-hub-file-transfer/sns.tf
@@ -1,6 +1,7 @@
 module "sns_pagerduty_high_priority" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/sns/aws"
-  version = "6.2.0"
+  version = "7.1.1"
 
   name = "pagerduty-high-priority"
   subscriptions = {
@@ -23,8 +24,9 @@ module "sns_pagerduty_high_priority" {
 }
 
 module "sns_pagerduty_low_priority" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   source  = "terraform-aws-modules/sns/aws"
-  version = "6.2.0"
+  version = "7.1.1"
 
   name = "pagerduty-low-priority"
   subscriptions = {


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed

Adds PagerDuty delivery for the Integration Hub Managed File Transfer CloudWatch alarms.

- Creates dedicated high- and low-priority SNS topics, subscribed to the centrally managed Integration Hub PagerDuty services.
- Classifies alarms explicitly so paging remains useful: transfer-blocking failures, populated dead-letter queues, malware scan failures, and DDoS detection are high priority; performance pressure and diagnostic signals are low priority.
- Routes high-priority production alerts to the high-priority service. Production low-priority and non-production high-priority alerts go to the low-priority service. Low-priority non-production alarms remain visible in CloudWatch without notifying PagerDuty.
- Keeps the SNS topic names aligned with the existing `integration-hub-api` alarm-topic lookups.

This is an initial alerting baseline. We should tune the classifications after the first deployment and real operational feedback, before alert fatigue gets any ideas. 🙂

## Context

There is no work item for this change yet. I ought to raise one in [ministryofjustice/integration-hub](https://github.com/ministryofjustice/integration-hub) so we can track this work.

My goal here is to get alarms reporting to us on Slack via PagerDuty. I'm trying to keep it strict; things that break live services go to high priority, things we should be investigating go to low priority. If we keep our alerting focused we can continue to pay attention to it.

## Validation

- `terraform init`
- `terraform fmt`
- Further validation will run in CI.

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>