### PR TITLE
AMG: grant AWS team access and use Grafana 12.4

### DIFF
--- a/terraform/environments/cloud-platform/amg.tf
+++ b/terraform/environments/cloud-platform/amg.tf
@@ -132,6 +132,15 @@ resource "aws_grafana_workspace" "this" {
   role_arn                 = aws_iam_role.amg[0].arn
   grafana_version          = "12.4"
 
+  # Grafana-managed (unified) alerting must be enabled before AMG will accept an
+  # upgrade to Grafana v12 (otherwise UpdateWorkspaceConfiguration returns
+  # "Grafana alerting must be enabled before upgrading to v12").
+  configuration = jsonencode({
+    unifiedAlerting = {
+      enabled = true
+    }
+  })
+
   data_sources = [
     "PROMETHEUS",
     "CLOUDWATCH",

--- a/terraform/environments/cloud-platform/amg.tf
+++ b/terraform/environments/cloud-platform/amg.tf
@@ -130,7 +130,7 @@ resource "aws_grafana_workspace" "this" {
   authentication_providers = ["AWS_SSO"]
   permission_type          = "SERVICE_MANAGED"
   role_arn                 = aws_iam_role.amg[0].arn
-  grafana_version          = "10.4"
+  grafana_version          = "12.4"
 
   data_sources = [
     "PROMETHEUS",
@@ -148,21 +148,26 @@ resource "aws_grafana_workspace" "this" {
 # AMG workspace role association — platform engineers get ADMIN
 #------------------------------------------------------------------------------
 
-# The cloud-platform-engineers IDC group ID is hardcoded because the
-# ModernisationPlatformSSOReadOnly role returns ResourceNotFoundException when
-# calling GetGroupId despite having identitystore:Get*. This mirrors the same
-# workaround used for ArgoCD RBAC in cluster/locals.tf.
+# IDC group IDs are hardcoded because the ModernisationPlatformSSOReadOnly role
+# returns ResourceNotFoundException when calling GetGroupId despite having
+# identitystore:Get*. This mirrors the same workaround (and the same two groups)
+# used for ArgoCD RBAC in cluster/locals.tf.
 # TODO: switch back to a data.aws_identitystore_group lookup once the read role
 # permissions are fixed.
 locals {
   cloud_platform_engineers_group_id = "664252b4-7021-701e-49b9-6c46ccc7899e"
+  # AWS ProServe team building the platform; needs AMG access to inspect dashboards.
+  container_platform_aws_group_id = "7682a204-00f1-7031-257e-713bb28289c6"
 }
 
 resource "aws_grafana_role_association" "platform_admin" {
   count = local.enable_amg ? 1 : 0
 
-  role         = "ADMIN"
-  group_ids    = [local.cloud_platform_engineers_group_id]
+  role = "ADMIN"
+  group_ids = [
+    local.cloud_platform_engineers_group_id,
+    local.container_platform_aws_group_id,
+  ]
   workspace_id = aws_grafana_workspace.this[0].id
 }
 

--- a/terraform/environments/cloud-platform/locals.tf
+++ b/terraform/environments/cloud-platform/locals.tf
@@ -16,11 +16,7 @@ locals {
   #-----------------------------------------------------------------------------
   amg_host_workspaces = [
     "cloud-platform-live",
-    # cloud-platform-development is temporarily disabled to destroy the existing
-    # Grafana 10.4 dev workspace, which cannot be upgraded in place to 12.4
-    # ("alerting must be enabled before upgrading to v12"). A follow-up change
-    # re-adds it so it is recreated fresh at 12.4 with unified alerting enabled.
-    # "cloud-platform-development",
+    "cloud-platform-development",
   ]
   enable_amg         = contains(local.amg_host_workspaces, terraform.workspace)
   amg_workspace_name = "${terraform.workspace}-observability"

--- a/terraform/environments/cloud-platform/locals.tf
+++ b/terraform/environments/cloud-platform/locals.tf
@@ -16,7 +16,11 @@ locals {
   #-----------------------------------------------------------------------------
   amg_host_workspaces = [
     "cloud-platform-live",
-    "cloud-platform-development",
+    # cloud-platform-development is temporarily disabled to destroy the existing
+    # Grafana 10.4 dev workspace, which cannot be upgraded in place to 12.4
+    # ("alerting must be enabled before upgrading to v12"). A follow-up change
+    # re-adds it so it is recreated fresh at 12.4 with unified alerting enabled.
+    # "cloud-platform-development",
   ]
   enable_amg         = contains(local.amg_host_workspaces, terraform.workspace)
   amg_workspace_name = "${terraform.workspace}-observability"


### PR DESCRIPTION
## Summary

Two small follow-up fixes to the centralised AMG workspace (added in #19065), from review feedback:

1. **Grant the AWS ProServe team (`container-platform-aws`) AMG ADMIN access.** Previously only `cloud-platform-engineers` had access, so the AWS team could not inspect dashboards. Adds the `container-platform-aws` IDC group to the ADMIN role association, using the same hardcoded group id as the ArgoCD RBAC workaround in `cluster/locals.tf` (the `ModernisationPlatformSSOReadOnly` role can't resolve groups by name).

2. **Bump Grafana version 10.4 → 12.4.** 10.4 was a stale default carried from the original draft; AMG now supports creating Grafana 12.4 workspaces (the current major on AMG, close to the OSS latest of 13.0). This is a brand-new workspace so there is no upgrade/downgrade risk to weigh.

## Validation

- `terraform fmt` — clean
- `checkov` — no failures on the AMG resources (the documented `CKV_AWS_355` skips on the data-source policies still apply)

Root cannot be fully `terraform validate`d offline (needs a selected workspace + backend — pre-existing behaviour); the AMG plan will be exercised by the pipeline on `cloud-platform-development`.

## Access model (ADR-005)

| Actor | AMG Role |
|-------|----------|
| Platform engineers (`cloud-platform-engineers`) | ADMIN |
| AWS ProServe team (`container-platform-aws`) | ADMIN |
| BU app engineers | Viewer (read-only, per-BU) — delivered in ministryofjustice/cloud-platform#8509 |

Part of ministryofjustice/cloud-platform#8508

Successfully deployed in development account

<img width="1718" height="710" alt="image" src="https://github.com/user-attachments/assets/a2747085-f66a-4190-96df-4be538aff615" />

