### PR TITLE
fix: list Dependabot Terraform directories explicitly

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -74,11 +74,15 @@ if [[ -n "$tf_dirs" ]]; then
     # Group identifiers are used in branch names, so keep them to safe characters
     group_name=$(basename "$dir" | sed 's/[^A-Za-z0-9_-]/-/g')
 
+    echo "  - package-ecosystem: \"terraform\"" >> "$dependabot_file"
+    echo "    directories:" >> "$dependabot_file"
+
+    # Directories are listed explicitly; Dependabot rejects wildcards it cannot prove are non-overlapping
+    echo "$tf_dirs" | grep -E "^${dir}(/|\$)" | while IFS= read -r tf_dir; do
+      echo "      - \"$tf_dir\"" >> "$dependabot_file"
+    done
+
     cat >> "$dependabot_file" << EOL
-  - package-ecosystem: "terraform"
-    directories:
-      - "$dir"
-      - "$dir/**/*"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
## What

Follow-up to #18901. Dependabot rejected the generated config with:

> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Dependabot cannot determine if 'terraform' has overlapping directories.

Each application entry used a wildcard (`terraform/environments/<application>/**/*`). Dependabot cannot statically prove that wildcards across multiple `terraform` entries do not overlap, so it refuses the whole file.

The script now enumerates each application's Terraform directories explicitly, which it already has to hand from the `find` at the top of the script.

## Verification

Regenerating locally produces 100 `terraform` entries covering 348 directories — all unique, no wildcards, no duplicates — and the file parses as valid YAML.

`.github/dependabot.yml` is not included here; the `Generate dependabot file` workflow will regenerate it and raise its own PR.
