### PR TITLE
fix(data-platform): promote litellm 1.98.0 to production

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -117,7 +117,7 @@ locals {
       elasticache_node_type                     = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.98.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Promotes production LiteLLM from `1.97.0` to `1.98.0`.
- Leaves development and test on `1.97.0` and preproduction on `1.98.0`; this run performs only the pending promotion action and does not start a new-version rollout.
- The latest stable upstream release is [v1.100.0](https://github.com/BerriAI/litellm/releases/tag/v1.100.0); it is deliberately deferred because completing an in-progress promotion takes precedence. Prereleases, including `v1.101.0-rc.1`, were excluded.

## Rollout evidence

- Merged first stage: [#18566](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18566)
- Merged paired Compose update: [data-platform-app#227](https://github.com/ministryofjustice/data-platform-app/pull/227)
- Earlier production promotion: [#18596](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18596)
- Rollback after key-revocation issues: [#18605](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18605)
- Merged preproduction restoration: [#18606](https://github.com/ministryofjustice/modernisation-platform-environments/pull/18606)

Merge remains contingent on confirming the `1.98.0` preproduction deployment is healthy and that the key-revocation issue which triggered #18605 is resolved or accepted.

## Compatibility

The merged first-stage evidence was rechecked against the authoritative [`AIGatewayClient`](https://github.com/ministryofjustice/data-platform-app/blob/main/ai_gateway/client.py). The target retains the consumed master-key bearer-authenticated contracts: `GET /v1/access_group`, `GET /organization/list`, team create/delete/info/update and daily activity, virtual-key generate/regenerate/delete/info/list/update (including `page`, `size`, `keys`, and `total_pages`), and `GET /v1/model/info`. The fields consumed for access groups, organisations, teams, models, keys, spend and breakdowns remain available. The application raises mapped errors for non-success HTTP responses and does not import the LiteLLM Python package.

The [v1.98.0 release evidence](https://github.com/BerriAI/litellm/releases/tag/v1.98.0) and [v1.97.0...v1.98.0 comparison](https://github.com/BerriAI/litellm/compare/v1.97.0...v1.98.0) identify additive schema changes and supplied migrations. Existing Helm values enable the migration job and Prisma migration. No new application, Terraform, model, access-group, organisation, team or key configuration change is required for this promotion.

## Validation

- `terraform fmt -check -diff terraform/environments/data-platform/ai-gateway/environment-configuration.tf`
- `git diff --check`
- Confirmed resulting versions: development `1.97.0`, test `1.97.0`, preproduction `1.98.0`, production `1.98.0`.

## Evidence limitations

This promotion reuses merged source/configuration compatibility evidence for the exact `1.98.0` image. It does not itself prove live preproduction health or resolution of the earlier key-revocation issue; operators must confirm those before merge. The newer `1.99.x` and `1.100.0` releases are not included in this change and require a later staged rollout.

## PagerDuty communications

**Before deployment**

> AI Gateway production maintenance starting: LiteLLM will be promoted from v1.97.0 to v1.98.0 via this PR. Preproduction is already on v1.98.0. We will monitor proxy/admin health, Prisma migration completion, management API errors, and key generation, regeneration and revocation. Rollback target: v1.97.0.

**Successful completion**

> AI Gateway production maintenance complete: LiteLLM production is now on v1.98.0. Proxy/admin health, Prisma migration, management API operations, and key generation, regeneration and revocation have been verified. No customer action is required.

**Failure/rollback**

> AI Gateway production maintenance encountered a problem while promoting LiteLLM to v1.98.0. Rollback to v1.97.0 has been initiated. We are monitoring service health and key lifecycle operations; further impact and recovery updates will follow in this incident.