### PR TITLE
feat(ai-gateway): Bedrock batch inference infrastructure (dev, single model)

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-access-groups.tf
@@ -9,6 +9,17 @@ resource "litellm_unified_access_group" "amazon_bedrock" {
   ]
 }
 
+resource "litellm_unified_access_group" "amazon_bedrock_batch" {
+  for_each = local.ai_gateway_bedrock_batch_models
+
+  access_group_name  = "bedrock-batch-${each.key}"
+  access_model_names = [litellm_model.amazon_bedrock_batch[each.key].model_name]
+  assigned_team_ids = [
+    for team_key, team in local.ai_gateway_configuration.teams : litellm_team.teams[team_key].team_id
+    if contains(try(team.unified_access_groups, []), "bedrock-batch-${each.key}")
+  ]
+}
+
 resource "litellm_unified_access_group" "google_gemini_enterprise_agent_platform" {
   for_each = try(local.ai_gateway_models_filtered.google_gemini_enterprise_agent_platform, {})
 

--- a/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
+++ b/terraform/environments/data-platform/ai-gateway/ai-gateway-models.tf
@@ -24,6 +24,40 @@ resource "litellm_model" "amazon_bedrock" {
   ]
 }
 
+# Companion "batch" mode deployment for models that support Bedrock batch inference; a separate
+# model_name is required because LiteLLM routes batch vs. real-time traffic by model deployment.
+resource "litellm_model" "amazon_bedrock_batch" {
+  for_each = local.ai_gateway_bedrock_batch_models
+
+  custom_llm_provider = "bedrock"
+  model_name          = "bedrock-batch-${each.key}"
+  base_model          = each.value.model_id
+  tier                = "paid"
+  mode                = "batch"
+
+  aws_region_name = each.value.region
+  aws_role_name   = module.iam_role.arn
+
+  additional_litellm_params = {
+    s3_bucket_name       = module.batch_inference.s3_bucket_id
+    s3_region_name       = each.value.region
+    aws_batch_role_arn   = aws_iam_role.bedrock_batch_execution.arn
+    s3_encryption_key_id = module.ai_gateway_batch_inference_kms_key.key_arn
+
+    ai_model_provider            = try(each.value.model_provider, "Amazon Bedrock")
+    ai_model_family              = each.value.model_family
+    ai_model_name                = each.value.model_name
+    ai_model_generally_available = each.value.generally_available
+    additional_drop_params       = "[\"ai_model_provider\",\"ai_model_family\",\"ai_model_name\",\"ai_model_generally_available\"]"
+  }
+
+  depends_on = [
+    helm_release.ai_gateway_configuration,
+    helm_release.litellm,
+    helm_release.litellm_admin
+  ]
+}
+
 resource "litellm_model" "google_gemini_enterprise_agent_platform" {
   for_each = try(local.ai_gateway_models_filtered.google_gemini_enterprise_agent_platform, {})
 

--- a/terraform/environments/data-platform/ai-gateway/bedrock-batch-execution-role.tf
+++ b/terraform/environments/data-platform/ai-gateway/bedrock-batch-execution-role.tf
@@ -1,0 +1,86 @@
+# Service role that Bedrock (not the AI Gateway pod) assumes while a batch inference job runs,
+# to read the input file from and write results to the batch inference bucket.
+data "aws_iam_policy_document" "bedrock_batch_execution_trust" {
+  statement {
+    sid     = "AllowBedrockAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:bedrock:eu-west-2:${data.aws_caller_identity.current.account_id}:model-invocation-job/*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "bedrock_batch_execution_permissions" {
+  statement {
+    sid    = "BatchInferenceS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.batch_inference.s3_bucket_arn,
+      "${module.batch_inference.s3_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    sid    = "BatchInferenceKMSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [module.ai_gateway_batch_inference_kms_key.key_arn]
+  }
+
+  # Bedrock invokes the model using this role during the job, mirroring the invoke
+  # permissions already granted to the AI Gateway pod role in iam-policies.tf
+  statement {
+    sid       = "BedrockInferenceProfileAccess"
+    effect    = "Allow"
+    actions   = ["bedrock:InvokeModel*"]
+    resources = formatlist("arn:aws:bedrock:%s:${data.aws_caller_identity.current.account_id}:inference-profile/*", ["eu-west-1", "eu-west-2"])
+  }
+
+  statement {
+    sid       = "BedrockFoundationModelAccess"
+    effect    = "Allow"
+    actions   = ["bedrock:InvokeModel*"]
+    resources = ["arn:aws:bedrock:eu-*::foundation-model/*"]
+  }
+}
+
+module "bedrock_batch_execution_iam_policy" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-policy?ref=1d73bcb359419e1b41872ac5ccaf8808b8f1150e" # v6.6.0
+
+  name_prefix = "${local.component_name}-bedrock-batch-execution"
+
+  policy = data.aws_iam_policy_document.bedrock_batch_execution_permissions.json
+}
+
+resource "aws_iam_role" "bedrock_batch_execution" {
+  name               = "${local.component_name}-bedrock-batch-execution"
+  assume_role_policy = data.aws_iam_policy_document.bedrock_batch_execution_trust.json
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock_batch_execution" {
+  role       = aws_iam_role.bedrock_batch_execution.name
+  policy_arn = module.bedrock_batch_execution_iam_policy.arn
+}

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -84,24 +84,31 @@ models:
       region: eu-west-2
       generally_available: true
     # Anthropic
+    # batch_available is only set on models confirmed against AWS's "Supported Regions and
+    # models for batch inference" table for the eu cross-region inference profile used here.
+    # claude-opus-4-7, claude-opus-4-8 and claude-sonnet-5 are deliberately left unset because
+    # they don't yet appear in that table - re-check before flipping them on.
     claude-haiku-4-5:
       model_id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Haiku 4.5 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-opus-4-5:
       model_id: "eu.anthropic.claude-opus-4-5-20251101-v1:0"
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Opus 4.5 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-opus-4-6:
       model_id: eu.anthropic.claude-opus-4-6-v1
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Opus 4.6 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-opus-4-7:
       model_id: eu.anthropic.claude-opus-4-7
       model_family: "Anthropic Claude"
@@ -120,18 +127,21 @@ models:
       model_name: "Anthropic Claude Opus 5 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-sonnet-4-5:
       model_id: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Sonnet 4.5 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-sonnet-4-6:
       model_id: eu.anthropic.claude-sonnet-4-6
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Sonnet 4.6 (EU)"
       region: eu-west-2
       generally_available: true
+      batch_available: true
     claude-sonnet-5:
       model_id: eu.anthropic.claude-sonnet-5
       model_family: "Anthropic Claude"

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -84,10 +84,10 @@ models:
       region: eu-west-2
       generally_available: true
     # Anthropic
-    # batch_available is only set on models confirmed against AWS's "Supported Regions and
-    # models for batch inference" table for the eu cross-region inference profile used here.
-    # claude-opus-4-7, claude-opus-4-8 and claude-sonnet-5 are deliberately left unset because
-    # they don't yet appear in that table - re-check before flipping them on.
+    # batch_available is deliberately set on claude-haiku-4-5 only, to keep the initial batch
+    # inference rollout scoped to a single model for testing. Other models here are confirmed
+    # against AWS's "Supported Regions and models for batch inference" table for the eu
+    # cross-region inference profile used here and can be flagged on once validated end-to-end.
     claude-haiku-4-5:
       model_id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
       model_family: "Anthropic Claude"
@@ -101,14 +101,12 @@ models:
       model_name: "Anthropic Claude Opus 4.5 (EU)"
       region: eu-west-2
       generally_available: true
-      batch_available: true
     claude-opus-4-6:
       model_id: eu.anthropic.claude-opus-4-6-v1
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Opus 4.6 (EU)"
       region: eu-west-2
       generally_available: true
-      batch_available: true
     claude-opus-4-7:
       model_id: eu.anthropic.claude-opus-4-7
       model_family: "Anthropic Claude"
@@ -127,21 +125,18 @@ models:
       model_name: "Anthropic Claude Opus 5 (EU)"
       region: eu-west-2
       generally_available: true
-      batch_available: true
     claude-sonnet-4-5:
       model_id: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Sonnet 4.5 (EU)"
       region: eu-west-2
       generally_available: true
-      batch_available: true
     claude-sonnet-4-6:
       model_id: eu.anthropic.claude-sonnet-4-6
       model_family: "Anthropic Claude"
       model_name: "Anthropic Claude Sonnet 4.6 (EU)"
       region: eu-west-2
       generally_available: true
-      batch_available: true
     claude-sonnet-5:
       model_id: eu.anthropic.claude-sonnet-5
       model_family: "Anthropic Claude"

--- a/terraform/environments/data-platform/ai-gateway/iam-policies.tf
+++ b/terraform/environments/data-platform/ai-gateway/iam-policies.tf
@@ -41,6 +41,78 @@ data "aws_iam_policy_document" "ai_gateway" {
     ]
   }
 
+  # Lets the pod submit batch inference jobs against the same models it can already invoke directly
+  statement {
+    sid     = "BedrockCreateBatchInferenceJob"
+    effect  = "Allow"
+    actions = ["bedrock:CreateModelInvocationJob"]
+    resources = concat(
+      formatlist("arn:aws:bedrock:%s:${data.aws_caller_identity.current.account_id}:inference-profile/*", ["eu-west-1", "eu-west-2"]),
+      ["arn:aws:bedrock:eu-*::foundation-model/*"],
+      ["arn:aws:bedrock:eu-west-2:${data.aws_caller_identity.current.account_id}:model-invocation-job/*"]
+    )
+  }
+
+  statement {
+    sid    = "BedrockManageBatchInferenceJobs"
+    effect = "Allow"
+    actions = [
+      "bedrock:GetModelInvocationJob",
+      "bedrock:StopModelInvocationJob"
+    ]
+    resources = ["arn:aws:bedrock:eu-west-2:${data.aws_caller_identity.current.account_id}:model-invocation-job/*"]
+  }
+
+  # ListModelInvocationJobs/TagResource/etc. don't support resource-level scoping
+  statement {
+    sid    = "BedrockListBatchInferenceJobs"
+    effect = "Allow"
+    actions = [
+      "bedrock:ListModelInvocationJobs",
+      "bedrock:TagResource",
+      "bedrock:UntagResource",
+      "bedrock:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "PassBedrockBatchExecutionRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.bedrock_batch_execution.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["bedrock.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "BatchInferenceS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.batch_inference.s3_bucket_arn,
+      "${module.batch_inference.s3_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    sid    = "BatchInferenceKMSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [module.ai_gateway_batch_inference_kms_key.key_arn]
+  }
+
   statement {
     sid       = "AuditLogS3Access"
     effect    = "Allow"

--- a/terraform/environments/data-platform/ai-gateway/kms-keys.tf
+++ b/terraform/environments/data-platform/ai-gateway/kms-keys.tf
@@ -93,6 +93,17 @@ module "ai_gateway_audit_logs_kms_key" {
   deletion_window_in_days = 7
 }
 
+module "ai_gateway_batch_inference_kms_key" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
+
+  description           = "KMS key for AI Gateway batch inference S3 bucket encryption"
+  enable_default_policy = true
+
+  aliases = ["s3/${local.component_name}-batch-inference"]
+
+  deletion_window_in_days = 7
+}
+
 module "ai_gateway_aurora_kms_key" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=407e3db34a65b384c20ef718f55d9ceacb97a846" # v4.2.0
 

--- a/terraform/environments/data-platform/ai-gateway/locals.tf
+++ b/terraform/environments/data-platform/ai-gateway/locals.tf
@@ -25,6 +25,15 @@ locals {
     }
   }
 
+  # Bedrock models eligible for batch inference: same-account only (batch inference for
+  # cross-account models, i.e. those with aws_account_name set, is out of scope for now)
+  # and explicitly opted in via `batch_available: true` in configuration.yml.
+  ai_gateway_bedrock_batch_models = {
+    for model_key, model in try(local.ai_gateway_models_filtered.amazon_bedrock, {}) :
+    model_key => model
+    if try(model.batch_available, false) && !can(model.aws_account_name)
+  }
+
   # RDS
   has_reader = contains(keys(local.environment_configuration.aurora_instances), "reader")
   # checkov:skip=CKV_SECRET_6: Dummy placeholder for IAM auth flow, not a real secret

--- a/terraform/environments/data-platform/ai-gateway/s3.tf
+++ b/terraform/environments/data-platform/ai-gateway/s3.tf
@@ -1,6 +1,7 @@
 locals {
   alb_access_logs_bucket_name = "mojdp-${local.environment}-${local.component_name}-alb-logs"
   audit_logs_bucket_name      = "mojdp-${local.environment}-${local.component_name}-audit-logs"
+  batch_inference_bucket_name = "mojdp-${local.environment}-${local.component_name}-batch-inference"
 }
 
 data "aws_iam_policy_document" "alb_access_logs_bucket_policy" {
@@ -59,6 +60,47 @@ module "alb_access_logs" {
 
       expiration = {
         days = 365
+      }
+    }
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# TODO(data-protection-review): the 30-day expiry below is a PROVISIONAL value
+# only, not a final decision. Unlike the audit-logs bucket (which stores audit
+# metadata), this bucket stores the full prompts and completions submitted to
+# and returned from Bedrock batch inference jobs. Retention MUST be confirmed
+# with the data protection / security team before this is relied on in
+# test/preproduction/production.
+# ---------------------------------------------------------------------------
+module "batch_inference" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=af0286ff37a66c2b79faf360e6e2663744b8e5b5" # v5.13.0
+
+  bucket = local.batch_inference_bucket_name
+
+  force_destroy = false
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = module.ai_gateway_batch_inference_kms_key.key_arn
+      }
+      bucket_key_enabled = true
+    }
+  }
+
+  versioning = {
+    status = "Disabled"
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "expire-batch-inference-files"
+      enabled = true
+
+      expiration = {
+        days = 30
       }
     }
   ]


### PR DESCRIPTION
POC relates to https://github.com/ministryofjustice/data-platform/issues/724 

## What
Adds the AWS infrastructure and LiteLLM Terraform configuration needed to support
Amazon Bedrock **batch inference** through the AI Gateway, scoped to:
- same-account Bedrock models only (cross-account models are out of scope)
- a single model (`claude-haiku-4-5`) for initial end-to-end testing before
  widening to the other confirmed-compatible Anthropic models

## Why
Investigation and rationale are captured in the (untracked, local) plan doc
used to drive this change - happy to share separately if useful for review.

## Changes
- `kms-keys.tf` - dedicated `ai_gateway_batch_inference_kms_key`
- `s3.tf` - new `batch_inference` S3 bucket for batch input/output files.
  **Retention (30 days) is provisional** - flagged in-file, needs a data
  protection/security review before relied on beyond dev.
- `bedrock-batch-execution-role.tf` (new) - IAM role assumed by
  `bedrock.amazonaws.com` to read/write the bucket and invoke the model
  during a batch job
- `iam-policies.tf` - pod role extended with batch job management actions,
  scoped `iam:PassRole`, and S3/KMS access to the new bucket
- `locals.tf` - `ai_gateway_bedrock_batch_models` (same-account +
  `batch_available` opted-in models only)
- `ai-gateway-models.tf` - `litellm_model.amazon_bedrock_batch` companion
  `mode = "batch"` resources
- `ai-gateway-access-groups.tf` - matching `bedrock-batch-*` unified access
  groups (no team opted in yet - separate follow-up)
- `configuration.yml` - `batch_available: true` on `claude-haiku-4-5` only

## Not in this PR
- Cross-account Bedrock models
- Any user-facing UX for batch access
- Assigning any team to the new `bedrock-batch-*` access group
- Rollout to test/preproduction/production

## Testing
Not yet applied/tested against a live AWS account - `terraform fmt`/`validate`
pass. Manual end-to-end testing (upload file -> create batch -> poll ->
retrieve output) still to be run against dev once applied. See PR checklist /
follow-up comments for the test plan.

## Outstanding follow-ups (tracked, not blocking this draft)
1. Confirm minimum LiteLLM version required for Bedrock Batches support
   (currently 1.100.0 in dev) and whether Enterprise license scope covers it
2. Validate that omitting `s3_access_key_id`/`s3_secret_access_key` correctly
   falls back to the pod's IRSA credentials
3. Data protection review of the batch bucket's retention policy

## Related
Relates to ministryofjustice/data-platform#724

## Update
End-to-end functional test now passes against dev (see `scripts/batch-inference-test.sh` and `scripts/batch-inference-sample.jsonl`): file upload -> batch creation -> polling -> completed -> output retrieved successfully.
