### PR TITLE
feat(data-platform): autoscale ElevenLabs aligner endpoint

### DIFF
--- a/terraform/environments/data-platform/sagemaker/autoscaling.tf
+++ b/terraform/environments/data-platform/sagemaker/autoscaling.tf
@@ -1,0 +1,28 @@
+resource "aws_appautoscaling_target" "elevenlabs_asr" {
+  count = local.is-test ? 0 : 1
+
+  min_capacity       = 1
+  max_capacity       = 10
+  resource_id        = "endpoint/${aws_sagemaker_endpoint.elevenlabs_asr[0].name}/variant/${aws_sagemaker_endpoint_configuration.elevenlabs_asr[0].production_variants[0].variant_name}"
+  scalable_dimension = "sagemaker:variant:DesiredInstanceCount"
+  service_namespace  = "sagemaker"
+}
+
+resource "aws_appautoscaling_policy" "elevenlabs_asr" {
+  count = local.is-test ? 0 : 1
+
+  name               = "${local.deployment_name}-autoscaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.elevenlabs_asr[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.elevenlabs_asr[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.elevenlabs_asr[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    # ElevenLabs recommends six concurrent requests per replica for the -with-aligner model.
+    target_value = 6
+
+    predefined_metric_specification {
+      predefined_metric_type = "SageMakerVariantConcurrentRequestsPerModelHighResolution"
+    }
+  }
+}


### PR DESCRIPTION
Justice Transcribe is gradually increasing traffic to the ElevenLabs Scribe V2 Turbo `-with-aligner` model on `ml.g6e.xlarge`. The endpoint currently has one initial instance and no autoscaling configuration. This adds native SageMaker target tracking using ElevenLabs' deployment guide recommendations.

- Register the existing endpoint/production variant as a scalable target with a minimum of 1 and maximum of 10 instances.
- Target 6 concurrent requests per instance using `SageMakerVariantConcurrentRequestsPerModelHighResolution`, as recommended for the aligner variant. AWS manages the target-tracking alarms; cooldowns use AWS defaults.
- Derive the resource ID from the existing endpoint and production variant, avoiding the endpoint-configuration/variant-name mismatch in the vendor example.
- Follow the existing resource condition: enabled in development, preproduction and production; omitted in test.

The model, instance type, routing and Justice Transcribe traffic settings are unchanged. The maximum of 10 follows the vendor's example and is a scaling ceiling, not an initial allocation. The requester confirmed the aligner package, instance type and absence of scaling configuration outside Terraform.

Validation:
- `terraform fmt -check terraform/environments/data-platform/sagemaker` passed.
- `git diff --cached --check` passed.
- `terraform validate` passed for a temporary copy of the full SageMaker configuration, initialized with `-backend=false` and AWS provider 6.63.0 within the existing version constraint. No generated provider locks or downloaded modules are included in this PR.
- A live Terraform plan was not run: AWS backend/state access is held by the platform team. Please review the CI/platform plan and confirm sufficient regional SageMaker `ml.g6e.xlarge` quota for the chosen maximum before merge.

Reference: ElevenLabs-supplied “AWS Deployment Guide - Scribe V2 Turbo Batch”, “Advanced Usage: Aligner Model Package Variant” recommends target concurrency 6. AWS metric documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling-add-code-define.html#endpoint-auto-scaling-add-code-high-res
