### PR TITLE
Data Platform: Add Gemini 3.5 Transcribe Preview model and audio test script

### DIFF
--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -10,6 +10,7 @@ teams:
     models: ["no-default-models"]
     unified_access_groups:
       - generally-available-models
+      - gemini-gemini-3-5-transcribe-preview
   justice-engineering-ai-enablement:
     alias: Justice Engineering AI Enablement
     organisation: ministryofjustice
@@ -434,6 +435,13 @@ models:
       model_family: "Google Gemini"
       model_name: "Google Gemini 3.5 Flash"
       location: "europe-west2"
+      generally_available: false
+      environments_available: ["development", "production"]
+    gemini-3-5-transcribe-preview:
+      model_id: "gemini-3.5-transcribe-preview"
+      model_family: "Google Gemini"
+      model_name: "Google Gemini 3.5 Transcribe Preview"
+      location: "global"
       generally_available: false
       environments_available: ["development", "production"]
     gemini-3-6-flash:

--- a/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
+++ b/terraform/environments/data-platform/ai-gateway/configuration/configuration.yml
@@ -10,7 +10,6 @@ teams:
     models: ["no-default-models"]
     unified_access_groups:
       - generally-available-models
-      - gemini-gemini-3-5-transcribe-preview
   justice-engineering-ai-enablement:
     alias: Justice Engineering AI Enablement
     organisation: ministryofjustice

--- a/terraform/environments/data-platform/ai-gateway/scripts/audio-transcription-test.sh
+++ b/terraform/environments/data-platform/ai-gateway/scripts/audio-transcription-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if [[ -z "${AWS_SSO_PROFILE}" ]]; then
+  echo "AWS_SSO_PROFILE not set, please run 'aws-sso exec ...' for example 'aws-sso exec --profile data-platform-development:platform-engineer-admin'"
+  exit 1
+fi
+
+AUDIO_FILE="$1"
+MODEL="${2:-gemini-3-5-transcribe-preview}"
+
+if [[ -z "${AUDIO_FILE}" || ! -f "${AUDIO_FILE}" ]]; then
+  echo "Usage: $0 <path-to-audio-file> [model]"
+  echo "e.g. $0 sample.wav gemini-3-5-transcribe-preview"
+  exit 1
+fi
+
+FORMAT="${AUDIO_FILE##*.}"
+
+ENVIRONMENT="$(cut -d: -f1 <<< "${AWS_SSO_PROFILE#data-platform-}")"
+
+if [[ "${ENVIRONMENT}" == "production" ]]; then
+  AI_GATEWAY_URL="https://ai-gateway.justice.gov.uk"
+  AI_GATEWAY_ADMIN_URL="https://admin.ai-gateway.justice.gov.uk"
+else
+  AI_GATEWAY_URL="https://${ENVIRONMENT}.ai-gateway.justice.gov.uk"
+  AI_GATEWAY_ADMIN_URL="https://admin.${ENVIRONMENT}.ai-gateway.justice.gov.uk"
+fi
+
+AI_GATEWAY_MASTER_KEY=$(aws secretsmanager get-secret-value --secret-id ai-gateway/litellm-master-key --query SecretString --output text)
+
+AUDIO_BASE64=$(base64 -w0 "${AUDIO_FILE}")
+
+jq -n --arg model "${MODEL}" --arg audio "${AUDIO_BASE64}" --arg format "${FORMAT}" \
+  '{model: $model, messages: [{role: "user", content: [{type: "input_audio", input_audio: {data: $audio, format: $format}}]}]}' \
+  | curl \
+    --silent \
+    --request POST \
+    --url "${AI_GATEWAY_URL}/chat/completions" \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Bearer ${AI_GATEWAY_MASTER_KEY}" \
+    --data @- | jq .


### PR DESCRIPTION
> [!NOTE]  
> This model is GLOBAL.

> [!NOTE]  
> Tested in development. Will test in production. Due to the nature of how our Google projects are set up, this will not work in Test or Production



- Adds `gemini-3-5-transcribe-preview` (Vertex AI publisher model `gemini-3.5-transcribe-preview`, `location: global`) to the ai-gateway `configuration.yml`.
- Adds `scripts/audio-transcription-test.sh`, which base64-encodes a local audio file and sends it to `/chat/completions` as an `input_audio` content part, for testing audio transcription requests against the gateway.

## Testing

To test this I used Voice Memos, created an M4A file, and passed this to the new script:

```
./scripts/audio-transcription-test.sh sample.m4a gemini-3-5-transcribe-preview
```

This returned a successful transcription response from the model via the development environment ai-gateway. The test audio file itself is not included in this PR.
