### PR TITLE
removed secrets from dev

### DIFF
--- a/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
+++ b/terraform/environments/data-platform/monitoring/alerting-pagerduty.tf
@@ -1,47 +1,47 @@
-# # ------------------------------------------------------------------------------
-# # PAGERDUTY CONTACT POINT
-# # Creates a Grafana contact point that sends alerts to PagerDuty Event
-# # Orchestrator. The routing key is read from Secrets Manager.
-# # ------------------------------------------------------------------------------
-# resource "grafana_contact_point" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# PAGERDUTY CONTACT POINT
+# Creates a Grafana contact point that sends alerts to PagerDuty Event
+# Orchestrator. The routing key is read from Secrets Manager.
+# ------------------------------------------------------------------------------
+resource "grafana_contact_point" "pagerduty" {
+  count = terraform.workspace == "data-platform-production" && local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   name = "pagerduty"
+  name = "pagerduty"
 
-#   pagerduty {
-#     integration_key = local.pagerduty_routing_key
-#     severity        = "{{ .CommonLabels.severity }}"
-#     component       = "{{ .CommonLabels.component }}"
-#     group           = "{{ .CommonLabels.environment }}"
+  pagerduty {
+    integration_key = local.pagerduty_routing_key
+    severity        = "{{ .CommonLabels.severity }}"
+    component       = "{{ .CommonLabels.component }}"
+    group           = "{{ .CommonLabels.environment }}"
 
-#     # Include all labels as custom details in the PagerDuty payload
-#     details = {
-#       environment = "{{ .CommonLabels.environment }}"
-#       severity    = "{{ .CommonLabels.severity }}"
-#       component   = "{{ .CommonLabels.component }}"
-#       metric      = "{{ .CommonLabels.metric }}"
-#       alertname   = "{{ .CommonLabels.alertname }}"
-#       summary     = "{{ .CommonAnnotations.summary }}"
-#       description = "{{ .CommonAnnotations.description }}"
-#     }
-#   }
+    # Include all labels as custom details in the PagerDuty payload
+    details = {
+      environment = "{{ .CommonLabels.environment }}"
+      severity    = "{{ .CommonLabels.severity }}"
+      component   = "{{ .CommonLabels.component }}"
+      metric      = "{{ .CommonLabels.metric }}"
+      alertname   = "{{ .CommonLabels.alertname }}"
+      summary     = "{{ .CommonAnnotations.summary }}"
+      description = "{{ .CommonAnnotations.description }}"
+    }
+  }
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}
 
-# # ------------------------------------------------------------------------------
-# # NOTIFICATION POLICY
-# # Routes alerts to the PagerDuty contact point. Each alert fires individually
-# # without grouping.
-# # ------------------------------------------------------------------------------
-# resource "grafana_notification_policy" "pagerduty" {
-#   count = local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
+# ------------------------------------------------------------------------------
+# NOTIFICATION POLICY
+# Routes alerts to the PagerDuty contact point. Each alert fires individually
+# without grouping.
+# ------------------------------------------------------------------------------
+resource "grafana_notification_policy" "pagerduty" {
+  count = terraform.workspace == "data-platform-production" && local.grafana_alerting_manageable && local.pagerduty_routing_key != "" ? 1 : 0
 
-#   contact_point   = grafana_contact_point.pagerduty[0].name
-#   group_by        = ["..."]
-#   group_wait      = "0s"
-#   group_interval  = "1m"
-#   repeat_interval = "4h"
+  contact_point   = grafana_contact_point.pagerduty[0].name
+  group_by        = ["..."]
+  group_wait      = "0s"
+  group_interval  = "1m"
+  repeat_interval = "4h"
 
-#   depends_on = [helm_release.grafana]
-# }
+  depends_on = [helm_release.grafana]
+}

--- a/terraform/environments/data-platform/monitoring/secrets.tf
+++ b/terraform/environments/data-platform/monitoring/secrets.tf
@@ -51,7 +51,7 @@ module "cloud_platform_live_namespace_secret" {
 }
 
 module "pagerduty_orchestrator_integration_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+  count = terraform.workspace == "data-platform-production" ? 1 : 0
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
 
@@ -67,7 +67,7 @@ module "pagerduty_orchestrator_integration_key_secret" {
 }
 
 module "pagerduty_slack_connection_api_key_secret" {
-  count = contains(["data-platform-development", "data-platform-production"], terraform.workspace) ? 1 : 0
+  count = terraform.workspace == "data-platform-production" ? 1 : 0
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git?ref=82029345dea22bc49989a6f46c5d8d8e555b84c9" # v2.0.1
 


### PR DESCRIPTION
This pull request restricts the creation of PagerDuty-related resources and secrets in the monitoring Terraform configuration to only the `data-platform-production` environment. This ensures that PagerDuty alerting and its secrets are only managed in production, preventing unnecessary resources in development environments.

**PagerDuty alerting and secrets management (production-only):**

* The `grafana_contact_point.pagerduty` and `grafana_notification_policy.pagerduty` resources in `alerting-pagerduty.tf` are now only created when the workspace is `data-platform-production`, rather than in both development and production.
* The `pagerduty_orchestrator_integration_key_secret` and `pagerduty_slack_connection_api_key_secret` secrets in `secrets.tf` are now only created in the `data-platform-production` workspace, instead of both development and production. [[1]](diffhunk://#diff-829660ed160e104e7c02f44207aeb98c4a8647fe2a21d4156f94e32cbcea434aL54-R54) [[2]](diffhunk://#diff-829660ed160e104e7c02f44207aeb98c4a8647fe2a21d4156f94e32cbcea434aL70-R70)