### PR TITLE
Fix Secure Browser preprod bookmark links pointing to dev

### DIFF
--- a/terraform/environments/laa-pui-secure-browser/workspaces-secure-browser/locals.tf
+++ b/terraform/environments/laa-pui-secure-browser/workspaces-secure-browser/locals.tf
@@ -45,11 +45,13 @@ locals {
   # Environment-specific application URLs
   pui_url = (
     local.environment == "production" ? "ccms-pui.laa.service.justice.gov.uk" :
+    local.environment == "preproduction" ? "ccms-pui.laa-preproduction.modernisation-platform.service.justice.gov.uk" :
     local.environment == "test" ? "ccms-pui.laa-test.modernisation-platform.service.justice.gov.uk" :
     "ccms-pui.laa-development.modernisation-platform.service.justice.gov.uk"
   )
   oia_url = (
     local.environment == "production" ? "ccms-opa.laa.service.justice.gov.uk" :
+    local.environment == "preproduction" ? "ccms-opa.laa-preproduction.modernisation-platform.service.justice.gov.uk" :
     local.environment == "test" ? "ccms-opa.laa-test.modernisation-platform.service.justice.gov.uk" :
     "ccms-opa.laa-development.modernisation-platform.service.justice.gov.uk"
   )


### PR DESCRIPTION
## What was broken

For the LAA PUI **Secure Browser** (`terraform/environments/laa-pui-secure-browser/workspaces-secure-browser`), links were not being generated correctly for the **preproduction** environment. The WorkSpaces Web managed bookmarks (and matching URL allowlist entries) pointed at the **development** URLs instead of the preproduction ones.

The `pui_url` and `oia_url` locals only special-cased `production` and `test`, then fell through to the development host. There was no `preproduction` branch, so in the preproduction workspace both bookmarks resolved to `*.laa-development.modernisation-platform.service.justice.gov.uk`.

(Note: `create_resources` already includes `preproduction`, so the resources themselves were being created — the gap was purely the per-environment link/URL generation.)

## The fix

Add a `preproduction` conditional branch to the `pui_url` and `oia_url` locals, using the standard preproduction host convention (`<app>.laa-preproduction.modernisation-platform.service.justice.gov.uk`), matching the existing production/test/development pattern. Verified against the preproduction hostnames already used in `ccms-oia/application_variables.json`. `terraform fmt -check` passes.

## Who reported it

Chased by **Lyndsey Shaw** and **Michael Farrell** since ~30 Jul — the external Secure Browser bookmark was pointing at the dev environment rather than pre-prod. (Internal already had a working preproduction environment; this was the external gap.)

## Review

Needs review from a `modernisation-platform-environments` codeowner for this path (`@ministryofjustice/ecp-admin`, `@ministryofjustice/modernisation-platform`). Please confirm the preproduction hostnames are correct before merge. Not merging.

### Out of scope / for reviewer awareness
The `laa_sign_in_url` and `legal_aid_services_url` locals have the same missing-`preproduction` structure, but their preproduction hostnames are not referenced elsewhere in the repo, so I did not guess them. They are currently only used in the (commented-out) SSO cookie config, not in the active bookmarks, so they do not affect the reported bookmark issue. Worth a follow-up if those ever go live in preprod.