### PR TITLE
Fix Firehose CMK permissions for Auth0 stream

### DIFF
--- a/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
@@ -4,6 +4,12 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   name        = local.component_name
   destination = "extended_s3"
 
+  server_side_encryption {
+    enabled  = true
+    key_type = "CUSTOMER_MANAGED_CMK"
+    key_arn  = module.destination_kms_key[0].key_arn
+  }
+
   extended_s3_configuration {
     role_arn            = module.firehose_iam_role[0].arn
     bucket_arn          = module.s3_bucket[0].s3_bucket_arn

--- a/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/firehose.tf
@@ -4,12 +4,6 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   name        = local.component_name
   destination = "extended_s3"
 
-  server_side_encryption {
-    enabled  = true
-    key_type = "CUSTOMER_MANAGED_CMK"
-    key_arn  = module.destination_kms_key[0].key_arn
-  }
-
   extended_s3_configuration {
     role_arn            = module.firehose_iam_role[0].arn
     bucket_arn          = module.s3_bucket[0].s3_bucket_arn

--- a/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
@@ -39,12 +39,16 @@ module "firehose_iam_role" {
     KMSAccess = {
       effect = "Allow"
       actions = [
-        "kms:CreateGrant",
         "kms:Decrypt",
         "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey",
       ]
+      resources = [module.destination_kms_key[0].key_arn]
+    }
+    KMSGrant = {
+      effect    = "Allow"
+      actions   = ["kms:CreateGrant"]
       resources = [module.destination_kms_key[0].key_arn]
       condition = [
         {

--- a/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/iam-roles.tf
@@ -46,18 +46,6 @@ module "firehose_iam_role" {
       ]
       resources = [module.destination_kms_key[0].key_arn]
     }
-    KMSGrant = {
-      effect    = "Allow"
-      actions   = ["kms:CreateGrant"]
-      resources = [module.destination_kms_key[0].key_arn]
-      condition = [
-        {
-          test     = "Bool"
-          variable = "kms:GrantIsForAWSResource"
-          values   = ["true"]
-        }
-      ]
-    }
     CloudWatchLogsGroupAccess = {
       effect = "Allow"
       actions = [
@@ -100,4 +88,25 @@ module "cross_region_iam_role" {
       resources = [module.destination_eventbridge[0].eventbridge_bus_arn]
     }
   }
+}
+
+data "aws_iam_policy_document" "eventbridge_firehose_kms" {
+  count = local.is-production ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [module.destination_kms_key[0].key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "eventbridge_firehose_kms" {
+  count = local.is-production ? 1 : 0
+
+  name   = "${local.component_name}-eventbridge-firehose-kms"
+  role   = module.destination_eventbridge[0].eventbridge_role_name
+  policy = data.aws_iam_policy_document.eventbridge_firehose_kms[0].json
 }

--- a/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
+++ b/terraform/environments/developer-experience/auth0-event-stream/kms-keys.tf
@@ -24,12 +24,22 @@ module "destination_kms_key" {
       sid = "Firehose"
       actions = [
         "kms:Decrypt",
-        "kms:CreateGrant",
         "kms:DescribeKey",
         "kms:Encrypt",
         "kms:GenerateDataKey",
         "kms:ReEncrypt*",
       ]
+      resources = ["*"]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["firehose.amazonaws.com"]
+        }
+      ]
+    },
+    {
+      sid       = "FirehoseGrant"
+      actions   = ["kms:CreateGrant"]
       resources = ["*"]
       principals = [
         {


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/88

## Summary

Fix the KMS permissions required for EventBridge to write records to the customer-managed-key-encrypted Auth0 Firehose stream.

## Root cause

The Auth0 event path reaches the destination EventBridge rule, but Firehose rejects every record with `InvalidKMSResourceException`. The deployed DLQ reported that the grant for the customer-managed CMK to the delivery stream might have been revoked or that the caller might not have sufficient permissions.

AWS documents that, for a customer-managed CMK, the caller of Firehose `PutRecord`/`PutRecordBatch` needs `kms:GenerateDataKey` and `kms:Decrypt`. In this configuration, that caller is the EventBridge target role, not the Firehose S3 delivery role.

The previous implementation granted the normal KMS permissions only to the Firehose delivery role. It also applied `kms:GrantIsForAWSResource` to the normal cryptographic actions, even though that condition is specific to `kms:CreateGrant`.

## Change

- Retain customer-managed CMK encryption for the Firehose stream to satisfy the Firehose encryption controls.
- Add `kms:Decrypt` and `kms:GenerateDataKey` on the destination CMK to the EventBridge Firehose target role.
- Keep Firehose cryptographic permissions separate from `kms:CreateGrant`.
- Constrain `kms:CreateGrant` with `kms:GrantIsForAWSResource = true` in the CMK policy.
- Keep the S3 destination encrypted with the same customer-managed CMK.

## Validation

- `terraform validate -no-color`
- `git diff --check`
- Static analysis should pass because Firehose stream-level CMK encryption is retained.

The deployed EventBridge DLQ remains available to capture any further target invocation errors.