### PR TITLE
permissions for the personal rota

### DIFF
--- a/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_iam.tf
@@ -3079,3 +3079,39 @@ module "trigger_cpr_job_iam_role" {
     }] }
   }
 }
+
+# ------------------------------------------------------------------------------
+# IAM role and policy for the rota personal digest Lambda
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "rota_personal_digest" {
+  name               = "rota_personal_digest_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "rota_personal_digest_policy_document" {
+  statement {
+    sid    = "ReadRotaDigestSecrets"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      module.live_feed_github_app.secret_arn,
+      module.rota_personal_digest_slack.secret_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "rota_personal_digest" {
+  name   = "rota_personal_digest_lambda_policy"
+  policy = data.aws_iam_policy_document.rota_personal_digest_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "rota_personal_digest_attach" {
+  role       = aws_iam_role.rota_personal_digest.name
+  policy_arn = aws_iam_policy.rota_personal_digest.arn
+}

--- a/terraform/environments/electronic-monitoring-data/lambdas_main.tf
+++ b/terraform/environments/electronic-monitoring-data/lambdas_main.tf
@@ -402,13 +402,13 @@ module "load_fms_lambda" {
   subnet_ids                     = data.aws_subnets.shared-private.ids
   cloudwatch_retention_days      = 7
   environment_variables = {
-    ATHENA_QUERY_BUCKET = module.s3-athena-bucket.bucket.id
-    ACCOUNT_NUMBER      = data.aws_caller_identity.current.account_id
-    STAGING_BUCKET      = module.s3-create-a-derived-table-bucket.bucket.id
-    ENVIRONMENT_NAME    = local.environment_shorthand
-    CLEANUP_QUEUE_URL   = aws_sqs_queue.clean_dlt_load_queue.id
-    SNS_TOPIC_ARN       = aws_sns_topic.emds_alerts.arn
-    MAX_RECEIVE_COUNT   = tostring(local.load_sqs_max_receive_count)
+    ATHENA_QUERY_BUCKET     = module.s3-athena-bucket.bucket.id
+    ACCOUNT_NUMBER          = data.aws_caller_identity.current.account_id
+    STAGING_BUCKET          = module.s3-create-a-derived-table-bucket.bucket.id
+    ENVIRONMENT_NAME        = local.environment_shorthand
+    CLEANUP_QUEUE_URL       = aws_sqs_queue.clean_dlt_load_queue.id
+    SNS_TOPIC_ARN           = aws_sns_topic.emds_alerts.arn
+    MAX_RECEIVE_COUNT       = tostring(local.load_sqs_max_receive_count)
     MOD_PLAT_ACCOUNT_ALIAS  = terraform.workspace
     MOD_PLAT_ACCOUNT_NUMBER = local.env_account_id
   }
@@ -1263,7 +1263,7 @@ module "live_feed_incident_manager" {
 #-----------------------------------------------------------------------------------
 
 module "trigger_cpr_integration" {
-  count =  local.is-development || local.is-test || local.is-preproduction ? 1 : 0
+  count                   = local.is-development || local.is-test || local.is-preproduction ? 1 : 0
   source                  = "./modules/lambdas"
   is_image                = true
   function_name           = "trigger_cpr_job"
@@ -1275,9 +1275,56 @@ module "trigger_cpr_integration" {
   core_shared_services_id = local.environment_management.account_ids["core-shared-services-production"]
   production_dev          = local.is-production ? "prod" : local.is-preproduction ? "preprod" : local.is-test ? "test" : "dev"
   security_group_ids      = [aws_security_group.lambda_cp_sg.id]
-  subnet_ids                     = data.aws_subnets.shared-private.ids
+  subnet_ids              = data.aws_subnets.shared-private.ids
 
   environment_variables = {
     API_BASE_URL = local.is-development || local.is-test ? "https://electronic-monitoring-data-person-match-api-dev.internal-non-prod.cloud-platform.service.justice.gov.uk" : local.is-preproduction ? "https://electronic-monitoring-data-person-match-api-preprod.internal-non-prod.cloud-platform.service.justice.gov.uk" : ""
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Rota personal digest
+# ------------------------------------------------------------------------------
+
+module "rota_personal_digest" {
+  source                         = "./modules/lambdas"
+  is_image                       = true
+  function_name                  = "rota_personal_digest"
+  role_name                      = aws_iam_role.rota_personal_digest.name
+  role_arn                       = aws_iam_role.rota_personal_digest.arn
+  handler                        = "rota_personal_digest.handler"
+  memory_size                    = 512
+  timeout                        = 60
+  reserved_concurrent_executions = 1
+
+  core_shared_services_id = local.environment_management.account_ids[
+    "core-shared-services-production"
+  ]
+
+  production_dev = local.is-production ? "prod" : (
+    local.is-preproduction ? "preprod" : (
+      local.is-test ? "test" : "dev"
+    )
+  )
+
+  environment_variables = {
+    ENVIRONMENT             = local.environment_shorthand
+    POWERTOOLS_LOG_LEVEL    = "INFO"
+    POWERTOOLS_SERVICE_NAME = "rota-personal-digest"
+
+    GITHUB_SECRET_ARN = module.live_feed_github_app.secret_arn
+    GITHUB_OWNER      = "moj-analytical-services"
+    GITHUB_REPOSITORY = "dmet-em"
+
+    PAGERDUTY_SCHEDULE_ID = "P3MCA8L"
+    PAGERDUTY_TIME_ZONE   = "Europe/London"
+    PAGERDUTY_TO_GITHUB = jsonencode(
+      local.live_feed_pagerduty_to_github
+    )
+    PAGERDUTY_TO_SLACK = jsonencode(
+      local.live_feed_pagerduty_to_slack
+    )
+
+    SLACK_SECRET_ARN = module.rota_personal_digest_slack.secret_arn
   }
 }

--- a/terraform/environments/electronic-monitoring-data/rota_personal_digest.tf
+++ b/terraform/environments/electronic-monitoring-data/rota_personal_digest.tf
@@ -1,0 +1,86 @@
+# ------------------------------------------------------------------------------
+# Personal rota digest configuration
+# ------------------------------------------------------------------------------
+
+locals {
+  live_feed_pagerduty_to_slack = {
+    PEYIF4Q = "U_REPLACE_PEYIF4Q"
+    PSYDXO9 = "U_REPLACE_PSYDXO9"
+    PLV2QS6 = "U_REPLACE_PLV2QS6"
+    PREPU2L = "U_REPLACE_PREPU2L"
+  }
+}
+
+module "rota_personal_digest_slack" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name = "rota-personal-digest-slack-${local.environment_shorthand}"
+
+  description = "Slack bot credentials for the personal rota digest"
+
+  recovery_window_in_days = 7
+
+  ignore_secret_changes = true
+  secret_string         = jsonencode({})
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
+# Production weekday schedule - 09:05 Europe/London
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "rota_personal_digest_scheduler" {
+  count = local.is-production ? 1 : 0
+
+  name = "rota_personal_digest_scheduler_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "rota_personal_digest_scheduler_invoke" {
+  count = local.is-production ? 1 : 0
+
+  name = "rota_personal_digest_scheduler_invoke_policy"
+  role = aws_iam_role.rota_personal_digest_scheduler[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = [module.rota_personal_digest.lambda_function_arn]
+      }
+    ]
+  })
+}
+
+resource "aws_scheduler_schedule" "rota_personal_digest" {
+  count = local.is-production ? 1 : 0
+
+  name        = "rota_personal_digest_0905"
+  description = "Runs the personal rota digest at 09:05 on weekdays"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(5 9 ? * MON-FRI *)"
+  schedule_expression_timezone = "Europe/London"
+
+  target {
+    arn      = module.rota_personal_digest.lambda_function_arn
+    role_arn = aws_iam_role.rota_personal_digest_scheduler[0].arn
+  }
+}

--- a/terraform/environments/electronic-monitoring-data/rota_personal_digest.tf
+++ b/terraform/environments/electronic-monitoring-data/rota_personal_digest.tf
@@ -4,10 +4,10 @@
 
 locals {
   live_feed_pagerduty_to_slack = {
-    PEYIF4Q = "U_REPLACE_PEYIF4Q"
-    PSYDXO9 = "U_REPLACE_PSYDXO9"
-    PLV2QS6 = "U_REPLACE_PLV2QS6"
-    PREPU2L = "U_REPLACE_PREPU2L"
+    PEYIF4Q = "U0680GPDM2S"
+    PSYDXO9 = "U03U6CVFF4Z"
+    PLV2QS6 = "U09EH99R7AT"
+    PREPU2L = "U0851BJQCSW"
   }
 }
 


### PR DESCRIPTION
Deploy and schedule the personal rota digest.

Changes

- Add the rota digest Lambda and IAM permissions
- Add Slack bot secret configuration
- Add PagerDuty-to-Slack member mapping
- Schedule the digest at 09:05 on production weekdays

Outcome

The current rota engineer receives a private daily GitHub and operational work
summary after the rota changes.