### PR TITLE
♻️ Add lifecycle rule for GitHub Audit logs

### DIFF
--- a/terraform/environments/developer-experience/github-audit-log-stream/s3-buckets.tf
+++ b/terraform/environments/developer-experience/github-audit-log-stream/s3-buckets.tf
@@ -45,7 +45,7 @@ module "s3_bucket" {
         - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#logs-for-internal-services
         - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#maximum-retention-period
     */
-    id     = "retain-github-audit-logs"
+    id     = "audit-log-retention"
     status = "Enabled"
 
     transition = [

--- a/terraform/environments/developer-experience/github-audit-log-stream/s3-buckets.tf
+++ b/terraform/environments/developer-experience/github-audit-log-stream/s3-buckets.tf
@@ -38,4 +38,44 @@ module "s3_bucket" {
   versioning = {
     status = "Enabled"
   }
+
+  lifecycle_rule = [{
+    /*
+      This lifecycle rule complies with the MOJ’s Security Policy for internal services logging as of 02/09/2026
+        - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#logs-for-internal-services
+        - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#maximum-retention-period
+    */
+    id     = "retain-github-audit-logs"
+    status = "Enabled"
+
+    transition = [
+      {
+        days          = 90
+        storage_class = "STANDARD_IA"
+      },
+      {
+        days          = 395
+        storage_class = "GLACIER_IR"
+      }
+    ]
+
+    expiration = {
+      days = 730
+    }
+
+    noncurrent_version_transition = [
+      {
+        noncurrent_days = 90
+        storage_class   = "STANDARD_IA"
+      },
+      {
+        noncurrent_days = 395
+        storage_class   = "GLACIER_IR"
+      }
+    ]
+
+    noncurrent_version_expiration = {
+      noncurrent_days = 730
+    }
+  }]
 }


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/76

## Proposed Changes

- Implements a lifecycle rule that conforms with MOJ's Security policy for internal services logging as of 02/09/2026
  - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#logs-for-internal-services
  - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#maximum-retention-period

- Transition to standard infrequent access after 90 days
- Transition to glacier instant retrieveal after 395 days / 13 months
- Expire after 2 years

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>