### PR TITLE
Data Platform: Update input strength for the Bedrock guardrail

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/bedrock-guardrails.tf
+++ b/terraform/environments/data-platform/ai-gateway/bedrock-guardrails.tf
@@ -24,7 +24,7 @@ resource "aws_bedrock_guardrail" "prompt_attack" {
 }
 
 resource "aws_bedrock_guardrail_version" "prompt_attack" {
-  description   = "Prompt-attack policy for the AI Gateway"
+  description   = "Prompt-attack policy for the AI Gateway - input strength MEDIUM"
   guardrail_arn = aws_bedrock_guardrail.prompt_attack.guardrail_arn
   skip_destroy  = true
 }

--- a/terraform/environments/data-platform/ai-gateway/bedrock-guardrails.tf
+++ b/terraform/environments/data-platform/ai-gateway/bedrock-guardrails.tf
@@ -16,7 +16,7 @@ resource "aws_bedrock_guardrail" "prompt_attack" {
       type            = "PROMPT_ATTACK"
       input_enabled   = true
       input_action    = "BLOCK"
-      input_strength  = "HIGH"
+      input_strength  = "MEDIUM"
       output_enabled  = false
       output_strength = "NONE"
     }


### PR DESCRIPTION
This PR reduces the Bedrock Prompt Attack input guardrail from HIGH to MEDIUM while keeping the filter enabled and blocking suspicious prompts. The change is intended to reduce false positives without removing the safeguard.