### PR TITLE
Fix Firehose KMS grant permission

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
@@ -24,6 +24,7 @@ module "destination_kms_key" {
       sid = "Firehose"
       actions = [
         "kms:Decrypt",
+        "kms:CreateGrant",
         "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey",
@@ -34,6 +35,13 @@ module "destination_kms_key" {
         {
           type        = "Service"
           identifiers = ["firehose.amazonaws.com"]
+        }
+      ]
+      condition = [
+        {
+          test     = "Bool"
+          variable = "kms:GrantIsForAWSResource"
+          values   = ["true"]
         }
       ]
     },


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88

## Summary

Allow Amazon Data Firehose to create the AWS-managed KMS grant required to encrypt records written to the Auth0 event-stream delivery stream.

## Root cause

The deployed EventBridge DLQ captured the exact target failure:

`InvalidKMSResourceException`: the grant for the destination CMK to the `auth0-event-stream` delivery stream might have been revoked or the caller might not have sufficient permissions.

The Firehose KMS key policy already allowed `kms:Decrypt`, `kms:DescribeKey`, `kms:Encrypt`, and `kms:GenerateDataKey`, but not `kms:CreateGrant`. This caused EventBridge to reach the destination rule successfully while Firehose rejected the record before accepting it.

## Change

Add `kms:CreateGrant` to the Firehose service-principal statement, constrained by `kms:GrantIsForAWSResource = true`. This keeps the permission limited to AWS-managed grants for the destination CMK.

## Validation

- `terraform validate -no-color`
- Confirmed the change is limited to `terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf`.