### PR TITLE
fix(data-platform): roll back litellm to 1.97.0

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,7 +1,7 @@
 locals {
   environment_configurations = {
     development = {
-      litellm_version     = "1.98.0"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -41,7 +41,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.98.0"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.98.0"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -121,7 +121,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.98.0"
+      litellm_version     = "1.97.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Rolls back `litellm_version` from `1.98.0` to `1.97.0` for development, test, preproduction, and production in [`environment-configuration.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/gary-h9-rollback-litellm-1-97-0/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L3-L124).
- Reverses the staged `1.98.0` rollout completed by [#18566](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18566) for development/test and [#18596](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18596) for preproduction/production.
- Restores the previously deployed `1.97.0` version introduced through [#18228](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18228) and [#18308](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18308).

This is required as we are currently seeing issues relating to revoking keys etc. 