### PR TITLE
CC-2979: EBS DB wallet & apps keystore certificate expiry check

### DIFF
--- a/terraform/environments/ccms-ebs/ccms-cert-wallet-monitor.tf
+++ b/terraform/environments/ccms-ebs/ccms-cert-wallet-monitor.tf
@@ -1,0 +1,118 @@
+resource "aws_ssm_document" "certificate_wallet_expiry_check" {
+  name            = "CCMS-Certificate-Wallet-Expiry-Check"
+  document_type   = "Command"
+  document_format = "YAML"
+
+  content = file("ssm/ccms-ssm-document-certificate-wallet-expiry-check.yaml")
+}
+
+# Placeholder value - must be set manually in the AWS console/CLI by the DBA/AppOps team, never committed here
+resource "aws_ssm_parameter" "ebsdb_wallet_password" {
+  count = local.environment == "production" ? 1 : 0
+
+  name        = "/ccms-ebs/${local.environment}/certificate-monitor/ebsdb-wallet-password"
+  description = "Password for the EBS DB Oracle wallet used by the certificate expiry check"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(local.tags,
+    { Name = "ebsdb-wallet-password" }
+  )
+}
+
+# Placeholder value - must be set manually in the AWS console/CLI by the DBA/AppOps team, never committed here
+resource "aws_ssm_parameter" "ebsapps_keystore_password" {
+  count = local.environment == "production" ? 1 : 0
+
+  name        = "/ccms-ebs/${local.environment}/certificate-monitor/ebsapps-keystore-password"
+  description = "Password for the EBS apps adkeystore.dat used by the certificate expiry check"
+  type        = "SecureString"
+  value       = "changeme"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(local.tags,
+    { Name = "ebsapps-keystore-password" }
+  )
+}
+
+resource "aws_iam_policy" "certificate_wallet_expiry_check_sns_publish" {
+  count = local.environment == "production" ? 1 : 0
+
+  name        = "certificate-wallet-expiry-check-sns-publish-${local.environment}"
+  description = "Allows EC2 instances to publish certificate expiry alerts to the cw_alerts SNS topic"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["sns:Publish"]
+        Resource = [aws_sns_topic.cw_alerts.arn]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "certificate_wallet_expiry_check_sns_publish" {
+  count = local.environment == "production" ? 1 : 0
+
+  role       = aws_iam_role.role_stsassume_oracle_base.name
+  policy_arn = one(aws_iam_policy.certificate_wallet_expiry_check_sns_publish[*].arn)
+}
+
+# EBS DB Oracle wallet check - path/password confirmed for production only (per Jira CC-2979 comments).
+# Do not extend to other environments until the DBA team confirms the wallet path for each.
+resource "aws_ssm_association" "certificate_wallet_expiry_check_ebsdb" {
+  count = local.environment == "production" ? 1 : 0
+
+  name             = aws_ssm_document.certificate_wallet_expiry_check.name
+  association_name = "certificate-wallet-expiry-check-ebsdb"
+
+  parameters = {
+    certType              = "orapki"
+    keystorePath          = "/CCMS/EBS/techst/1210/owm/wallets/oracle/rptest"
+    passwordParameterName = one(aws_ssm_parameter.ebsdb_wallet_password[*].name)
+    snsTopicArn           = aws_sns_topic.cw_alerts.arn
+    thresholdDays         = "90"
+  }
+
+  targets {
+    key    = "tag:Name"
+    values = [lower(format("ec2-%s-%s-ebsdb", local.application_name, local.environment))]
+  }
+
+  apply_only_at_cron_interval = false
+  schedule_expression         = "cron(0 6 ? * MON *)"
+}
+
+# CCMS/CWA EBS apps adkeystore.dat check - path confirmed for production only (per Jira CC-2979 ticket description).
+# Do not extend to other environments until the DBA team confirms the keystore path for each.
+resource "aws_ssm_association" "certificate_wallet_expiry_check_ebsapps" {
+  count = local.environment == "production" ? 1 : 0
+
+  name             = aws_ssm_document.certificate_wallet_expiry_check.name
+  association_name = "certificate-wallet-expiry-check-ebsapps"
+
+  parameters = {
+    certType              = "keytool"
+    keystorePath          = "/u03/oracle/prod/ebsprod/apps/apps_st/appl/admin/adkeystore.dat"
+    passwordParameterName = one(aws_ssm_parameter.ebsapps_keystore_password[*].name)
+    snsTopicArn           = aws_sns_topic.cw_alerts.arn
+    thresholdDays         = "90"
+  }
+
+  targets {
+    key    = "tag:Name"
+    values = [lower(format("ec2-%s-%s-ebsapps-*", local.application_name, local.environment))]
+  }
+
+  apply_only_at_cron_interval = false
+  schedule_expression         = "cron(0 6 ? * MON *)"
+}

--- a/terraform/environments/ccms-ebs/ssm/ccms-ssm-document-certificate-wallet-expiry-check.yaml
+++ b/terraform/environments/ccms-ebs/ssm/ccms-ssm-document-certificate-wallet-expiry-check.yaml
@@ -1,0 +1,87 @@
+# ccms-ssm-document-certificate-wallet-expiry-check.yaml
+---
+schemaVersion: "2.2"
+description: Check an Oracle wallet or Java keystore for certificates expiring within a threshold and alert via SNS.
+parameters:
+  certType:
+    type: String
+    allowedValues:
+      - orapki
+      - keytool
+    description: Type of keystore to check
+  keystorePath:
+    type: String
+    description: Full path to the wallet (orapki) or keystore (keytool) file
+  passwordParameterName:
+    type: String
+    description: Name of the SSM SecureString parameter holding the keystore password
+  snsTopicArn:
+    type: String
+    description: SNS topic ARN to publish expiry alerts to
+  thresholdDays:
+    type: String
+    default: "90"
+    description: Alert if a certificate expires within this many days
+mainSteps:
+  - name: CheckCertificateExpiry
+    action: aws:runShellScript
+    isEnd: true
+    precondition:
+      StringEquals:
+        - platformType
+        - Linux
+    inputs:
+      runCommand:
+        - |
+          set -euo pipefail
+          REGION="eu-west-2"
+          PASSWORD=$(aws ssm get-parameter --name "{{ passwordParameterName }}" --with-decryption --query Parameter.Value --output text --region "$REGION")
+          THRESHOLD_DAYS="{{ thresholdDays }}"
+          NOW_EPOCH=$(date +%s)
+          WORKDIR=$(mktemp -d)
+          trap 'rm -rf "$WORKDIR"' EXIT
+
+          alert() {
+            local subject="$1"
+            local message="$2"
+            aws sns publish --region "$REGION" --topic-arn "{{ snsTopicArn }}" --subject "$subject" --message "$message"
+          }
+
+          check_expiry() {
+            local label="$1"
+            local end_date="$2"
+            local end_epoch
+            end_epoch=$(date -d "$end_date" +%s 2>/dev/null) || { echo "Could not parse expiry date for $label: $end_date"; return; }
+            local days_left=$(( (end_epoch - NOW_EPOCH) / 86400 ))
+            echo "$label expires in $days_left days ($end_date)"
+            if [ "$days_left" -le "$THRESHOLD_DAYS" ]; then
+              alert "Certificate expiring soon: $label" "Certificate '$label' on $(hostname) ({{ keystorePath }}) expires in $days_left days ($end_date). Renew before it lapses."
+            fi
+          }
+
+          if [ "{{ certType }}" = "keytool" ]; then
+            KEYTOOL_OUT=$(keytool -list -v -keystore "{{ keystorePath }}" -storepass "$PASSWORD")
+            ALIAS=""
+            while IFS= read -r line; do
+              case "$line" in
+                "Alias name: "*) ALIAS="${line#Alias name: }" ;;
+                *"until: "*)
+                  END_DATE="${line##*until: }"
+                  check_expiry "$ALIAS" "$END_DATE"
+                  ;;
+              esac
+            done <<< "$KEYTOOL_OUT"
+          else
+            # orapki wallet display/export invocation is unverified against a live wallet - validate before relying on it
+            SUBJECTS=$(orapki wallet display -wallet "{{ keystorePath }}" -pwd "$PASSWORD" | awk -F'Subject:[[:space:]]*' '/Subject:/ {print $2}')
+            while IFS= read -r dn; do
+              [ -z "$dn" ] && continue
+              CERT_FILE="$WORKDIR/cert.pem"
+              if orapki wallet export -wallet "{{ keystorePath }}" -pwd "$PASSWORD" -dn "$dn" -cert "$CERT_FILE" >/dev/null 2>&1; then
+                END_DATE=$(openssl x509 -enddate -noout -in "$CERT_FILE" | cut -d= -f2)
+                check_expiry "$dn" "$END_DATE"
+              else
+                echo "Could not export certificate for $dn to check expiry"
+              fi
+            done <<< "$SUBJECTS"
+          fi


### PR DESCRIPTION
## Summary
- Adds an SSM Command document (`CCMS-Certificate-Wallet-Expiry-Check`) that checks either an Oracle wallet (`orapki`) or a Java keystore (`keytool -list -v`) for certs expiring within a threshold (90 days), and alerts via the existing `cw_alerts` SNS topic (already wired to Slack `#laa-appops-certificate-renewal-alerts` via `cloudwatch_slack_integration_v2`).
- Wires this up via weekly `aws_ssm_association`s for the EBS DB instance (wallet path from Jira comments) and EBS apps instances (`adkeystore.dat` path from the ticket description).
- Adds two SecureString SSM parameter placeholders for the wallet/keystore passwords (`changeme`, `ignore_changes` on value) — must be set manually by the DBA/AppOps team, no real password committed.
- Grants the existing `role_stsassume_oracle_base` instance role `sns:Publish` on `cw_alerts`.

## Scope note
Only wired up for **production** — gated with `count = local.environment == "production" ? 1 : 0`. Maciej's comment on CC-2979 shows a *different* `adkeystore.dat` path on the dev DB host than the ticket's confirmed prod apps path, so dev/test/preprod paths are unverified. Do not extend to other environments until the DBA team confirms their exact wallet/keystore paths.

The `orapki wallet display`/`export` invocation follows the standard Oracle wallet CLI pattern but hasn't been run against a live wallet — flagged inline in the script. Worth a dry run before relying on it. The `keytool -list -v` path uses the well-documented, standard output format.

Not included: removing the Baltimore certificates from the RDS keystore (also mentioned on this ticket) — that's a destructive one-time change against production and needs explicit separate sign-off.

## Test plan
- [ ] `terraform fmt` / `terraform validate` in CI
- [ ] DBA team confirms wallet/keystore paths for non-prod before extending
- [ ] Populate the two SSM SecureString password parameters manually
- [ ] Dry-run the SSM association manually against the prod EBS DB/apps instances and confirm an SNS/Slack alert fires correctly (e.g. temporarily lowering thresholdDays)

Jira: CC-2979