### PR TITLE
CC-4851: ✨ Add Observability Platform Cloudwatch Data Sharing

### DIFF
--- a/terraform/environments/observability-platform/environment-configurations.tf
+++ b/terraform/environments/observability-platform/environment-configurations.tf
@@ -48,7 +48,7 @@ locals {
           aws_accounts = {
             "observability-platform-production" = {
               cloudwatch_enabled              = true
-              cloudwatch_shared_with_teams    = ["ccms-monitoring"]
+              cloudwatch_shared_with_teams    = ["ccms"]
               prometheus_push_enabled         = false
               amazon_prometheus_query_enabled = false
               xray_enabled                    = true

--- a/terraform/environments/observability-platform/environment-configurations.tf
+++ b/terraform/environments/observability-platform/environment-configurations.tf
@@ -48,6 +48,7 @@ locals {
           aws_accounts = {
             "observability-platform-production" = {
               cloudwatch_enabled              = true
+              cloudwatch_shared_with_teams    = ["ccms-monitoring"]
               prometheus_push_enabled         = false
               amazon_prometheus_query_enabled = false
               xray_enabled                    = true

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/cloudwatch_data_sharing.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/cloudwatch_data_sharing.tf
@@ -1,0 +1,40 @@
+locals {
+  shared_cloudwatch_permissions = flatten([
+    for account_name, account in var.aws_accounts : [
+      for team_name in try(account.cloudwatch_shared_with_teams, []) : {
+        key             = "${account_name}:${team_name}"
+        datasource_name = "${account_name}-cloudwatch"
+        team_name       = team_name
+      }
+    ] if try(account.cloudwatch_enabled, false)
+  ])
+}
+
+data "grafana_data_source" "shared_cloudwatch" {
+  for_each = {
+    for item in local.shared_cloudwatch_permissions : item.key => item
+  }
+
+  name = each.value.datasource_name
+}
+
+data "grafana_team" "shared_cloudwatch" {
+  for_each = toset([
+    for item in local.shared_cloudwatch_permissions : item.team_name
+  ])
+
+  name = each.value
+}
+
+resource "grafana_data_source_permission" "shared_cloudwatch" {
+  for_each = {
+    for item in local.shared_cloudwatch_permissions : item.key => item
+  }
+
+  datasource_uid = data.grafana_data_source.shared_cloudwatch[each.key].uid
+
+  permissions {
+    team_id    = data.grafana_team.shared_cloudwatch[each.value.team_name].id
+    permission = "Query"
+  }
+}

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/outputs.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/outputs.tf
@@ -7,3 +7,8 @@ output "folder_uid" {
   description = "The Grafana folder UID for this team"
   value       = module.team.folder_uid
 }
+
+output "team_id" {
+  description = "The ID of the team"
+  value       = grafana_team.this.id
+}

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/outputs.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/outputs.tf
@@ -7,8 +7,3 @@ output "folder_uid" {
   description = "The Grafana folder UID for this team"
   value       = module.team.folder_uid
 }
-
-output "team_id" {
-  description = "The ID of the team"
-  value       = grafana_team.this.id
-}

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/providers.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/providers.tf
@@ -5,6 +5,10 @@ terraform {
       version               = "~> 5.0"
       configuration_aliases = [aws.sso]
     }
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3.0"
+    }
   }
   required_version = "~> 1.0"
 }

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/variables.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/variables.tf
@@ -13,6 +13,7 @@ variable "identity_centre_team" {
 variable "aws_accounts" {
   type = map(object({
     cloudwatch_enabled                 = optional(bool)
+    cloudwatch_shared_with_teams       = optional(list(string), [])
     cloudwatch_custom_namespaces       = optional(string)
     prometheus_push_enabled            = optional(bool)
     amazon_prometheus_query_enabled    = optional(bool)


### PR DESCRIPTION
## 👀 Purpose

- Relates to https://dsdmoj.atlassian.net/browse/CC-4851?atlOrigin=eyJpIjoiZGQwZTZiNjRiNzBjNGU3ZDlmOWFiMWM1ZGYyNWU5YjEiLCJwIjoiaiJ9
- To allow LAA to see aggregated Security Hub Data across their accounts

## ♻️ What's changed

- Added the feature for a tenant to specify additional teams to share their CloudWatch data source with
- Added the `ccms-monitoring` team to see the Observability Platform CloudWatch data source

## 📝 Notes

- For some reason I had to use the team name `ccms` as that's what appears in grafana, rather than the actual team `ccms-monitoring`. Potentially grafana is cutting off the `-` when creating the team? 🤔 
- Another thing to note is that the current solution will only look up an existing team, so it currently doesn't work for sharing with a team that doesn't exist in Grafana.