### PR TITLE
Grant RDS s3:PutObject and enable S3 role on EDW DEV

### DIFF
--- a/terraform/environments/edw-19c/rds-iam.tf
+++ b/terraform/environments/edw-19c/rds-iam.tf
@@ -3,16 +3,17 @@
 ##################################################################################################################
 
 resource "aws_iam_policy" "rds_s3_access_policy" {
-  count = local.enable_ecp_replication ? 1 : 0
+  count = local.enable_rds_s3_access ? 1 : 0
 
   name        = "${local.application_name}-rds-s3-access-policy"
-  description = "Policy to allow RDS access to S3 buckets for Data Pump imports"
+  description = "Policy to allow RDS access to S3 buckets for Data Pump imports/exports"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
         Effect = "Allow"
         Action = [
+          "s3:PutObject",
           "s3:GetObject",
           "s3:ListBucket"
         ]
@@ -27,7 +28,7 @@ resource "aws_iam_policy" "rds_s3_access_policy" {
 }
 
 resource "aws_iam_role" "rds_s3_access_role" {
-  count = local.enable_ecp_replication ? 1 : 0
+  count = local.enable_rds_s3_access ? 1 : 0
 
   name = "${local.application_name}-rds-s3-access-role"
   assume_role_policy = jsonencode({
@@ -45,7 +46,7 @@ resource "aws_iam_role" "rds_s3_access_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "rds_s3_access_attachment" {
-  count = local.enable_ecp_replication ? 1 : 0
+  count = local.enable_rds_s3_access ? 1 : 0
 
   role       = aws_iam_role.rds_s3_access_role[0].name
   policy_arn = aws_iam_policy.rds_s3_access_policy[0].arn

--- a/terraform/environments/edw-19c/rds.tf
+++ b/terraform/environments/edw-19c/rds.tf
@@ -9,8 +9,8 @@ locals {
   # Keep EDW available in non-live for integration testing, including DEV.
   enable_edw_rds = contains(["development", "preproduction"], local.environment)
 
-  # Legacy cross-account replication from ECP is no longer required.
-  enable_ecp_replication = false
+  # RDS S3 role/bucket used by Data Pump export/import (rdsadmin.rdsadmin_s3_tasks) on DEV and PREPROD.
+  enable_rds_s3_access = contains(["development", "preproduction"], local.environment)
 }
 
 resource "random_password" "rds_password_new" {
@@ -228,7 +228,7 @@ resource "aws_db_instance" "edw_rds_instance" {
 ##################################################################################################################
 
 resource "aws_db_instance_role_association" "edw_rds_instance_role_association" {
-  count = local.enable_ecp_replication ? 1 : 0
+  count = local.enable_rds_s3_access ? 1 : 0
 
   db_instance_identifier = aws_db_instance.edw_rds_instance[0].identifier
   role_arn               = aws_iam_role.rds_s3_access_role[0].arn

--- a/terraform/environments/edw-19c/s3.tf
+++ b/terraform/environments/edw-19c/s3.tf
@@ -1,18 +1,23 @@
-resource "aws_s3_bucket" "replica" {
-  count = local.enable_ecp_replication ? 1 : 0
+locals {
+  # Preprod bucket name is kept as-is (pre-dates this variable) to avoid forcing a bucket replacement.
+  replica_bucket_name = local.environment == "development" ? "edw-19c-dev-replica-bucket" : "edw-19c-preprod-replica-bucket"
+}
 
-  bucket = "edw-19c-preprod-replica-bucket"
+resource "aws_s3_bucket" "replica" {
+  count = local.enable_rds_s3_access ? 1 : 0
+
+  bucket = local.replica_bucket_name
 
   tags = {
-    Name        = "edw-19c-preprod-replica-bucket"
-    Environment = "preproduction"
-    Purpose     = "s3-replication-destination"
+    Name        = local.replica_bucket_name
+    Environment = local.environment
+    Purpose     = "rds-datapump-bucket"
     ManagedBy   = "terraform"
   }
 }
 
 resource "aws_s3_bucket_versioning" "replica" {
-  count  = local.enable_ecp_replication ? 1 : 0
+  count  = local.enable_rds_s3_access ? 1 : 0
   bucket = aws_s3_bucket.replica[0].id
 
   versioning_configuration {
@@ -21,7 +26,7 @@ resource "aws_s3_bucket_versioning" "replica" {
 }
 
 resource "aws_s3_bucket_public_access_block" "replica" {
-  count  = local.enable_ecp_replication ? 1 : 0
+  count  = local.enable_rds_s3_access ? 1 : 0
   bucket = aws_s3_bucket.replica[0].id
 
 
@@ -32,7 +37,8 @@ resource "aws_s3_bucket_public_access_block" "replica" {
 }
 
 resource "aws_s3_bucket_policy" "replica" {
-  count  = local.enable_ecp_replication ? 1 : 0
+  # Legacy cross-account replication from ECP; only ever applied to the preprod bucket.
+  count  = local.enable_rds_s3_access && local.environment == "preproduction" ? 1 : 0
   bucket = aws_s3_bucket.replica[0].id
 
   policy = jsonencode({


### PR DESCRIPTION
Preprod's rds_s3_access_policy only allowed GetObject/ListBucket, so RDS Data Pump exports to S3 (edw_metadata.dmp) failed on write. The whole S3 role/bucket block was also disabled globally (enable_ecp_replication = false) by STB-4512, so nothing was attached to the DEV RDS instance either.

- Add s3:PutObject to the RDS S3 access policy
- Re-enable the block for both development and preproduction (renamed local to enable_rds_s3_access to reflect its actual purpose: RDS Data Pump S3 access, not ECP replication)
- Give development its own replica bucket (edw-19c-dev-replica-bucket); preprod's existing bucket name is left untouched to avoid a destructive recreate
- Scope the legacy cross-account ECP replication bucket policy to preprod only, since it references a preprod-specific role