### PR TITLE
Fix Auth0 EventBridge delivery setup

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
@@ -32,6 +32,8 @@ resource "aws_cloudwatch_event_rule" "source" {
     source      = [data.aws_cloudwatch_event_source.this[0].name]
     detail-type = ["Auth0 log"]
   })
+
+  depends_on = [module.source_eventbridge]
 }
 
 resource "aws_cloudwatch_event_target" "cross_region" {
@@ -69,8 +71,9 @@ module "destination_eventbridge" {
   targets = {
     auth0_logs = [
       {
-        name = "auth0-log-archive"
-        arn  = aws_kinesis_firehose_delivery_stream.this[0].arn
+        name            = "auth0-log-archive"
+        arn             = aws_kinesis_firehose_delivery_stream.this[0].arn
+        attach_role_arn = true
       }
     ]
   }


### PR DESCRIPTION
## Summary

Fix the initial Auth0 EventBridge deployment failures by making the resource dependency and Firehose target role explicit.

## Context

The Auth0 log stream architecture uses a regional split:

```text
us-east-1
  Auth0 partner event source
    -> partner EventBridge bus
    -> forwarding rule
    -> eu-west-2 EventBridge bus

 eu-west-2
  EventBridge rule
    -> Kinesis Data Firehose
    -> KMS-encrypted S3 archive
```

The first deployment exposed two Terraform configuration issues:

1. The source EventBridge rule could be created before the partner event bus because Terraform could not infer the dependency from the shared data-source name.
2. The destination EventBridge module's Firehose target had no `RoleArn`.

## Changes

### Ensure source bus exists before its rule

Add an explicit dependency from `aws_cloudwatch_event_rule.source` to `module.source_eventbridge`:

```terraform
depends_on = [module.source_eventbridge]
```

The partner bus is still created in `us-east-1` using the resolved Auth0 partner event-source name. The explicit dependency ensures `PutRule` is not attempted before the bus exists.

### Provide EventBridge's Firehose target role

Set the destination Firehose target to:

```terraform
attach_role_arn = true
```

The pinned EventBridge module then attaches its generated EventBridge target role to the Firehose target. The existing Firehose delivery role remains separate and continues to be assumed by Firehose for S3, KMS and CloudWatch Logs access.

This resolves the deployment error:

```text
RoleArn is required for target arn:aws:firehose:eu-west-2:...
```

## Known deployment prerequisite

The failed deployment also showed that the deployment role used for the `us-east-1` CMK does not have `kms:TagResource`:

```text
not authorized to perform: kms:TagResource
```

This is an account/platform IAM prerequisite rather than a change that can be fixed in this environment's Terraform. The role used to create the source CMK needs the approved KMS tagging permission, or the CMK must be created through an approved role.

## Validation

- `terraform fmt`
- `terraform init -upgrade -backend=false`
- `terraform validate`

No Terraform plan or apply was run for this fix.