### PR TITLE
feat: replicate Aurora production configuration to preproduction for ai-gateway

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -110,15 +110,11 @@ locals {
         max_replicas                      = 3
         target_cpu_utilization_percentage = 60
       }
-      aurora_instance_class = "db.serverless"
-      aurora_engine_version = "18.4"
-      aurora_instances      = { writer = {} }
-      aurora_serverlessv2_scaling_configuration = {
-        min_capacity             = 0
-        max_capacity             = 4
-        seconds_until_auto_pause = 3600
-      }
-      elasticache_node_type = "cache.t4g.medium"
+      aurora_instance_class                     = "db.t4g.medium"
+      aurora_engine_version                     = "18.4"
+      aurora_instances                          = { writer = {}, reader = {} }
+      aurora_serverlessv2_scaling_configuration = null
+      elasticache_node_type                     = "cache.t4g.medium"
     }
     production = {
       litellm_version     = "1.97.0"


### PR DESCRIPTION
## Description

Replicates the Aurora production configuration to the preproduction environment for the data-platform `ai-gateway`.

Preproduction now matches production:

| Setting | Before (preprod) | After (preprod / prod) |
| --- | --- | --- |
| `aurora_instance_class` | `db.serverless` | `db.t4g.medium` |
| `aurora_instances` | `{ writer = {} }` | `{ writer = {}, reader = {} }` |
| `aurora_serverlessv2_scaling_configuration` | scaling block | `null` |

`aurora_engine_version` and `elasticache_node_type` were already aligned.

## Checklist
- [x] British English used
- [x] Follows Modernisation Platform Terraform style guide