### PR TITLE
Property reduce rds chunk size v2

### DIFF
--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -23,7 +23,7 @@ module "rds_export" {
   name                     = "planetfm"
   db_name                  = "planetfm"
   database_refresh_mode    = "full"
-  output_parquet_file_size = 50
+  output_parquet_file_size = 100
   max_concurrency          = 5
   environment              = local.environment_shorthand
   vpc_id                   = module.vpc.vpc_id

--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -23,7 +23,7 @@ module "rds_export" {
   name                     = "planetfm"
   db_name                  = "planetfm"
   database_refresh_mode    = "full"
-  output_parquet_file_size = 200
+  output_parquet_file_size = 50
   max_concurrency          = 5
   environment              = local.environment_shorthand
   vpc_id                   = module.vpc.vpc_id

--- a/terraform/environments/property-cafm-data-migration/main.tf
+++ b/terraform/environments/property-cafm-data-migration/main.tf
@@ -14,7 +14,7 @@ module "csv_export" {
 }
 
 module "rds_export" {
-  source = "github.com/ministryofjustice/terraform-rds-export?ref=3732d27b3bed9a9b6ac23691b03591455bc3555b"
+  source = "github.com/ministryofjustice/terraform-rds-export?ref=cc7d74586b037ab75072ef3234b283553e18bdd1"
   providers = {
     aws = aws
   }
@@ -23,7 +23,8 @@ module "rds_export" {
   name                     = "planetfm"
   db_name                  = "planetfm"
   database_refresh_mode    = "full"
-  output_parquet_file_size = 100
+  output_parquet_file_size = 200
+  database_export_processor_memory_size = 8192
   max_concurrency          = 5
   environment              = local.environment_shorthand
   vpc_id                   = module.vpc.vpc_id


### PR DESCRIPTION
This pull request updates the configuration for the `rds_export` module in the `property-cafm-data-migration` environment. The main changes include updating the module source to a newer commit and increasing the memory allocation for the database export processor.

**Module updates and configuration changes:**

* Updated the `rds_export` module source to use a newer commit, which may include important fixes or features.
* Increased the `database_export_processor_memory_size` to `8192` to allocate more memory for export processing.