### PR TITLE
feat: group Terraform Dependabot updates by application folder

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -55,22 +55,41 @@ updates:
       - "ministryofjustice/devcontainer-community"
 EOL
 
-# Add Terraform ecosystem entries (dynamically only for top-level directories containing .tf files)
+# Add Terraform ecosystem entries, one per application directory under
+# terraform/environments (and one per top-level area elsewhere, e.g. terraform/modules).
+# Each entry groups all of its updates into a single pull request named after the
+# application, so teams can find their own updates instead of scanning hundreds of PRs.
 if [[ -n "$tf_dirs" ]]; then
-  echo "Generating Terraform ecosystem entry..."
-  echo "  - package-ecosystem: \"terraform\"" >> "$dependabot_file"
-  echo "    directories:" >> "$dependabot_file"
+  echo "Generating Terraform ecosystem entries..."
 
-  # Extract only top-level directories and ensure we don't add duplicates
-  echo "$tf_dirs" | awk -F/ '{print $1}' | sort -u | while IFS= read -r dir; do
-    echo "      - \"$dir/**/*\"" >> "$dependabot_file"
-  done
-  
-  echo "    schedule:" >> "$dependabot_file"
-  echo "      interval: \"daily\"" >> "$dependabot_file"
-  echo "    open-pull-requests-limit: 200" >> "$dependabot_file"
-  echo "    cooldown:" >> "$dependabot_file"
-  echo "      default-days: ${dependabot_cooldown_default_days}" >> "$dependabot_file"
+  tf_groups=$(echo "$tf_dirs" | awk -F/ '
+    $1 == "terraform" && $2 == "environments" && NF >= 3 { print $1"/"$2"/"$3; next }
+    NF >= 2 { print $1"/"$2; next }
+    { print $1 }
+  ' | sort -u)
+
+  while IFS= read -r dir; do
+    [[ -z "$dir" ]] && continue
+
+    # Group identifiers are used in branch names, so keep them to safe characters
+    group_name=$(basename "$dir" | sed 's/[^A-Za-z0-9_-]/-/g')
+
+    cat >> "$dependabot_file" << EOL
+  - package-ecosystem: "terraform"
+    directories:
+      - "$dir"
+      - "$dir/**/*"
+    schedule:
+      interval: "daily"
+    groups:
+      ${group_name}:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 50
+    cooldown:
+      default-days: ${dependabot_cooldown_default_days}
+EOL
+  done <<< "$tf_groups"
 fi
 
 # Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)


### PR DESCRIPTION
## What

Changes `scripts/generate-dependabot-file.sh` so that Terraform Dependabot updates are grouped by application folder.

Previously a single `terraform` entry covered `terraform/**/*`, which produced one pull request per dependency per directory — hundreds of open Dependabot PRs with nothing to distinguish one team's from another's.

The script now emits one `updates` entry per `terraform/environments/<application>` folder (plus one for other top-level Terraform areas such as `terraform/modules`). Each entry uses a `groups` rule matching all dependencies, so an application's updates arrive as a single grouped pull request named after that application.

## Why

Teams cannot find their own Dependabot pull requests amongst the noise. Grouping puts the application name in both the pull request title (`Bump the <application> group ...`) and the branch name (`dependabot/terraform/<application>-<hash>`), so they can be filtered easily.

## Notes for reviewers

- `.github/dependabot.yml` is intentionally **not** updated in this PR. The existing `Generate dependabot file` workflow will regenerate it and raise a follow-up PR, which can be reviewed on its own.
- `open-pull-requests-limit` is 50 per application. The largest estate (`digital-prison-reporting`) has 32 directories declaring external modules or providers, so this leaves headroom. The limit only throttles concurrent pull requests; nothing is skipped, and security updates are exempt.
- Applications with nested Terraform stacks still get one grouped pull request per directory, all named after the application.
- On merge, expect a burst of churn as Dependabot closes the existing ungrouped pull requests and replaces them with grouped ones.
