### PR TITLE
Fix Auth0 cross-region EventBridge delivery

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/eventbridge.tf
@@ -41,6 +41,8 @@ resource "aws_cloudwatch_event_target" "cross_region" {
 
   provider = aws.us-east-1
 
+  depends_on = [module.destination_eventbridge]
+
   rule           = aws_cloudwatch_event_rule.source[0].name
   event_bus_name = data.aws_cloudwatch_event_source.this[0].name
   arn            = module.destination_eventbridge[0].eventbridge_bus_arn
@@ -54,6 +56,13 @@ module "destination_eventbridge" {
 
   bus_name           = local.component_name
   kms_key_identifier = module.destination_kms_key[0].key_arn
+
+  create_permissions = true
+  permissions = {
+    "${data.aws_caller_identity.current.account_id} CrossRegionPutEvents" = {
+      action = "events:PutEvents"
+    }
+  }
 
   attach_kinesis_firehose_policy = true
   kinesis_firehose_target_arns   = [aws_kinesis_firehose_delivery_stream.this[0].arn]


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88

Enable the destination EventBridge bus policy for the Auth0 event stream.

The cross-region target forwards Auth0 events from the partner bus in `us-east-1` to the event-stream bus in `eu-west-2`. EventBridge validates the destination bus resource policy when creating the target; without an account-scoped `events:PutEvents` permission, it returns `AccessDeniedException` from `PutTargets`.

This change creates that permission for the current account on the destination bus. The target explicitly depends on the destination EventBridge module because its destination ARN creates a graph dependency on the bus, but not on the module's separately-created bus permission. This ensures the accepting policy exists before EventBridge calls `PutTargets`.

Validation: `terraform validate -no-color`.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>