### PR TITLE
CC-4851: 🔧 Fix CloudWatch Data Source Fighting For Permissions

### DIFF
--- a/terraform/environments/observability-platform/modules/grafana/team/main.tf
+++ b/terraform/environments/observability-platform/modules/grafana/team/main.tf
@@ -23,15 +23,13 @@ data "grafana_data_source" "cloudwatch" {
   name = "${each.key}-cloudwatch"
 }
 
-resource "grafana_data_source_permission" "cloudwatch" {
+resource "grafana_data_source_permission_item" "cloudwatch" {
   for_each = var.aws_accounts
 
   datasource_uid = trimprefix(data.grafana_data_source.cloudwatch[each.key].id, "1:")
 
-  permissions {
-    team_id    = grafana_team.this.id
-    permission = "Query"
-  }
+  team       = grafana_team.this.id
+  permission = "Query"
 }
 
 data "grafana_data_source" "xray" {

--- a/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/cloudwatch_data_sharing.tf
+++ b/terraform/environments/observability-platform/modules/observability-platform/tenant-configuration/cloudwatch_data_sharing.tf
@@ -26,15 +26,13 @@ data "grafana_team" "shared_cloudwatch" {
   name = each.value
 }
 
-resource "grafana_data_source_permission" "shared_cloudwatch" {
+resource "grafana_data_source_permission_item" "shared_cloudwatch" {
   for_each = {
     for item in local.shared_cloudwatch_permissions : item.key => item
   }
 
   datasource_uid = data.grafana_data_source.shared_cloudwatch[each.key].uid
 
-  permissions {
-    team_id    = data.grafana_team.shared_cloudwatch[each.value.team_name].id
-    permission = "Query"
-  }
+  team       = data.grafana_team.shared_cloudwatch[each.value.team_name].id
+  permission = "Query"
 }


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://dsdmoj.atlassian.net/browse/CC-4851?atlOrigin=eyJpIjoiNTBhY2IwYjRkYWE5NDIwYjg3MjFlODhkNjE4ZjY1NzAiLCJwIjoiaiJ9
- Fixes #19021 
- We are currently using https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source_permission in two places, both want to fully control permissions, leading to every apply swapping the permissions over. 

## ♻️ What's changed

- I have migrated from https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source_permission to https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source_permission_item for CloudWatch Data Source Permissions, so that permissions for CloudWatch data sources can be managed independently.

## 📝 Notes

- The reasoning for having the permissions managed independently is that I believe the team module should only set default permissions for a data source for teams. So adding in the extra functionality of what the data source is shared with should be managed separately outside of that module.