### PR TITLE
fix(data-platform): promote litellm 1.100.0 to pre-production and production

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
+++ b/terraform/environments/data-platform/ai-gateway/environment-configuration.tf
@@ -81,7 +81,7 @@ locals {
       elasticache_node_type = "cache.t4g.medium"
     }
     preproduction = {
-      litellm_version     = "1.98.0"
+      litellm_version     = "1.100.0"
       ai_gateway_hostname = "preproduction.ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN
@@ -117,7 +117,7 @@ locals {
       elasticache_node_type                     = "cache.t4g.medium"
     }
     production = {
-      litellm_version     = "1.97.0"
+      litellm_version     = "1.100.0"
       ai_gateway_hostname = "ai-gateway.justice.gov.uk"
       ai_gateway_ingress_allowlist = [
         # VPN


### PR DESCRIPTION
## Summary

- Promotes `preproduction` LiteLLM from `1.98.0` to `1.100.0` and `production` from `1.97.0` to `1.100.0` in [`environment-configuration.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/fix/promote-litellm-1.100.0-to-production/terraform/environments/data-platform/ai-gateway/environment-configuration.tf#L83-L121).
- Leaves `development` and `test` unchanged at `1.100.0`; that first stage merged in [modernisation-platform-environments#19030](https://github.com/ministryofjustice/modernisation-platform-environments/pull/19030).
- This promotion is the required next state-machine action and therefore takes precedence over starting another upgrade. The associated Compose attempt is [data-platform-app#255](https://github.com/ministryofjustice/data-platform-app/pull/255); it was closed without merge during the promotion run, so the Data Platform App image remains `v1.98.0` and no duplicate PR is opened here.
- `v1.100.1` is now the latest published non-draft, non-prerelease release, published on 2026-09-10 after this promotion PR opened. This promotion intentionally remains on `1.100.0`: the rollout state machine promotes the exact version already deployed to development and test before beginning a newer upgrade.
- The post-target [`v1.100.0...v1.100.1` comparison](https://github.com/BerriAI/litellm/compare/v1.100.0...v1.100.1) changes router retry-breadcrumb retention, package metadata, tests, and the lockfile; it does not change the management API, database schema or migrations, or Helm chart files reviewed for this deployment.

## Data Platform client compatibility

No breaking changes affecting the current Data Platform AI Gateway client were identified across the complete `1.97.0` to `1.100.0` range. The authoritative latest-main [`AIGatewayClient`](https://github.com/ministryofjustice/data-platform-app/blob/main/ai_gateway/client.py), tagged LiteLLM source, intervening release notes, linked upstream changes, and the current Modernisation Platform deployment configuration were reviewed.

- **Access groups and organisations:** `GET /v1/access_group` and `GET /organization/list?org_alias=...` retain their methods, parameters, and the consumed `access_group_name`, `access_group_id`, `access_model_names`, `organization_alias`, and `organization_id` fields. Upstream changes are compatible: access-group responses gained additive resolved resource names ([commit `c5c10bc`](https://github.com/BerriAI/litellm/commit/c5c10bc91fe1b6e7aba457fae4a081059f588a5d)); organisation changes concern internal typing, write validation, and v2 update handling, not the v1 list contract used here.
- **Teams:** `POST /team/new`, `POST /team/delete`, `GET /team/info?team_id=...`, `POST /team/update`, and `GET /team/daily/activity` retain their routes and the request/response data consumed by the application, including `team_id`, `team_info`, `access_group_ids`, `results`, `metrics`, and `breakdown`. Relevant changes fix partial updates preserving metadata ([#36328](https://github.com/BerriAI/litellm/pull/36328)), serialize membership/delete writes ([#37969](https://github.com/BerriAI/litellm/pull/37969)), and add per-user spend reporting ([#39771](https://github.com/BerriAI/litellm/pull/39771)); they do not remove or rename the consumed contract.
- **Virtual keys:** `POST /key/generate`, `POST /key/{key}/regenerate`, `POST /key/delete`, `GET /key/info?key=...`, `GET /key/list` with `team_id`, `return_full_object`, `size`, and `page`, and `POST /key/update` retain the bodies and `key`, `keys`, `models`, and `total_pages` fields consumed by the client. Changes in the range add validation for optional logging/batch-token settings not sent by this client and fix MCP grant preservation ([#38463](https://github.com/BerriAI/litellm/pull/38463)), budget-window resets ([#38686](https://github.com/BerriAI/litellm/pull/38686)), raw-key list searches ([commit `9baa19c`](https://github.com/BerriAI/litellm/commit/9baa19c7d13c4d5937d7c6f337659b94b514f773)), and JWT mapping invalidation on regeneration ([commit `2f7ee395`](https://github.com/BerriAI/litellm/commit/2f7ee39545ad66c527c5827b4f58d5cc9c1dcfdf)).
- **Models, authentication, and errors:** `GET /v1/model/info` retains the `data` envelope used by `list_models_v1_info`. The application still authenticates with a bearer master key through pinned `httpx==0.28.1` and raises its own exceptions for HTTP and transport failures; it does not import the LiteLLM Python package.
- The upstream endpoint files did change between `v1.98.0` and `v1.100.0`; compatibility is based on direct contract and implementation review, not an unchanged-file assertion. The focused Data Platform client suite recorded in [data-platform-app#255](https://github.com/ministryofjustice/data-platform-app/pull/255) passed all 26 tests, including auth, error handling, team operations, and `/key/list` pagination.

## Other breaking changes

- No applicable breaking-change notice was identified in the [v1.99.0](https://github.com/BerriAI/litellm/releases/tag/v1.99.0), [v1.99.1](https://github.com/BerriAI/litellm/releases/tag/v1.99.1), or [v1.100.0](https://github.com/BerriAI/litellm/releases/tag/v1.100.0) release notes.
- The tagged [`schema.prisma`](https://github.com/BerriAI/litellm/blob/v1.100.0/litellm-proxy-extras/litellm_proxy_extras/schema.prisma) contains additive nullable/defaulted columns and new tables across this range, including `LiteLLM_ModelAccessGroupBudgetTable`, `LiteLLM_BudgetWindowSpend`, `LiteLLM_ProxyWorkerHeartbeat`, and `LiteLLM_DailyGuardrailUsageUnits`. No destructive schema change applicable to this deployment was found.
- The current [`litellm-admin` values](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm-admin/values.yml.tftpl#L190-L191) enable `migrationJob`; the proxy [`litellm` values](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/src/helm/values/litellm/values.yml.tftpl#L161-L162) leave it disabled. [BerriAI/litellm#36975](https://github.com/BerriAI/litellm/pull/36975) adds optional `migrationJob.activeDeadlineSeconds` with a default of 1800 seconds; no values change is required here.
- The `ncecere/litellm` Terraform provider remains independently pinned to `~> 2.0` in [`versions.tf`](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/data-platform/ai-gateway/versions.tf). Provider additions in [BerriAI/litellm#37918](https://github.com/BerriAI/litellm/pull/37918) are optional and do not couple the provider version to this proxy image update.
- `v1.99.1` is a [Docker-only release](https://github.com/BerriAI/litellm/releases/tag/v1.99.1); this deployment uses the `ghcr.io/berriai/litellm` image, so that packaging distinction does not block promotion.

## Release notes

- [LiteLLM 1.100.0 release notes](https://github.com/BerriAI/litellm/releases/tag/v1.100.0)
- [Full upstream comparison v1.97.0...v1.100.0](https://github.com/BerriAI/litellm/compare/v1.97.0...v1.100.0)
- [Pre-production comparison v1.98.0...v1.100.0](https://github.com/BerriAI/litellm/compare/v1.98.0...v1.100.0)
- [Latest stable LiteLLM 1.100.1 release notes (not this promotion target)](https://github.com/BerriAI/litellm/releases/tag/v1.100.1)
- [Post-target comparison v1.100.0...v1.100.1](https://github.com/BerriAI/litellm/compare/v1.100.0...v1.100.1)
