### PR TITLE
PDHD-274 allow move-a-prisoner team to publish DPDs to S3

### DIFF
--- a/terraform/environments/digital-prison-reporting/data_product_definitions_s3.tf
+++ b/terraform/environments/digital-prison-reporting/data_product_definitions_s3.tf
@@ -11,6 +11,11 @@ locals {
       github_repo_id = "1353761083"
       s3_prefix   = "incident-reporting"
     }
+    "move-a-prisoner" = {
+      github_repo = "hmpps-dpr-move-a-prisoner-dpds"
+      github_repo_id = "1361146782"
+      s3_prefix   = "move-a-prisoner"
+    }
   }
 }
 


### PR DESCRIPTION
These changes allow the Github workflow from https://github.com/ministryofjustice/hmpps-dpr-move-a-prisoner-dpds to publish DPDs to the move-a-prisoner folder in S3. 