### PR TITLE
Log integration hub file transfer IDP logins for 400 days in production

### DIFF
--- a/terraform/environments/integration-hub-file-transfer/custom-idp-lambda.tf
+++ b/terraform/environments/integration-hub-file-transfer/custom-idp-lambda.tf
@@ -73,7 +73,7 @@ module "lambda_custom_idp" {
   attach_tracing_policy = true
 
   cloudwatch_logs_kms_key_id        = module.kms_cloudwatch_logs.key_arn
-  cloudwatch_logs_retention_in_days = 30
+  cloudwatch_logs_retention_in_days = local.cloudwatch_retention_days
 
   tags = local.tags
 }


### PR DESCRIPTION
* Ensure production logins are held in line with existing standards; 13 month minimum for production internet-facing services.