### PR TITLE
fix(data-platform): upgrade litellm preproduction to 1.98.0

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.98.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Upgrades preproduction LiteLLM from `1.97.0` to `1.98.0` in [`environment-configuration.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/fix/update-litellm-to-1.98.0/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L83-L85).
- Development, test, and production intentionally remain on `1.97.0`.

## Context

- This is a preproduction-only rollout following the development and test rollout in [#18566](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18566).
- It follows the all-environment rollback in [#18605](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18605), which restored preproduction to `1.97.0`.

## Release notes

- [LiteLLM v1.98.0](https://github.com/BerriAI/litellm/releases/tag/v1.98.0)