### PR TITLE
added for prepod

### DIFF
--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/application_variables.json
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/application_variables.json
@@ -5,6 +5,7 @@
       "cron_schedule": "cron(30 07 ? * MON *)",
       "source_bucket_role_name": "ppud-parquet-exports-batch-copy-dev-role",
       "short_name_environment": "dev",
+      "ppud_replication_environment": "dev",
       "analytical_platform_share": [
         {
           "target_account_name": "analytical-platform-data-production",
@@ -29,13 +30,15 @@
       "days_back": "1",
       "cron_schedule": "cron(30 07 ? * TUE *)",
       "source_bucket_role_name": "ppud-parquet-exports-batch-copy-preprod-role",
-      "short_name_environment": "preprod"
+      "short_name_environment": "preprod",
+      "ppud_replication_environment": "uat"
     },
     "production": {
       "days_back": "1",
       "cron_schedule": "cron(30 07 * * ? *)",
       "source_bucket_role_name": "ppud-parquet-exports-batch-copy-prod-role",
-      "short_name_environment": "prod"
+      "short_name_environment": "prod",
+      "ppud_replication_environment": "prod"
     }
   }
 }

--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/locals.tf
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/locals.tf
@@ -4,5 +4,5 @@ locals {
   short_name_environment    = local.is-test ? "test" : local.application_data.accounts[local.environment].short_name_environment
   source_bucket_role_arn    = local.is-test ? "arn" : "arn:aws:iam::${local.environment_management.account_ids["analytical-platform-data-engineering-production"]}:role/${local.application_data.accounts[local.environment].source_bucket_role_name}"
   analytical_platform_share = can(local.application_data.accounts[local.environment].analytical_platform_share) ? { for share in local.application_data.accounts[local.environment].analytical_platform_share : share.target_account_name => share } : {}
-
+  ppud_replication_environment  = local.is-test ? "test" : local.application_data.accounts[local.environment].ppud_replication_environment
 }

--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "ppud_replication_destination_bucket_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.environment_management.account_ids["ppud-${local.environment}"]}:role/service-role/iam_role_s3_bucket_moj_database_source_dev"
+        "arn:aws:iam::${local.environment_management.account_ids["ppud-${local.environment}"]}:role/service-role/iam_role_s3_bucket_moj_database_source_${local.ppud_replication_environment}"
       ]
     }
   }

--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
@@ -1,6 +1,6 @@
 # policy to allow replication in destination bucket
 data "aws_iam_policy_document" "ppud_replication_destination_bucket_policy" {
-  count = local.is-development ? 1 : 0
+  count = (local.is-development || local.is-preproduction) ? 1 : 0
 
   statement {
     sid    = "Set-permissions-for-objects"
@@ -57,7 +57,7 @@ module "ppud_replication_destination" {
 
   sse_algorithm = "AES256"
 
-  bucket_policy = local.is-development ? [data.aws_iam_policy_document.ppud_replication_destination_bucket_policy[0].json] : []
+  bucket_policy = (local.is-development || local.is-preproduction) ? [data.aws_iam_policy_document.ppud_replication_destination_bucket_policy[0].json] : []
 
   lifecycle_rule = [
     {

--- a/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
+++ b/terraform/environments/digital-prison-reporting/ppud-pipeline/s3.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "ppud_replication_destination_bucket_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.environment_management.account_ids["ppud-${local.environment}"]}:role/service-role/iam_role_s3_bucket_moj_database_source_dev"
+        "arn:aws:iam::${local.environment_management.account_ids["ppud-${local.environment}"]}:role/service-role/iam_role_s3_bucket_moj_database_source_${local.ppud_replication_environment}"
       ]
     }
   }


### PR DESCRIPTION
This pull request updates the S3 bucket policy logic in the `ppud-pipeline` Terraform configuration to ensure that the replication destination bucket policy is also applied in the preproduction environment, not just development. This change helps align preproduction and development configuration, improving environment parity.

**Environment configuration changes:**

* Updated the policy document and bucket policy assignments in `s3.tf` to apply when either `local.is-development` or `local.is-preproduction` is true, instead of only in development. [[1]](diffhunk://#diff-74ba7e717a34934d3a570e1099cceff48f533e2353f58bff4c3fc6fe72209313L3-R3) [[2]](diffhunk://#diff-74ba7e717a34934d3a570e1099cceff48f533e2353f58bff4c3fc6fe72209313L60-R60)