### PR TITLE
fix: Re-trigger container-platform apply for octo-live spoke

### DIFF
--- a/terraform/environments/cloud-platform/cluster/environment-configuration.tf
+++ b/terraform/environments/cloud-platform/cluster/environment-configuration.tf
@@ -489,6 +489,7 @@ locals {
 
       /* ArgoCD — spokes registered with the live hub */
       argocd_registered_spokes = [
+        # Registers octo-live as a live spoke.
         "container-platform-octo-live",
       ]
 


### PR DESCRIPTION
## What
Adds a one-line comment on the live-tier `argocd_registered_spokes` octo-live entry.

## Why
Re-triggers `container-platform.yml`. The prior apply run stalled: `terraform-main` (https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/33860819642) never scheduled, so `container-platform-octo-live` was never applied and the live spoke registration did not take effect. Merging this fires a fresh run.

Ref: ministryofjustice/cloud-platform#8497
