### PR TITLE
CC-4695: Checkout SHA Pin v7.0.1 Cleanup

### DIFF
--- a/.github/workflows/data-platform-network-firewall-schema-validation.yml
+++ b/.github/workflows/data-platform-network-firewall-schema-validation.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Fully cleans up `actions/checkout` SHA pin references across `modernisation-platform-environments` to ensure v7.0.1 is used