### PR TITLE
Add 100GB to DB u01 and u03 Prod only

### DIFF
--- a/terraform/environments/cica-tariff/locals.tf
+++ b/terraform/environments/cica-tariff/locals.tf
@@ -141,7 +141,7 @@ locals {
   tariffdb_volume_layout = [
     {
       device_name = "xvde"
-      size        = 100
+      size        = local.environment == "production" ? 200 : 100
     },
     {
       device_name = "xvdf"
@@ -149,7 +149,7 @@ locals {
     },
     {
       device_name = "xvdg"
-      size        = 100
+      size        = local.environment == "production" ? 200 : 100
     },
     {
       device_name = "xvdh"


### PR DESCRIPTION
This pull request updates the disk volume sizes for the `tariffdb_volume_layout` in the `cica-tariff` environment to allocate more storage in production environments. The main change is to conditionally increase the sizes of certain devices when the environment is set to production.

Storage configuration changes:

* [`terraform/environments/cica-tariff/locals.tf`](diffhunk://#diff-40c22bf0c62f372d3f88a73ac9f3f326bfe524f1087987a8c135ea2f8ce647d5L144-R152): Updated the `size` for devices `xvde` and `xvdg` to be `200` in production environments, otherwise keeping them at `100`.