### PR TITLE
🔐 chore: encrypt Integration Hub File Transfer SNS topics with KMS

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub-file-transfer/kms.tf
@@ -325,6 +325,14 @@ module "kms_sqs" {
           identifiers = ["cloudwatch.amazonaws.com"]
         }
       ]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        }
+      ]
     },
     {
       sid = "AllowEventBridgePublishers"
@@ -338,6 +346,14 @@ module "kms_sqs" {
         {
           type        = "Service"
           identifiers = ["events.amazonaws.com"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
         }
       ]
     },
@@ -401,6 +417,14 @@ module "kms_sns" {
           identifiers = ["cloudwatch.amazonaws.com"]
         }
       ]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
+        }
+      ]
     },
     {
       sid = "AllowEventBridgePublishers"
@@ -414,6 +438,14 @@ module "kms_sns" {
         {
           type        = "Service"
           identifiers = ["events.amazonaws.com"]
+        }
+      ]
+
+      condition = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = [data.aws_caller_identity.current.account_id]
         }
       ]
     },

--- a/terraform/environments/integration-hub-file-transfer/kms.tf
+++ b/terraform/environments/integration-hub-file-transfer/kms.tf
@@ -370,3 +370,79 @@ module "kms_sqs" {
 
   tags = local.tags
 }
+
+module "kms_sns" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source  = "terraform-aws-modules/kms/aws"
+  version = "4.2.1"
+
+  aliases                 = ["sns/${local.application_name}-${local.environment}"]
+  description             = "KMS CMK for SNS encryption"
+  enable_default_policy   = true
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  key_usage               = "ENCRYPT_DECRYPT"
+  is_enabled              = true
+
+  key_administrators = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+
+  key_statements = [
+    {
+      sid = "AllowCloudWatchAlarmPublishers"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*",
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["cloudwatch.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "AllowEventBridgePublishers"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*",
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "AllowSNSService"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:ReEncrypt*"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["sns.amazonaws.com"]
+        }
+      ]
+      condition = [
+        {
+          test     = "ArnLike"
+          variable = "kms:EncryptionContext:aws:sns:topicArn"
+          values   = ["arn:aws:sns:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
+        }
+      ]
+    }
+  ]
+
+  tags = local.tags
+}

--- a/terraform/environments/integration-hub-file-transfer/sns.tf
+++ b/terraform/environments/integration-hub-file-transfer/sns.tf
@@ -3,7 +3,7 @@ module "sns_pagerduty_high_priority" {
   source  = "terraform-aws-modules/sns/aws"
   version = "7.1.1"
 
-  name = "pagerduty-high-priority"
+  name              = "pagerduty-high-priority"
   kms_master_key_id = module.kms_sns.key_arn
   subscriptions = {
     pagerduty = {
@@ -36,7 +36,7 @@ module "sns_pagerduty_low_priority" {
   source  = "terraform-aws-modules/sns/aws"
   version = "7.1.1"
 
-  name = "pagerduty-low-priority"
+  name              = "pagerduty-low-priority"
   kms_master_key_id = module.kms_sns.key_arn
   subscriptions = {
     pagerduty = {

--- a/terraform/environments/integration-hub-file-transfer/sns.tf
+++ b/terraform/environments/integration-hub-file-transfer/sns.tf
@@ -4,6 +4,7 @@ module "sns_pagerduty_high_priority" {
   version = "7.1.1"
 
   name = "pagerduty-high-priority"
+  kms_master_key_id = module.kms_sns.key_arn
   subscriptions = {
     pagerduty = {
       protocol = "https"
@@ -36,6 +37,7 @@ module "sns_pagerduty_low_priority" {
   version = "7.1.1"
 
   name = "pagerduty-low-priority"
+  kms_master_key_id = module.kms_sns.key_arn
   subscriptions = {
     pagerduty = {
       protocol = "https"

--- a/terraform/environments/integration-hub-file-transfer/transfer-server.tf
+++ b/terraform/environments/integration-hub-file-transfer/transfer-server.tf
@@ -1,5 +1,5 @@
 resource "aws_transfer_server" "this" {
-  certificate            = aws_acm_certificate.ftps.arn
+  certificate                 = aws_acm_certificate.ftps.arn
   domain                      = "S3"
   endpoint_type               = "VPC"
   function                    = module.lambda_custom_idp.lambda_function_arn
@@ -23,7 +23,7 @@ resource "aws_transfer_server" "this" {
   tags = merge(
     local.tags,
     {
-      Name = "${local.application_name}-transfer-server"
+      Name                           = "${local.application_name}-transfer-server"
       "transfer:customHostname"      = local.is-production == false ? "sftp.${local.environment}.file-transfer.service.justice.gov.uk" : "sftp.file-transfer.service.justice.gov.uk"
       "transfer:route53HostedZoneId" = "/hostedzone/${data.aws_route53_zone.service.zone_id}"
     }


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## Summary

🔐 Encrypt the Integration Hub File Transfer PagerDuty SNS topics at rest with a customer-managed KMS key. Alert delivery continues to work because CloudWatch retains the permissions it needs to publish encrypted notifications.

This change follows AWS Well-Architected Framework review work.

## Changes

- Add a dedicated KMS key for SNS, including automatic annual rotation.
- Encrypt the high- and low-priority PagerDuty SNS topics with that key.
- Permit CloudWatch alarms, EventBridge, and SNS to use the key for encrypted message delivery.

## Validation

- `terraform fmt`
- `terraform init`
- `terraform plan`
- `git diff --check origin/main...HEAD`

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>