### PR TITLE
DBA-1285: extend data volume for t1-nomis-db-2-a

### DIFF
--- a/terraform/environments/nomis/locals_test.tf
+++ b/terraform/environments/nomis/locals_test.tf
@@ -300,7 +300,7 @@ locals {
           "/dev/sdc" = { label = "app", size = 100 }
         })
         ebs_volume_config = merge(local.ec2_instances.db.ebs_volume_config, {
-          data  = { total_size = 700 }
+          data  = { total_size = 1000 }
           flash = { total_size = 50 }
         })
         instance = merge(local.ec2_instances.db.instance, {


### PR DESCRIPTION
This pull request makes a small but important change to the EBS volume configuration in the `locals_test.tf` file for the `nomis` environment. The total size of the `data` EBS volume has been increased from 700 to 1000.

- Increased the `total_size` of the `data` EBS volume from 700 to 1000 in the `ebs_volume_config` for database EC2 instances in `terraform/environments/nomis/locals_test.tf`.