### PR TITLE
CC-4679: Enable Deletion Protection (All Envs) for Apex and MAAT LBs

### DIFF
--- a/.github/workflows/maat.yml
+++ b/.github/workflows/maat.yml
@@ -25,6 +25,11 @@ on:
         options:
           - deploy
           - destroy
+      do_state_refresh_on_plan:
+        description: 'Run terraform apply -refresh-only before plan'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -48,6 +53,7 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
+      do_state_refresh_on_plan: "${{ inputs.do_state_refresh_on_plan }}"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/maat.yml
+++ b/.github/workflows/maat.yml
@@ -25,11 +25,6 @@ on:
         options:
           - deploy
           - destroy
-      do_state_refresh_on_plan:
-        description: 'Run terraform apply -refresh-only before plan'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -53,7 +48,6 @@ jobs:
       application: "${{ github.workflow }}"
       environment: "${{ matrix.target }}"
       action: "${{ matrix.action }}"
-      do_state_refresh_on_plan: "${{ inputs.do_state_refresh_on_plan }}"
     secrets:
       MODERNISATION_PLATFORM_ACCOUNT_ID: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_ID }}
       PASSPHRASE: ${{ secrets.PASSPHRASE }}

--- a/terraform/environments/apex/alb.tf
+++ b/terraform/environments/apex/alb.tf
@@ -43,7 +43,7 @@ module "alb" {
   account_number                   = local.environment_management.account_ids[terraform.workspace]
   environment                      = local.environment
   region                           = "eu-west-2"
-  enable_deletion_protection       = local.environment == "production" ? true : false
+  enable_deletion_protection       = true
   idle_timeout                     = 65
   force_destroy_bucket             = true
   security_group_ingress_from_port = 443

--- a/terraform/environments/maat/application_variables.json
+++ b/terraform/environments/maat/application_variables.json
@@ -3,7 +3,7 @@
     "development": {
       "env_short_name": "dev",
       "cloudfront_domain_name": "modernisation-platform.service.justice.gov.uk",
-      "ext_lb_enable_deletion_protection": "false",
+      "ext_lb_enable_deletion_protection": "true",
       "instance_type": "m5.large",
       "maat_ec2_asg_desired_capacity": "1",
       "maat_ec2_asg_min_size": "1",
@@ -49,7 +49,7 @@
     "test": {
       "env_short_name": "test",
       "cloudfront_domain_name": "modernisation-platform.service.justice.gov.uk",
-      "ext_lb_enable_deletion_protection": "false",
+      "ext_lb_enable_deletion_protection": "true",
       "instance_type": "m5.large",
       "maat_ec2_asg_desired_capacity": "1",
       "maat_ec2_asg_min_size": "1",
@@ -95,7 +95,7 @@
     "preproduction": {
       "env_short_name": "preproduction",
       "cloudfront_domain_name": "modernisation-platform.service.justice.gov.uk",
-      "ext_lb_enable_deletion_protection": "false",
+      "ext_lb_enable_deletion_protection": "true",
       "instance_type": "m5.large",
       "maat_ec2_asg_desired_capacity": "1",
       "maat_ec2_asg_min_size": "1",


### PR DESCRIPTION
Updates `apex` and `maat` Load balancers to have `enable_deletion_protection` enabled by default across all environments, rather than just `production`, to add greater security and safety to critical resources, and align to the approach taken by other apps within modernisation-platform-environments, such as `ppud`, `tribunals`, `ccms-pui/oia`, `laa-ccms-soa`

This would not affect how Apex/MAAT operate in any way, the setting merely acts as a safety net for infrastructure changes that may have unintentionally negative impacts.