### PR TITLE
Grant QuickSight admin access to disparity secret

### DIFF
--- a/terraform/environments/youth-justice-app-framework/kms.tf
+++ b/terraform/environments/youth-justice-app-framework/kms.tf
@@ -125,6 +125,35 @@ module "kms" {
           values   = [data.aws_caller_identity.current.account_id]
         }
       ]
+    },
+    {
+      sid    = "AllowQuickSightAdminToDecryptDisparityToolkitSecret"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/quicksight-admin-access"]
+        }
+      ]
+
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "kms:ViaService"
+          values   = ["secretsmanager.${data.aws_region.current.name}.amazonaws.com"]
+        },
+        {
+          test     = "StringLike"
+          variable = "kms:EncryptionContext:SecretARN"
+          values   = ["arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.project_name}/disparity-toolkit/redshift-serverless-*"]
+        }
+      ]
     }
   ]
   tags = local.tags

--- a/terraform/environments/youth-justice-app-framework/secrets.tf
+++ b/terraform/environments/youth-justice-app-framework/secrets.tf
@@ -200,6 +200,26 @@ resource "aws_secretsmanager_secret_version" "disparity_toolkit" {
   }
 }
 
+resource "aws_secretsmanager_secret_policy" "disparity_toolkit" {
+  secret_arn          = aws_secretsmanager_secret.disparity_toolkit.arn
+  block_public_policy = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowQuickSightAdminAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/quicksight-admin-access"
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = aws_secretsmanager_secret.disparity_toolkit.arn
+      }
+    ]
+  })
+}
+
 resource "aws_secretsmanager_secret" "Root_CA_secret" {
   #checkov:skip=CKV2_AWS_57:doesn't need rotation
   name        = "${local.project_name}/Root_CA"


### PR DESCRIPTION
## What this changes

This is a follow-on to #19000.

- grants the platform-managed `quicksight-admin-access` role `secretsmanager:GetSecretValue` through the application-owned secret policy
- grants KMS decrypt access only when the role accesses the Disparity Toolkit secret through Secrets Manager
- keeps the application-specific permissions out of the shared Modernisation Platform role definition

## Why

The QuickSight API caller needs permission to read the selected secret when configuring it as data-source credentials. PR #19000 separately grants the QuickSight service role the runtime access used for dashboard and SPICE refreshes.

## Validation

- `terraform fmt -check`
- `terraform validate`
- `git diff --check`