### PR TITLE
Update generate-dependabot-file.sh

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -68,7 +68,7 @@ if [[ -n "$tf_dirs" ]]; then
   
   echo "    schedule:" >> "$dependabot_file"
   echo "      interval: \"daily\"" >> "$dependabot_file"
-  echo "    open-pull-requests-limit: 150" >> "$dependabot_file"
+  echo "    open-pull-requests-limit: 200" >> "$dependabot_file"
   echo "    cooldown:" >> "$dependabot_file"
   echo "      default-days: ${dependabot_cooldown_default_days}" >> "$dependabot_file"
 fi


### PR DESCRIPTION
Increasing dependabot limit for terraform dependabots as its hitting the limit and failing to create new dependabots. 

<img width="559" height="144" alt="image" src="https://github.com/user-attachments/assets/6b1fcaf1-65c9-4f6a-8c2a-57bab4b922e9" />
