### PR TITLE
Reduce EKS Auto Mode logging to compute logs only

### DIFF
--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -109,10 +109,13 @@ locals {
 ## Delivery destinations. The naming alone does not grant write access — see the
 ## resource policy below.
 resource "aws_cloudwatch_log_group" "auto_mode" {
+  #checkov:skip=CKV_AWS_338:Per ADR-017, CloudWatch is the 30-day operational tier; long-term retention lives in the S3 archive
+  #checkov:skip=CKV_AWS_158:Per ADR-017, CloudWatch encryption at rest is the default AES-256; customer-managed KMS is required only on the S3 archive
+
   for_each = local.auto_mode_log_types
 
   name              = "/aws/vendedlogs/eks/cluster/${each.key}/${local.cluster_name}"
-  retention_in_days = 365
+  retention_in_days = 30
 
   tags = merge(local.tags, { Name = "/aws/vendedlogs/eks/cluster/${each.key}/${local.cluster_name}" })
 }

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -98,17 +98,11 @@ module "eks" {
 ## EKS Auto Mode component logs via CloudWatch Vended Logs
 locals {
   auto_mode_log_types = {
-    AUTO_MODE_COMPUTE_LOGS        = "compute"        # Karpenter
-    AUTO_MODE_BLOCK_STORAGE_LOGS  = "block-storage"  # EBS CSI
-    AUTO_MODE_LOAD_BALANCING_LOGS = "load-balancing" # AWS Load Balancer Controller
-    AUTO_MODE_IPAM_LOGS           = "ipam"           # VPC CNI IP address management
+    AUTO_MODE_COMPUTE_LOGS = "compute" # Karpenter
   }
 
   auto_mode_source_names = {
-    AUTO_MODE_COMPUTE_LOGS        = aws_cloudwatch_log_delivery_source.auto_mode_compute.name
-    AUTO_MODE_BLOCK_STORAGE_LOGS  = aws_cloudwatch_log_delivery_source.auto_mode_block_storage.name
-    AUTO_MODE_LOAD_BALANCING_LOGS = aws_cloudwatch_log_delivery_source.auto_mode_load_balancing.name
-    AUTO_MODE_IPAM_LOGS           = aws_cloudwatch_log_delivery_source.auto_mode_ipam.name
+    AUTO_MODE_COMPUTE_LOGS = aws_cloudwatch_log_delivery_source.auto_mode_compute.name
   }
 }
 
@@ -162,59 +156,13 @@ resource "aws_cloudwatch_log_resource_policy" "auto_mode_vendedlogs" {
   policy_document = data.aws_iam_policy_document.auto_mode_vendedlogs.json
 }
 
-## Created one at a time with waits: each triggers an async EKS cluster update and
-## the API allows only one, so parallel creation hits ConflictException.
+## Compute only for now.
 resource "aws_cloudwatch_log_delivery_source" "auto_mode_compute" {
   name         = "${local.cluster_name}-compute"
   log_type     = "AUTO_MODE_COMPUTE_LOGS"
   resource_arn = module.eks.cluster_arn
 
   tags = local.tags
-}
-
-resource "time_sleep" "auto_mode_after_compute" {
-  depends_on      = [aws_cloudwatch_log_delivery_source.auto_mode_compute]
-  create_duration = "120s"
-}
-
-resource "aws_cloudwatch_log_delivery_source" "auto_mode_block_storage" {
-  name         = "${local.cluster_name}-block-storage"
-  log_type     = "AUTO_MODE_BLOCK_STORAGE_LOGS"
-  resource_arn = module.eks.cluster_arn
-
-  tags = local.tags
-
-  depends_on = [time_sleep.auto_mode_after_compute]
-}
-
-resource "time_sleep" "auto_mode_after_block_storage" {
-  depends_on      = [aws_cloudwatch_log_delivery_source.auto_mode_block_storage]
-  create_duration = "120s"
-}
-
-resource "aws_cloudwatch_log_delivery_source" "auto_mode_load_balancing" {
-  name         = "${local.cluster_name}-load-balancing"
-  log_type     = "AUTO_MODE_LOAD_BALANCING_LOGS"
-  resource_arn = module.eks.cluster_arn
-
-  tags = local.tags
-
-  depends_on = [time_sleep.auto_mode_after_block_storage]
-}
-
-resource "time_sleep" "auto_mode_after_load_balancing" {
-  depends_on      = [aws_cloudwatch_log_delivery_source.auto_mode_load_balancing]
-  create_duration = "120s"
-}
-
-resource "aws_cloudwatch_log_delivery_source" "auto_mode_ipam" {
-  name         = "${local.cluster_name}-ipam"
-  log_type     = "AUTO_MODE_IPAM_LOGS"
-  resource_arn = module.eks.cluster_arn
-
-  tags = local.tags
-
-  depends_on = [time_sleep.auto_mode_after_load_balancing]
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "auto_mode" {

--- a/terraform/environments/cloud-platform/cluster/eks-cluster.tf
+++ b/terraform/environments/cloud-platform/cluster/eks-cluster.tf
@@ -112,7 +112,7 @@ resource "aws_cloudwatch_log_group" "auto_mode" {
   for_each = local.auto_mode_log_types
 
   name              = "/aws/vendedlogs/eks/cluster/${each.key}/${local.cluster_name}"
-  retention_in_days = 30
+  retention_in_days = 365
 
   tags = merge(local.tags, { Name = "/aws/vendedlogs/eks/cluster/${each.key}/${local.cluster_name}" })
 }


### PR DESCRIPTION
Temporarily reduces Auto Mode enhanced logging to the compute (Karpenter) log type, to unblock cluster deploys. Part of #8430.

## Why

Each Auto Mode delivery source triggers an asynchronous EKS cluster update, and EKS allows only one at a time, so creating all four fails with:

```
ConflictException: Cannot VendedLogsUpdate because cluster <name> currently has update <id> in progress
```

The `time_sleep`-based sequencing (120s between sources) proved inconsistent in practice — Terraform's parallel processing doesn't line up with a strictly sequential API requirement.

## What changed (`cluster/eks-cluster.tf` only)

- `auto_mode_log_types` and `auto_mode_source_names` reduced to `AUTO_MODE_COMPUTE_LOGS`
- Removed the block storage, load balancing and IPAM delivery sources
- Removed all three `time_sleep` resources — no sequencing left to fail
- Log group, destination and delivery needed no changes (they `for_each` the local, so 4 → 1 automatically)

## :warning: Plan will show destroys

On clusters that already have all four, this destroys the three removed log groups, sources, destinations and deliveries — which deletes their log data. New clusters simply get compute only.

## Follow-up

A new ticket has been created for reliable sequencing of all four log types; the three come back once that is solved.