### PR TITLE
Reduced rds module chunk size from 200MB to 50MB due to OOM

### DIFF
--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -23,7 +23,7 @@ module "rds_export" {
   name                     = "planetfm"
   db_name                  = "planetfm"
   database_refresh_mode    = "full"
-  output_parquet_file_size = 200
+  output_parquet_file_size = 50
   max_concurrency          = 5
   environment              = local.environment_shorthand
   vpc_id                   = module.vpc.vpc_id


### PR DESCRIPTION
This pull request makes a minor configuration adjustment to the `rds_export` module in the data migration Terraform environment. The only change is a reduction in the `output_parquet_file_size` parameter, which will affect the size of the exported Parquet files.

- Reduced `output_parquet_file_size` from 200 to 50 in the `rds_export` module to generate smaller Parquet files during export.