### PR TITLE
PDHD-274 added incident-reporting

### DIFF
--- a/terraform/environments/digital-prison-reporting/data_product_definitions_s3.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions_s3.tf
@@ -5,6 +5,10 @@ locals {
       github_repo = "hmpps-dpr-activities-dpds"
       s3_prefix   = "activities"
     }
+    "incident-reporting" = {
+      github_repo = "hmpps-dpr-incident-reporting-dpds"
+      s3_prefix   = "incident-reporting"
+    }
   }
 }
 


### PR DESCRIPTION
Added permissions for the new incident reporting repo: https://github.com/ministryofjustice/hmpps-dpr-incident-reporting-dpds to allow publishing DPDs to S3.