### PR TITLE
Register container-platform-octo-live as ArgoCD spoke on live hub

### DIFF
--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -488,7 +488,9 @@ locals {
       eks_cluster_version = "1.35"
 
       /* ArgoCD — spokes registered with the live hub */
-      argocd_registered_spokes = []
+      argocd_registered_spokes = [
+        "container-platform-octo-live",
+      ]
 
       /* ArgoCD — additional RBAC role mappings for this tier (beyond the
          always-present ADMIN mapping added in locals.tf). Keys: EDITOR, VIEWER


### PR DESCRIPTION
## What
Adds `container-platform-octo-live` to the live tier `argocd_registered_spokes` in `terraform/environments/cloud-platform/cluster/environment-configuration.tf`. The live tier allowlist was previously empty.

## Why
The live deployment path was blocked because the live hub had no registration for the octo-live spoke. Registering it lets the live hub deploy to the live cluster. This unblocks the live-path acceptance criteria on the parent ticket.

## Effect on apply
The spoke creates the argocd-hub access entry and RBAC, and the live hub creates the matching cluster registration Secret and AppProjects.

Relates to ministryofjustice/cloud-platform#8497
Parent: ministryofjustice/cloud-platform#8446
