### PR TITLE
fix(data-platform): update litellm to 1.99.1 in development and test

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -1,7 +1,7 @@
 locals {
   environment_configurations = {
     development = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.99.1"
       ai_gateway_hostname = "development.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -41,7 +41,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     test = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.99.1"
       ai_gateway_hostname = "test.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Updates `litellm_version` from `1.97.0` to `1.99.1` for **development and test only** in [`environment-configuration.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/fix/update-litellm-to-1.99.1/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L3-L44).
- Leaves preproduction at `1.98.0` and production at `1.97.0`; this is not a promotion PR. The staged policy requires the exact candidate to be deployed and verified in development/test before it can be promoted.
- Paired local-compose change: [data-platform-app#250](https://github.com/ministryofjustice/data-platform-app/pull/250).
- `v1.99.1` is the latest published non-draft, non-prerelease release as at 2026-09-05. The full stable path assessed is [v1.97.1](https://github.com/BerriAI/litellm/releases/tag/v1.97.1), [v1.98.0](https://github.com/BerriAI/litellm/releases/tag/v1.98.0), [v1.99.0](https://github.com/BerriAI/litellm/releases/tag/v1.99.0), and [v1.99.1](https://github.com/BerriAI/litellm/releases/tag/v1.99.1); prereleases were excluded.

## Rollout stage and prior evidence

This is **stage 1** only. No promotion PR is created because `1.99.1` is not yet the exact version deployed to and verified in development/test. The approved 1.98.0 stage-1 evidence is retained in [#18566](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18566) and its paired [data-platform-app#227](https://github.com/ministryofjustice/data-platform-app/pull/227); it covers the 1.97.0-to-1.98.0 compatibility segment but cannot substitute for runtime evidence of 1.99.1.

## Compatibility assessment

The authoritative current Terraform wiring applies `litellm_version` to both the `litellm-helm` chart and the non-root image tag for [admin](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/helm-charts.tf#L21-L107) and [proxy](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/helm-charts.tf#L97-L107). Its values configure node placement and the Prisma migration job: [proxy values](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl#L99-L180) and [admin values](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl#L94-L213).

The current Data Platform application contract was checked against the target source: [`AIGatewayClient`](https://github.com/ministryofjustice/data-platform-app/blob/main/ai_gateway/client.py#L74-L251) consumes access-group, organisation, team, virtual-key, v1 model-info and daily-activity endpoints, all retained by target-tag sources for [access groups](https://github.com/BerriAI/litellm/blob/v1.99.1/litellm/proxy/management_endpoints/access_group_endpoints.py#L313), [organisations](https://github.com/BerriAI/litellm/blob/v1.99.1/litellm/proxy/management_endpoints/organization_endpoints.py#L957), [teams/activity](https://github.com/BerriAI/litellm/blob/v1.99.1/litellm/proxy/management_endpoints/team_endpoints.py#L1156-L5957), [keys](https://github.com/BerriAI/litellm/blob/v1.99.1/litellm/proxy/management_endpoints/key_management_endpoints.py#L1617-L5465), and [model info](https://github.com/BerriAI/litellm/blob/v1.99.1/litellm/proxy/proxy_server.py#L13963). No removed or renamed consumed route, or incompatible required payload field, was identified. The app uses HTTP via pinned [`httpx==0.28.1`](https://github.com/ministryofjustice/data-platform-app/blob/main/pyproject.toml#L13), not the LiteLLM Python package.

## Validation

- `terraform fmt -check -diff terraform/environments/data-platform/ai-gateway/environment-configuration.tf` passed.
- `git diff --check` passed.
- Confirmed the resulting versions are development `1.99.1`, test `1.99.1`, preproduction `1.98.0`, and production `1.97.0`; the committed diff contains only the two stage-1 version changes.
- The paired application PR passed Compose configuration, Ruff checks, and all 26 focused AI Gateway client contract tests.

## Evidence limitations

The upstream release pages provide signed-image artefacts but no complete human-authored compatibility changelog, so this review relies on tag-pinned source and current MOJ code/configuration. Cosign was unavailable locally; image signature verification was not run. This PR cannot establish post-deployment health or migration success; promotion remains contingent on that stage evidence.

## Release notes

- [LiteLLM 1.99.1](https://github.com/BerriAI/litellm/releases/tag/v1.99.1)
- [Upstream comparison](https://github.com/BerriAI/litellm/compare/v1.98.0...v1.99.1)