### PR TITLE
Allow Firehose delivery role to create KMS grants

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
@@ -39,12 +39,20 @@ module "firehose_iam_role" {
     KMSAccess = {
       effect = "Allow"
       actions = [
+        "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey",
       ]
       resources = [module.destination_kms_key[0].key_arn]
+      condition = [
+        {
+          test     = "Bool"
+          variable = "kms:GrantIsForAWSResource"
+          values   = ["true"]
+        }
+      ]
     }
     CloudWatchLogsGroupAccess = {
       effect = "Allow"


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88

## Summary

Allow the Firehose delivery role for the Auth0 event stream to create the AWS-managed KMS grant required to use the destination CMK.

## Root cause

The deployed EventBridge DLQ showed that events reached the destination rule, but Firehose rejected every record with `InvalidKMSResourceException`:

> The grant for the CMK to this delivery stream might have been revoked or caller might not have sufficient permissions for the CMK.

The destination CMK key policy already allows `firehose.amazonaws.com` to create AWS-resource grants. However, the IAM role assumed by Firehose (`auth0-event-stream-firehose`) only allowed `kms:Decrypt`, `kms:DescribeKey`, `kms:Encrypt`, and `kms:GenerateDataKey`. It did not allow `kms:CreateGrant`.

## Change

Add `kms:CreateGrant` to the Firehose role's KMS permissions, constrained by `kms:GrantIsForAWSResource = true` and scoped to the destination CMK.

## Validation

- `terraform validate -no-color`
- Confirmed the change is limited to `terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf`.