### PR TITLE
CC-4739: Update Apex Cloudfront Logging S3 Lifecycle Policy

### DIFF
--- a/terraform/environments/apex/alb.tf
+++ b/terraform/environments/apex/alb.tf
@@ -14,9 +14,9 @@ locals {
   }
 
   prod_validation = {
-    "${local.application_data.accounts[local.environment].acm_cert_domain_name}" = {
+    local.application_data.accounts[local.environment].acm_cert_domain_name = {
       account   = "core-network-services"
-      zone_name = "${local.application_data.accounts[local.environment].acm_cert_domain_name}"
+      zone_name = local.application_data.accounts[local.environment].acm_cert_domain_name
     }
   }
 

--- a/terraform/environments/apex/cloudfront.tf
+++ b/terraform/environments/apex/cloudfront.tf
@@ -180,8 +180,13 @@ resource "aws_s3_bucket_policy" "cloudfront_bucket_secure_transport" {
   policy = data.aws_iam_policy_document.cloudfront_bucket_secure_transport.json
 }
 
+# Retains the production resource in state now the rule applies to every environment
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.cloudfront[0]
+  to   = aws_s3_bucket_lifecycle_configuration.cloudfront
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "cloudfront" {
-  count  = local.environment == "production" ? 1 : 0
   bucket = aws_s3_bucket.cloudfront.id
 
   rule {

--- a/terraform/environments/apex/event_triggers.tf
+++ b/terraform/environments/apex/event_triggers.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_mon_sun" {
 resource "aws_cloudwatch_event_target" "snapshotDBFunctioncheck_mon_sun" {
   rule  = aws_cloudwatch_event_rule.snapshotDBFunctionmon_sun.name
   arn   = aws_lambda_function.create_db_snapshots.arn
-  input = jsonencode({ "appname" : "${local.database_ec2_name}" })
+  input = jsonencode({ "appname" : local.database_ec2_name })
 }
 
 resource "aws_cloudwatch_event_rule" "deletesnapshotFunction_mon_fri" {

--- a/terraform/environments/apex/guardduty.tf
+++ b/terraform/environments/apex/guardduty.tf
@@ -186,7 +186,7 @@ resource "aws_iam_role_policy" "lambda_guardduty_sns_policy" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.guardduty_slack_notify.function_name}:*"
+        Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.guardduty_slack_notify.function_name}:*"
       },
       {
         Effect = "Allow"

--- a/terraform/environments/apex/platform_data.tf
+++ b/terraform/environments/apex/platform_data.tf
@@ -43,63 +43,63 @@ data "aws_subnets" "shared-public" {
 data "aws_subnet" "data_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "data_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "data_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-data-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "private_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}a"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "private_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}b"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "private_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.name}c"
+    "Name" = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-private-${data.aws_region.current.region}c"
   }
 }
 
 data "aws_subnet" "public_subnets_a" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}a"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}a"
   }
 }
 
 data "aws_subnet" "public_subnets_b" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}b"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}b"
   }
 }
 
 data "aws_subnet" "public_subnets_c" {
   vpc_id = data.aws_vpc.shared.id
   tags = {
-    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.name}c"
+    Name = "${var.networking[0].business-unit}-${local.environment}-${var.networking[0].set}-public-${data.aws_region.current.region}c"
   }
 }
 

--- a/terraform/environments/apex/s3-lambda-delivery.tf
+++ b/terraform/environments/apex/s3-lambda-delivery.tf
@@ -48,7 +48,10 @@ resource "aws_s3_bucket_policy" "shared_bucket_policy" {
         "Effect" : "Deny",
         "Principal" : "*",
         "Action" : "s3:*",
-        "Resource" : ["${module.s3-bucket-shared.bucket.arn}/*", "${module.s3-bucket-shared.bucket.arn}"],
+        "Resource" : [
+          "${module.s3-bucket-shared.bucket.arn}/*", 
+          module.s3-bucket-shared.bucket.arn
+        ],
         "Condition" : {
           "Bool" : {
             "aws:SecureTransport" : "false"
@@ -62,7 +65,10 @@ resource "aws_s3_bucket_policy" "shared_bucket_policy" {
           AWS = "*"
         },
         Action   = "s3:*",
-        Resource = ["${module.s3-bucket-shared.bucket.arn}/*", "${module.s3-bucket-shared.bucket.arn}"],
+        Resource = [
+          "${module.s3-bucket-shared.bucket.arn}/*", 
+          module.s3-bucket-shared.bucket.arn
+        ],
         Condition = {
           NumericLessThan = {
             "s3:TlsVersion" = "1.2"

--- a/terraform/environments/apex/s3-lambda-delivery.tf
+++ b/terraform/environments/apex/s3-lambda-delivery.tf
@@ -49,7 +49,7 @@ resource "aws_s3_bucket_policy" "shared_bucket_policy" {
         "Principal" : "*",
         "Action" : "s3:*",
         "Resource" : [
-          "${module.s3-bucket-shared.bucket.arn}/*", 
+          "${module.s3-bucket-shared.bucket.arn}/*",
           module.s3-bucket-shared.bucket.arn
         ],
         "Condition" : {
@@ -64,9 +64,9 @@ resource "aws_s3_bucket_policy" "shared_bucket_policy" {
         Principal = {
           AWS = "*"
         },
-        Action   = "s3:*",
+        Action = "s3:*",
         Resource = [
-          "${module.s3-bucket-shared.bucket.arn}/*", 
+          "${module.s3-bucket-shared.bucket.arn}/*",
           module.s3-bucket-shared.bucket.arn
         ],
         Condition = {


### PR DESCRIPTION
Ticket: [CC-4739](https://dsdmoj.atlassian.net/browse/CC-4739)

Extends Apex `"aws_s3_bucket_lifecycle_configuration" "cloudfront"` across all environments rather than just being production-scoped such that:

- Objects are deleted after 90 days
- Noncurrent versions expire after 90 days

`moved` block added to reflect `count` removal from resource to mitigate any prod-level resource changes, this can be safely removed once prod deployment occurs

[CC-4739]: https://dsdmoj.atlassian.net/browse/CC-4739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Misc:
- `data.aws_region.current.id` attribute deprecation resolved - `id` replaced by `region`
- "Interpolated only" expression deprecations resolved