### PR TITLE
CC-4872: MAAT - Clean up Terraform Plan (Build Artefacts and Policy S3 Resources)

### DIFF
--- a/terraform/environments/maat/artifacts.tf
+++ b/terraform/environments/maat/artifacts.tf
@@ -30,49 +30,43 @@ module "artifacts-s3" {
     }
   ]
 
+  bucket_policy = [jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        "Sid" : "DenyInsecureTransport",
+        "Effect" : "Deny",
+        "Principal" : "*",
+        "Action" : "s3:*",
+        "Resource" : [
+          module.s3-bucket-shared.bucket.arn,
+          "${module.s3-bucket-shared.bucket.arn}/*"
+        ],
+        "Condition" : {
+          "Bool" : {
+            "aws:SecureTransport" : "false"
+          }
+        }
+      },
+      {
+        "Sid" = "EnforceTLSv12orHigher",
+        "Action" : "s3:*",
+        "Effect" : "Deny",
+        "Resource" : [
+          module.s3-bucket-shared.bucket.arn,
+          "${module.s3-bucket-shared.bucket.arn}/*"
+        ],
+        "Condition" : {
+          "NumericLessThan" : {
+            "s3:TlsVersion" : "1.2"
+          }
+        },
+        "Principal" : {
+          "AWS" : "*"
+        }
+      }
+    ]
+  })]
+
   tags = local.tags
-}
-
-data "aws_iam_policy_document" "artifacts_secure_transport" {
-  statement {
-    sid    = "DenyInsecureTransport"
-    effect = "Deny"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions = ["s3:*"]
-    resources = [
-      module.artifacts-s3.bucket.arn,
-      "${module.artifacts-s3.bucket.arn}/*",
-    ]
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
-    }
-  }
-  statement {
-    sid    = "RestrictToTLSRequestsOnly"
-    effect = "Deny"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions = ["s3:*"]
-    resources = [
-      module.artifacts-s3.bucket.arn,
-      "${module.artifacts-s3.bucket.arn}/*",
-    ]
-    condition {
-      test     = "NumericLessThan"
-      variable = "s3:TlsVersion"
-      values   = ["1.2"]
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "artifacts_secure_transport" {
-  bucket = module.artifacts-s3.bucket.id
-  policy = data.aws_iam_policy_document.artifacts_secure_transport.json
 }

--- a/terraform/environments/maat/artifacts.tf
+++ b/terraform/environments/maat/artifacts.tf
@@ -30,43 +30,49 @@ module "artifacts-s3" {
     }
   ]
 
-  bucket_policy = [jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        "Sid" : "DenyInsecureTransport",
-        "Effect" : "Deny",
-        "Principal" : "*",
-        "Action" : "s3:*",
-        "Resource" : [
-          module.s3-bucket-shared.bucket.arn,
-          "${module.s3-bucket-shared.bucket.arn}/*"
-        ],
-        "Condition" : {
-          "Bool" : {
-            "aws:SecureTransport" : "false"
-          }
-        }
-      },
-      {
-        "Sid" = "EnforceTLSv12orHigher",
-        "Action" : "s3:*",
-        "Effect" : "Deny",
-        "Resource" : [
-          module.s3-bucket-shared.bucket.arn,
-          "${module.s3-bucket-shared.bucket.arn}/*"
-        ],
-        "Condition" : {
-          "NumericLessThan" : {
-            "s3:TlsVersion" : "1.2"
-          }
-        },
-        "Principal" : {
-          "AWS" : "*"
-        }
-      }
-    ]
-  })]
-
   tags = local.tags
+}
+
+data "aws_iam_policy_document" "artifacts_secure_transport" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    resources = [
+      module.artifacts-s3.bucket.arn,
+      "${module.artifacts-s3.bucket.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+  statement {
+    sid    = "RestrictToTLSRequestsOnly"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    resources = [
+      module.artifacts-s3.bucket.arn,
+      "${module.artifacts-s3.bucket.arn}/*",
+    ]
+    condition {
+      test     = "NumericLessThan"
+      variable = "s3:TlsVersion"
+      values   = ["1.2"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "artifacts_secure_transport" {
+  bucket = module.artifacts-s3.bucket.id
+  policy = data.aws_iam_policy_document.artifacts_secure_transport.json
 }

--- a/terraform/environments/maat/artifacts.tf
+++ b/terraform/environments/maat/artifacts.tf
@@ -30,49 +30,43 @@ module "artifacts-s3" {
     }
   ]
 
+  bucket_policy = [jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        "Sid" : "DenyInsecureTransport",
+        "Effect" : "Deny",
+        "Principal" : "*",
+        "Action" : "s3:*",
+        "Resource" : [
+          module.artifacts-s3.bucket.arn,
+          "${module.artifacts-s3.bucket.arn}/*"
+        ],
+        "Condition" : {
+          "Bool" : {
+            "aws:SecureTransport" : "false"
+          }
+        }
+      },
+      {
+        "Sid" : "EnforceTLSv12orHigher",
+        "Action" : "s3:*",
+        "Effect" : "Deny",
+        "Resource" : [
+          module.artifacts-s3.bucket.arn,
+          "${module.artifacts-s3.bucket.arn}/*"
+        ],
+        "Condition" : {
+          "NumericLessThan" : {
+            "s3:TlsVersion" : "1.2"
+          }
+        },
+        "Principal" : {
+          "AWS" : "*"
+        }
+      }
+    ]
+  })]
+
   tags = local.tags
-}
-
-data "aws_iam_policy_document" "artifacts_secure_transport" {
-  statement {
-    sid    = "DenyInsecureTransport"
-    effect = "Deny"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions = ["s3:*"]
-    resources = [
-      module.artifacts-s3.bucket.arn,
-      "${module.artifacts-s3.bucket.arn}/*",
-    ]
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
-    }
-  }
-  statement {
-    sid    = "RestrictToTLSRequestsOnly"
-    effect = "Deny"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions = ["s3:*"]
-    resources = [
-      module.artifacts-s3.bucket.arn,
-      "${module.artifacts-s3.bucket.arn}/*",
-    ]
-    condition {
-      test     = "NumericLessThan"
-      variable = "s3:TlsVersion"
-      values   = ["1.2"]
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "artifacts_secure_transport" {
-  bucket = module.artifacts-s3.bucket.id
-  policy = data.aws_iam_policy_document.artifacts_secure_transport.json
 }


### PR DESCRIPTION
Moves MAAT S3 Policy into module call rather than separate resource, similar to #18607

This avoids unnecessary noise being generated within Terraform plan for MAAT, as there appeared to be conflicts between the default policy implemented by the S3 module, and the dedicated policy resource

Verified noise reduction across multiple sequential runs:

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/34234141714/job/102096102580?pr=19034

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/34237714911/job/102099855570?pr=19034

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/34238520239