### PR TITLE
🧪 Add Lambda unit tests to the file transfer pipeline

### DIFF
--- a/.github/workflows/integration-hub-file-transfer.yml
+++ b/.github/workflows/integration-hub-file-transfer.yml
@@ -36,7 +36,46 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
+  python-tests:
+    if: inputs.action != 'destroy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Run Unit Tests
+        working-directory: terraform/environments/integration-hub-file-transfer
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r requirements; do
+            if ! output=$(python -m pip install -r "$requirements" 2>&1); then
+              printf '%s\n' "$output"
+              exit 1
+            fi
+          done < <(find lambda -type f -name '*requirements.txt' | sort)
+
+          for test_directory in lambda/*; do
+            if find "$test_directory" -maxdepth 1 -type f -name 'test_*.py' -print -quit | grep -q .; then
+              if output=$(python -m unittest discover -s "$test_directory" -p 'test_*.py' -v 2>&1); then
+                summary=$(printf '%s\n' "$output" | sed -n '/^Ran /p')
+                printf '%s: %s\n' "${test_directory#lambda/}" "$summary"
+              else
+                printf '%s\n' "$output"
+                exit 1
+              fi
+            fi
+          done
+
+          printf '%s\n' 'All Lambda unit tests passed.'
+
   strategy:
+    needs: python-tests
     uses: ./.github/workflows/reusable_terraform_components_strategy.yml
     if: inputs.action != 'destroy'
     with:

--- a/terraform/environments/integration-hub-file-transfer/lambda/file-received-adapter/lambda_function.py
+++ b/terraform/environments/integration-hub-file-transfer/lambda/file-received-adapter/lambda_function.py
@@ -130,3 +130,4 @@ def lambda_handler(event, _context):
             extra={"source_event_id": source_event_id},
         )
         raise
+    


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## What changed

This adds a Python 3.12 unit-test job to the `integration-hub-file-transfer` workflow. It:

- installs the requirements for each Lambda
- runs each Lambda's `unittest` suite before the Terraform strategy job
- stops the pipeline if dependency installation or a test fails
- keeps successful logs to one summary line per Lambda, while retaining the full output for failures

The current five suites run **89 tests** in total.

## Why

The Lambda tests existed, but were not being run by GitHub Actions. This makes them a required gate before Terraform planning or deployment can continue.

## Worth knowing

The reusable Terraform strategy only selects the root component when a top-level Terraform file changes. A Lambda- or schema-only change still needs a harmless root-level Terraform change to trigger a Terraform run. The no-op change to `lambda_function.py` in this PR was used to exercise that behaviour.

## Checks

- ✅ Python unit tests: 89 passed
- ✅ Terraform static analysis
- ✅ OPA policy tests
- ✅ Binary and archive file check

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>