### PR TITLE
CC-4851 :✨ Add CCMS Accounts to Security Hub Map

### DIFF
--- a/terraform/environments/observability-platform/locals.tf
+++ b/terraform/environments/observability-platform/locals.tf
@@ -28,7 +28,11 @@ locals {
   securityhub_event_bus_name = "securityhub-central"
 
   ccms_account_ids = [
-    for account_name, _ in lookup(local.environment_configuration.tenant_configuration["ccms"], "aws_accounts", {}) :
+    for account_name, _ in lookup(
+      lookup(local.environment_configuration.tenant_configuration, "ccms", {}),
+      "aws_accounts",
+      {}
+    ) :
     local.all_account_ids[account_name]
     if contains(keys(local.all_account_ids), account_name)
   ]

--- a/terraform/environments/observability-platform/locals.tf
+++ b/terraform/environments/observability-platform/locals.tf
@@ -27,14 +27,22 @@ locals {
 
   securityhub_event_bus_name = "securityhub-central"
 
-  securityhub_source_account_ids = sort(distinct([
-    for account_name, account_id in local.environment_management.account_ids : account_id
-    if can(regex("^core-", account_name))
-  ]))
+  ccms_account_ids = [
+    for account_name, _ in lookup(local.environment_configuration.tenant_configuration["ccms"], "aws_accounts", {}) :
+    local.all_account_ids[account_name]
+    if contains(keys(local.all_account_ids), account_name)
+  ]
+
+  securityhub_source_account_ids = sort(distinct(concat(
+    [
+      for account_name, account_id in local.environment_management.account_ids : account_id
+      if can(regex("^core-", account_name))
+    ],
+    local.ccms_account_ids
+  )))
 
   securityhub_account_name_map = {
     for account_name, account_id in local.all_account_ids :
     account_id => account_name if contains(local.securityhub_source_account_ids, account_id)
   }
-
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://dsdmoj.atlassian.net/browse/CC-4851?atlOrigin=eyJpIjoiZTMwZGI0ZGUzNDdjNGZjNzkxNWIzNjc5YWYwYWJjMWMiLCJwIjoiaiJ9 and #19021 
- Adds CCMS Accounts to the Security Hub Account ID Map and Name Maps so that the lambda can properly record the account name when raising the metric

## ♻️ What's changed

- Added ccms_accounts_id local to gather all the account IDs from the CCMS tenant
- Updated the securityhub_source_account_ids to include CCMS account IDs

## 📝 Notes

- I belive this change is required as the lambda job tries to append the account name to the metric here if available https://github.com/ministryofjustice/modernisation-platform-environments/blob/add-laa-ccms-accounts-to-security-hub-map/terraform/environments/observability-platform/lambda/securityhub_metrics/app.py#L64-L64. Without this, I will not be able to see differentiate which accounts the alert is coming from.