### PR TITLE
Add Auth0 log stream archive

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/cloudwatch.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/cloudwatch.tf
@@ -1,0 +1,16 @@
+module "firehose_cloudwatch_log_group" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-cloudwatch.git//modules/log-group?ref=82e5143738712a283ab7a8cb4110e7a3e708a834" # v5.7.3
+
+  name              = "/aws/kinesisfirehose/${local.component_name}"
+  kms_key_id        = module.destination_kms_key[0].key_arn
+  retention_in_days = 400
+}
+
+resource "aws_cloudwatch_log_stream" "firehose" {
+  count = local.is-production ? 1 : 0
+
+  name           = "S3Delivery"
+  log_group_name = module.firehose_cloudwatch_log_group[0].cloudwatch_log_group_name
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/data.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/data.tf
@@ -1,0 +1,7 @@
+data "aws_cloudwatch_event_source" "this" {
+  count = local.is-production ? 1 : 0
+
+  provider = aws.us-east-1
+
+  name_prefix = local.auth0_event_source_name
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
@@ -1,0 +1,77 @@
+module "source_eventbridge" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eventbridge.git?ref=f9934726324c988f823682884b4fa003586a7b6f" # v4.3.2
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  bus_name           = data.aws_cloudwatch_event_source.this[0].name
+  event_source_name  = data.aws_cloudwatch_event_source.this[0].name
+  kms_key_identifier = module.source_kms_key[0].key_arn
+
+  create_log_delivery = false
+  create_pipes        = false
+  create_schedules    = false
+  create_targets      = false
+  create_rules        = false
+  create_role         = false
+  create_permissions  = false
+}
+
+resource "aws_cloudwatch_event_rule" "source" {
+  count = local.is-production ? 1 : 0
+
+  provider = aws.us-east-1
+
+  name           = local.component_name
+  event_bus_name = data.aws_cloudwatch_event_source.this[0].name
+
+  event_pattern = jsonencode({
+    source      = [data.aws_cloudwatch_event_source.this[0].name]
+    detail-type = ["Auth0 log"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "cross_region" {
+  count = local.is-production ? 1 : 0
+
+  provider = aws.us-east-1
+
+  rule           = aws_cloudwatch_event_rule.source[0].name
+  event_bus_name = data.aws_cloudwatch_event_source.this[0].name
+  arn            = module.destination_eventbridge[0].eventbridge_bus_arn
+  role_arn       = module.cross_region_iam_role[0].arn
+}
+
+module "destination_eventbridge" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eventbridge.git?ref=f9934726324c988f823682884b4fa003586a7b6f" # v4.3.2
+
+  bus_name           = local.component_name
+  kms_key_identifier = module.destination_kms_key[0].key_arn
+
+  attach_kinesis_firehose_policy = true
+  kinesis_firehose_target_arns   = [aws_kinesis_firehose_delivery_stream.this[0].arn]
+
+  rules = {
+    auth0_logs = {
+      description = "Route Auth0 log stream events to S3 via Firehose"
+      event_pattern = jsonencode({
+        source      = [data.aws_cloudwatch_event_source.this[0].name]
+        detail-type = ["Auth0 log"]
+      })
+    }
+  }
+
+  targets = {
+    auth0_logs = [
+      {
+        name = "auth0-log-archive"
+        arn  = aws_kinesis_firehose_delivery_stream.this[0].arn
+      }
+    ]
+  }
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
@@ -1,0 +1,29 @@
+resource "aws_kinesis_firehose_delivery_stream" "this" {
+  count = local.is-production ? 1 : 0
+
+  name        = local.component_name
+  destination = "extended_s3"
+
+  server_side_encryption {
+    enabled  = true
+    key_type = "CUSTOMER_MANAGED_CMK"
+    key_arn  = module.destination_kms_key[0].key_arn
+  }
+
+  extended_s3_configuration {
+    role_arn            = module.firehose_iam_role[0].arn
+    bucket_arn          = module.s3_bucket[0].s3_bucket_arn
+    buffering_interval  = 300
+    buffering_size      = 5
+    compression_format  = "GZIP"
+    kms_key_arn         = module.destination_kms_key[0].key_arn
+    prefix              = "raw/"
+    error_output_prefix = "errors/!{firehose:error-output-type}/"
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = module.firehose_cloudwatch_log_group[0].cloudwatch_log_group_name
+      log_stream_name = aws_cloudwatch_log_stream.firehose[0].name
+    }
+  }
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
@@ -1,0 +1,91 @@
+module "firehose_iam_role" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role?ref=ba3fd6ded6911e0454092147fe3704171cc05e00" # v6.8.1
+
+  name            = "${local.component_name}-firehose"
+  use_name_prefix = false
+
+  trust_policy_permissions = {
+    Firehose = {
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["firehose.amazonaws.com"]
+      }]
+    }
+  }
+
+  create_inline_policy = true
+  inline_policy_permissions = {
+    S3BucketAccess = {
+      effect = "Allow"
+      actions = [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+      ]
+      resources = [module.s3_bucket[0].s3_bucket_arn]
+    }
+    S3ObjectAccess = {
+      effect = "Allow"
+      actions = [
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject",
+      ]
+      resources = ["${module.s3_bucket[0].s3_bucket_arn}/*"]
+    }
+    KMSAccess = {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = [module.destination_kms_key[0].key_arn]
+    }
+    CloudWatchLogsGroupAccess = {
+      effect = "Allow"
+      actions = [
+        "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
+      ]
+      resources = [module.firehose_cloudwatch_log_group[0].cloudwatch_log_group_arn]
+    }
+    CloudWatchLogsAccess = {
+      effect    = "Allow"
+      actions   = ["logs:PutLogEvents"]
+      resources = [aws_cloudwatch_log_stream.firehose[0].arn]
+    }
+  }
+}
+
+module "cross_region_iam_role" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role?ref=ba3fd6ded6911e0454092147fe3704171cc05e00" # v6.8.1
+
+  name            = "${local.component_name}-eventbridge-cross-region"
+  use_name_prefix = false
+
+  trust_policy_permissions = {
+    EventBridge = {
+      actions = ["sts:AssumeRole"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["events.amazonaws.com"]
+      }]
+    }
+  }
+
+  create_inline_policy = true
+  inline_policy_permissions = {
+    EventBridge = {
+      effect    = "Allow"
+      actions   = ["events:PutEvents"]
+      resources = [module.destination_eventbridge[0].eventbridge_bus_arn]
+    }
+  }
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
@@ -57,7 +57,7 @@ module "destination_kms_key" {
         {
           test     = "ArnLike"
           variable = "kms:EncryptionContext:aws:logs:arn"
-          values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${local.component_name}"]
+          values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${local.component_name}*"]
         }
       ]
     }

--- a/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
@@ -1,0 +1,90 @@
+module "destination_kms_key" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=af1d45558a6073c017a732d2273efcc733b34d0f" # v4.2.1
+
+  aliases = [local.component_name]
+
+  key_statements = [
+    {
+      sid = "AWSEventBridge"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = ["*"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "Firehose"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncrypt*",
+      ]
+      resources = ["*"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["firehose.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid = "CloudWatchLogs"
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncrypt*",
+        "kms:DescribeKey",
+      ]
+      resources = ["*"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["logs.eu-west-2.amazonaws.com"]
+        }
+      ]
+      condition = [
+        {
+          test     = "ArnLike"
+          variable = "kms:EncryptionContext:aws:logs:arn"
+          values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${local.component_name}"]
+        }
+      ]
+    }
+  ]
+}
+
+module "source_kms_key" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=af1d45558a6073c017a732d2273efcc733b34d0f" # v4.2.1
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  aliases = ["${local.component_name}-source"]
+
+  key_statements = [{
+    sid = "AWSEventBridge"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = ["*"]
+    principals = [{
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }]
+  }]
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/locals.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  global_config = yamldecode(file("${path.module}/../configuration/global.yml"))
+
+  auth0_event_source_name = "aws.partner/auth0.com/operations-engineering-855d764e-dfd4-47d0-8220-db395f5e9815/auth0.logs"
+  bucket_name             = "${local.global_config.s3_bucket_prefix}-${local.environment}-${local.component_name}"
+}

--- a/terraform/environments/developer-experience/auth0-event-stream/s3-buckets.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/s3-buckets.tf
@@ -1,0 +1,102 @@
+data "aws_iam_policy_document" "s3_bucket" {
+  count = local.is-production ? 1 : 0
+
+  statement {
+    sid    = "AllowFirehoseBucketActions"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+    ]
+    resources = [module.s3_bucket[0].s3_bucket_arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.firehose_iam_role[0].arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowFirehoseObjectActions"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+    resources = ["${module.s3_bucket[0].s3_bucket_arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.firehose_iam_role[0].arn]
+    }
+  }
+}
+
+module "s3_bucket" {
+  count = local.is-production ? 1 : 0
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=dd0c434de5e74d8864e249ee020d917b076b6e32" # v5.15.4
+
+  bucket = local.bucket_name
+
+  attach_policy                         = true
+  policy                                = data.aws_iam_policy_document.s3_bucket[0].json
+  attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = true
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.destination_kms_key[0].key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  versioning = {
+    status = "Enabled"
+  }
+
+  lifecycle_rule = [{
+    /*
+      This lifecycle rule complies with the MOJ's Security Policy for internal services logging as of 02/09/2026
+        - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#logs-for-internal-services
+        - https://justiceuk.sharepoint.com/sites/SecurityPolicyandGuidance/SitePages/Policy%20and%20Guidance/Operations%20Security/Logging-and-Monitoring.aspx#maximum-retention-period
+    */
+    id     = "audit-log-retention"
+    status = "Enabled"
+
+    transition = [
+      {
+        days          = 90
+        storage_class = "STANDARD_IA"
+      },
+      {
+        days          = 395
+        storage_class = "GLACIER_IR"
+      }
+    ]
+
+    expiration = {
+      days = 730
+    }
+
+    noncurrent_version_transition = [
+      {
+        noncurrent_days = 90
+        storage_class   = "STANDARD_IA"
+      },
+      {
+        noncurrent_days = 395
+        storage_class   = "GLACIER_IR"
+      }
+    ]
+
+    noncurrent_version_expiration = {
+      noncurrent_days = 730
+    }
+  }]
+}


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88

## Summary

Add the initial infrastructure for exporting Auth0 tenant log-stream events through Amazon EventBridge into a Kinesis Data Firehose delivery stream and a retained S3 archive.

The implementation supports the required regional split:

```text
Auth0 log stream
  -> us-east-1 Auth0 partner event source and partner EventBridge bus
  -> cross-region EventBridge target
  -> eu-west-2 EventBridge bus
  -> eu-west-2 Kinesis Data Firehose
  -> eu-west-2 KMS-encrypted S3 bucket
```

## Why

The goal is to create a durable data source from which we can later determine when principals last authenticated to Auth0-backed services. The Auth0 log stream is used rather than the Auth0 event-stream product because it provides the broader tenant authentication log feed, including successful and failed authentication activity and the associated service/principal fields.

The raw event is retained in its full EventBridge envelope so it can be queried or transformed later. The expected Auth0 payload is nested below `detail.data`, including fields such as:

- `date`
- `type`
- `description`
- `user_id`
- `client_id`
- `client_name`
- `connection`
- `ip`
- `hostname`
- PII fields where present

This keeps the landing data flexible while allowing a later Athena/Glue/Parquet projection for a derived last-login dataset.

## Implementation

### EventBridge ingress

- Discover the Auth0 partner event source in `us-east-1`.
- Create the partner event bus using the AWS-resolved event-source name.
- Match the Auth0 source and `Auth0 log` detail type.
- Forward matching events to the `eu-west-2` destination bus.
- Use a dedicated EventBridge IAM role with only `events:PutEvents` permission on the destination bus.

### UK archive path

- Create a destination EventBridge bus in `eu-west-2`.
- Route the forwarded events to an extended-S3 Firehose delivery stream.
- Buffer for up to five minutes or five MiB, whichever is reached first.
- Compress delivered S3 objects with GZIP.
- Store records under the `raw/` prefix and failed delivery output under `errors/`.
- Preserve the complete EventBridge event envelope for future processing.

### Encryption and access control

- Create separate regional customer-managed KMS keys because KMS keys are regional.
- Use the source key for the `us-east-1` partner EventBridge bus.
- Use the destination key for the `eu-west-2` EventBridge bus, Firehose, S3 bucket and Firehose CloudWatch log group.
- Configure both Firehose destination encryption and Firehose stream-level encryption with the destination CMK. The destination setting protects data delivered to S3; the stream-level `CUSTOMER_MANAGED_CMK` setting protects the Firehose delivery stream itself.
- Grant the Firehose service principal the KMS permissions required to use the destination CMK, including encryption, decryption, data-key generation, re-encryption and key description.
- Grant the Firehose delivery role the required `kms:Encrypt` and `kms:DescribeKey` permissions in addition to decryption and data-key generation.
- Add service-principal key policy permissions for EventBridge and CloudWatch Logs.
- Use dedicated IAM-module roles for Firehose delivery and cross-region EventBridge forwarding.
- Separate S3 bucket-level and object-level permissions and scope each to the correct ARN.
- Enforce encrypted S3 transport and latest TLS through the S3 module.

### Retention

The S3 bucket is versioned and follows the same audit-log lifecycle used by the GitHub audit-log stream:

- Standard-IA after 90 days.
- Glacier Instant Retrieval after 395 days.
- Expire current objects after 730 days.
- Apply equivalent lifecycle treatment to non-current versions.

CloudWatch delivery logs are retained for 400 days.

### Terraform module style

External modules are pinned to commit SHAs with version comments, consistent with the existing developer-experience components:

- EventBridge `v4.3.2`
- CloudWatch `v5.7.3`
- IAM `v6.8.1`
- S3 bucket `v5.15.4`
- KMS `v4.2.1`

The Firehose resource remains a raw AWS resource because there is no suitable Firehose module in the selected module set.

## Scope and follow-up

This PR does not add Athena or Glue resources. The newline-delimiter option is not exposed by the current Terraform AWS provider schema, so the landing path uses compressed raw Firehose output and preserves the data for a later normalisation step.

Potential follow-up work includes:

- Confirming the Auth0 partner source becomes `ACTIVE` after deployment.
- Adding an EventBridge archive and/or dead-letter queue.
- Adding Firehose delivery alarms.
- Adding an Athena raw table and a curated last-login projection.
- Confirming the exact set of successful-login event types from live Auth0 traffic.
- Applying Auth0-side log filtering or PII masking where appropriate.

## Validation

- `terraform fmt`
- `terraform fmt-check`
- `terraform init -upgrade -backend=false`
- `terraform validate`
- Checkov `CKV_AWS_240` and `CKV_AWS_241`
- AWS Well-Architected checks for security services and storage/security posture were consulted.

No Terraform plan or apply was run as part of this change.